### PR TITLE
[CLI] Add a parser for CLI-specific flags

### DIFF
--- a/cli/cli_command/cli_command.go
+++ b/cli/cli_command/cli_command.go
@@ -27,6 +27,10 @@ var (
 	//
 	// It is nil until Register in cli_command/register is called.
 	Aliases map[string]*Command
+
+	// BBFlagSetsByCommand contains BB-specific flags.
+	// Unlike CommandsByName, it may contain Bazel commands such as "run" if they have BB-specific flags.
+	BBFlagSetsByCommand = map[string][]*flag.FlagSet{}
 )
 
 // GetCommand returns the Command corresponding to the provided command name or
@@ -39,4 +43,15 @@ func GetCommand(commandName string) *Command {
 		return command
 	}
 	return nil
+}
+
+// RegisterBBFlagSet adds BB-specific flags to a command. The command may be a
+// BB command or a Bazel command.
+func RegisterBBFlagSet(commandName string, flags *flag.FlagSet) {
+	BBFlagSetsByCommand[commandName] = append(BBFlagSetsByCommand[commandName], flags)
+}
+
+// GetBBFlagSets returns the BB-specific flag sets registered for a command.
+func GetBBFlagSets(commandName string) []*flag.FlagSet {
+	return BBFlagSetsByCommand[commandName]
 }

--- a/cli/cli_command/cli_command.go
+++ b/cli/cli_command/cli_command.go
@@ -27,10 +27,6 @@ var (
 	//
 	// It is nil until Register in cli_command/register is called.
 	Aliases map[string]*Command
-
-	// BBFlagSetsByCommand contains BB-specific flags.
-	// Unlike CommandsByName, it may contain Bazel commands such as "run" if they have BB-specific flags.
-	BBFlagSetsByCommand = map[string][]*flag.FlagSet{}
 )
 
 // GetCommand returns the Command corresponding to the provided command name or
@@ -43,15 +39,4 @@ func GetCommand(commandName string) *Command {
 		return command
 	}
 	return nil
-}
-
-// RegisterBBFlagSet adds BB-specific flags to a command. The command may be a
-// BB command or a Bazel command.
-func RegisterBBFlagSet(commandName string, flags *flag.FlagSet) {
-	BBFlagSetsByCommand[commandName] = append(BBFlagSetsByCommand[commandName], flags)
-}
-
-// GetBBFlagSets returns the BB-specific flag sets registered for a command.
-func GetBBFlagSets(commandName string) []*flag.FlagSet {
-	return BBFlagSetsByCommand[commandName]
 }

--- a/cli/parser/options/BUILD
+++ b/cli/parser/options/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//cli/parser/bazelrc",
         "//cli/parser/options/flag_form",
         "//proto:bazel_flags_go_proto",
+        "//server/util/flagutil",
         "//server/util/lib/seq",
         "//server/util/lib/set",
     ],
@@ -25,5 +26,6 @@ go_test(
         ":options",
         "//cli/parser/options/flag_form",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/cli/parser/options/BUILD
+++ b/cli/parser/options/BUILD
@@ -25,6 +25,7 @@ go_test(
     deps = [
         ":options",
         "//cli/parser/options/flag_form",
+        "//server/util/flagutil/types",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/cli/parser/options/options.go
+++ b/cli/parser/options/options.go
@@ -204,34 +204,46 @@ func NewDefinition(name string, opts ...DefinitionOpt) *Definition {
 
 // DefinitionsFromFlagSet converts CLI-specific flags declared in a Go flag set
 // into definitions understood by the argument parser.
-func DefinitionsFromFlagSet(flagSet *flag.FlagSet, supportedCommands ...string) []*Definition {
+func DefinitionsFromFlagSet(flagSet *flag.FlagSet, supportedCommands ...string) ([]*Definition, error) {
 	if flagSet == nil {
-		return nil
+		return nil, nil
 	}
 	var definitions []*Definition
+	var visitErr error
 	flagSet.VisitAll(func(f *flag.Flag) {
+		if visitErr != nil {
+			return
+		}
 		opts := []DefinitionOpt{
 			WithPluginID(NativeBuiltinPluginID),
 			WithSupportFor(supportedCommands...),
 		}
+		// Determine the flag's underlying data type so we know which flag options to apply.
 		valueType, err := flagutil.GetTypeForFlagValue(f.Value)
 		if err != nil {
-			valueType = reflect.TypeOf(f.Value)
+			visitErr = fmt.Errorf("cannot determine type for flag %q: %w", f.Name, err)
+			return
 		}
 		for valueType.Kind() == reflect.Pointer {
 			valueType = valueType.Elem()
 		}
+		// Boolean flags support a negative flag but don't require a value.
 		if valueType.Kind() == reflect.Bool {
 			opts = append(opts, WithNegative())
 		} else {
+			// Non-booleans flags require a value.
 			opts = append(opts, WithRequiresValue())
 		}
+		// Slices and maps support multiple values.
 		if valueType.Kind() == reflect.Slice || valueType.Kind() == reflect.Map {
 			opts = append(opts, WithMulti())
 		}
 		definitions = append(definitions, NewDefinition(f.Name, opts...))
 	})
-	return definitions
+	if visitErr != nil {
+		return nil, visitErr
+	}
+	return definitions, nil
 }
 
 // DefinitionFrom takes a FlagInfo proto message and converts it into a

--- a/cli/parser/options/options.go
+++ b/cli/parser/options/options.go
@@ -1,8 +1,10 @@
 package options
 
 import (
+	"flag"
 	"fmt"
 	"iter"
+	"reflect"
 	"slices"
 	"strings"
 
@@ -10,6 +12,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/arguments"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazelrc"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/options/flag_form"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/lib/seq"
 	"github.com/buildbuddy-io/buildbuddy/server/util/lib/set"
 
@@ -197,6 +200,38 @@ func NewDefinition(name string, opts ...DefinitionOpt) *Definition {
 		opt(d)
 	}
 	return d
+}
+
+// DefinitionsFromFlagSet converts CLI-specific flags declared in a Go flag set
+// into definitions understood by the argument parser.
+func DefinitionsFromFlagSet(flagSet *flag.FlagSet, supportedCommands ...string) []*Definition {
+	if flagSet == nil {
+		return nil
+	}
+	var definitions []*Definition
+	flagSet.VisitAll(func(f *flag.Flag) {
+		opts := []DefinitionOpt{
+			WithPluginID(NativeBuiltinPluginID),
+			WithSupportFor(supportedCommands...),
+		}
+		valueType, err := flagutil.GetTypeForFlagValue(f.Value)
+		if err != nil {
+			valueType = reflect.TypeOf(f.Value)
+		}
+		for valueType.Kind() == reflect.Pointer {
+			valueType = valueType.Elem()
+		}
+		if valueType.Kind() == reflect.Bool {
+			opts = append(opts, WithNegative())
+		} else {
+			opts = append(opts, WithRequiresValue())
+		}
+		if valueType.Kind() == reflect.Slice || valueType.Kind() == reflect.Map {
+			opts = append(opts, WithMulti())
+		}
+		definitions = append(definitions, NewDefinition(f.Name, opts...))
+	})
+	return definitions
 }
 
 // DefinitionFrom takes a FlagInfo proto message and converts it into a

--- a/cli/parser/options/options_test.go
+++ b/cli/parser/options/options_test.go
@@ -1,12 +1,31 @@
 package options_test
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/options"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/options/flag_form"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestDefinitionsFromFlagSet(t *testing.T) {
+	testFlags := flag.NewFlagSet("test_flagset", flag.ContinueOnError)
+	testFlags.Bool("enabled", false, "")
+	testFlags.String("name", "", "")
+
+	definitions := options.DefinitionsFromFlagSet(testFlags, "test_command")
+	byName := make(map[string]*options.Definition, len(definitions))
+	for _, definition := range definitions {
+		byName[definition.Name()] = definition
+	}
+
+	require.True(t, byName["enabled"].HasNegative())
+	require.False(t, byName["enabled"].RequiresValue())
+	require.True(t, byName["name"].RequiresValue())
+	require.False(t, byName["name"].Multi())
+}
 
 func RequiredValueDefinition(name, oldname, shortname string, opts ...options.DefinitionOpt) *options.Definition {
 	return options.NewDefinition(

--- a/cli/parser/options/options_test.go
+++ b/cli/parser/options/options_test.go
@@ -8,14 +8,19 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/options/flag_form"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	flagtypes "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/types"
 )
 
 func TestDefinitionsFromFlagSet(t *testing.T) {
 	testFlags := flag.NewFlagSet("test_flagset", flag.ContinueOnError)
 	testFlags.Bool("enabled", false, "")
 	testFlags.String("name", "", "")
+	flagtypes.StringSlice(testFlags, "tags", nil, "")
+	flagtypes.JSONMap[map[string]string](testFlags, "labels", map[string]string{}, "")
 
-	definitions := options.DefinitionsFromFlagSet(testFlags, "test_command")
+	definitions, err := options.DefinitionsFromFlagSet(testFlags, "test_command")
+	require.NoError(t, err)
 	byName := make(map[string]*options.Definition, len(definitions))
 	for _, definition := range definitions {
 		byName[definition.Name()] = definition
@@ -25,6 +30,10 @@ func TestDefinitionsFromFlagSet(t *testing.T) {
 	require.False(t, byName["enabled"].RequiresValue())
 	require.True(t, byName["name"].RequiresValue())
 	require.False(t, byName["name"].Multi())
+	// Slice- and map-valued flags are repeatable, so they should receive the
+	// Multi() option.
+	require.True(t, byName["tags"].Multi())
+	require.True(t, byName["labels"].Multi())
 }
 
 func RequiredValueDefinition(name, oldname, shortname string, opts ...options.DefinitionOpt) *options.Definition {

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -5,6 +5,7 @@ package parser
 import (
 	"bytes"
 	"encoding/base64"
+	"flag"
 	"fmt"
 	"io"
 	"maps"
@@ -165,8 +166,8 @@ func NewParser(optionDefinitions []*options.Definition, commands []string, alias
 	return p
 }
 
-// GetNativeParser can parse native bb options without needing to start the bazel
-// client or server.
+// GetNativeParser returns a lightweight parser for commands and flags implemented
+// by the bb CLI. It does not load Bazel's full flag definitions.
 func GetNativeParser() *Parser {
 	definitions := slices.Collect(maps.Values(nativeDefinitions))
 	aliases := map[string]string{}
@@ -178,6 +179,39 @@ func GetNativeParser() *Parser {
 		slices.Collect(maps.Keys(cli_command.CommandsByName)),
 		aliases,
 	)
+}
+
+// GetBBParserForCommand returns a parser for the BB-specific flags associated
+// with the given command. Commands can be either CLI-specific commands, or
+// Bazel commands that are extended by the bb CLI.
+func GetBBParserForCommand(commandName string) (*Parser, error) {
+	p := GetNativeParser()
+
+	// Parses flags for bb CLI-specific commands.
+	if command := cli_command.GetCommand(commandName); command != nil {
+		if err := p.AddFlagSet(command.Flags, command.Name); err != nil {
+			return nil, err
+		}
+	}
+
+	// Parses CLI flags that apply to regular bazel commands.
+	// (e.g. `--stream_run_logs` for `bazel run`)
+	for _, flags := range cli_command.GetBBFlagSets(commandName) {
+		if err := p.AddFlagSet(flags, commandName); err != nil {
+			return nil, err
+		}
+	}
+	return p, nil
+}
+
+// AddFlagSet teaches the parser about CLI-specific flags declared in a Go flagset.
+func (p *Parser) AddFlagSet(flagSet *flag.FlagSet, supportedCommands ...string) error {
+	for _, definition := range options.DefinitionsFromFlagSet(flagSet, supportedCommands...) {
+		if err := p.AddOptionDefinition(definition); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // GetHelpParser returns a parser that can parse bazel options, native options,

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -182,22 +182,15 @@ func GetNativeParser() *Parser {
 }
 
 // GetBBParserForCommand returns a parser for the BB-specific flags associated
-// with the given command. Commands can be either CLI-specific commands, or
-// Bazel commands that are extended by the bb CLI.
+// with the given command.
 func GetBBParserForCommand(commandName string) (*Parser, error) {
 	p := GetNativeParser()
 
-	// Parses flags for bb CLI-specific commands.
+	// For CLI-specific commands, add its flags, defined as a flag.FlagSet, to the parser.
+	//
+	// (CLI flags that apply to regular bazel commands are added as `nativeDefinitions`.
 	if command := cli_command.GetCommand(commandName); command != nil {
 		if err := p.AddFlagSet(command.Flags, command.Name); err != nil {
-			return nil, err
-		}
-	}
-
-	// Parses CLI flags that apply to regular bazel commands.
-	// (e.g. `--stream_run_logs` for `bazel run`)
-	for _, flags := range cli_command.GetBBFlagSets(commandName) {
-		if err := p.AddFlagSet(flags, commandName); err != nil {
 			return nil, err
 		}
 	}

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -188,7 +188,7 @@ func GetBBParserForCommand(commandName string) (*Parser, error) {
 
 	// For CLI-specific commands, add its flags, defined as a flag.FlagSet, to the parser.
 	//
-	// (CLI flags that apply to regular bazel commands are added as `nativeDefinitions`.
+	// (CLI flags that apply to regular bazel commands are added as `nativeDefinitions`.)
 	if command := cli_command.GetCommand(commandName); command != nil {
 		if err := p.AddFlagSet(command.Flags, command.Name); err != nil {
 			return nil, err
@@ -199,7 +199,11 @@ func GetBBParserForCommand(commandName string) (*Parser, error) {
 
 // AddFlagSet teaches the parser about CLI-specific flags declared in a Go flagset.
 func (p *Parser) AddFlagSet(flagSet *flag.FlagSet, supportedCommands ...string) error {
-	for _, definition := range options.DefinitionsFromFlagSet(flagSet, supportedCommands...) {
+	definitions, err := options.DefinitionsFromFlagSet(flagSet, supportedCommands...)
+	if err != nil {
+		return err
+	}
+	for _, definition := range definitions {
 		if err := p.AddOptionDefinition(definition); err != nil {
 			return err
 		}

--- a/server/util/flagutil/flagutil.go
+++ b/server/util/flagutil/flagutil.go
@@ -1,9 +1,18 @@
 package flagutil
 
 import (
+	stdflag "flag"
+	"reflect"
+
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil/common"
 )
+
+// GetTypeForFlagValue returns the Go type stored by a flag value, unwrapping
+// BuildBuddy flag wrappers when necessary.
+func GetTypeForFlagValue(value stdflag.Value) (reflect.Type, error) {
+	return common.GetTypeForFlagValue(value)
+}
 
 // SetValueForFlagName sets the value for a flag by name. setFlags is the set of
 // flags that have already been set on the command line; those flags will not be

--- a/server/util/flagutil/flagutil.go
+++ b/server/util/flagutil/flagutil.go
@@ -1,11 +1,16 @@
 package flagutil
 
 import (
+	stdflag "flag"
+	"reflect"
+
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil/common"
 )
 
-var GetTypeForFlagValue = common.GetTypeForFlagValue
+func GetTypeForFlagValue(value stdflag.Value) (reflect.Type, error) {
+	return common.GetTypeForFlagValue(value)
+}
 
 // SetValueForFlagName sets the value for a flag by name. setFlags is the set of
 // flags that have already been set on the command line; those flags will not be

--- a/server/util/flagutil/flagutil.go
+++ b/server/util/flagutil/flagutil.go
@@ -1,18 +1,11 @@
 package flagutil
 
 import (
-	stdflag "flag"
-	"reflect"
-
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil/common"
 )
 
-// GetTypeForFlagValue returns the Go type stored by a flag value, unwrapping
-// BuildBuddy flag wrappers when necessary.
-func GetTypeForFlagValue(value stdflag.Value) (reflect.Type, error) {
-	return common.GetTypeForFlagValue(value)
-}
+var GetTypeForFlagValue = common.GetTypeForFlagValue
 
 // SetValueForFlagName sets the value for a flag by name. setFlags is the set of
 // flags that have already been set on the command line; those flags will not be


### PR DESCRIPTION
We specify CLI flags using Go flags. This PR adds a function that converts Go flags into `option.Definition`s, which is the type expected by the CLI parser. We can then reuse the existing parsing code to parse CLI flags

This is in preparation of supporting a .bbrc parser (so that we can inject CLI-specific flags using a file mirroring .bazelrc). When parsing a --bb_config, we can use the CLI parser to insert CLI flags at the right place