### PR TITLE
[RB] Report executable path in RunTargetAnalyzed

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1257,6 +1257,7 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 							RunfilesRoot:       runScriptInfo.runfilesRoot,
 							Runfiles:           runScriptInfo.runfiles,
 							RunfileDirectories: runScriptInfo.runfileDirs,
+							ExecutablePath:     runScriptInfo.executablePath,
 						}},
 					}
 					ar.reporter.Publish(e)
@@ -1372,10 +1373,11 @@ func deserializeAction(actionString string) (*config.Action, error) {
 }
 
 type runInfo struct {
-	args         []string
-	runfiles     []*bespb.File
-	runfileDirs  []*bespb.Tree
-	runfilesRoot string
+	args           []string
+	runfiles       []*bespb.File
+	runfileDirs    []*bespb.Tree
+	runfilesRoot   string
+	executablePath string
 }
 
 func collectRunfiles(runfilesDir string) (map[digest.Key]string, map[string]string, error) {
@@ -1551,6 +1553,10 @@ func processRunScript(ctx context.Context, runScript string) (*runInfo, error) {
 		return nil, status.UnknownErrorf("could not detect binary workspace root: %s", err)
 	}
 	wsRoot := filepath.Dir(wsFile)
+	executablePath, err := filepath.Rel(wsRoot, bin)
+	if err != nil {
+		return nil, status.UnknownErrorf("could not determine workspace-relative binary path: %s", err)
+	}
 
 	// The second line changes the working directory to within the runfiles directory.
 	cdLine := runScriptLines[1]
@@ -1578,10 +1584,11 @@ func processRunScript(ctx context.Context, runScript string) (*runInfo, error) {
 	}
 
 	return &runInfo{
-		args:         args,
-		runfiles:     runfiles,
-		runfileDirs:  runfileDirs,
-		runfilesRoot: runfilesRoot,
+		args:           args,
+		runfiles:       runfiles,
+		runfileDirs:    runfileDirs,
+		runfilesRoot:   runfilesRoot,
+		executablePath: executablePath,
 	}, nil
 }
 

--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -1658,6 +1658,8 @@ message RunTargetAnalyzed {
   repeated File runfiles = 3;
   // Any runtime directory dependencies for the runnable target.
   repeated Tree runfileDirectories = 4;
+  // Workspace-relative path to the executable selected by `bazel run`.
+  string executable_path = 5;
 }
 
 // Message describing a build event. Events will have an identifier that


### PR DESCRIPTION
With Remote Bazel, we support building remotely and running an executable locally. The ci_runner emits the RunTargetAnalyzed event with data about the generated run script

Previously the CLI would assume that the run target only had 1 output, which was the generated executable. However some rules, like sh_binary, generate multiple outputs. If we explicitly include the executable path in the RunTargetAnalyzed event, the CLI can still identify the executable path, even if there are multiple outputs

[[Bug report]](https://buildbuddy-corp.slack.com/archives/C0BG9TB4B8E/p1783695894329319?thread_ts=1783694753.397199&cid=C0BG9TB4B8E)