### PR TITLE
Store ci_runner git fetch metrics in clickhouse

### DIFF
--- a/enterprise/server/cmd/ci_runner/BUILD
+++ b/enterprise/server/cmd/ci_runner/BUILD
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 # gazelle:default_visibility //enterprise:__subpackages__
 package(
@@ -10,7 +10,7 @@ package(
 )
 
 go_library(
-    name = "main",
+    name = "ci_runner_lib",
     srcs = ["main.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/cmd/ci_runner",
     deps = [
@@ -56,7 +56,7 @@ go_library(
 
 go_binary(
     name = "ci_runner",
-    embed = [":main"],
+    embed = [":ci_runner_lib"],
     pure = "on",
     static = "on",
 )
@@ -73,4 +73,11 @@ go_image(
     base = ":base_image",
     binary = ":ci_runner",
     tags = ["manual"],
+)
+
+go_test(
+    name = "ci_runner_test",
+    srcs = ["main_test.go"],
+    embed = [":ci_runner_lib"],
+    deps = ["@com_github_stretchr_testify//assert"],
 )

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/base64"
@@ -17,6 +18,7 @@ import (
 	"regexp"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -271,6 +273,13 @@ type workspace struct {
 	// An error that occurred while setting up the workspace, which should be
 	// reported for all action logs instead of actually executing the action.
 	setupError error
+
+	// Total bytes fetched by git fetch commands run during setup, parsed from
+	// git trace2 event logs.
+	gitFetchTotalBytes int64
+
+	// Total time spent running git fetch commands during setup.
+	gitFetchDuration time.Duration
 
 	// The start time of the setup phase.
 	startTime time.Time
@@ -1089,8 +1098,24 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 		return err
 	}
 	if !*skipAutomaticCheckout {
-		if err := ws.setup(ctx); err != nil {
-			return status.WrapError(err, "failed to set up git repo")
+		setupErr := ws.setup(ctx)
+		// Report git fetch stats even if setup failed, since the time spent
+		// fetching may help diagnose the failure.
+		gitFetchEvent := &bespb.BuildEvent{
+			Id: &bespb.BuildEventId{Id: &bespb.BuildEventId_GitFetchCompleted{GitFetchCompleted: &bespb.BuildEventId_GitFetchCompletedId{}}},
+			Payload: &bespb.BuildEvent_GitFetchCompleted{GitFetchCompleted: &bespb.GitFetchCompleted{
+				TotalBytes: ws.gitFetchTotalBytes,
+				Duration:   durationpb.New(ws.gitFetchDuration),
+			}},
+		}
+		publishErr := ar.reporter.Publish(gitFetchEvent)
+		// Return the setup error before handling any publish error, so that a
+		// broken build event stream doesn't mask a real setup failure.
+		if setupErr != nil {
+			return status.WrapError(setupErr, "failed to set up git repo")
+		}
+		if publishErr != nil {
+			return nil
 		}
 	}
 	action, err := getActionToRun()
@@ -2232,7 +2257,10 @@ func (ws *workspace) fetch(ctx context.Context, remoteURL string, refs []string,
 			return status.UnknownErrorf("Command `git remote add %q <url>` failed.", remoteName)
 		}
 	}
-	fetchArgs := []string{"fetch", "--force"}
+	// Force progress reporting (rather than relying on stderr being a
+	// terminal), since git only logs fetched byte totals to the trace2 event
+	// log when progress meters are active.
+	fetchArgs := []string{"fetch", "--force", "--progress"}
 	for _, filter := range *gitFetchFilters {
 		fetchArgs = append(fetchArgs, "--filter="+filter)
 	}
@@ -2253,10 +2281,79 @@ func (ws *workspace) fetch(ctx context.Context, remoteURL string, refs []string,
 	}
 	fetchArgs = append(fetchArgs, remoteName)
 	fetchArgs = append(fetchArgs, refs...)
-	if _, err := git(ctx, ws.log, fetchArgs...); err != nil {
-		return status.WrapError(err, err.Output)
+
+	// Have git log trace2 events to a file under .git/info, from which the
+	// exact number of fetched bytes is parsed once the fetch completes. The
+	// log is deleted after parsing.
+	fetchEnv := map[string]string{}
+	// GIT_TRACE2 requires an abspath.
+	trace2Path, err := filepath.Abs(filepath.Join(".git", "info", "fetch_trace2.jsonl"))
+	if err != nil {
+		backendLog.Warningf("Could not resolve the git trace2 event log path; git fetch stats will not be collected: %s", err)
+	} else {
+		// Remove any leftover log (e.g. if a previous run was interrupted
+		// mid-fetch), since git appends to the log file.
+		_ = os.Remove(trace2Path)
+		fetchEnv["GIT_TRACE2_EVENT"] = trace2Path
+		// Progress data events can be nested inside other trace2 regions;
+		// raise the nesting limit (default 2) so they aren't dropped.
+		fetchEnv["GIT_TRACE2_EVENT_NESTING"] = "5"
+	}
+
+	fetchStart := time.Now()
+	_, fetchErr := gitWithEnv(ctx, ws.log, fetchEnv, fetchArgs...)
+	ws.gitFetchDuration += time.Since(fetchStart)
+	// Count fetched bytes even if the fetch failed, since a failed fetch may
+	// be retried (e.g. with a different depth) and we want the total to
+	// reflect all data transferred.
+	if fetchEnv["GIT_TRACE2_EVENT"] != "" {
+		if f, err := os.Open(trace2Path); err != nil {
+			backendLog.Warningf("Could not open the git trace2 event log; git fetch stats may be undercounted: %s", err)
+		} else {
+			ws.gitFetchTotalBytes += parseGitFetchedBytes(f)
+			f.Close()
+		}
+		_ = os.Remove(trace2Path)
+	}
+	if fetchErr != nil {
+		return status.WrapError(fetchErr, fetchErr.Output)
 	}
 	return nil
+}
+
+// parseGitFetchedBytes returns the total number of bytes fetched by a git
+// command, parsed from its trace2 event log. Progress meters that display
+// throughput (such as "Receiving objects") log a "total_bytes" data event
+// when they complete. Child processes such as git-index-pack inherit
+// GIT_TRACE2_EVENT and append their events to the same log file. Returns 0
+// if the log contains no such events (e.g. everything was already up to
+// date).
+func parseGitFetchedBytes(trace2EventLog io.Reader) int64 {
+	var total int64
+	scanner := bufio.NewScanner(trace2EventLog)
+	// Trace2 event lines are small (typically well under 1KiB); a line
+	// exceeding this limit would stop the scan and drop the remaining events.
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+	for scanner.Scan() {
+		var event struct {
+			Event    string `json:"event"`
+			Category string `json:"category"`
+			Key      string `json:"key"`
+			Value    string `json:"value"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			continue
+		}
+		if event.Event != "data" || event.Category != "progress" || event.Key != "total_bytes" {
+			continue
+		}
+		n, err := strconv.ParseInt(event.Value, 10, 64)
+		if err != nil {
+			continue
+		}
+		total += n
+	}
+	return total
 }
 
 // Writes a wrapper script that invokes the ci_runner with the bazel_wrapper subcommand.
@@ -2334,10 +2431,14 @@ func isAlreadyUpToDate(err error) bool {
 }
 
 func git(ctx context.Context, out io.Writer, args ...string) (string, *commandError) {
+	return gitWithEnv(ctx, out, nil /*=env*/, args...)
+}
+
+func gitWithEnv(ctx context.Context, out io.Writer, env map[string]string, args ...string) (string, *commandError) {
 	if err := printCommandLine(out, "git", args...); err != nil {
 		return "", &commandError{err, ""}
 	}
-	return runCommandWithOutput(ctx, "git", args, map[string]string{} /*=env*/, "" /*=dir*/, out)
+	return runCommandWithOutput(ctx, "git", args, env, "" /*=dir*/, out)
 }
 
 func isPushedRefInFork() bool {

--- a/enterprise/server/cmd/ci_runner/main_test.go
+++ b/enterprise/server/cmd/ci_runner/main_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseGitFetchedBytes(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		trace2Log string
+		want      int64
+	}{
+		{
+			name:      "empty log",
+			trace2Log: "",
+			want:      0,
+		},
+		{
+			// A fetch with no new objects starts no progress meters, so the
+			// log contains only process lifecycle and transfer events.
+			name: "fetch with no new objects",
+			trace2Log: `{"event":"version","sid":"sid1","thread":"main","time":"2026-07-14T15:23:39.915Z","file":"common-main.c","line":50,"evt":"3","exe":"2.43.0"}
+{"event":"start","sid":"sid1","thread":"main","time":"2026-07-14T15:23:39.915Z","file":"common-main.c","line":51,"t_abs":0.001,"argv":["git","fetch","--force","origin","master"]}
+{"event":"data","sid":"sid1","thread":"main","time":"2026-07-14T15:23:39.917Z","file":"connect.c","line":175,"t_abs":0.002,"t_rel":0.001,"nesting":2,"category":"transfer","key":"negotiated-version","value":"2"}
+{"event":"exit","sid":"sid1","thread":"main","time":"2026-07-14T15:23:40.100Z","file":"git.c","line":712,"t_abs":0.185,"code":0}
+`,
+			want: 0,
+		},
+		{
+			// Receiving a pack logs a "total_bytes" data event under the
+			// "Receiving objects" progress region when the meter completes.
+			// Sibling data events such as "total_objects" are not byte
+			// counts and are expected to be ignored.
+			name: "received pack",
+			trace2Log: `{"event":"region_enter","sid":"sid1/sid2","thread":"main","time":"2026-07-14T15:23:59.947Z","file":"progress.c","line":270,"repo":1,"nesting":1,"category":"progress","label":"Receiving objects"}
+{"event":"data","sid":"sid1/sid2","thread":"main","time":"2026-07-14T15:24:00.100Z","file":"progress.c","line":341,"repo":1,"t_abs":0.153,"t_rel":0.153,"nesting":2,"category":"progress","key":"total_objects","value":"155"}
+{"event":"data","sid":"sid1/sid2","thread":"main","time":"2026-07-14T15:24:00.100Z","file":"progress.c","line":345,"repo":1,"t_abs":0.153,"t_rel":0.153,"nesting":2,"category":"progress","key":"total_bytes","value":"12985331"}
+{"event":"region_leave","sid":"sid1/sid2","thread":"main","time":"2026-07-14T15:24:00.100Z","file":"progress.c","line":348,"repo":1,"t_rel":0.153,"nesting":1,"category":"progress","label":"Receiving objects"}
+`,
+			want: 12985331,
+		},
+		{
+			// Small fetches unpack objects directly rather than indexing a
+			// pack; the "Unpacking objects" progress meter also logs a
+			// "total_bytes" data event.
+			name: "unpacked objects",
+			trace2Log: `{"event":"data","sid":"sid1/sid2","thread":"main","time":"2026-07-14T15:24:00.100Z","file":"progress.c","line":345,"repo":1,"t_abs":0.010,"t_rel":0.010,"nesting":2,"category":"progress","key":"total_bytes","value":"1034"}
+`,
+			want: 1034,
+		},
+		{
+			// A fetch may receive multiple packs (e.g. submodule fetches
+			// append events from their own processes to the same log).
+			// Expect the byte counts to be summed.
+			name: "multiple packs",
+			trace2Log: `{"event":"data","sid":"sid1/sid2","thread":"main","time":"2026-07-14T15:24:00.100Z","file":"progress.c","line":345,"repo":1,"nesting":2,"category":"progress","key":"total_bytes","value":"1000"}
+{"event":"data","sid":"sid1/sid3","thread":"main","time":"2026-07-14T15:24:01.100Z","file":"progress.c","line":345,"repo":1,"nesting":2,"category":"progress","key":"total_bytes","value":"234"}
+`,
+			want: 1234,
+		},
+		{
+			// Progress meters without throughput (such as "Resolving
+			// deltas") log only object counts. A "total_bytes" key under a
+			// different category should not be counted as fetched bytes.
+			name: "non-progress categories ignored",
+			trace2Log: `{"event":"data","sid":"sid1","thread":"main","time":"2026-07-14T15:24:00.100Z","file":"progress.c","line":341,"repo":1,"nesting":2,"category":"progress","key":"total_objects","value":"155"}
+{"event":"data","sid":"sid1","thread":"main","time":"2026-07-14T15:24:00.100Z","file":"index-pack.c","line":100,"repo":1,"nesting":2,"category":"pack","key":"total_bytes","value":"999"}
+`,
+			want: 0,
+		},
+		{
+			// Concurrent processes appending to the log can in rare cases
+			// interleave partial lines. Expect malformed lines to be skipped
+			// without affecting other events.
+			name: "malformed lines skipped",
+			trace2Log: `{"event":"data","sid":"sid1","thread":"main","cat
+{"event":"data","sid":"sid1/sid2","thread":"main","time":"2026-07-14T15:24:00.100Z","file":"progress.c","line":345,"repo":1,"nesting":2,"category":"progress","key":"total_bytes","value":"4096"}
+not json at all
+{"event":"data","sid":"sid1/sid2","thread":"main","time":"2026-07-14T15:24:00.100Z","file":"progress.c","line":345,"repo":1,"nesting":2,"category":"progress","key":"total_bytes","value":"not-a-number"}
+`,
+			want: 4096,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parseGitFetchedBytes(strings.NewReader(tc.trace2Log)))
+		})
+	}
+}

--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -295,6 +295,13 @@ message BuildEventId {
   // default arguments and runtime files.
   message RunTargetAnalyzedId {}
 
+  // Identifier of an event reporting stats about the git fetches performed
+  // by a remote runner (i.e. Workflows or remote bazel) while setting up the
+  // git repository. Only published when the runner performs the automatic
+  // checkout; not published if auto-checkout is skipped (e.g. remote bazel
+  // runs with --skip_auto_checkout).
+  message GitFetchCompletedId {}
+
   oneof id {
     UnknownBuildEventId unknown = 1;
     ProgressId progress = 2;
@@ -334,6 +341,7 @@ message BuildEventId {
     ChildInvocationsConfiguredId child_invocations_configured = 1002;
     ChildInvocationCompletedId child_invocation_completed = 1003;
     RunTargetAnalyzedId run_target_analyzed = 1004;
+    GitFetchCompletedId git_fetch_completed = 1005;
   }
 }
 
@@ -1660,6 +1668,20 @@ message RunTargetAnalyzed {
   repeated Tree runfileDirectories = 4;
 }
 
+// Event reporting stats about the git fetches performed by a remote runner
+// (i.e. Workflows or remote bazel) while setting up the git repository.
+// Only published when the runner performs the automatic checkout; not
+// published if auto-checkout is skipped (e.g. remote bazel runs with
+// --skip_auto_checkout). Fetches performed by the action itself, such as
+// bazel-triggered fetches of external git repos, are not counted.
+message GitFetchCompleted {
+  // Total number of bytes fetched, parsed from git trace2 event logs.
+  int64 total_bytes = 1;
+
+  // Total time spent running git fetch commands.
+  google.protobuf.Duration duration = 2;
+}
+
 // Message describing a build event. Events will have an identifier that
 // is unique within a given build invocation; they also announce follow-up
 // events as children. More details, which are specific to the kind of event
@@ -1706,5 +1728,6 @@ message BuildEvent {
     ChildInvocationsConfigured child_invocations_configured = 1002;
     ChildInvocationCompleted child_invocation_completed = 1003;
     RunTargetAnalyzed run_target_analyzed = 1004;
+    GitFetchCompleted git_fetch_completed = 1005;
   }
 }

--- a/server/build_event_protocol/accumulator/accumulator.go
+++ b/server/build_event_protocol/accumulator/accumulator.go
@@ -86,6 +86,8 @@ type BEValues struct {
 	outputFilesMap            map[string]*build_event_stream.File
 	kytheSSTableResourceName  *rspb.ResourceName
 	profileName               string
+	gitFetchTotalBytes        int64
+	gitFetchDuration          time.Duration
 
 	failedTestOutputURIs []*url.URL
 	passedTestOutputURIs []*url.URL
@@ -163,6 +165,10 @@ func (v *BEValues) AddEvent(event *build_event_stream.BuildEvent) error {
 		v.populateWorkspaceInfoFromBuildMetadata(p.BuildMetadata)
 	case *build_event_stream.BuildEvent_WorkflowConfigured:
 		v.handleWorkflowConfigured(p.WorkflowConfigured)
+	case *build_event_stream.BuildEvent_GitFetchCompleted:
+		// The remote runner reports cumulative totals, so the last event wins.
+		v.gitFetchTotalBytes = p.GitFetchCompleted.GetTotalBytes()
+		v.gitFetchDuration = p.GitFetchCompleted.GetDuration().AsDuration()
 	case *build_event_stream.BuildEvent_Finished:
 		v.sawFinishedEvent = true
 	case *build_event_stream.BuildEvent_BuildToolLogs:
@@ -232,6 +238,18 @@ func (v *BEValues) OutputFiles() map[string]*build_event_stream.File {
 
 func (v *BEValues) KytheSSTableResourceName() *rspb.ResourceName {
 	return v.kytheSSTableResourceName
+}
+
+// GitFetchTotalBytes returns the total number of bytes fetched by git while
+// a remote runner set up the git repository, or 0 if not reported.
+func (v *BEValues) GitFetchTotalBytes() int64 {
+	return v.gitFetchTotalBytes
+}
+
+// GitFetchDuration returns the total time a remote runner spent running git
+// fetch commands, or 0 if not reported.
+func (v *BEValues) GitFetchDuration() time.Duration {
+	return v.gitFetchDuration
 }
 
 func (v *BEValues) DisableCommitStatusReporting() bool {

--- a/server/build_event_protocol/build_event_handler/BUILD
+++ b/server/build_event_protocol/build_event_handler/BUILD
@@ -81,6 +81,7 @@ go_test(
         "//server/tables",
         "//server/testutil/testauth",
         "//server/testutil/testenv",
+        "//server/testutil/testolapdb",
         "//server/testutil/testusage",
         "//server/usage/sku",
         "//server/util/authutil",
@@ -94,5 +95,6 @@ go_test(
         "@org_golang_google_protobuf//encoding/prototext",
         "@org_golang_google_protobuf//testing/protocmp",
         "@org_golang_google_protobuf//types/known/anypb",
+        "@org_golang_google_protobuf//types/known/durationpb",
     ],
 )

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -249,6 +249,11 @@ type recordStatsTask struct {
 	persist                  *PersistArtifacts
 	kytheSSTableResourceName *rspb.ResourceName
 	invocationStatus         inspb.InvocationStatus
+	// Git fetch stats reported by the remote runner, if any. These are stored
+	// only in the OLAP DB, so they are carried here rather than read back from
+	// the primary DB at flush time.
+	gitFetchTotalBytes   int64
+	gitFetchDurationUsec int64
 }
 
 // statsRecorder listens for finalized invocations and copies cache stats from
@@ -312,6 +317,8 @@ func (r *statsRecorder) Enqueue(ctx context.Context, beValues *accumulator.BEVal
 		invocationStatus:         invocation.GetInvocationStatus(),
 		persist:                  persist,
 		kytheSSTableResourceName: beValues.KytheSSTableResourceName(),
+		gitFetchTotalBytes:       beValues.GitFetchTotalBytes(),
+		gitFetchDurationUsec:     beValues.GitFetchDuration().Microseconds(),
 	}
 	select {
 	case r.tasks <- req:
@@ -342,14 +349,18 @@ func (r *statsRecorder) lookupInvocation(ctx context.Context, ij *invocationInfo
 	return r.env.GetInvocationDB().LookupInvocation(ctx, ij.id)
 }
 
-func (r *statsRecorder) flushInvocationStatsToOLAPDB(ctx context.Context, ij *invocationInfo) error {
+func (r *statsRecorder) flushInvocationStatsToOLAPDB(ctx context.Context, task *recordStatsTask) error {
 	if r.env.GetOLAPDBHandle() == nil || !*writeToOLAPDBEnabled {
 		return nil
 	}
-	inv, err := r.lookupInvocation(ctx, ij)
+	inv, err := r.lookupInvocation(ctx, task.invocationInfo)
 	if err != nil {
-		return status.InternalErrorf("failed to look up invocation for invocation id %q: %s", ij.id, err)
+		return status.InternalErrorf("failed to look up invocation for invocation id %q: %s", task.invocationInfo.id, err)
 	}
+	// Git fetch stats are stored only in the OLAP DB, so they are carried on
+	// the task instead of being read back from the primary DB.
+	inv.GitFetchTotalBytes = task.gitFetchTotalBytes
+	inv.GitFetchDurationUsec = task.gitFetchDurationUsec
 
 	err = r.env.GetOLAPDBHandle().FlushInvocationStats(ctx, inv)
 	if err != nil {
@@ -471,7 +482,7 @@ func (r *statsRecorder) handleTask(ctx context.Context, task *recordStatsTask) {
 
 	if task.invocationStatus == inspb.InvocationStatus_COMPLETE_INVOCATION_STATUS {
 		// only flush complete invocation to clickhouse.
-		err = r.flushInvocationStatsToOLAPDB(ctx, task.invocationInfo)
+		err = r.flushInvocationStatsToOLAPDB(ctx, task)
 		if err != nil {
 			log.CtxErrorf(ctx, "Failed to flush stats to clickhouse: %s", err)
 		}

--- a/server/build_event_protocol/build_event_handler/build_event_handler_test.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testolapdb"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testusage"
 	"github.com/buildbuddy-io/buildbuddy/server/usage/sku"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
@@ -28,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	bspb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 	bepb "github.com/buildbuddy-io/buildbuddy/proto/build_events"
@@ -276,6 +278,20 @@ func finishedEvent() *anypb.Any {
 		Id: &bspb.BuildEventId{Id: &bspb.BuildEventId_BuildFinished{}},
 	})
 	return finishedAny
+}
+
+func gitFetchCompletedEvent(totalBytes int64, duration time.Duration) *anypb.Any {
+	gitFetchAny := &anypb.Any{}
+	gitFetchAny.MarshalFrom(&bspb.BuildEvent{
+		Payload: &bspb.BuildEvent_GitFetchCompleted{
+			GitFetchCompleted: &bspb.GitFetchCompleted{
+				TotalBytes: totalBytes,
+				Duration:   durationpb.New(duration),
+			},
+		},
+		Id: &bspb.BuildEventId{Id: &bspb.BuildEventId_GitFetchCompleted{}},
+	})
+	return gitFetchAny
 }
 
 func assertAPIKeyRedacted(t *testing.T, invocation *inpb.Invocation, apiKey string) {
@@ -935,6 +951,57 @@ func TestFinishedFinalize(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "abc123", invocation.CommitSha)
 	assert.Equal(t, inspb.InvocationStatus_COMPLETE_INVOCATION_STATUS, invocation.InvocationStatus)
+}
+
+func TestGitFetchStatsFlushedToOLAPDB(t *testing.T) {
+	te := testenv.GetTestEnv(t)
+	auth := testauth.NewTestAuthenticator(t, testauth.TestUsers("USER1", "GROUP1"))
+	te.SetAuthenticator(auth)
+	olapDB := testolapdb.NewHandle()
+	te.SetOLAPDBHandle(olapDB)
+	ctx := context.Background()
+	testUUID, err := uuid.NewRandom()
+	require.NoError(t, err)
+	testInvocationID := testUUID.String()
+
+	handler := build_event_handler.NewBuildEventHandler(te)
+	channel, err := handler.OpenChannel(ctx, testInvocationID)
+	require.NoError(t, err)
+	defer channel.Close()
+
+	// Send a started event announcing a workspace status event.
+	request := streamRequest(startedEvent("--remote_header='"+authutil.APIKeyHeader+"=USER1'", &bspb.BuildEventId_WorkspaceStatus{}), testInvocationID, 1)
+	err = channel.HandleEvent(request)
+	require.NoError(t, err)
+
+	// Send the workspace status event to complete the metadata.
+	request = streamRequest(workspaceStatusEvent("COMMIT_SHA", "abc123"), testInvocationID, 2)
+	err = channel.HandleEvent(request)
+	require.NoError(t, err)
+
+	// Send a GitFetchCompleted event reporting git fetch stats, as published
+	// by the remote runner after setting up the git repo.
+	request = streamRequest(gitFetchCompletedEvent(9_000_000, 3*time.Second), testInvocationID, 3)
+	err = channel.HandleEvent(request)
+	require.NoError(t, err)
+
+	// Complete and finalize the invocation, which triggers the flush to the
+	// OLAP DB.
+	request = streamRequest(finishedEvent(), testInvocationID, 4)
+	err = channel.HandleEvent(request)
+	require.NoError(t, err)
+	err = channel.FinalizeInvocation(testInvocationID)
+	require.NoError(t, err)
+
+	// The stats recorder flushes asynchronously; wait for the invocation to
+	// show up in the OLAP DB and expect the git fetch stats to be set on it.
+	var inv *tables.Invocation
+	require.Eventually(t, func() bool {
+		inv = olapDB.GetFlushedInvocation(testInvocationID)
+		return inv != nil
+	}, 30*time.Second, 50*time.Millisecond)
+	assert.Equal(t, int64(9_000_000), inv.GitFetchTotalBytes)
+	assert.Equal(t, (3 * time.Second).Microseconds(), inv.GitFetchDurationUsec)
 }
 
 func TestUnfinishedFinalizeWithCanceledContext(t *testing.T) {

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -183,6 +183,13 @@ type Invocation struct {
 	Tags string
 
 	ParentRunID string `gorm:"index:parent_run_id_index"`
+
+	// Git fetch stats reported by the remote runner (i.e. Workflows or remote
+	// bazel), if any. These are stored only in the OLAP DB; they are excluded
+	// from the primary DB schema and are populated in memory just before
+	// flushing the invocation to the OLAP DB.
+	GitFetchTotalBytes   int64 `gorm:"-"`
+	GitFetchDurationUsec int64 `gorm:"-"`
 }
 
 func (i *Invocation) TableName() string {

--- a/server/testutil/testolapdb/testolapdb.go
+++ b/server/testutil/testolapdb/testolapdb.go
@@ -20,6 +20,7 @@ import (
 type Handle struct {
 	executionIDsByInvID sync.Map // map of invocationID => a slice of execution IDs
 	invIDs              sync.Map // map of invocationID => struct{}
+	invocationsByInvID  sync.Map // map of invocationID => *tables.Invocation
 }
 
 func (h *Handle) DialectName() string {
@@ -54,7 +55,18 @@ func (h *Handle) DateFromUsecTimestamp(fieldNmae string, timezoneOffsetMinutes i
 
 func (h *Handle) FlushInvocationStats(ctx context.Context, ti *tables.Invocation) error {
 	h.invIDs.LoadOrStore(ti.InvocationID, struct{}{})
+	h.invocationsByInvID.Store(ti.InvocationID, ti)
 	return nil
+}
+
+// GetFlushedInvocation returns the invocation flushed with the given
+// invocation ID, or nil if no invocation with that ID was flushed.
+func (h *Handle) GetFlushedInvocation(invID string) *tables.Invocation {
+	v, ok := h.invocationsByInvID.Load(invID)
+	if !ok {
+		return nil
+	}
+	return v.(*tables.Invocation)
 }
 
 func (h *Handle) FlushUsages(ctx context.Context, rows []*schema.RawUsage) error {

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -136,6 +136,11 @@ type Invocation struct {
 	RunID                             string
 	ParentRunID                       string
 	RunStatus                         int64
+
+	// Git fetch stats reported by the remote runner (i.e. Workflows or remote
+	// bazel), if any.
+	GitFetchTotalBytes   int64
+	GitFetchDurationUsec int64
 }
 
 func (i *Invocation) ExcludedFields() []string {
@@ -803,5 +808,7 @@ func ToInvocationFromPrimaryDB(ti *tables.Invocation) *Invocation {
 		RunID:                             ti.RunID,
 		ParentRunID:                       ti.ParentRunID,
 		RunStatus:                         ti.RunStatus,
+		GitFetchTotalBytes:                ti.GitFetchTotalBytes,
+		GitFetchDurationUsec:              ti.GitFetchDurationUsec,
 	}
 }


### PR DESCRIPTION
- Use GIT_TRACE2, writing progress output to `.git/info/fetch_trace2.jsonl`
  - This is a stable, repo-local path which makes the ownership/lifecycle clear.
  - It should only written by one ci_runner instance at a time.
- Parse the trace and report fetch metrics via BES
- Store these BES metrics in ClickHouse only