### PR TITLE
Add missing subcommands to CLI

### DIFF
--- a/cli/parser/bazelrc/bazelrc.go
+++ b/cli/parser/bazelrc/bazelrc.go
@@ -54,17 +54,20 @@ var (
 	// Inheritance hierarchy: https://bazel.build/run/bazelrc#option-defaults
 	// All commands inherit from "common".
 	parentCommand = map[string]string{
-		"test":           "build",
-		"run":            "build",
-		"clean":          "build",
-		"mobile-install": "build",
-		"info":           "build",
-		"print_action":   "build",
-		"config":         "build",
-		"cquery":         "build",
-		"aquery":         "build",
+		"aquery":             "build",
+		"canonicalize-flags": "build",
+		"clean":              "build",
+		"config":             "build",
+		"info":               "build",
+		"license":            "build",
+		"mobile-install":     "build",
+		"print_action":       "build",
+		"run":                "build",
+		"test":               "build",
 
 		"coverage": "test",
+		"cquery":   "test",
+		"fetch":    "test",
 		"vendor":   "test",
 	}
 

--- a/cli/parser/bazelrc/bazelrc.go
+++ b/cli/parser/bazelrc/bazelrc.go
@@ -31,6 +31,7 @@ var (
 		"build":              {},
 		"canonicalize-flags": {},
 		"clean":              {},
+		"config":             {},
 		"coverage":           {},
 		"cquery":             {},
 		"dump":               {},
@@ -46,6 +47,7 @@ var (
 		"shutdown":           {},
 		"sync":               {},
 		"test":               {},
+		"vendor":             {},
 		"version":            {},
 	}
 
@@ -63,6 +65,7 @@ var (
 		"aquery":         "build",
 
 		"coverage": "test",
+		"vendor":   "test",
 	}
 
 	unconditionalCommandPhases = set.Set[string]{


### PR DESCRIPTION
Without these in this list previously we would intersperse command line
flags incorrectly resulting in failures:

```
% bb config
[FATAL 17:25:30.996 src/main/cpp/blaze.cc:1255] Unknown startup option: '--build_metadata=BRANCH_NAME=main'.
  For more info, run 'bazel help startup_options'.
```

This also fixes some parents that either drifted or were always a bit off