### PR TITLE
Fix total_cached_action_exec_usec for AC proxy hits

### DIFF
--- a/enterprise/server/hit_tracker_client/BUILD
+++ b/enterprise/server/hit_tracker_client/BUILD
@@ -49,5 +49,6 @@ go_test(
         "//server/util/usageutil",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//metadata",
+        "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )

--- a/enterprise/server/hit_tracker_client/hit_tracker_client.go
+++ b/enterprise/server/hit_tracker_client/hit_tracker_client.go
@@ -198,18 +198,19 @@ func (t *NoOpTransferTimer) Record(bytesTransferred int64, duration time.Duratio
 }
 
 type HitTrackerClient struct {
-	ctx             context.Context
-	enqueueFn       func(context.Context, *hitpb.CacheHit)
-	client          hitpb.HitTrackerServiceClient
-	requestMetadata *repb.RequestMetadata
-	cacheType       rspb.CacheType
+	ctx                    context.Context
+	enqueueFn              func(context.Context, *hitpb.CacheHit)
+	client                 hitpb.HitTrackerServiceClient
+	requestMetadata        *repb.RequestMetadata
+	executedActionMetadata *repb.ExecutedActionMetadata
+	cacheType              rspb.CacheType
 }
 
-// TODO(https://github.com/buildbuddy-io/buildbuddy-internal/issues/4875) Implement
 func (h *HitTrackerClient) SetExecutedActionMetadata(md *repb.ExecutedActionMetadata) {
-	// This is used to track action durations and is not used for non-RBE executions.
-	// Currently skip-remote behavior is not used for RBE, so do nothing in this case.
+	// Attach the metadata to reported hits so the backend records cached
+	// execution duration usage for AC hits served without consulting it.
 	if proxy_util.SkipRemote(h.ctx) {
+		h.executedActionMetadata = md
 		return
 	}
 	// By default, AC hit tracking should be handled by the remote cache.
@@ -306,6 +307,9 @@ type TransferTimer struct {
 	client           hitpb.HitTrackerServiceClient
 	cacheType        rspb.CacheType
 	cacheRequestType capb.RequestType
+	// onClose is called with the hit before it is enqueued, to attach fields
+	// that may only be known after the timer starts.
+	onClose func(*hitpb.CacheHit)
 }
 
 func (t *TransferTimer) CloseWithBytesTransferred(bytesTransferredCache, bytesTransferredClient int64, compressor repb.Compressor_Value, serverLabel string) error {
@@ -320,12 +324,23 @@ func (t *TransferTimer) CloseWithBytesTransferred(bytesTransferredCache, bytesTr
 		Duration:         durationpb.New(time.Since(t.start)),
 		CacheRequestType: t.cacheRequestType,
 	}
+	if t.onClose != nil {
+		t.onClose(hit)
+	}
 	t.enqueueFn(t.ctx, hit)
 	return nil
 }
 
 func (t *TransferTimer) Record(bytesTransferred int64, duration time.Duration, compressor repb.Compressor_Value) error {
 	return status.InternalError("Unxpected call to hit_tracker_client.Record()")
+}
+
+// attachExecutedActionMetadata copies the client's executed action metadata
+// onto the hit. It runs when a transfer timer closes because the metadata may
+// only be set after the timer starts (e.g. GetActionResult tracks the download
+// before fetching the ActionResult that carries the metadata).
+func (h *HitTrackerClient) attachExecutedActionMetadata(hit *hitpb.CacheHit) {
+	hit.ExecutedActionMetadata = h.executedActionMetadata
 }
 
 func (h *HitTrackerClient) TrackDownload(digest *repb.Digest) interfaces.TransferTimer {
@@ -338,6 +353,7 @@ func (h *HitTrackerClient) TrackDownload(digest *repb.Digest) interfaces.Transfe
 		client:           h.client,
 		cacheType:        h.cacheType,
 		cacheRequestType: capb.RequestType_READ,
+		onClose:          h.attachExecutedActionMetadata,
 	}
 }
 
@@ -352,6 +368,7 @@ func (h *HitTrackerClient) TrackUpload(digest *repb.Digest) interfaces.TransferT
 			client:           h.client,
 			cacheType:        h.cacheType,
 			cacheRequestType: capb.RequestType_WRITE,
+			onClose:          h.attachExecutedActionMetadata,
 		}
 	}
 	// If writes hit the backing cache, it will handle hit tracking.

--- a/enterprise/server/hit_tracker_client/hit_tracker_client_test.go
+++ b/enterprise/server/hit_tracker_client/hit_tracker_client_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/usageutil"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	capb "github.com/buildbuddy-io/buildbuddy/proto/cache"
 	hitpb "github.com/buildbuddy-io/buildbuddy/proto/hit_tracker"
@@ -75,6 +76,7 @@ type testHitTracker struct {
 	casBytesUploaded   map[string]*atomic.Int64
 	acDownloads        map[string]*atomic.Int64
 	acBytesDownloaded  map[string]*atomic.Int64
+	acCachedExecUsec   map[string]*atomic.Int64
 	acUploads          map[string]*atomic.Int64
 	acBytesUploaded    map[string]*atomic.Int64
 }
@@ -89,6 +91,7 @@ func newTestHitTracker(t testing.TB, authenticator interfaces.Authenticator) *te
 		casBytesUploaded:   map[string]*atomic.Int64{},
 		acDownloads:        map[string]*atomic.Int64{},
 		acBytesDownloaded:  map[string]*atomic.Int64{},
+		acCachedExecUsec:   map[string]*atomic.Int64{},
 		acUploads:          map[string]*atomic.Int64{},
 		acBytesUploaded:    map[string]*atomic.Int64{},
 	}
@@ -99,6 +102,7 @@ func newTestHitTracker(t testing.TB, authenticator interfaces.Authenticator) *te
 		out.casBytesUploaded[k] = &atomic.Int64{}
 		out.acDownloads[k] = &atomic.Int64{}
 		out.acBytesDownloaded[k] = &atomic.Int64{}
+		out.acCachedExecUsec[k] = &atomic.Int64{}
 		out.acUploads[k] = &atomic.Int64{}
 		out.acBytesUploaded[k] = &atomic.Int64{}
 	}
@@ -115,6 +119,10 @@ func (ht *testHitTracker) Track(ctx context.Context, req *hitpb.TrackRequest) (*
 			if hit.GetResource().GetCacheType() == rspb.CacheType_AC {
 				ht.acDownloads[key].Add(1)
 				ht.acBytesDownloaded[key].Add(hit.GetSizeBytes())
+				if md := hit.GetExecutedActionMetadata(); md != nil {
+					execDuration := md.GetExecutionCompletedTimestamp().AsTime().Sub(md.GetExecutionStartTimestamp().AsTime())
+					ht.acCachedExecUsec[key].Add(execDuration.Microseconds())
+				}
 			} else {
 				ht.casDownloads[key].Add(1)
 				ht.casBytesDownloaded[key].Add(hit.GetSizeBytes())
@@ -210,12 +218,20 @@ func TestACHitTracker_SkipRemote(t *testing.T) {
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(proxy_util.SkipRemoteKey, "true"))
 	hitTracker := hitTrackerFactory.NewACHitTracker(ctx, &repb.RequestMetadata{})
 	hitTracker.TrackMiss(aDigest)
-	hitTracker.TrackDownload(bDigest).CloseWithBytesTransferred(1000, 2000, repb.Compressor_IDENTITY, "test")
+	// Metadata is set after the timer starts, as in action_cache_server.
+	download := hitTracker.TrackDownload(bDigest)
+	execStart := time.Unix(1000, 0)
+	hitTracker.SetExecutedActionMetadata(&repb.ExecutedActionMetadata{
+		ExecutionStartTimestamp:     timestamppb.New(execStart),
+		ExecutionCompletedTimestamp: timestamppb.New(execStart.Add(90 * time.Second)),
+	})
+	download.CloseWithBytesTransferred(1000, 2000, repb.Compressor_IDENTITY, "test")
 	hitTracker.TrackUpload(cDigest).CloseWithBytesTransferred(3000, 4000, repb.Compressor_IDENTITY, "test")
 
 	expectation := hitTrackerService.acDownloadExpectation(anonKey, 1)
 	require.Eventually(t, expectation, 10*time.Second, 100*time.Millisecond)
 	require.Equal(t, int64(2000), hitTrackerService.acBytesDownloaded[anonKey].Load())
+	require.Equal(t, (90 * time.Second).Microseconds(), hitTrackerService.acCachedExecUsec[anonKey].Load())
 	require.Equal(t, int64(1), hitTrackerService.acUploads[anonKey].Load())
 	require.Equal(t, int64(4000), hitTrackerService.acBytesUploaded[anonKey].Load())
 	require.Equal(t, int64(0), hitTrackerService.casDownloads[anonKey].Load())

--- a/enterprise/server/hit_tracker_service/BUILD
+++ b/enterprise/server/hit_tracker_service/BUILD
@@ -43,5 +43,6 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_protobuf//types/known/durationpb",
+        "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )

--- a/enterprise/server/hit_tracker_service/hit_tracker_service.go
+++ b/enterprise/server/hit_tracker_service/hit_tracker_service.go
@@ -33,6 +33,7 @@ func (h HitTrackerService) Track(ctx context.Context, req *hitpb.TrackRequest) (
 		var hitTracker interfaces.HitTracker
 		if hit.GetResource().GetCacheType() == rspb.CacheType_AC {
 			hitTracker = h.hitTrackerFactory.NewRemoteACHitTracker(ctx, hit.GetRequestMetadata(), req.GetServer())
+			hitTracker.SetExecutedActionMetadata(hit.GetExecutedActionMetadata())
 		} else if hit.GetResource().GetCacheType() == rspb.CacheType_CAS {
 			hitTracker = h.hitTrackerFactory.NewRemoteCASHitTracker(ctx, hit.GetRequestMetadata(), req.GetServer())
 		} else {

--- a/enterprise/server/hit_tracker_service/hit_tracker_service_test.go
+++ b/enterprise/server/hit_tracker_service/hit_tracker_service_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	capb "github.com/buildbuddy-io/buildbuddy/proto/cache"
 	hitpb "github.com/buildbuddy-io/buildbuddy/proto/hit_tracker"
@@ -266,8 +267,9 @@ func TestHitTrackerService_Usage(t *testing.T) {
 						Server: "servicio",
 					},
 					Counts: tables.UsageCounts{
-						ActionCacheHits:        2,
-						TotalDownloadSizeBytes: 456,
+						ActionCacheHits:           2,
+						TotalDownloadSizeBytes:    456,
+						TotalCachedActionExecUsec: (3 * time.Minute).Microseconds(),
 					},
 				},
 			},
@@ -278,8 +280,9 @@ func TestHitTrackerService_Usage(t *testing.T) {
 						sku.Server: "servicio",
 					},
 					Counts: map[sku.SKU]int64{
-						sku.RemoteCacheACHits:             2,
-						sku.RemoteCacheCASDownloadedBytes: 456,
+						sku.RemoteCacheACHits:                    2,
+						sku.RemoteCacheCASDownloadedBytes:        456,
+						sku.RemoteCacheACCachedExecDurationNanos: (3 * time.Minute).Nanoseconds(),
 					},
 				},
 			},
@@ -329,12 +332,17 @@ func TestHitTrackerService_Usage(t *testing.T) {
 				SizeBytes: 456,
 			}
 			rn := digest.NewResourceName(&d, "", tc.cacheType, repb.DigestFunction_SHA256)
+			execStart := time.Unix(1000, 0)
 			hit := hitpb.CacheHit{
 				RequestMetadata:  rmd,
 				Resource:         rn.ToProto(),
 				SizeBytes:        456,
 				Duration:         durationpb.New(time.Minute),
 				CacheRequestType: tc.requestType,
+				ExecutedActionMetadata: &repb.ExecutedActionMetadata{
+					ExecutionStartTimestamp:     timestamppb.New(execStart),
+					ExecutionCompletedTimestamp: timestamppb.New(execStart.Add(3 * time.Minute)),
+				},
 			}
 			req := hitpb.TrackRequest{Hits: []*hitpb.CacheHit{&emptyHit, &hit}, Server: "servicio"}
 			_, err = env.GetHitTrackerServiceServer().Track(ctx, &req)

--- a/proto/hit_tracker.proto
+++ b/proto/hit_tracker.proto
@@ -23,6 +23,11 @@ message CacheHit {
   google.protobuf.Duration duration = 4;
 
   cache.RequestType cache_request_type = 5;
+
+  // Execution metadata of the action whose result was served. Used to record
+  // cached execution duration for Action Cache hits.
+  build.bazel.remote.execution.v2.ExecutedActionMetadata
+      executed_action_metadata = 6;
 }
 
 message TrackRequest {


### PR DESCRIPTION
Cache proxies report locally-served AC hits to the backend via `HitTrackerService`, but the `CacheHit` proto had no field for `ExecutedActionMetadata`, so cached execution duration was silently dropped and never recorded as usage (total_cached_action_exec_usec). 

This didn't matter before because skip-remote AC reads were only snapshot manifest lookups with no execution timestamps, but the AC TTL fast path (#12245) serves RBE-produced results with real timestamps, so this usage is undercounted for every TTL hit as the flag rolls out. 

This change adds `executed_action_metadata` to `CacheHit`, attaches it to hits reported by the proxy, and applies it on the backend, restoring parity with hits served directly by the apps.
