### PR TITLE
Upload `java.log` to artifacts when we hit exit code `38`

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -134,9 +134,10 @@ const (
 	// Bazel exit codes
 	// https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/util/ExitCode.java
 
-	bazelOOMErrorExitCode                = 33
-	bazelLocalEnvironmentalErrorExitCode = 36
-	bazelInternalErrorExitCode           = 37
+	bazelOOMErrorExitCode                              = 33
+	bazelLocalEnvironmentalErrorExitCode               = 36
+	bazelInternalErrorExitCode                         = 37
+	bazelTransientBuildEventServiceUploadErrorExitCode = 38
 
 	// ANSI codes for cases where the aurora equivalent is not supported by our UI
 	// (ex: aurora's "grayscale" mode results in some ANSI codes that we don't currently
@@ -1266,6 +1267,14 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 				if err := os.Link(heapDumpPath, filepath.Join(artifactsDir, "heapdump.hprof")); err != nil {
 					ar.reporter.Printf("%sfailed to preserve heapdump.hprof: %s%s\n", ansiGray, err, ansiReset)
 				}
+			}
+		}
+		if exitCode == bazelTransientBuildEventServiceUploadErrorExitCode {
+			javaLogPath := filepath.Join(ar.rootDir, outputBaseDirName, "java.log")
+			// java.log is normally a symlink to a file that the Bazel server keeps
+			// open, so copy it rather than hard-linking it like the crash outputs.
+			if err := disk.CopyViaTmpSibling(javaLogPath, filepath.Join(artifactsDir, "java.log")); err != nil {
+				ar.reporter.Printf("%sfailed to preserve java.log: %s%s\n", ansiGray, err, ansiReset)
 			}
 		}
 

--- a/enterprise/server/test/integration/ci_runner/ci_runner_test.go
+++ b/enterprise/server/test/integration/ci_runner/ci_runner_test.go
@@ -2303,6 +2303,83 @@ actions:
 	require.Contains(t, string(b), "java.lang.OutOfMemoryError")
 }
 
+func TestArtifactUploads_JavaLogOnBESUploadError(t *testing.T) {
+	workspaceSimulateBESUploadError := map[string]string{
+		"BUILD": `
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+sh_binary(name = "write_java_log", srcs = ["write_java_log.sh"])
+`,
+		"write_java_log.sh": `
+output_base="$1"
+echo "BES upload timed out" >> "$output_base/java.log"
+exit 38
+`,
+		"buildbuddy.yaml": `
+actions:
+  - name: "Test"
+    triggers:
+      pull_request: { branches: [ master ] }
+      push: { branches: [ master ] }
+    steps:
+      - run: |
+          output_base=$(bazel info output_base)
+          bazel run :write_java_log "$output_base"
+`,
+	}
+
+	wsPath := testfs.MakeTempDir(t)
+	repoPath, headCommitSHA := makeGitRepo(t, workspaceSimulateBESUploadError)
+
+	runnerFlags := []string{
+		"--workflow_id=test-workflow",
+		"--action_name=Test",
+		"--trigger_event=push",
+		"--pushed_repo_url=file://" + repoPath,
+		"--pushed_branch=master",
+		"--commit_sha=" + headCommitSHA,
+		"--target_repo_url=file://" + repoPath,
+		"--target_branch=master",
+	}
+	app := buildbuddy.Run(t)
+	runnerFlags = append(runnerFlags, app.BESBazelFlags()...)
+	runnerFlags = append(runnerFlags, "--cache_backend="+app.GRPCAddress())
+
+	result := invokeRunner(t, runnerFlags, []string{}, wsPath)
+	require.Equal(t, 38, result.ExitCode, "bazel should have exited with code 38 due to a BES upload failure")
+
+	runnerInvocation := getRunnerInvocation(t, app, result)
+	var javaLog *bespb.File
+	for _, tg := range runnerInvocation.GetTargetGroups() {
+		for _, target := range tg.GetTargets() {
+			for _, file := range target.GetFiles() {
+				if file.GetName() == "java.log" {
+					javaLog = file
+				}
+			}
+		}
+	}
+	require.NotNil(t, javaLog)
+	require.NotEmpty(t, javaLog.GetUri())
+
+	downloadURL := fmt.Sprintf(
+		"%s/file/download?invocation_id=%s&bytestream_url=%s",
+		app.HTTPURL(),
+		url.QueryEscape(runnerInvocation.GetInvocationId()),
+		url.QueryEscape(javaLog.GetUri()))
+	res, err := http.Get(downloadURL)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		b, _ := io.ReadAll(res.Body)
+		require.FailNowf(t, res.Status, "response body: %s", string(b))
+	}
+
+	b, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(b), "BES upload timed out")
+}
+
 func TestTimeout(t *testing.T) {
 	repoPath, _ := makeGitRepo(t, workspaceContentsWithRunScript)
 


### PR DESCRIPTION
This allows us to look for any issues with build event stream half-closes, ACKs, etc.