### PR TITLE
Fix race in mockmetadata

### DIFF
--- a/enterprise/server/testutil/mockmetadata/mockmetadata.go
+++ b/enterprise/server/testutil/mockmetadata/mockmetadata.go
@@ -39,6 +39,13 @@ func NewServer(maxSizeBytes int64, fs filestore.Store) (*Server, error) {
 func (rc *Server) evict(key string, md *sgpb.FileMetadata, reason lru.EvictionReason) {
 	log.Infof("Evicted %+v (REASON: %s)", md, reason)
 
+	if reason == lru.ConflictEviction {
+		// Don't delete the blob if it was evicted due to a conflict, since an
+		// in-flight read may still be using it. This does leave orphaned blobs,
+		// but it's fine for tests.
+		return
+	}
+
 	if inlineMetadata := md.GetStorageMetadata().GetInlineMetadata(); inlineMetadata != nil {
 		return
 	}

--- a/server/testutil/mockgcs/mockgcs.go
+++ b/server/testutil/mockgcs/mockgcs.go
@@ -68,10 +68,10 @@ func (m *mockGCS) Reader(ctx context.Context, blobName string, offset, limit int
 	defer m.mu.Unlock()
 	blob, ok := m.items[blobName]
 	if !ok {
-		return nil, status.NotFoundError("mock gcs blob not found")
+		return nil, status.NotFoundErrorf("mock gcs blob not found: %s", blobName)
 	}
 	if m.expired(blobName) {
-		return nil, status.InternalError("mock gcs blob expired")
+		return nil, status.InternalErrorf("mock gcs blob expired: %s", blobName)
 	}
 	data := blob.data[offset:]
 	if limit > 0 && limit < int64(len(data)) {
@@ -119,10 +119,10 @@ func (m *mockGCS) UpdateCustomTime(ctx context.Context, blobName string, t time.
 	m.updateCustomTimeCallCount++
 	blob, ok := m.items[blobName]
 	if !ok {
-		return status.NotFoundError("mock gcs blob not found")
+		return status.NotFoundErrorf("mock gcs blob not found: %s", blobName)
 	}
 	if m.expired(blobName) {
-		return status.NotFoundError("mock gcs blob expired")
+		return status.NotFoundErrorf("mock gcs blob expired: %s", blobName)
 	}
 	if t.Before(blob.customTime) {
 		return status.FailedPreconditionError("custom time can only move forward")


### PR DESCRIPTION
This fixes `BenchmarkParallel` in `//enterprise/server/test/performance/cache:cache_test` for the metacache.

There was a race before:
1. Write 1 for digest foo arrives
2. Write 2 for digest foo arrives
3. Both writes write to GCS, but with different blob names
4. Write 1 commits
5. Read for foo arrives. it reads the metadata from write 1
6. Write 2 commits. In mockmetadata.go, this evicts write 1, including deleting the GCS blob
7. The read from step 5 fails because the GCS blob has been deleted