### PR TITLE
Add metrics on AC hits served from proxy fast path

### DIFF
--- a/enterprise/server/action_cache_server_proxy/action_cache_server_proxy.go
+++ b/enterprise/server/action_cache_server_proxy/action_cache_server_proxy.go
@@ -236,9 +236,10 @@ func (s *ActionCacheServerProxy) GetActionResult(ctx context.Context, req *repb.
 	if authutil.EncryptionEnabled(ctx, s.authenticator) && !s.supportsEncryption(ctx) {
 		resp, err := s.remoteACClient.GetActionResult(ctx, req)
 		labels := prometheus.Labels{
-			metrics.StatusLabel:           status.MetricsLabel(err),
-			metrics.CacheHitMissStatus:    metrics.UncacheableStatusLabel,
-			metrics.CacheProxyRequestType: proxy_util.RequestTypeLabelFromContext(ctx),
+			metrics.StatusLabel:            status.MetricsLabel(err),
+			metrics.CacheHitMissStatus:     metrics.UncacheableStatusLabel,
+			metrics.CacheProxyRequestType:  proxy_util.RequestTypeLabelFromContext(ctx),
+			metrics.CacheProxyResultSource: "remote_uncacheable",
 		}
 		metrics.ActionCacheProxiedReadRequests.With(labels).Inc()
 		metrics.ActionCacheProxiedReadBytes.With(labels).Add(float64(proto.Size(resp)))
@@ -258,9 +259,10 @@ func (s *ActionCacheServerProxy) GetActionResult(ctx context.Context, req *repb.
 			cacheStatus = metrics.HitStatusLabel
 		}
 		labels := prometheus.Labels{
-			metrics.StatusLabel:           status.MetricsLabel(err),
-			metrics.CacheHitMissStatus:    cacheStatus,
-			metrics.CacheProxyRequestType: metrics.LocalOnlyCacheProxyRequestLabel,
+			metrics.StatusLabel:            status.MetricsLabel(err),
+			metrics.CacheHitMissStatus:     cacheStatus,
+			metrics.CacheProxyRequestType:  metrics.LocalOnlyCacheProxyRequestLabel,
+			metrics.CacheProxyResultSource: "local_only",
 		}
 		metrics.ActionCacheProxiedReadRequests.With(labels).Inc()
 		metrics.ActionCacheProxiedReadBytes.With(labels).Add(float64(proto.Size(rsp)))
@@ -297,9 +299,10 @@ func (s *ActionCacheServerProxy) GetActionResult(ctx context.Context, req *repb.
 				sizeBytes := int64(proto.Size(localResult))
 				s.recordLocalACHit(ctx, req, localResult, sizeBytes)
 				labels := prometheus.Labels{
-					metrics.StatusLabel:           status.MetricsLabel(nil),
-					metrics.CacheHitMissStatus:    metrics.HitStatusLabel,
-					metrics.CacheProxyRequestType: metrics.DefaultCacheProxyRequestLabel,
+					metrics.StatusLabel:            status.MetricsLabel(nil),
+					metrics.CacheHitMissStatus:     metrics.HitStatusLabel,
+					metrics.CacheProxyRequestType:  metrics.DefaultCacheProxyRequestLabel,
+					metrics.CacheProxyResultSource: "ttl_fast_path",
 				}
 				metrics.ActionCacheProxiedReadRequests.With(labels).Inc()
 				metrics.ActionCacheProxiedReadBytes.With(labels).Add(float64(sizeBytes))
@@ -331,6 +334,7 @@ func (s *ActionCacheServerProxy) GetActionResult(ctx context.Context, req *repb.
 		proto.Equal(req.GetCachedActionResultDigest(), resp.GetActionResultDigest()) {
 		resp = local
 		labels[metrics.CacheHitMissStatus] = metrics.HitStatusLabel
+		labels[metrics.CacheProxyResultSource] = "remote_digest_match"
 		if ttl > 0 {
 			casRN := digest.NewCASResourceName(req.GetCachedActionResultDigest(), req.GetInstanceName(), req.GetDigestFunction()).ToProto()
 			casRNProto, marshalErr := proto.Marshal(casRN)
@@ -357,6 +361,7 @@ func (s *ActionCacheServerProxy) GetActionResult(ctx context.Context, req *repb.
 			s.cacheActionResultToLocalCAS(ctx, localKey, req, resp)
 		}
 		labels[metrics.CacheHitMissStatus] = metrics.MissStatusLabel
+		labels[metrics.CacheProxyResultSource] = "remote_result"
 	}
 
 	metrics.ActionCacheProxiedReadRequests.With(labels).Inc()

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -358,6 +358,9 @@ const (
 	// should fall back to the remote cache as the source of truth.
 	CacheProxyRequestType = "proxy_request_type"
 
+	// Source used by a cache proxy action cache read to produce a response.
+	CacheProxyResultSource = "result_source"
+
 	OCIResourceTypeLabel = "oci_resource_type"
 
 	OpLabel = "op"
@@ -3656,11 +3659,12 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "proxy",
 		Name:      "action_cache_read_requests",
-		Help:      "The number of ActionCache.GetActionResult requests served by a ActionCacheServerProxy by gRPC status and cache hit/miss status.",
+		Help:      "The number of ActionCache.GetActionResult requests served by a ActionCacheServerProxy by gRPC status, cache hit/miss status, request type, and result source.",
 	}, []string{
 		StatusLabel,
 		CacheHitMissStatus,
 		CacheProxyRequestType,
+		CacheProxyResultSource,
 	})
 	ActionCacheProxiedWriteRequests = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
@@ -3676,11 +3680,12 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "proxy",
 		Name:      "action_cache_read_bytes",
-		Help:      "The number of ActionCache.GetActionResult bytes served by a ActionCacheServerProxy by gRPC status and cache hit/miss status.",
+		Help:      "The number of ActionCache.GetActionResult bytes served by a ActionCacheServerProxy by gRPC status, cache hit/miss status, request type, and result source.",
 	}, []string{
 		StatusLabel,
 		CacheHitMissStatus,
 		CacheProxyRequestType,
+		CacheProxyResultSource,
 	})
 	ActionCacheProxiedWriteBytes = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,


### PR DESCRIPTION
Gives us a bit more insights into how well this is performing