### PR TITLE
oci fetcher: when blob HEAD request encounters 401 or 405, fall back to GET

### DIFF
--- a/enterprise/server/oci/ocifetcher/BUILD
+++ b/enterprise/server/oci/ocifetcher/BUILD
@@ -44,6 +44,7 @@ go_test(
         "//proto:oci_fetcher_go_proto",
         "//proto:registry_go_proto",
         "//proto:remote_execution_go_proto",
+        "//server/http/httpclient",
         "//server/interfaces",
         "//server/testutil/testauth",
         "//server/testutil/testcache",

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -635,13 +635,14 @@ func (s *ociFetcherServer) getRemoteOpts(ctx context.Context, creds *rgpb.Creden
 		}))
 	}
 
-	tr := NewBlobHeadFallbackTransport(httpclient.New(s.allowedPrivateIPs, "oci_fetcher"))
-
+	client := httpclient.New(s.allowedPrivateIPs, "oci_fetcher")
+	// The mirror transport sits inside the client, below the blob HEAD fallback transport, so
+	// the fallback's allowlist check sees original registry hostnames rather than mirror
+	// hostnames and its ranged GETs get the same mirror rewriting as any other request.
 	if len(s.mirrors) > 0 {
-		opts = append(opts, remote.WithTransport(NewMirrorTransport(tr, s.mirrors)))
-	} else {
-		opts = append(opts, remote.WithTransport(tr))
+		client.Transport = NewMirrorTransport(client.Transport, s.mirrors)
 	}
+	opts = append(opts, remote.WithTransport(NewBlobHeadFallbackTransport(client)))
 
 	return opts
 }
@@ -885,6 +886,9 @@ func (t *blobHeadFallbackTransport) rangedGet(headReq *http.Request) (*http.Resp
 		Request:       headReq,
 	}
 	out.Header.Del("Content-Range")
+	// Content-Encoding describes the ranged GET's body, which the synthesized response doesn't
+	// carry; drop it so the result reads like a real HEAD response.
+	out.Header.Del("Content-Encoding")
 	out.Header.Set("Content-Length", strconv.FormatInt(size, 10))
 	return out, nil
 }

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -802,7 +802,7 @@ func Mirrors() []interfaces.MirrorConfig {
 var blobsPathRegexp = regexp.MustCompile(`^/v2/.+/blobs/[a-z0-9+._-]+:[a-zA-Z0-9=_-]+$`)
 
 // NewBlobHeadFallbackTransport wraps client's transport to retry blob HEAD requests rejected
-// with 401 (public.ecr.aws rejects all blob HEADs), 403, or 405 as single-byte ranged GETs.
+// with 401 (public.ecr.aws rejects all blob HEADs) or 405 as single-byte ranged GETs.
 func NewBlobHeadFallbackTransport(client *http.Client) http.RoundTripper {
 	return &blobHeadFallbackTransport{client: client}
 }
@@ -818,11 +818,9 @@ func (t *blobHeadFallbackTransport) RoundTrip(in *http.Request) (*http.Response,
 	if err != nil || in.Method != http.MethodHead || !blobsPathRegexp.MatchString(in.URL.Path) {
 		return resp, err
 	}
-	// Only these statuses can mean the HEAD method itself was rejected; others apply equally
-	// to GET, so extra requests would be pointless (404, 5xx) or counterproductive (429).
-	if resp.StatusCode != http.StatusUnauthorized &&
-		resp.StatusCode != http.StatusForbidden &&
-		resp.StatusCode != http.StatusMethodNotAllowed {
+	// Only 401 and 405 can mean the HEAD method itself was rejected; other statuses (403,
+	// 404, 429, 5xx) are genuine answers that would apply equally to a GET.
+	if resp.StatusCode != http.StatusUnauthorized && resp.StatusCode != http.StatusMethodNotAllowed {
 		return resp, nil
 	}
 	fallbackResp, fallbackErr := t.rangedGet(in)

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -67,6 +67,10 @@ var (
 	blobHeadFallbackRegistries = flag.Slice("ocifetcher.blob_head_fallback_registries", []string{ecrPublicRegistry}, "Registry hosts whose rejected blob HEAD requests are retried as single-byte ranged GETs.")
 
 	blobBufPool = bytebufferpool.VariableSize(blobChunkSize)
+
+	// blobsPathRegexp matches blob pull paths, "/v2/<name>/blobs/<digest>" per
+	// https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-blobs.
+	blobsPathRegexp = regexp.MustCompile(`^/v2/.+/blobs/[a-z0-9+._-]+:[a-zA-Z0-9=_-]+$`)
 )
 
 type ociFetcherServer struct {
@@ -808,10 +812,6 @@ func ParseAllowedPrivateIPs() ([]*net.IPNet, error) {
 func Mirrors() []interfaces.MirrorConfig {
 	return *mirrors
 }
-
-// blobsPathRegexp matches blob pull paths, "/v2/<name>/blobs/<digest>" per
-// https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-blobs.
-var blobsPathRegexp = regexp.MustCompile(`^/v2/.+/blobs/[a-z0-9+._-]+:[a-zA-Z0-9=_-]+$`)
 
 // NewBlobHeadFallbackTransport wraps client's transport to retry blob HEAD requests that
 // registries in blobHeadFallbackRegistries reject with 401 or 405 as single-byte ranged GETs.

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -47,12 +47,24 @@ const (
 
 	accessProofCacheTTL        = 15 * time.Minute
 	accessProofCacheMaxEntries = 1000
+
+	// public.ecr.aws rejects all blob HEAD requests with 401; see blobHeadFallbackRegistries.
+	ecrPublicRegistry = "public.ecr.aws"
+	// A single-byte range keeps the blob HEAD fallback GET cheap while still exposing
+	// the full blob size in the response's Content-Range header.
+	blobHeadFallbackRange = "bytes=0-0"
+	// How much of a fallback response body to drain for connection reuse before closing.
+	blobHeadFallbackDrainLimit = 1024
 )
 
 var (
 	enabled           = flag.Bool("ocifetcher.enabled", false, "Whether to enable the OCI fetcher service.")
 	mirrors           = flag.Slice("executor.container_registry_mirrors", []interfaces.MirrorConfig{}, "")
 	allowedPrivateIPs = flag.Slice("executor.container_registry_allowed_private_ips", []string{}, "Allowed private IP ranges for container registries. Private IPs are disallowed by default.")
+
+	// Restricting the fallback to hosts known to reject blob HEADs keeps genuine 401s
+	// (e.g. expired credentials) from spawning an extra doomed GET per HEAD everywhere else.
+	blobHeadFallbackRegistries = flag.Slice("ocifetcher.blob_head_fallback_registries", []string{ecrPublicRegistry}, "Registry hosts whose rejected blob HEAD requests are retried as single-byte ranged GETs.")
 
 	blobBufPool = bytebufferpool.VariableSize(blobChunkSize)
 )
@@ -801,8 +813,8 @@ func Mirrors() []interfaces.MirrorConfig {
 // https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-blobs.
 var blobsPathRegexp = regexp.MustCompile(`^/v2/.+/blobs/[a-z0-9+._-]+:[a-zA-Z0-9=_-]+$`)
 
-// NewBlobHeadFallbackTransport wraps client's transport to retry blob HEAD requests rejected
-// with 401 (public.ecr.aws rejects all blob HEADs) or 405 as single-byte ranged GETs.
+// NewBlobHeadFallbackTransport wraps client's transport to retry blob HEAD requests that
+// registries in blobHeadFallbackRegistries reject with 401 or 405 as single-byte ranged GETs.
 func NewBlobHeadFallbackTransport(client *http.Client) http.RoundTripper {
 	return &blobHeadFallbackTransport{client: client}
 }
@@ -815,7 +827,7 @@ type blobHeadFallbackTransport struct {
 
 func (t *blobHeadFallbackTransport) RoundTrip(in *http.Request) (*http.Response, error) {
 	resp, err := t.client.Transport.RoundTrip(in)
-	if err != nil || in.Method != http.MethodHead || !blobsPathRegexp.MatchString(in.URL.Path) {
+	if err != nil || in.Method != http.MethodHead || !blobHeadFallbackHost(in.URL.Hostname()) || !blobsPathRegexp.MatchString(in.URL.Path) {
 		return resp, err
 	}
 	// Only 401 and 405 can mean the HEAD method itself was rejected; other statuses (403,
@@ -832,12 +844,22 @@ func (t *blobHeadFallbackTransport) RoundTrip(in *http.Request) (*http.Response,
 	return fallbackResp, nil
 }
 
+// blobHeadFallbackHost reports whether hostname is on the blob HEAD fallback allowlist.
+func blobHeadFallbackHost(hostname string) bool {
+	for _, h := range *blobHeadFallbackRegistries {
+		if strings.EqualFold(hostname, h) {
+			return true
+		}
+	}
+	return false
+}
+
 // rangedGet reissues a rejected blob HEAD request as a single-byte ranged GET and synthesizes
 // an equivalent HEAD response, with the full blob size from Content-Range or Content-Length.
 func (t *blobHeadFallbackTransport) rangedGet(headReq *http.Request) (*http.Response, error) {
 	req := headReq.Clone(headReq.Context())
 	req.Method = http.MethodGet
-	req.Header.Set("Range", "bytes=0-0")
+	req.Header.Set("Range", blobHeadFallbackRange)
 	// client.Do follows redirects to blob CDNs, stripping Authorization on cross-host redirects.
 	resp, err := t.client.Do(req)
 	if err != nil {
@@ -846,7 +868,7 @@ func (t *blobHeadFallbackTransport) rangedGet(headReq *http.Request) (*http.Resp
 	size, err := blobSizeFromRangedGetResponse(resp)
 	// Drain a range-honoring response (a single byte) so its connection can be reused; a body
 	// left unread beyond this (a registry that ignored Range) is aborted by the close instead.
-	io.Copy(io.Discard, io.LimitReader(resp.Body, 1024))
+	io.Copy(io.Discard, io.LimitReader(resp.Body, blobHeadFallbackDrainLimit))
 	resp.Body.Close()
 	if err != nil {
 		return nil, err
@@ -875,20 +897,24 @@ func blobSizeFromRangedGetResponse(resp *http.Response) (int64, error) {
 		contentRange := resp.Header.Get("Content-Range")
 		slash := strings.LastIndexByte(contentRange, '/')
 		if slash < 0 {
-			return 0, fmt.Errorf("missing or malformed Content-Range header %q", contentRange)
+			return 0, status.UnavailableErrorf("missing or malformed Content-Range header %q", contentRange)
+		}
+		if contentRange[slash+1:] == "*" {
+			// RFC 9110 permits "bytes 0-0/*" for an unknown complete length.
+			return 0, status.UnavailableErrorf("Content-Range header %q reports an unknown blob size", contentRange)
 		}
 		size, err := strconv.ParseInt(contentRange[slash+1:], 10, 64)
 		if err != nil || size < 0 {
-			return 0, fmt.Errorf("malformed Content-Range header %q", contentRange)
+			return 0, status.UnavailableErrorf("malformed Content-Range header %q", contentRange)
 		}
 		return size, nil
 	case http.StatusOK:
 		if resp.ContentLength < 0 {
-			return 0, fmt.Errorf("response has unknown content length")
+			return 0, status.UnavailableError("response reports an unknown content length")
 		}
 		return resp.ContentLength, nil
 	}
-	return 0, fmt.Errorf("HTTP status %d", resp.StatusCode)
+	return 0, status.UnavailableErrorf("HTTP status %d", resp.StatusCode)
 }
 
 // NewMirrorTransport wraps an http.RoundTripper with registry mirror support.

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -10,6 +10,8 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -616,7 +618,7 @@ func (s *ociFetcherServer) getRemoteOpts(ctx context.Context, creds *rgpb.Creden
 		}))
 	}
 
-	tr := httpclient.New(s.allowedPrivateIPs, "oci_fetcher").Transport
+	tr := NewBlobHeadFallbackTransport(httpclient.New(s.allowedPrivateIPs, "oci_fetcher").Transport)
 
 	if len(s.mirrors) > 0 {
 		opts = append(opts, remote.WithTransport(NewMirrorTransport(tr, s.mirrors)))
@@ -792,6 +794,126 @@ func ParseAllowedPrivateIPs() ([]*net.IPNet, error) {
 
 func Mirrors() []interfaces.MirrorConfig {
 	return *mirrors
+}
+
+// NewBlobHeadFallbackTransport wraps an http.RoundTripper so that HEAD
+// requests to blob endpoints that are rejected with HTTP 401, 403, or 405
+// are retried as GET requests with "Range: bytes=0-0", and the GET response
+// is converted back into an equivalent HEAD response. Some registries
+// (notably public.ecr.aws) reject every HEAD request to a blob endpoint with
+// 401, even though the OCI Distribution Spec requires HEAD support and the
+// same credentials authorize GET requests.
+//
+// The fallback is deliberately restricted to the statuses that can mean
+// "HEAD specifically was rejected": 401 (public.ecr.aws), 403 (e.g. a
+// redirect target presigned for GET only), and 405 (method not allowed).
+// Other statuses apply equally to GET, so issuing extra requests would be
+// pointless (404, 5xx) or counterproductive (429).
+func NewBlobHeadFallbackTransport(inner http.RoundTripper) http.RoundTripper {
+	return &blobHeadFallbackTransport{inner: inner}
+}
+
+var _ http.RoundTripper = (*blobHeadFallbackTransport)(nil)
+
+type blobHeadFallbackTransport struct {
+	inner http.RoundTripper
+}
+
+func (t *blobHeadFallbackTransport) RoundTrip(in *http.Request) (*http.Response, error) {
+	resp, err := t.inner.RoundTrip(in)
+	if err != nil ||
+		in.Method != http.MethodHead ||
+		!headRejectionStatus(resp.StatusCode) ||
+		!strings.Contains(in.URL.Path, "/blobs/") {
+		return resp, err
+	}
+	fallbackResp, fallbackErr := t.rangedGet(in)
+	if fallbackErr != nil {
+		log.CtxDebugf(in.Context(), "Ranged GET fallback for blob HEAD request that failed with HTTP status %d did not succeed either: %s", resp.StatusCode, fallbackErr)
+		return resp, nil
+	}
+	resp.Body.Close()
+	return fallbackResp, nil
+}
+
+// headRejectionStatus returns whether an HTTP status code in a HEAD response
+// can mean that the server rejected the HEAD method itself rather than the
+// resource being unavailable.
+func headRejectionStatus(statusCode int) bool {
+	switch statusCode {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusMethodNotAllowed:
+		return true
+	}
+	return false
+}
+
+// rangedGet reissues a failed blob HEAD request as a GET for the first byte
+// of the blob and synthesizes an equivalent HEAD response from the result.
+// If the registry honors the Range header, the transfer is a single byte and
+// the full blob size comes from the Content-Range header. If it ignores the
+// Range header and replies 200, the full size is in Content-Length and
+// closing the body without reading it aborts the transfer after a few
+// packets.
+func (t *blobHeadFallbackTransport) rangedGet(headReq *http.Request) (*http.Response, error) {
+	req := headReq.Clone(headReq.Context())
+	req.Method = http.MethodGet
+	req.Header.Set("Range", "bytes=0-0")
+	// Use an http.Client so that redirects to blob CDNs are followed, with
+	// sensitive headers like Authorization stripped on cross-host redirects.
+	client := &http.Client{Transport: t.inner}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	size, err := blobSizeFromRangedGetResponse(resp)
+	// Drain a range-honoring response (a single byte) so its connection can
+	// be reused, but no more than that: an oversized body is abandoned by
+	// closing the connection instead.
+	io.Copy(io.Discard, io.LimitReader(resp.Body, 1024))
+	resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	out := &http.Response{
+		Status:        fmt.Sprintf("%d %s", http.StatusOK, http.StatusText(http.StatusOK)),
+		StatusCode:    http.StatusOK,
+		Proto:         resp.Proto,
+		ProtoMajor:    resp.ProtoMajor,
+		ProtoMinor:    resp.ProtoMinor,
+		Header:        resp.Header.Clone(),
+		Body:          http.NoBody,
+		ContentLength: size,
+		Request:       headReq,
+	}
+	out.Header.Del("Content-Range")
+	out.Header.Set("Content-Length", strconv.FormatInt(size, 10))
+	return out, nil
+}
+
+// blobSizeFromRangedGetResponse extracts the full blob size from the response
+// to a single-byte ranged GET request.
+func blobSizeFromRangedGetResponse(resp *http.Response) (int64, error) {
+	switch resp.StatusCode {
+	case http.StatusPartialContent, http.StatusRequestedRangeNotSatisfiable:
+		// "Content-Range: bytes 0-0/123" (206), or "bytes */0" for a 416
+		// response to a zero-length blob.
+		contentRange := resp.Header.Get("Content-Range")
+		slash := strings.LastIndexByte(contentRange, '/')
+		if slash < 0 {
+			return 0, fmt.Errorf("missing or malformed Content-Range header %q", contentRange)
+		}
+		size, err := strconv.ParseInt(contentRange[slash+1:], 10, 64)
+		if err != nil || size < 0 {
+			return 0, fmt.Errorf("malformed Content-Range header %q", contentRange)
+		}
+		return size, nil
+	case http.StatusOK:
+		if resp.ContentLength < 0 {
+			return 0, fmt.Errorf("response has unknown content length")
+		}
+		return resp.ContentLength, nil
+	}
+	return 0, fmt.Errorf("HTTP status %d", resp.StatusCode)
 }
 
 // NewMirrorTransport wraps an http.RoundTripper with registry mirror support.

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -618,7 +619,7 @@ func (s *ociFetcherServer) getRemoteOpts(ctx context.Context, creds *rgpb.Creden
 		}))
 	}
 
-	tr := NewBlobHeadFallbackTransport(httpclient.New(s.allowedPrivateIPs, "oci_fetcher").Transport)
+	tr := NewBlobHeadFallbackTransport(httpclient.New(s.allowedPrivateIPs, "oci_fetcher"))
 
 	if len(s.mirrors) > 0 {
 		opts = append(opts, remote.WithTransport(NewMirrorTransport(tr, s.mirrors)))
@@ -796,36 +797,33 @@ func Mirrors() []interfaces.MirrorConfig {
 	return *mirrors
 }
 
-// NewBlobHeadFallbackTransport wraps an http.RoundTripper so that HEAD
-// requests to blob endpoints that are rejected with HTTP 401, 403, or 405
-// are retried as GET requests with "Range: bytes=0-0", and the GET response
-// is converted back into an equivalent HEAD response. Some registries
-// (notably public.ecr.aws) reject every HEAD request to a blob endpoint with
-// 401, even though the OCI Distribution Spec requires HEAD support and the
-// same credentials authorize GET requests.
-//
-// The fallback is deliberately restricted to the statuses that can mean
-// "HEAD specifically was rejected": 401 (public.ecr.aws), 403 (e.g. a
-// redirect target presigned for GET only), and 405 (method not allowed).
-// Other statuses apply equally to GET, so issuing extra requests would be
-// pointless (404, 5xx) or counterproductive (429).
-func NewBlobHeadFallbackTransport(inner http.RoundTripper) http.RoundTripper {
-	return &blobHeadFallbackTransport{inner: inner}
+// blobsPathRegexp matches blob pull paths, "/v2/<name>/blobs/<digest>" per
+// https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-blobs.
+var blobsPathRegexp = regexp.MustCompile(`^/v2/.+/blobs/[a-z0-9+._-]+:[a-zA-Z0-9=_-]+$`)
+
+// NewBlobHeadFallbackTransport wraps client's transport to retry blob HEAD requests rejected
+// with 401 (public.ecr.aws rejects all blob HEADs), 403, or 405 as single-byte ranged GETs.
+func NewBlobHeadFallbackTransport(client *http.Client) http.RoundTripper {
+	return &blobHeadFallbackTransport{client: client}
 }
 
 var _ http.RoundTripper = (*blobHeadFallbackTransport)(nil)
 
 type blobHeadFallbackTransport struct {
-	inner http.RoundTripper
+	client *http.Client
 }
 
 func (t *blobHeadFallbackTransport) RoundTrip(in *http.Request) (*http.Response, error) {
-	resp, err := t.inner.RoundTrip(in)
-	if err != nil ||
-		in.Method != http.MethodHead ||
-		!headRejectionStatus(resp.StatusCode) ||
-		!strings.Contains(in.URL.Path, "/blobs/") {
+	resp, err := t.client.Transport.RoundTrip(in)
+	if err != nil || in.Method != http.MethodHead || !blobsPathRegexp.MatchString(in.URL.Path) {
 		return resp, err
+	}
+	// Only these statuses can mean the HEAD method itself was rejected; others apply equally
+	// to GET, so extra requests would be pointless (404, 5xx) or counterproductive (429).
+	if resp.StatusCode != http.StatusUnauthorized &&
+		resp.StatusCode != http.StatusForbidden &&
+		resp.StatusCode != http.StatusMethodNotAllowed {
+		return resp, nil
 	}
 	fallbackResp, fallbackErr := t.rangedGet(in)
 	if fallbackErr != nil {
@@ -836,39 +834,20 @@ func (t *blobHeadFallbackTransport) RoundTrip(in *http.Request) (*http.Response,
 	return fallbackResp, nil
 }
 
-// headRejectionStatus returns whether an HTTP status code in a HEAD response
-// can mean that the server rejected the HEAD method itself rather than the
-// resource being unavailable.
-func headRejectionStatus(statusCode int) bool {
-	switch statusCode {
-	case http.StatusUnauthorized, http.StatusForbidden, http.StatusMethodNotAllowed:
-		return true
-	}
-	return false
-}
-
-// rangedGet reissues a failed blob HEAD request as a GET for the first byte
-// of the blob and synthesizes an equivalent HEAD response from the result.
-// If the registry honors the Range header, the transfer is a single byte and
-// the full blob size comes from the Content-Range header. If it ignores the
-// Range header and replies 200, the full size is in Content-Length and
-// closing the body without reading it aborts the transfer after a few
-// packets.
+// rangedGet reissues a rejected blob HEAD request as a single-byte ranged GET and synthesizes
+// an equivalent HEAD response, with the full blob size from Content-Range or Content-Length.
 func (t *blobHeadFallbackTransport) rangedGet(headReq *http.Request) (*http.Response, error) {
 	req := headReq.Clone(headReq.Context())
 	req.Method = http.MethodGet
 	req.Header.Set("Range", "bytes=0-0")
-	// Use an http.Client so that redirects to blob CDNs are followed, with
-	// sensitive headers like Authorization stripped on cross-host redirects.
-	client := &http.Client{Transport: t.inner}
-	resp, err := client.Do(req)
+	// client.Do follows redirects to blob CDNs, stripping Authorization on cross-host redirects.
+	resp, err := t.client.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	size, err := blobSizeFromRangedGetResponse(resp)
-	// Drain a range-honoring response (a single byte) so its connection can
-	// be reused, but no more than that: an oversized body is abandoned by
-	// closing the connection instead.
+	// Drain a range-honoring response (a single byte) so its connection can be reused; a body
+	// left unread beyond this (a registry that ignored Range) is aborted by the close instead.
 	io.Copy(io.Discard, io.LimitReader(resp.Body, 1024))
 	resp.Body.Close()
 	if err != nil {
@@ -890,13 +869,11 @@ func (t *blobHeadFallbackTransport) rangedGet(headReq *http.Request) (*http.Resp
 	return out, nil
 }
 
-// blobSizeFromRangedGetResponse extracts the full blob size from the response
-// to a single-byte ranged GET request.
+// blobSizeFromRangedGetResponse extracts the full blob size from a single-byte ranged GET response.
 func blobSizeFromRangedGetResponse(resp *http.Response) (int64, error) {
 	switch resp.StatusCode {
 	case http.StatusPartialContent, http.StatusRequestedRangeNotSatisfiable:
-		// "Content-Range: bytes 0-0/123" (206), or "bytes */0" for a 416
-		// response to a zero-length blob.
+		// "Content-Range: bytes 0-0/123" (206), or "bytes */0" (416, zero-length blob).
 		contentRange := resp.Header.Get("Content-Range")
 		slash := strings.LastIndexByte(contentRange, '/')
 		if slash < 0 {

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -831,8 +831,8 @@ func (t *blobHeadFallbackTransport) RoundTrip(in *http.Request) (*http.Response,
 	if err != nil || in.Method != http.MethodHead || !blobHeadFallbackHost(in.URL.Hostname()) || !blobsPathRegexp.MatchString(in.URL.Path) {
 		return resp, err
 	}
-	// Only 401 and 405 can mean the HEAD method itself was rejected; other statuses (403,
-	// 404, 429, 5xx) are genuine answers that would apply equally to a GET.
+	// If HEAD is not allowed (405) then fall back to a GET.
+	// `public.ecr.aws` returns 401 instead of an explicit 405, so we fall back to GET in that case as well.
 	if resp.StatusCode != http.StatusUnauthorized && resp.StatusCode != http.StatusMethodNotAllowed {
 		return resp, nil
 	}

--- a/enterprise/server/oci/ocifetcher/ocifetcher_test.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher_test.go
@@ -1012,6 +1012,94 @@ func TestBlobHeadFallbackTransport(t *testing.T) {
 		require.Empty(t, cdnAuth, "Authorization header should not be forwarded on a cross-host redirect")
 	})
 
+	t.Run("StripsContentEncodingFromSynthesizedResponse", func(t *testing.T) {
+		const blobSize = 42
+		registry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodHead {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			// A CDN in front of the ranged GET may report Content-Encoding for the
+			// (single-byte) body it's serving; that shouldn't leak into the synthesized HEAD.
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes 0-0/%d", blobSize))
+			w.Header().Set("Content-Length", "1")
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte{0})
+		}))
+		defer registry.Close()
+
+		tr := ocifetcher.NewBlobHeadFallbackTransport(testHTTPClient(t))
+		req, err := http.NewRequest(http.MethodHead, registry.URL+"/v2/test-image/blobs/sha256:abc", nil)
+		require.NoError(t, err)
+		resp, err := tr.RoundTrip(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, int64(blobSize), resp.ContentLength)
+		require.Empty(t, resp.Header.Get("Content-Encoding"))
+	})
+
+	t.Run("MirroredRegistryGetsFallbackViaMirror", func(t *testing.T) {
+		// Only the original registry host is allowlisted; the mirror host is not.
+		flags.Set(t, "ocifetcher.blob_head_fallback_registries", []string{"localhost"})
+
+		const blobSize = 1234
+		var mirrorHeads, mirrorGets int
+		mirror := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodHead {
+				mirrorHeads++
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			mirrorGets++
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes 0-0/%d", blobSize))
+			w.Header().Set("Content-Length", "1")
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte{0})
+		}))
+		defer mirror.Close()
+
+		var originHeads, originGets int
+		origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodHead {
+				originHeads++
+			} else {
+				originGets++
+			}
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer origin.Close()
+		originURL, err := url.Parse(origin.URL)
+		require.NoError(t, err)
+		originHost := "localhost:" + originURL.Port()
+
+		// Wire the transports the way getRemoteOpts does: the mirror transport inside the
+		// client, the fallback transport outside.
+		client := testHTTPClient(t)
+		client.Transport = ocifetcher.NewMirrorTransport(client.Transport, []interfaces.MirrorConfig{{
+			OriginalURL: "http://" + originHost,
+			MirrorURL:   mirror.URL,
+		}})
+		tr := ocifetcher.NewBlobHeadFallbackTransport(client)
+
+		req, err := http.NewRequest(http.MethodHead, "http://"+originHost+"/v2/test-image/blobs/sha256:abc", nil)
+		require.NoError(t, err)
+		resp, err := tr.RoundTrip(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, int64(blobSize), resp.ContentLength)
+		// The HEAD went to the mirror, then to the origin via the mirror transport's own
+		// fallback; the ranged GET was rewritten to the mirror and served there.
+		require.Equal(t, 1, mirrorHeads)
+		require.Equal(t, 1, mirrorGets)
+		require.Equal(t, 1, originHeads)
+		require.Equal(t, 0, originGets)
+	})
+
 	t.Run("FallsBackForAllHeadRejectionStatuses", func(t *testing.T) {
 		for _, rejectionStatus := range []int{
 			http.StatusUnauthorized,

--- a/enterprise/server/oci/ocifetcher/ocifetcher_test.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/oci/ocifetcher"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testenv"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testregistry"
+	"github.com/buildbuddy-io/buildbuddy/server/http/httpclient"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testcache"
@@ -828,13 +829,10 @@ func TestFetchBlobStreamsDirectlyWhenBlobMetadataLookupFails(t *testing.T) {
 	blobPath := "/v2/test-metadata-fallback/blobs/" + layerDigest.String()
 	assertRequests(t, counter, map[string]int{
 		http.MethodGet + " /v2/": 1,
-		// Blob data is streamed despite metadata failures. No ranged GET
-		// fallbacks: those are only made for HEAD requests failing with
-		// 401, not 500.
+		// Blob data streams despite metadata failures; no ranged GET fallbacks for 500s.
 		http.MethodGet + " " + blobPath: 1,
-		// Three blob HEADs: go-containerregistry's retry transport makes
-		// up to three attempts for the Size() HEAD since 500 is a
-		// retryable status.
+		// go-containerregistry's retry transport makes up to three attempts for the
+		// Size() HEAD since 500 is a retryable status.
 		http.MethodHead + " " + blobPath: 3,
 	})
 
@@ -852,11 +850,8 @@ func TestFetchBlobStreamsDirectlyWhenBlobMetadataLookupFails(t *testing.T) {
 	})
 }
 
-// TestBlobHeadFallbackToRangedGet simulates a registry that, like
-// public.ecr.aws, rejects every HEAD request to blob endpoints with 401 while
-// allowing GET requests. Blob metadata should be fetched via the single-byte
-// ranged GET fallback, and blob fetching (including read-through caching)
-// should keep working end to end.
+// TestBlobHeadFallbackToRangedGet simulates a registry that, like public.ecr.aws, rejects every
+// blob HEAD with 401 while allowing GETs, so metadata comes from the ranged GET fallback.
 func TestBlobHeadFallbackToRangedGet(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -952,9 +947,16 @@ func TestBlobHeadFallbackToRangedGet(t *testing.T) {
 	}
 }
 
-// TestBlobHeadFallbackTransport exercises NewBlobHeadFallbackTransport
-// directly against servers that mimic public.ecr.aws: HEAD requests to blob
-// endpoints fail, and blob GETs redirect to a CDN on a different host.
+// testHTTPClient returns an httpclient-package client that is allowed to reach test servers on loopback.
+func testHTTPClient(t *testing.T) *http.Client {
+	flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.0/8", "::1/128"})
+	allowedPrivateIPs, err := ocifetcher.ParseAllowedPrivateIPs()
+	require.NoError(t, err)
+	return httpclient.New(allowedPrivateIPs, "test")
+}
+
+// TestBlobHeadFallbackTransport exercises NewBlobHeadFallbackTransport directly against servers
+// that mimic public.ecr.aws: blob HEADs fail, and blob GETs redirect to a CDN on another host.
 func TestBlobHeadFallbackTransport(t *testing.T) {
 	t.Run("FollowsRedirectsAndStripsAuthorization", func(t *testing.T) {
 		const blobSize = 1234
@@ -968,9 +970,8 @@ func TestBlobHeadFallbackTransport(t *testing.T) {
 			_, _ = w.Write([]byte{0})
 		}))
 		defer cdn.Close()
-		// Redirect to the CDN via a different hostname so that the HTTP
-		// client treats it as a cross-host redirect and strips the
-		// Authorization header, as for a real registry-to-CDN redirect.
+		// Redirect via a different hostname so the client treats it as a cross-host
+		// redirect and strips Authorization, as for a real registry-to-CDN redirect.
 		cdnURL, err := url.Parse(cdn.URL)
 		require.NoError(t, err)
 		redirectTarget := "http://localhost:" + cdnURL.Port() + "/blob"
@@ -988,7 +989,7 @@ func TestBlobHeadFallbackTransport(t *testing.T) {
 		}))
 		defer registry.Close()
 
-		tr := ocifetcher.NewBlobHeadFallbackTransport(http.DefaultTransport)
+		tr := ocifetcher.NewBlobHeadFallbackTransport(testHTTPClient(t))
 		req, err := http.NewRequest(http.MethodHead, registry.URL+"/v2/test-image/blobs/sha256:abc", nil)
 		require.NoError(t, err)
 		req.Header.Set("Authorization", "Bearer registry-token")
@@ -1027,7 +1028,7 @@ func TestBlobHeadFallbackTransport(t *testing.T) {
 				}))
 				defer registry.Close()
 
-				tr := ocifetcher.NewBlobHeadFallbackTransport(http.DefaultTransport)
+				tr := ocifetcher.NewBlobHeadFallbackTransport(testHTTPClient(t))
 				req, err := http.NewRequest(http.MethodHead, registry.URL+"/v2/test-image/blobs/sha256:abc", nil)
 				require.NoError(t, err)
 				resp, err := tr.RoundTrip(req)
@@ -1053,7 +1054,7 @@ func TestBlobHeadFallbackTransport(t *testing.T) {
 		}))
 		defer registry.Close()
 
-		tr := ocifetcher.NewBlobHeadFallbackTransport(http.DefaultTransport)
+		tr := ocifetcher.NewBlobHeadFallbackTransport(testHTTPClient(t))
 		req, err := http.NewRequest(http.MethodHead, registry.URL+"/v2/test-image/blobs/sha256:abc", nil)
 		require.NoError(t, err)
 		resp, err := tr.RoundTrip(req)
@@ -1083,7 +1084,7 @@ func TestBlobHeadFallbackTransport(t *testing.T) {
 		}))
 		defer registry.Close()
 
-		tr := ocifetcher.NewBlobHeadFallbackTransport(http.DefaultTransport)
+		tr := ocifetcher.NewBlobHeadFallbackTransport(testHTTPClient(t))
 
 		// Successful blob HEAD: no fallback needed.
 		req, err := http.NewRequest(http.MethodHead, registry.URL+"/v2/test-image/blobs/sha256:abc", nil)
@@ -2245,9 +2246,8 @@ func TestFetchBlobSingleflightDifferentCredentials(t *testing.T) {
 		// Three /v2/ pings: one for each initial puller (creds1, creds2),
 		// plus one more when creds2 retries with a fresh puller after 401.
 		http.MethodGet + " /v2/": 3,
-		// Five blob GETs: one for creds1 (succeeds), two for creds2
-		// (first attempt 401, retry 401), plus one ranged GET fallback
-		// for each of creds2's two failed blob HEADs.
+		// Five blob GETs: one for creds1, two for creds2 (attempt + retry, both
+		// 401), plus one ranged GET fallback per failed creds2 blob HEAD.
 		http.MethodGet + " " + blobPath: 5,
 		// Three blob HEADs for layer.Size(): one for creds1 (succeeds),
 		// two for creds2 (Size is fetched before Compressed, so each

--- a/enterprise/server/oci/ocifetcher/ocifetcher_test.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher_test.go
@@ -4,8 +4,11 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -825,11 +828,13 @@ func TestFetchBlobStreamsDirectlyWhenBlobMetadataLookupFails(t *testing.T) {
 	blobPath := "/v2/test-metadata-fallback/blobs/" + layerDigest.String()
 	assertRequests(t, counter, map[string]int{
 		http.MethodGet + " /v2/": 1,
-		// Blob data is streamed despite metadata failures.
+		// Blob data is streamed despite metadata failures. No ranged GET
+		// fallbacks: those are only made for HEAD requests failing with
+		// 401, not 500.
 		http.MethodGet + " " + blobPath: 1,
-		// Three blob HEADs: MediaType() HEAD (500), Size() HEAD (500),
-		// plus one internal HEAD from go-containerregistry during
-		// Compressed() to determine content length.
+		// Three blob HEADs: go-containerregistry's retry transport makes
+		// up to three attempts for the Size() HEAD since 500 is a
+		// retryable status.
 		http.MethodHead + " " + blobPath: 3,
 	})
 
@@ -844,6 +849,269 @@ func TestFetchBlobStreamsDirectlyWhenBlobMetadataLookupFails(t *testing.T) {
 		// No /v2/ ping: puller stays cached across metadata failures.
 		http.MethodGet + " " + blobPath:  1,
 		http.MethodHead + " " + blobPath: 3,
+	})
+}
+
+// TestBlobHeadFallbackToRangedGet simulates a registry that, like
+// public.ecr.aws, rejects every HEAD request to blob endpoints with 401 while
+// allowing GET requests. Blob metadata should be fetched via the single-byte
+// ranged GET fallback, and blob fetching (including read-through caching)
+// should keep working end to end.
+func TestBlobHeadFallbackToRangedGet(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		// stripRange simulates a registry that ignores the Range header and
+		// responds 200 with the full blob instead of 206 with a single byte.
+		stripRange    bool
+		registryCreds *testregistry.BasicAuthCreds
+		requestCreds  *rgpb.Credentials
+	}{
+		{name: "RangeHonored/NoAuth"},
+		{
+			name:          "RangeHonored/WithAuth",
+			registryCreds: &testregistry.BasicAuthCreds{Username: "testuser", Password: "testpass"},
+			requestCreds:  &rgpb.Credentials{Username: "testuser", Password: "testpass"},
+		},
+		{name: "RangeIgnored/NoAuth", stripRange: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Only reject blob HEADs after the test image has been pushed.
+			var rejectBlobHeads atomic.Bool
+			reg, counter := setupRegistry(t, tc.registryCreds, func(w http.ResponseWriter, r *http.Request) bool {
+				if !rejectBlobHeads.Load() || !strings.Contains(r.URL.Path, "/blobs/") {
+					return true
+				}
+				if r.Method == http.MethodHead {
+					w.WriteHeader(http.StatusUnauthorized)
+					return false
+				}
+				if tc.stripRange {
+					r.Header.Del("Range")
+				}
+				return true
+			})
+			imageName, img := reg.PushNamedImage(t, "test-image", tc.registryCreds)
+			rejectBlobHeads.Store(true)
+
+			layers, err := img.Layers()
+			require.NoError(t, err)
+			require.NotEmpty(t, layers)
+			layer := layers[0]
+			digest, err := layer.Digest()
+			require.NoError(t, err)
+			expectedSize, expectedMediaType := layerMetadata(t, layer)
+			expectedData := layerData(t, layer)
+
+			_, bsClient, acClient := setupCacheEnv(t)
+			server := newTestServerWithCache(t, bsClient, acClient)
+			blobRef := imageName + "@" + digest.String()
+			blobPath := "/v2/test-image/blobs/" + digest.String()
+
+			// Blob metadata is fetched via the ranged GET fallback.
+			counter.Reset()
+			resp, err := server.FetchBlobMetadata(context.Background(), &ofpb.FetchBlobMetadataRequest{
+				Ref:         blobRef,
+				Credentials: tc.requestCreds,
+			})
+			require.NoError(t, err)
+			require.Equal(t, expectedSize, resp.GetSize())
+			require.Equal(t, expectedMediaType, resp.GetMediaType())
+			assertRequests(t, counter, map[string]int{
+				http.MethodGet + " /v2/":         1,
+				http.MethodHead + " " + blobPath: 1,
+				http.MethodGet + " " + blobPath:  1,
+			})
+
+			// Blob data still streams and populates the cache: one ranged
+			// GET fallback for the size lookup plus the data GET.
+			counter.Reset()
+			stream := &mockFetchBlobServer{ctx: context.Background()}
+			err = server.FetchBlob(&ofpb.FetchBlobRequest{
+				Ref:         blobRef,
+				Credentials: tc.requestCreds,
+			}, stream)
+			require.NoError(t, err)
+			require.Equal(t, expectedData, stream.collectData())
+			assertRequests(t, counter, map[string]int{
+				http.MethodHead + " " + blobPath: 1,
+				http.MethodGet + " " + blobPath:  2,
+			})
+
+			// The read-through cache was populated, so another fetch is
+			// served without contacting the registry.
+			counter.Reset()
+			stream = &mockFetchBlobServer{ctx: context.Background()}
+			err = server.FetchBlob(&ofpb.FetchBlobRequest{
+				Ref:         blobRef,
+				Credentials: tc.requestCreds,
+			}, stream)
+			require.NoError(t, err)
+			require.Equal(t, expectedData, stream.collectData())
+			assertRequests(t, counter, map[string]int{})
+		})
+	}
+}
+
+// TestBlobHeadFallbackTransport exercises NewBlobHeadFallbackTransport
+// directly against servers that mimic public.ecr.aws: HEAD requests to blob
+// endpoints fail, and blob GETs redirect to a CDN on a different host.
+func TestBlobHeadFallbackTransport(t *testing.T) {
+	t.Run("FollowsRedirectsAndStripsAuthorization", func(t *testing.T) {
+		const blobSize = 1234
+		var cdnAuth, cdnRange string
+		cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			cdnAuth = r.Header.Get("Authorization")
+			cdnRange = r.Header.Get("Range")
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes 0-0/%d", blobSize))
+			w.Header().Set("Content-Length", "1")
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte{0})
+		}))
+		defer cdn.Close()
+		// Redirect to the CDN via a different hostname so that the HTTP
+		// client treats it as a cross-host redirect and strips the
+		// Authorization header, as for a real registry-to-CDN redirect.
+		cdnURL, err := url.Parse(cdn.URL)
+		require.NoError(t, err)
+		redirectTarget := "http://localhost:" + cdnURL.Port() + "/blob"
+
+		var headCount, getCount int
+		registry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodHead:
+				headCount++
+				w.WriteHeader(http.StatusUnauthorized)
+			case http.MethodGet:
+				getCount++
+				http.Redirect(w, r, redirectTarget, http.StatusFound)
+			}
+		}))
+		defer registry.Close()
+
+		tr := ocifetcher.NewBlobHeadFallbackTransport(http.DefaultTransport)
+		req, err := http.NewRequest(http.MethodHead, registry.URL+"/v2/test-image/blobs/sha256:abc", nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer registry-token")
+		resp, err := tr.RoundTrip(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, int64(blobSize), resp.ContentLength)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Empty(t, body, "synthesized HEAD response should have no body")
+		require.Equal(t, 1, headCount)
+		require.Equal(t, 1, getCount)
+		require.Equal(t, "bytes=0-0", cdnRange)
+		require.Empty(t, cdnAuth, "Authorization header should not be forwarded on a cross-host redirect")
+	})
+
+	t.Run("FallsBackForAllHeadRejectionStatuses", func(t *testing.T) {
+		for _, rejectionStatus := range []int{
+			http.StatusUnauthorized,
+			http.StatusForbidden,
+			http.StatusMethodNotAllowed,
+		} {
+			t.Run(fmt.Sprint(rejectionStatus), func(t *testing.T) {
+				const blobSize = 999
+				registry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodHead {
+						w.WriteHeader(rejectionStatus)
+						return
+					}
+					w.Header().Set("Content-Range", fmt.Sprintf("bytes 0-0/%d", blobSize))
+					w.Header().Set("Content-Length", "1")
+					w.WriteHeader(http.StatusPartialContent)
+					_, _ = w.Write([]byte{0})
+				}))
+				defer registry.Close()
+
+				tr := ocifetcher.NewBlobHeadFallbackTransport(http.DefaultTransport)
+				req, err := http.NewRequest(http.MethodHead, registry.URL+"/v2/test-image/blobs/sha256:abc", nil)
+				require.NoError(t, err)
+				resp, err := tr.RoundTrip(req)
+				require.NoError(t, err)
+				defer resp.Body.Close()
+
+				require.Equal(t, http.StatusOK, resp.StatusCode)
+				require.Equal(t, int64(blobSize), resp.ContentLength)
+			})
+		}
+	})
+
+	t.Run("ReturnsOriginalResponseWhenFallbackFails", func(t *testing.T) {
+		var headCount, getCount int
+		registry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodHead {
+				headCount++
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			getCount++
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer registry.Close()
+
+		tr := ocifetcher.NewBlobHeadFallbackTransport(http.DefaultTransport)
+		req, err := http.NewRequest(http.MethodHead, registry.URL+"/v2/test-image/blobs/sha256:abc", nil)
+		require.NoError(t, err)
+		resp, err := tr.RoundTrip(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode, "original HEAD failure should be preserved")
+		require.Equal(t, 1, headCount)
+		require.Equal(t, 1, getCount, "fallback GET should have been attempted")
+	})
+
+	t.Run("NoFallbackForOtherStatusesOrNonBlobPaths", func(t *testing.T) {
+		var getCount int
+		registry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet {
+				getCount++
+			}
+			switch {
+			case strings.Contains(r.URL.Path, "/manifests/"):
+				w.WriteHeader(http.StatusUnauthorized)
+			case strings.HasSuffix(r.URL.Path, "ratelimited"):
+				w.WriteHeader(http.StatusTooManyRequests)
+			default:
+				w.Header().Set("Content-Length", "42")
+				w.WriteHeader(http.StatusOK)
+			}
+		}))
+		defer registry.Close()
+
+		tr := ocifetcher.NewBlobHeadFallbackTransport(http.DefaultTransport)
+
+		// Successful blob HEAD: no fallback needed.
+		req, err := http.NewRequest(http.MethodHead, registry.URL+"/v2/test-image/blobs/sha256:abc", nil)
+		require.NoError(t, err)
+		resp, err := tr.RoundTrip(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, int64(42), resp.ContentLength)
+
+		// Blob HEAD failing with a status other than 401 (e.g. 429): no
+		// fallback, so no additional load on an already-throttling registry.
+		req, err = http.NewRequest(http.MethodHead, registry.URL+"/v2/test-image/blobs/sha256:ratelimited", nil)
+		require.NoError(t, err)
+		resp, err = tr.RoundTrip(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+		require.Equal(t, http.StatusTooManyRequests, resp.StatusCode, "non-401 blob HEAD failures should not fall back to GET")
+
+		// Manifest HEAD failing with 401: only blob endpoints fall back.
+		req, err = http.NewRequest(http.MethodHead, registry.URL+"/v2/test-image/manifests/latest", nil)
+		require.NoError(t, err)
+		resp, err = tr.RoundTrip(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode, "manifest HEAD failures should not fall back to GET")
+
+		require.Equal(t, 0, getCount)
 	})
 }
 
@@ -1977,9 +2245,10 @@ func TestFetchBlobSingleflightDifferentCredentials(t *testing.T) {
 		// Three /v2/ pings: one for each initial puller (creds1, creds2),
 		// plus one more when creds2 retries with a fresh puller after 401.
 		http.MethodGet + " /v2/": 3,
-		// Three blob GETs: one for creds1 (succeeds), two for creds2
-		// (first attempt 401, retry 401).
-		http.MethodGet + " " + blobPath: 3,
+		// Five blob GETs: one for creds1 (succeeds), two for creds2
+		// (first attempt 401, retry 401), plus one ranged GET fallback
+		// for each of creds2's two failed blob HEADs.
+		http.MethodGet + " " + blobPath: 5,
 		// Three blob HEADs for layer.Size(): one for creds1 (succeeds),
 		// two for creds2 (Size is fetched before Compressed, so each
 		// attempt calls it before the blob GET fails).

--- a/enterprise/server/oci/ocifetcher/ocifetcher_test.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher_test.go
@@ -870,6 +870,7 @@ func TestBlobHeadFallbackToRangedGet(t *testing.T) {
 		{name: "RangeIgnored/NoAuth", stripRange: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			flags.Set(t, "ocifetcher.blob_head_fallback_registries", []string{"localhost"})
 			// Only reject blob HEADs after the test image has been pushed.
 			var rejectBlobHeads atomic.Bool
 			reg, counter := setupRegistry(t, tc.registryCreds, func(w http.ResponseWriter, r *http.Request) bool {
@@ -957,7 +958,10 @@ func testHTTPClient(t *testing.T) *http.Client {
 
 // TestBlobHeadFallbackTransport exercises NewBlobHeadFallbackTransport directly against servers
 // that mimic public.ecr.aws: blob HEADs fail, and blob GETs redirect to a CDN on another host.
+// httptest servers listen on 127.0.0.1, so that host is allowlisted for the fallback.
 func TestBlobHeadFallbackTransport(t *testing.T) {
+	flags.Set(t, "ocifetcher.blob_head_fallback_registries", []string{"127.0.0.1"})
+
 	t.Run("FollowsRedirectsAndStripsAuthorization", func(t *testing.T) {
 		const blobSize = 1234
 		var cdnAuth, cdnRange string
@@ -1063,6 +1067,54 @@ func TestBlobHeadFallbackTransport(t *testing.T) {
 		require.Equal(t, http.StatusUnauthorized, resp.StatusCode, "original HEAD failure should be preserved")
 		require.Equal(t, 1, headCount)
 		require.Equal(t, 1, getCount, "fallback GET should have been attempted")
+	})
+
+	t.Run("ReturnsOriginalResponseOnUnknownLengthContentRange", func(t *testing.T) {
+		registry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodHead {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			// RFC 9110 permits reporting an unknown complete length.
+			w.Header().Set("Content-Range", "bytes 0-0/*")
+			w.Header().Set("Content-Length", "1")
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte{0})
+		}))
+		defer registry.Close()
+
+		tr := ocifetcher.NewBlobHeadFallbackTransport(testHTTPClient(t))
+		req, err := http.NewRequest(http.MethodHead, registry.URL+"/v2/test-image/blobs/sha256:abc", nil)
+		require.NoError(t, err)
+		resp, err := tr.RoundTrip(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode, "unknown blob size should preserve the original HEAD failure")
+	})
+
+	t.Run("NoFallbackForNonAllowlistedHosts", func(t *testing.T) {
+		var getCount int
+		registry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet {
+				getCount++
+			}
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer registry.Close()
+
+		// Reach the server as "localhost", which is not on the fallback allowlist here.
+		registryURL, err := url.Parse(registry.URL)
+		require.NoError(t, err)
+		req, err := http.NewRequest(http.MethodHead, "http://localhost:"+registryURL.Port()+"/v2/test-image/blobs/sha256:abc", nil)
+		require.NoError(t, err)
+		tr := ocifetcher.NewBlobHeadFallbackTransport(testHTTPClient(t))
+		resp, err := tr.RoundTrip(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		require.Equal(t, 0, getCount, "non-allowlisted hosts should not fall back to GET")
 	})
 
 	t.Run("NoFallbackForOtherStatusesOrNonBlobPaths", func(t *testing.T) {
@@ -2254,9 +2306,10 @@ func TestFetchBlobSingleflightDifferentCredentials(t *testing.T) {
 		// Three /v2/ pings: one for each initial puller (creds1, creds2),
 		// plus one more when creds2 retries with a fresh puller after 401.
 		http.MethodGet + " /v2/": 3,
-		// Five blob GETs: one for creds1, two for creds2 (attempt + retry, both
-		// 401), plus one ranged GET fallback per failed creds2 blob HEAD.
-		http.MethodGet + " " + blobPath: 5,
+		// Three blob GETs: one for creds1 (succeeds), two for creds2
+		// (first attempt 401, retry 401). The blob HEAD fallback does not
+		// fire: this registry is not on the fallback allowlist.
+		http.MethodGet + " " + blobPath: 3,
 		// Three blob HEADs for layer.Size(): one for creds1 (succeeds),
 		// two for creds2 (Size is fetched before Compressed, so each
 		// attempt calls it before the blob GET fails).

--- a/enterprise/server/oci/ocifetcher/ocifetcher_test.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher_test.go
@@ -1011,7 +1011,6 @@ func TestBlobHeadFallbackTransport(t *testing.T) {
 	t.Run("FallsBackForAllHeadRejectionStatuses", func(t *testing.T) {
 		for _, rejectionStatus := range []int{
 			http.StatusUnauthorized,
-			http.StatusForbidden,
 			http.StatusMethodNotAllowed,
 		} {
 			t.Run(fmt.Sprint(rejectionStatus), func(t *testing.T) {
@@ -1077,6 +1076,8 @@ func TestBlobHeadFallbackTransport(t *testing.T) {
 				w.WriteHeader(http.StatusUnauthorized)
 			case strings.HasSuffix(r.URL.Path, "ratelimited"):
 				w.WriteHeader(http.StatusTooManyRequests)
+			case strings.HasSuffix(r.URL.Path, "forbidden"):
+				w.WriteHeader(http.StatusForbidden)
 			default:
 				w.Header().Set("Content-Length", "42")
 				w.WriteHeader(http.StatusOK)
@@ -1095,14 +1096,21 @@ func TestBlobHeadFallbackTransport(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		require.Equal(t, int64(42), resp.ContentLength)
 
-		// Blob HEAD failing with a status other than 401 (e.g. 429): no
-		// fallback, so no additional load on an already-throttling registry.
+		// Blob HEAD 429: no fallback, so no additional load on an already-throttling registry.
 		req, err = http.NewRequest(http.MethodHead, registry.URL+"/v2/test-image/blobs/sha256:ratelimited", nil)
 		require.NoError(t, err)
 		resp, err = tr.RoundTrip(req)
 		require.NoError(t, err)
 		resp.Body.Close()
-		require.Equal(t, http.StatusTooManyRequests, resp.StatusCode, "non-401 blob HEAD failures should not fall back to GET")
+		require.Equal(t, http.StatusTooManyRequests, resp.StatusCode, "429 blob HEAD failures should not fall back to GET")
+
+		// Blob HEAD 403: treated as a genuine authorization denial, no fallback.
+		req, err = http.NewRequest(http.MethodHead, registry.URL+"/v2/test-image/blobs/sha256:forbidden", nil)
+		require.NoError(t, err)
+		resp, err = tr.RoundTrip(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+		require.Equal(t, http.StatusForbidden, resp.StatusCode, "403 blob HEAD failures should not fall back to GET")
 
 		// Manifest HEAD failing with 401: only blob endpoints fall back.
 		req, err = http.NewRequest(http.MethodHead, registry.URL+"/v2/test-image/manifests/latest", nil)


### PR DESCRIPTION
[public.ecr.aws](public.ecr.aws) always responds HTTP 401 to blob `HEAD` requests.
This change falls back to making a `GET` request with a range of `0-0` in this case (and in the case of HTTP 405) for specified registries (defaults to `public.ecr.aws`).