### PR TITLE
Grow the column to fit API key names 

### DIFF
--- a/enterprise/app/api_keys/api_keys.css
+++ b/enterprise/app/api_keys/api_keys.css
@@ -18,6 +18,12 @@
 
 .api-keys .api-keys-list {
   padding: 8px 0;
+  /* Tracks: label | capabilities | value | edit | delete. Rows are subgrids
+   * so columns stay aligned across keys; tracks whose cells aren't rendered
+   * collapse to zero width. */
+  display: grid;
+  grid-template-columns: minmax(224px, max-content) repeat(4, max-content);
+  overflow-x: auto;
 }
 
 .api-keys .api-key-created-banner-content {
@@ -37,66 +43,32 @@
 }
 
 .api-keys .api-key-list-item {
-  display: flex;
-  align-items: baseline;
-  min-height: 40px;
-}
-
-.api-keys .api-key-list-item button {
-  flex-shrink: 0;
-}
-
-.api-keys .api-key-label,
-.api-keys .api-key-capabilities {
-  display: flex;
-  align-self: stretch;
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
   align-items: center;
+  min-height: 40px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #eee;
 }
 
 .api-keys .api-key-label {
   font-weight: 600;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow-x: hidden;
 }
 
 .api-keys .api-key-capabilities {
   white-space: nowrap;
-  overflow-x: hidden;
-  width: 0;
-  max-width: 192px;
-  flex-basis: 192px;
-  flex-shrink: 0;
 }
 
 .api-keys .untitled-key {
   color: #757575;
 }
 
-.api-keys .api-key-label,
-.api-keys .api-key-value {
-  width: 0;
-  display: flex;
-}
-
-.api-keys .api-key-label {
-  flex-basis: 224px;
-  flex-grow: 1;
-  flex-shrink: 1;
-}
-
 .api-keys .api-key-value {
   box-sizing: border-box;
-  width: fit-content;
-  flex-shrink: 0;
-}
-
-.api-keys .api-key-label > span {
-  flex-grow: 1;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  text-align: left;
-  overflow-x: hidden;
-}
-
-.api-keys .api-key-value {
   font-family: monospace;
   font-size: 12px;
   background: var(--color-bg-code);
@@ -134,12 +106,6 @@
 
 .api-keys .api-key-label svg {
   margin-right: 0px;
-}
-
-.api-keys .api-key-list-item {
-  padding-bottom: 8px;
-  border-bottom: 1px solid #eee;
-  max-width: 816px;
 }
 
 .api-keys .api-key-list-item > :not(:last-child) {
@@ -203,4 +169,8 @@
   color: var(--color-banner-info-text);
   padding: 16px;
   border-radius: 8px;
+  /* Span all list columns and wrap instead of widening the grid. */
+  grid-column: 1 / -1;
+  max-width: 800px;
+  box-sizing: border-box;
 }

--- a/enterprise/app/settings/settings.css
+++ b/enterprise/app/settings/settings.css
@@ -131,11 +131,18 @@
   align-self: flex-start;
 }
 
+.settings {
+  /* Settings tab sidebar dimensions on large screens. Also used to cap the
+   * autosized content width so it never overlaps the tabs. */
+  --settings-tabs-width: 200px;
+  --settings-tabs-margin: 32px;
+}
+
 /* Large screen */
 @media (min-width: 1281px) {
   .settings .settings-tabs {
-    margin-right: 32px;
-    width: 200px;
+    margin-right: var(--settings-tabs-margin);
+    width: var(--settings-tabs-width);
   }
 }
 
@@ -213,6 +220,23 @@
 .settings .settings-content {
   width: 800px;
   max-width: 100%;
+}
+
+/* The API keys tabs start at the default width but grow to fit long key
+ * names on one line, up to the space left by the settings tabs. */
+@media (min-width: 1281px) {
+  .settings .settings-content.settings-content-autosize {
+    width: fit-content;
+    min-width: 800px;
+    max-width: calc(100% - var(--settings-tabs-width) - var(--settings-tabs-margin));
+  }
+
+  /* Cap text blocks at the default width so only the key list drives the
+   * growth. */
+  .settings .settings-content.settings-content-autosize > :not(.api-keys),
+  .settings .settings-content.settings-content-autosize .api-keys > :not(.api-keys-list) {
+    max-width: 800px;
+  }
 }
 
 .settings .settings-tab-group {

--- a/enterprise/app/settings/settings.tsx
+++ b/enterprise/app/settings/settings.tsx
@@ -107,6 +107,7 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
 
     const activeTabId = this.getActiveTabId();
     const apiKeyValueReadbackEnabled = capabilities.config.apiKeyValueReadbackEnabled !== false;
+    const autosizeContent = activeTabId === TabId.OrgApiKeys || activeTabId === TabId.PersonalApiKeys;
 
     return (
       <div className="settings">
@@ -198,7 +199,7 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
                 )}
               </div>
             </div>
-            <div className="settings-content">
+            <div className={`settings-content ${autosizeContent ? "settings-content-autosize" : ""}`}>
               {activeTabId === "personal/preferences" && (
                 <>
                   <div className="settings-option-title">Dense mode</div>


### PR DESCRIPTION
<img width="1071" height="687" alt="Screenshot 2026-07-15 at 10 50 37 AM" src="https://github.com/user-attachments/assets/8e3dfd94-7050-4711-8fc7-d5b3785c7b69" />
<img width="1479" height="733" alt="Screenshot 2026-07-15 at 10 50 28 AM" src="https://github.com/user-attachments/assets/13c2819f-7705-417e-9a31-ee8fe5e629e3" />
<img width="1826" height="754" alt="Screenshot 2026-07-15 at 10 50 19 AM" src="https://github.com/user-attachments/assets/c48159f0-21ef-4393-be0d-70e84112210b" />
