### PR TITLE
Fix build event publisher recv error handling

### DIFF
--- a/server/build_event_publisher/BUILD
+++ b/server/build_event_publisher/BUILD
@@ -26,8 +26,11 @@ go_test(
     srcs = ["build_event_publisher_test.go"],
     deps = [
         ":build_event_publisher",
+        "//proto:build_event_stream_go_proto",
         "//proto:build_events_go_proto",
         "//proto:publish_build_event_go_proto",
+        "//server/testutil/testbes",
+        "//server/util/status",
         "@com_github_google_go_cmp//cmp",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/server/build_event_publisher/build_event_publisher.go
+++ b/server/build_event_publisher/build_event_publisher.go
@@ -125,7 +125,6 @@ loop:
 		// event to publish.
 		select {
 		case err, ok := <-recvErr:
-			_ = stream.CloseSend()
 			if !ok {
 				// Recv returned io.EOF which normally means the stream closed
 				// cleanly, but in this case it's unexpected because the server
@@ -133,7 +132,7 @@ loop:
 				// events.
 				return status.UnavailableErrorf("server stream unexpectedly closed while publishing events")
 			}
-			return status.WrapError(err, "recv")
+			return err
 		case obe, ok := <-events:
 			if !ok {
 				// No more events to publish

--- a/server/build_event_publisher/build_event_publisher.go
+++ b/server/build_event_publisher/build_event_publisher.go
@@ -100,9 +100,9 @@ func (p *Publisher) run(ctx context.Context) error {
 		return status.WrapError(err, "error dialing bes_backend")
 	}
 
-	doneReceiving := make(chan error, 1)
+	recvErr := make(chan error, 1)
 	go func() {
-		defer close(doneReceiving)
+		defer close(recvErr)
 		for {
 			_, err := stream.Recv()
 			if err == nil {
@@ -111,7 +111,7 @@ func (p *Publisher) run(ctx context.Context) error {
 			if err == io.EOF {
 				return
 			}
-			doneReceiving <- status.UnavailableErrorf("recv failed: %s", err)
+			recvErr <- status.UnavailableErrorf("recv failed: %s", err)
 			return
 		}
 	}()
@@ -119,10 +119,30 @@ func (p *Publisher) run(ctx context.Context) error {
 	events, cancel := p.events.Subscribe()
 	defer cancel()
 
-	for obe := range events {
-		req := &pepb.PublishBuildToolEventStreamRequest{OrderedBuildEvent: obe}
-		if err := stream.Send(req); err != nil {
-			return status.UnavailableErrorf("send failed: %s", err)
+loop:
+	for {
+		// Wait until either the server closes the stream or we have another
+		// event to publish.
+		select {
+		case err, ok := <-recvErr:
+			_ = stream.CloseSend()
+			if !ok {
+				// Recv returned io.EOF which normally means the stream closed
+				// cleanly, but in this case it's unexpected because the server
+				// should not close the stream until we're done publishing our
+				// events.
+				return status.UnavailableErrorf("server stream unexpectedly closed while publishing events")
+			}
+			return status.WrapError(err, "recv")
+		case obe, ok := <-events:
+			if !ok {
+				// No more events to publish
+				break loop
+			}
+			req := &pepb.PublishBuildToolEventStreamRequest{OrderedBuildEvent: obe}
+			if err := stream.Send(req); err != nil {
+				return status.UnavailableErrorf("send failed: %s", err)
+			}
 		}
 	}
 	// After successfully transmitting all events, close our side of the stream
@@ -130,8 +150,7 @@ func (p *Publisher) run(ctx context.Context) error {
 	if err := stream.CloseSend(); err != nil {
 		return status.UnavailableErrorf("close send failed: %s", err)
 	}
-	// Return any error from receiving ACKs
-	return <-doneReceiving
+	return <-recvErr
 }
 
 func (p *Publisher) Publish(bazelEvent *bespb.BuildEvent) error {

--- a/server/build_event_publisher/build_event_publisher_test.go
+++ b/server/build_event_publisher/build_event_publisher_test.go
@@ -2,22 +2,30 @@ package build_event_publisher_test
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_publisher"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testbes"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
-
-	bepb "github.com/buildbuddy-io/buildbuddy/proto/build_events"
-	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	bespb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
+	bepb "github.com/buildbuddy-io/buildbuddy/proto/build_events"
+	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
 )
 
 const eventWaitTimeout = time.Second
+
+// streamRequestWaitTimeout is the max time to wait for the test BES server to
+// receive a stream request. It accounts for the publisher's retry backoff.
+const streamRequestWaitTimeout = 15 * time.Second
 
 func TestEventBufferDeliveryScenarios(t *testing.T) {
 	tests := []struct {
@@ -185,6 +193,46 @@ func TestEventBuffer_MultipleSubscriptionsSerial(t *testing.T) {
 	requireClosed(t, events2)
 }
 
+func TestPublisher_RetriesAfterServerDisconnect(t *testing.T) {
+	// Set up a fake BES server that fails the stream with an error after
+	// receiving the first event, then acks events normally on any subsequent
+	// streams.
+	server, client := testbes.Run(t)
+	received := make(chan *pepb.PublishBuildToolEventStreamRequest, 16)
+	var failedOnce atomic.Bool
+	server.EventHandler = func(stream pepb.PublishBuildEvent_PublishBuildToolEventStreamServer, streamID *bepb.StreamId, event *pepb.PublishBuildToolEventStreamRequest) error {
+		received <- event
+		if failedOnce.CompareAndSwap(false, true) {
+			return status.UnavailableError("test-induced server error")
+		}
+		return testbes.Ack(stream, streamID, event)
+	}
+
+	publisher, err := build_event_publisher.New(client, "" /*=apiKey*/, "test-invocation-id")
+	require.NoError(t, err)
+	publisher.Start(t.Context())
+
+	// Publish an event. The server should receive it, then break the stream.
+	err = publisher.Publish(&bespb.BuildEvent{})
+	require.NoError(t, err)
+	event := recvStreamRequest(t, received)
+	assert.Equal(t, int64(1), event.GetOrderedBuildEvent().GetSequenceNumber())
+
+	// The publisher should notice the disconnect and retry the stream even
+	// though we aren't publishing any more events, re-sending the first event
+	// since it was never acked.
+	event = recvStreamRequest(t, received)
+	assert.Equal(t, int64(1), event.GetOrderedBuildEvent().GetSequenceNumber())
+
+	// Finish the stream. The publisher should publish the finished event on
+	// the retried stream, and Finish should succeed once the server acks all
+	// events.
+	err = publisher.Finish()
+	require.NoError(t, err)
+	event = recvStreamRequest(t, received)
+	assert.Equal(t, int64(2), event.GetOrderedBuildEvent().GetSequenceNumber())
+}
+
 func makeStreamID(invocationID, buildID string) *bepb.StreamId {
 	return &bepb.StreamId{
 		InvocationId: invocationID,
@@ -223,6 +271,17 @@ func recvEvent(tb testing.TB, ch <-chan *pepb.OrderedBuildEvent) (*pepb.OrderedB
 	case <-time.After(eventWaitTimeout):
 		tb.Fatalf("timed out waiting for event")
 		return nil, false
+	}
+}
+
+func recvStreamRequest(tb testing.TB, ch <-chan *pepb.PublishBuildToolEventStreamRequest) *pepb.PublishBuildToolEventStreamRequest {
+	tb.Helper()
+	select {
+	case req := <-ch:
+		return req
+	case <-time.After(streamRequestWaitTimeout):
+		tb.Fatalf("timed out waiting for the server to receive a stream request")
+		return nil
 	}
 }
 

--- a/server/build_event_publisher/build_event_publisher_test.go
+++ b/server/build_event_publisher/build_event_publisher_test.go
@@ -216,13 +216,13 @@ func TestPublisher_RetriesAfterServerDisconnect(t *testing.T) {
 	err = publisher.Publish(&bespb.BuildEvent{})
 	require.NoError(t, err)
 	event := recvStreamRequest(t, received)
-	assert.Equal(t, int64(1), event.GetOrderedBuildEvent().GetSequenceNumber())
+	require.Equal(t, int64(1), event.GetOrderedBuildEvent().GetSequenceNumber())
 
 	// The publisher should notice the disconnect and retry the stream even
 	// though we aren't publishing any more events, re-sending the first event
 	// since it was never acked.
 	event = recvStreamRequest(t, received)
-	assert.Equal(t, int64(1), event.GetOrderedBuildEvent().GetSequenceNumber())
+	require.Equal(t, int64(1), event.GetOrderedBuildEvent().GetSequenceNumber())
 
 	// Finish the stream. The publisher should publish the finished event on
 	// the retried stream, and Finish should succeed once the server acks all
@@ -230,7 +230,7 @@ func TestPublisher_RetriesAfterServerDisconnect(t *testing.T) {
 	err = publisher.Finish()
 	require.NoError(t, err)
 	event = recvStreamRequest(t, received)
-	assert.Equal(t, int64(2), event.GetOrderedBuildEvent().GetSequenceNumber())
+	require.Equal(t, int64(2), event.GetOrderedBuildEvent().GetSequenceNumber())
 }
 
 func makeStreamID(invocationID, buildID string) *bepb.StreamId {


### PR DESCRIPTION
If the server closed the BES stream while the publisher was idle waiting for more events, the publisher did not notice the error until the next event was published, and would hang if no more events came. Select on the recv error while publishing so the stream is retried promptly, and add a regression test using a fake BES server that fails the stream after the first event.