### PR TITLE
[RB] Always insert bazel flags before executable args

### DIFF
--- a/cli/arg/arg.go
+++ b/cli/arg/arg.go
@@ -47,8 +47,7 @@ func NewBazelArgs(args []string) (*BazelArgs, error) {
 	return b, nil
 }
 
-// NewBazelArgsNoResolve creates a BazelArgs from an already-resolved []string
-// without performing config/bazelrc expansion.
+// NewBazelArgsNoResolve creates a BazelArgs without performing config/bazelrc expansion.
 func NewBazelArgsNoResolve(args []string) (*BazelArgs, error) {
 	parsed, err := parser.ParseArgs(args)
 	if err != nil {

--- a/cli/arg/arg.go
+++ b/cli/arg/arg.go
@@ -20,6 +20,9 @@ type BazelArgs struct {
 	// resolved are the Bazel args that are used internally within the bb parser.
 	// --config and --bazelrc flags are expanded, so the parser has a complete view of the args.
 	resolved *parsed.OrderedArgs
+
+	// noResolve indicates that resolved args (i.e. --config and --bazelrc flags expanded) should not be computed.
+	noResolve bool
 }
 
 // Forwarded returns the forwarded args as a canonicalized []string.
@@ -29,6 +32,9 @@ func (a *BazelArgs) Forwarded() []string {
 
 // Resolved returns the resolved args as a canonicalized []string.
 func (a *BazelArgs) Resolved() []string {
+	if a.noResolve {
+		return a.Forwarded()
+	}
 	return a.resolved.Canonicalized().Format()
 }
 
@@ -42,14 +48,13 @@ func NewBazelArgs(args []string) (*BazelArgs, error) {
 }
 
 // NewBazelArgsNoResolve creates a BazelArgs from an already-resolved []string
-// without performing config/bazelrc expansion. Both forwarded and resolved are
-// set to the same parsed form of args.
+// without performing config/bazelrc expansion.
 func NewBazelArgsNoResolve(args []string) (*BazelArgs, error) {
 	parsed, err := parser.ParseArgs(args)
 	if err != nil {
 		return nil, err
 	}
-	return &BazelArgs{forwarded: parsed, resolved: cloneOrderedArgs(parsed)}, nil
+	return &BazelArgs{forwarded: parsed, noResolve: true}, nil
 }
 
 func cloneOrderedArgs(args *parsed.OrderedArgs) *parsed.OrderedArgs {
@@ -64,6 +69,9 @@ func (a *BazelArgs) Set(args []string) error {
 		return err
 	}
 	a.forwarded = forwarded
+	if a.noResolve {
+		return nil
+	}
 	return a.resolve()
 }
 
@@ -74,6 +82,9 @@ func (a *BazelArgs) Append(arg string) error {
 		return err
 	}
 	a.forwarded = newFwd
+	if a.noResolve {
+		return nil
+	}
 
 	if requiresResolve(arg) {
 		return a.resolve()
@@ -96,6 +107,9 @@ func (a *BazelArgs) AppendStartupOption(name, value string) error {
 	if err := a.forwarded.Append(opt); err != nil {
 		return err
 	}
+	if a.noResolve {
+		return nil
+	}
 
 	if requiresResolve(name) {
 		return a.resolve()
@@ -113,6 +127,9 @@ func (a *BazelArgs) Prepend(arg string) error {
 		return err
 	}
 	a.forwarded = newFwd
+	if a.noResolve {
+		return nil
+	}
 
 	if requiresResolve(arg) {
 		return a.resolve()
@@ -160,6 +177,10 @@ func (a *BazelArgs) Has(flagName string) bool {
 // resolve is expensive because it re-parses all rc files and expands configs. It is only necessary
 // when requiresResolve returns true for a flag.
 func (a *BazelArgs) resolve() error {
+	if a.noResolve {
+		return nil
+	}
+
 	// Clone to avoid mutation of a.forwarded by ResolveArgs.
 	clone := cloneOrderedArgs(a.forwarded)
 	resolved, err := parser.ResolveArgs(clone)
@@ -192,6 +213,9 @@ func (a *BazelArgs) StripBBFlag(flagName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if a.noResolve {
+		return flagVal, nil
+	}
 	a.resolved.RemoveCommandOptions(flagName)
 	return flagVal, nil
 }
@@ -206,6 +230,9 @@ func (a *BazelArgs) StripBBBoolFlag(flagName string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	if a.noResolve {
+		return set, nil
+	}
 	a.resolved.RemoveCommandOptions(flagName)
 	return set, nil
 }
@@ -213,7 +240,10 @@ func (a *BazelArgs) StripBBBoolFlag(flagName string) (bool, error) {
 // StripBBStartupOptions removes CLI-only startup options and returns the removed options.
 // TODO(#7389): If we support setting CLI flags via config, make sure we support reading them correctly.
 func (a *BazelArgs) StripBBStartupOptions(optionNames ...string) []*parsed.IndexedOption {
-	a.forwarded.RemoveStartupOptions(optionNames...)
+	forwardedRemoved := a.forwarded.RemoveStartupOptions(optionNames...)
+	if a.noResolve {
+		return forwardedRemoved
+	}
 	removed := a.resolved.RemoveStartupOptions(optionNames...)
 	return removed
 }
@@ -221,6 +251,9 @@ func (a *BazelArgs) StripBBStartupOptions(optionNames ...string) []*parsed.Index
 // GetRemoteHeaderVal returns the value of a --remote_header flag matching the
 // given key, reading from the resolved args.
 func (a *BazelArgs) GetRemoteHeaderVal(key string) string {
+	if a.noResolve {
+		return parser.GetRemoteHeaderVal(a.forwarded, key)
+	}
 	return parser.GetRemoteHeaderVal(a.resolved, key)
 }
 
@@ -235,6 +268,9 @@ func (a *BazelArgs) Pop(flagName string) (string, error) {
 			return "", err
 		}
 		a.forwarded = newFwd
+		if a.noResolve {
+			return value, nil
+		}
 
 		if requiresResolve(flagName) {
 			return value, a.resolve()

--- a/cli/arg/arg_test.go
+++ b/cli/arg/arg_test.go
@@ -181,6 +181,19 @@ build:ci --remote_cache=grpc://ci-cache
 	}, args.Resolved())
 }
 
+func TestPrepend_NoResolve(t *testing.T) {
+	setupWorkspace(t, ``)
+	args, err := NewBazelArgsNoResolve([]string{"run", "//foo", "--", "--flag=value"})
+	require.NoError(t, err)
+
+	err = args.Prepend("--config=remote_only")
+	require.NoError(t, err)
+
+	want := []string{"run", "--config=remote_only", "//foo", "--", "--flag=value"}
+	require.Equal(t, want, args.Forwarded())
+	require.Equal(t, want, args.Resolved())
+}
+
 func TestPop(t *testing.T) {
 	setupWorkspace(t, `
 build --bes_backend=grpc://default-bes

--- a/cli/remotebazel/BUILD
+++ b/cli/remotebazel/BUILD
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
 # gazelle:default_visibility //cli:__subpackages__,//enterprise:__subpackages__
 package(default_visibility = [
@@ -52,6 +53,7 @@ go_test(
     srcs = ["remotebazel_test.go"],
     embed = [":remotebazel"],
     deps = [
+        "//cli/arg",
         "//cli/login",
         "//cli/parser",
         "//cli/parser/test_data",

--- a/cli/remotebazel/BUILD
+++ b/cli/remotebazel/BUILD
@@ -1,5 +1,4 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
 # gazelle:default_visibility //cli:__subpackages__,//enterprise:__subpackages__
 package(default_visibility = [

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -65,7 +65,9 @@ const (
 
 	// Name of the dir where the remote runner should write bazel run scripts
 	// (used to facilitate building a target remotely and running it locally).
-	runScriptDirName = "bazel-run-scripts"
+	runScriptDirName  = "bazel-run-scripts"
+	runScriptPathFlag = "--script_path=$BUILDBUDDY_CI_RUNNER_ROOT_DIR/" +
+		runScriptDirName + "/run.sh"
 
 	// `git remote` output is expected to look like:
 	// `origin	git@github.com:buildbuddy-io/buildbuddy.git (fetch)`
@@ -1383,19 +1385,7 @@ func HandleRemoteBazel(commandLineArgs []string) (int, error) {
 		// If we are running the target locally, remove the exec arguments for now,
 		// and append them when we actually run it
 		if runOutputLocally {
-			// Use shlex.Quote so that the command will be correctly parsed by the shell
-			// command line.
-			quotedArgs := shlex.Quote(bazelArgs...)
-
-			// To support building the target on the remote runner and running it locally,
-			// have Bazel write out a run script using the --script_path flag so we can
-			// extract run options (i.e. args, runfile information) from the generated run script.
-			//
-			// We do not pass this to shlex.Quote, or the env var won't be expanded
-			// correctly.
-			extraFlags := fmt.Sprintf("--script_path=$BUILDBUDDY_CI_RUNNER_ROOT_DIR/%s/run.sh", runScriptDirName)
-
-			cmd = fmt.Sprintf("bazel %s %s", quotedArgs, extraFlags)
+			cmd = fmt.Sprintf("bazel %s", quoteRemoteBazelArgs(bazelArgs))
 			localExecArgs = execArgs
 		} else {
 			cmd = fmt.Sprintf("bazel %s", shlex.Quote(arg.JoinExecutableArgs(bazelArgs, execArgs)...))
@@ -1469,6 +1459,12 @@ func parseArgs(commandLineArgs []string) ([]string, []string, error) {
 	if (!*runRemotely && bazelCmd == "run") || bazelCmd == "build" {
 		extraArgs = append(extraArgs, "--remote_upload_local_results")
 	}
+	// To support building the target on the remote runner and running it locally,
+	// have Bazel write out a run script using the --script_path flag so we can
+	// extract run options (i.e. args, runfile information) from the generated run script.
+	if !*runRemotely && bazelCmd == "run" {
+		extraArgs = append(extraArgs, runScriptPathFlag)
+	}
 	for _, extraArg := range extraArgs {
 		if err := bazelArgsStruct.Prepend(extraArg); err != nil {
 			return nil, nil, fmt.Errorf("add remote bazel arg: %w", err)
@@ -1476,6 +1472,25 @@ func parseArgs(commandLineArgs []string) ([]string, []string, error) {
 	}
 
 	return bazelArgsStruct.Forwarded(), execArgs, nil
+}
+
+// quoteRemoteBazelArgs quotes Bazel args for the remote shell so that the command will be correctly parsed by the shell
+// command line.
+func quoteRemoteBazelArgs(args []string) string {
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		// The run script path flag contains an env var that we *want* expanded on the remote runner.
+		// We do not want to use shlex.Quote, which explicitly prevents env var expansion.
+		if path, ok := strings.CutPrefix(arg, "--script_path="); ok {
+			runnerRoot := "$BUILDBUDDY_CI_RUNNER_ROOT_DIR"
+			if relativePath, ok := strings.CutPrefix(path, runnerRoot+"/"); ok {
+				quoted = append(quoted, `--script_path="`+runnerRoot+`"`+shlex.Quote("/"+relativePath))
+				continue
+			}
+		}
+		quoted = append(quoted, shlex.Quote(arg))
+	}
+	return strings.Join(quoted, " ")
 }
 
 // parseRemoteCliFlags parses flags that affect configuration of remote bazel.

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -1438,12 +1438,9 @@ func parseArgs(commandLineArgs []string) ([]string, []string, error) {
 	}
 
 	// Because Remote Bazel just forwards the command to a remote runner, it
-	// doesn't need to use the traditional CLI parser, which attempts
-	// to expand --config and --bazelrc flags for an internal view of resolved flags.
+	// doesn't need to expand --config and --bazelrc flags for an internal view of resolved flags.
 	// (Attempting to use the parser would actually fail, because we add --config flags that
 	// are only defined on the remote runners.)
-	// Manually construct a BazelArgs struct because the login code expects it.
-	// TODO: Find a less hacky way to handle this.
 	bazelArgsStruct, err := arg.NewBazelArgsNoResolve(bazelArgs)
 	if err != nil {
 		return nil, nil, fmt.Errorf("parse bazel args: %w", err)
@@ -1451,24 +1448,34 @@ func parseArgs(commandLineArgs []string) ([]string, []string, error) {
 	if err := login.ConfigureAPIKey(bazelArgsStruct); err != nil {
 		return nil, nil, fmt.Errorf("configure api key: %w", err)
 	}
-	bazelArgs = bazelArgsStruct.Resolved()
 
 	// Ensure all bazel remote runs use the remote cache.
 	// The goal is to keep remote workloads close to our servers, so use the same
 	// app backend as the remote runner.
-	bazelArgs = arg.Remove(bazelArgs, "bes_backend")
-	bazelArgs = arg.Remove(bazelArgs, "remote_cache")
-	bazelArgs = append(bazelArgs, "--config=buildbuddy_bes_backend")
-	bazelArgs = append(bazelArgs, "--config=buildbuddy_bes_results_url")
-	bazelArgs = append(bazelArgs, "--config=buildbuddy_remote_cache")
-
-	// If the CLI needs to fetch build outputs, make sure the remote runner uploads them.
-	bazelCmd, _ := parser.GetBazelCommandAndIndex(bazelArgs)
-	if (!*runRemotely && bazelCmd == "run") || bazelCmd == "build" {
-		bazelArgs = append(bazelArgs, "--remote_upload_local_results")
+	if _, err := bazelArgsStruct.Pop("bes_backend"); err != nil {
+		return nil, nil, fmt.Errorf("remove BES backend: %w", err)
+	}
+	if _, err := bazelArgsStruct.Pop("remote_cache"); err != nil {
+		return nil, nil, fmt.Errorf("remove remote cache: %w", err)
+	}
+	extraArgs := []string{
+		"--config=buildbuddy_bes_backend",
+		"--config=buildbuddy_bes_results_url",
+		"--config=buildbuddy_remote_cache",
 	}
 
-	return bazelArgs, execArgs, nil
+	// If the CLI needs to fetch build outputs, make sure the remote runner uploads them.
+	bazelCmd := bazelArgsStruct.GetCommand()
+	if (!*runRemotely && bazelCmd == "run") || bazelCmd == "build" {
+		extraArgs = append(extraArgs, "--remote_upload_local_results")
+	}
+	for _, extraArg := range extraArgs {
+		if err := bazelArgsStruct.Prepend(extraArg); err != nil {
+			return nil, nil, fmt.Errorf("add remote bazel arg: %w", err)
+		}
+	}
+
+	return bazelArgsStruct.Forwarded(), execArgs, nil
 }
 
 // parseRemoteCliFlags parses flags that affect configuration of remote bazel.

--- a/cli/remotebazel/remotebazel_test.go
+++ b/cli/remotebazel/remotebazel_test.go
@@ -731,12 +731,30 @@ func TestParseArgs_RunAddsRemoteArgsBeforeExecutableArgs(t *testing.T) {
 		"buildbuddy_remote_cache",
 	}, arg.GetMulti(forwardedBazelArgs, "config"))
 	require.Contains(t, forwardedBazelArgs, "--remote_upload_local_results")
+	require.Equal(t,
+		"$BUILDBUDDY_CI_RUNNER_ROOT_DIR/bazel-run-scripts/run.sh",
+		arg.Get(forwardedBazelArgs, "script_path"),
+	)
 	require.Equal(t, []string{
 		"generate-hashes",
 		"--includeTargetType",
 		"-w",
 		".",
 	}, forwardedExecArgs)
+	require.Contains(t,
+		quoteRemoteBazelArgs(bazelArgs),
+		`--script_path="$BUILDBUDDY_CI_RUNNER_ROOT_DIR"/bazel-run-scripts/run.sh`,
+	)
+}
+
+func TestQuoteRemoteBazelArgs_RunScriptEnvVarExpanded(t *testing.T) {
+	// This flag should not be quoted with shlex.Quote, which explicitly prevents env var expansion.
+	// The path should be quoted with double quotes, so the remote shell expands the BUILDBUDDY_CI_RUNNER_ROOT_DIR
+	// env var.
+	require.Equal(t,
+		`--script_path="$BUILDBUDDY_CI_RUNNER_ROOT_DIR"/bazel-run-scripts/run.sh`,
+		quoteRemoteBazelArgs([]string{runScriptPathFlag}),
+	)
 }
 
 func TestGetRemoteRunnerTarget(t *testing.T) {

--- a/cli/remotebazel/remotebazel_test.go
+++ b/cli/remotebazel/remotebazel_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/login"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/test_data"
@@ -683,6 +684,10 @@ func TestParseArgs(t *testing.T) {
 		// Startup flags should be preserved.
 		"--output_base=/tmp/output_base",
 		"test",
+		// Remote configs should be added immediately after the Bazel command.
+		"--config=buildbuddy_remote_cache",
+		"--config=buildbuddy_bes_results_url",
+		"--config=buildbuddy_bes_backend",
 		// Bazel flags should be canonicalized.
 		"--compilation_mode=opt",
 		// Config flags should not be expanded and passed through to the remote runner as is.
@@ -692,13 +697,46 @@ func TestParseArgs(t *testing.T) {
 		// API key should be set.
 		"--remote_header=x-buildbuddy-api-key=test-api-key",
 		"//foo",
-		// Remote flags should be removed and replaced by the CLI.
-		"--config=buildbuddy_bes_backend",
-		"--config=buildbuddy_bes_results_url",
-		"--config=buildbuddy_remote_cache",
 	}, bazelArgs)
 	// Exec args should be preserved.
 	require.Equal(t, []string{"--exec_arg"}, execArgs)
+}
+
+func TestParseArgs_RunAddsRemoteArgsBeforeExecutableArgs(t *testing.T) {
+	t.Setenv("BUILDBUDDY_API_KEY", "test-api-key")
+	originalRunRemotely := *runRemotely
+	*runRemotely = false
+	t.Cleanup(func() { *runRemotely = originalRunRemotely })
+
+	bazelArgs, execArgs, err := parseArgs([]string{
+		"run",
+		"@bazel-diff//cli:bazel-diff",
+		"generate-hashes",
+		"--",
+		"--includeTargetType",
+		"-w",
+		".",
+	})
+	require.NoError(t, err)
+
+	// Rejoin and re-split the args to ensure that they are still properly formatted.
+	forwardedBazelArgs, forwardedExecArgs := arg.SplitExecutableArgs(
+		arg.JoinExecutableArgs(bazelArgs, execArgs),
+	)
+	require.Equal(t, "run", arg.GetCommand(forwardedBazelArgs))
+	require.Equal(t, []string{"@bazel-diff//cli:bazel-diff"}, arg.GetTargets(forwardedBazelArgs))
+	require.ElementsMatch(t, []string{
+		"buildbuddy_bes_backend",
+		"buildbuddy_bes_results_url",
+		"buildbuddy_remote_cache",
+	}, arg.GetMulti(forwardedBazelArgs, "config"))
+	require.Contains(t, forwardedBazelArgs, "--remote_upload_local_results")
+	require.Equal(t, []string{
+		"generate-hashes",
+		"--includeTargetType",
+		"-w",
+		".",
+	}, forwardedExecArgs)
 }
 
 func TestGetRemoteRunnerTarget(t *testing.T) {


### PR DESCRIPTION
Use the CLI parser when adding Bazel flags with Remote Bazel.

The pre-existing logic hit an edge case when `bazel run` was used with a subcommand (i.e. `bazel run @bazel-diff//cli:bazel-diff generate-hashes`). The parser treats the subcommand `generate-hashes` as an executable arg, and appends `--` before. Remote Bazel later tried to blindly append bazel args to the end of the arg slice, but because they're after the `--`, they're incorrectly passed to the executable. 

By using the parser, we can make sure to insert the args at the correct position