### PR TITLE
[RB] Use explicit run target executable path when building remotely, running locally

### DIFF
--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -922,6 +922,16 @@ func downloadOutputs(ctx context.Context, env environment.Env, mainOutputs []*be
 	return mainLocalArtifacts, nil
 }
 
+func findExecutableOutput(outputs []string, outputBaseDir, executablePath string) (string, error) {
+	expectedPath := filepath.Clean(filepath.Join(outputBaseDir, BuildBuddyArtifactDir, executablePath))
+	for _, output := range outputs {
+		if filepath.Clean(output) == expectedPath {
+			return output, nil
+		}
+	}
+	return "", fmt.Errorf("run executable %q not found among downloaded artifacts", executablePath)
+}
+
 func getWorkingDirectory(workspaceFilePath string) (string, error) {
 	repoRootPath, err := storage.RepoRootPath()
 	if err != nil {
@@ -1137,6 +1147,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 	var runfiles []*bespb.File
 	var runfileDirectories []*bespb.Tree
 	var defaultRunArgs []string
+	executablePath := ""
 	for _, e := range inRsp.GetInvocation()[0].GetEvent() {
 		if _, ok := e.GetBuildEvent().GetPayload().(*bespb.BuildEvent_ChildInvocationCompleted); ok {
 			childIID = e.GetBuildEvent().GetId().GetChildInvocationCompleted().GetInvocationId()
@@ -1147,6 +1158,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 				runfiles = rta.RunTargetAnalyzed.GetRunfiles()
 				runfileDirectories = rta.RunTargetAnalyzed.GetRunfileDirectories()
 				defaultRunArgs = rta.RunTargetAnalyzed.GetArguments()
+				executablePath = rta.RunTargetAnalyzed.GetExecutablePath()
 			}
 		}
 	}
@@ -1171,10 +1183,10 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 				return 1, fmt.Errorf("download invocation outputs for %q: %w", childIID, err)
 			}
 			if opts.RunOutputLocally {
-				if len(outputs) > 1 {
-					return 1, fmt.Errorf("run requested but target produced more than one artifact")
+				binPath, err := findExecutableOutput(outputs, outputsBaseDir, executablePath)
+				if err != nil {
+					return 1, err
 				}
-				binPath := outputs[0]
 				if err := os.Chmod(binPath, 0755); err != nil {
 					return 1, fmt.Errorf("prepare binary %q for execution: %w", binPath, err)
 				}

--- a/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
+++ b/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
@@ -152,7 +152,7 @@ func makeLocalGitRepo(t *testing.T, contents map[string]string) (path, commitSHA
 
 // Run remote bazel in a separate process so it doesn't interfere with
 // the local server and cause a race condition.
-func runRemoteBazelInSeparateProcess(t *testing.T, workDir string, serverAddress string, args ...string) {
+func runRemoteBazelInSeparateProcess(t *testing.T, workDir string, serverAddress string, args ...string) string {
 	cmd := testcli.Command(t, workDir, append(
 		[]string{
 			"remote",
@@ -166,6 +166,7 @@ func runRemoteBazelInSeparateProcess(t *testing.T, workDir string, serverAddress
 	b, err := cmd.CombinedOutput()
 	t.Log(string(b))
 	require.NoError(t, err)
+	return string(b)
 }
 
 func TestWithPrivateRepo(t *testing.T) {
@@ -486,6 +487,45 @@ int main() {
 	})
 	require.NoError(t, err)
 	require.NotContains(t, string(logResp.GetBuffer()), "Hello from main!")
+}
+
+func TestBuildRemotelyRunLocally_ShBinary(t *testing.T) {
+	repoDir, _ := makeLocalGitRepo(t, map[string]string{
+		"BUILD": `
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
+genrule(
+    name = "generated_script",
+    srcs = ["main.sh"],
+    outs = ["main-generated.sh"],
+    cmd = "cp $< $@",
+    executable = True,
+)
+
+sh_binary(
+    name = "main",
+    srcs = [":generated_script"],
+)
+`,
+		"main.sh": `#!/usr/bin/env bash
+echo "Hello from sh_binary!"
+`,
+	})
+
+	// Run a server and executor locally to run remote bazel against.
+	env, bbServer, _ := runLocalServerAndExecutor(t, "", "", nil)
+
+	// rules_shell sh_binary exposes both the runnable entrypoint and its
+	// underlying script as outputs. Verify that Remote Bazel selects the
+	// entrypoint among the multiple outputs.
+	randomStr := fmt.Sprintf("%d", time.Now().UnixMilli())
+	output := runRemoteBazelInSeparateProcess(t, repoDir, bbServer.GRPCAddress(),
+		"--runner_exec_properties=instance_name="+randomStr,
+		"--run_remotely=0",
+		"run",
+		":main",
+		fmt.Sprintf("--remote_header=x-buildbuddy-api-key=%s", env.APIKey1))
+	require.Contains(t, output, "Hello from sh_binary!")
 }
 
 func TestAccessingSecrets(t *testing.T) {


### PR DESCRIPTION
Follow up to https://github.com/buildbuddy-io/buildbuddy/pull/12718