### PR TITLE
Render upgrade prompts in the UI

### DIFF
--- a/app/BUILD.bazel
+++ b/app/BUILD.bazel
@@ -78,6 +78,7 @@ genrule(
         "//app/components/checkbox:checkbox.css",
         "//app/components/spinner:spinner.css",
         "//app/components/tooltip:tooltip.css",
+        "//app/components/upgrade:upgrade.css",
         "//app/profile:profile.css",
     ],
     outs = ["style.css"],

--- a/app/components/upgrade/BUILD
+++ b/app/components/upgrade/BUILD
@@ -1,0 +1,16 @@
+load("//rules/typescript:index.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob(["*.css"]))
+
+ts_library(
+    name = "upgrade",
+    srcs = ["upgrade.tsx"],
+    deps = [
+        "//:node_modules/@types/react",
+        "//:node_modules/react",
+        "//app/components/banner",
+        "//proto:upgrade_ts_proto",
+    ],
+)

--- a/app/components/upgrade/upgrade.css
+++ b/app/components/upgrade/upgrade.css
@@ -1,0 +1,3 @@
+.upgrade-prompt-banner {
+  margin: 16px 0;
+}

--- a/app/components/upgrade/upgrade.tsx
+++ b/app/components/upgrade/upgrade.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { upgrade } from "../../../proto/upgrade_ts_proto";
+import Banner from "../banner/banner";
+
+export interface UpgradePromptProps {
+  // The upgrade prompt from the server, if any. Nothing is rendered when
+  // this is unset.
+  prompt?: upgrade.IPrompt | null;
+}
+
+function bannerType(urgency: upgrade.Prompt.Urgency | null | undefined): "info" | "warning" | "error" {
+  switch (urgency) {
+    case upgrade.Prompt.Urgency.CRITICAL:
+      return "error";
+    case upgrade.Prompt.Urgency.HIGH:
+    case upgrade.Prompt.Urgency.MEDIUM:
+      return "warning";
+    default:
+      return "info";
+  }
+}
+
+// mostUrgent picks the prompt to display from several server responses
+// (e.g. one per region), preferring higher urgency.
+export function mostUrgent(prompts: (upgrade.IPrompt | null | undefined)[]): upgrade.IPrompt | null {
+  let best: upgrade.IPrompt | null = null;
+  for (const prompt of prompts) {
+    if (!prompt?.message) continue;
+    if (!best || (prompt.urgency ?? 0) > (best.urgency ?? 0)) {
+      best = prompt;
+    }
+  }
+  return best;
+}
+
+/**
+ * A banner prompting the user to upgrade out-of-date components, styled
+ * according to the urgency the server assigned.
+ */
+export default class UpgradePrompt extends React.Component<UpgradePromptProps> {
+  render() {
+    const prompt = this.props.prompt;
+    if (!prompt?.message) {
+      return null;
+    }
+    return (
+      <Banner type={bannerType(prompt.urgency)} className="upgrade-prompt-banner">
+        {prompt.message}
+      </Banner>
+    );
+  }
+}

--- a/enterprise/app/cache_proxies/BUILD
+++ b/enterprise/app/cache_proxies/BUILD
@@ -16,6 +16,7 @@ ts_library(
         "//app/auth:auth_service",
         "//app/components/breadcrumbs",
         "//app/components/button:link_button",
+        "//app/components/upgrade",
         "//app/router",
         "//app/service:rpc_service",
         "//app/util:errors",

--- a/enterprise/app/cache_proxies/cache_proxies.tsx
+++ b/enterprise/app/cache_proxies/cache_proxies.tsx
@@ -4,6 +4,7 @@ import { Subscription } from "rxjs";
 import { User } from "../../../app/auth/auth_service";
 import Breadcrumbs from "../../../app/components/breadcrumbs/breadcrumbs";
 import LinkButton from "../../../app/components/button/link_button";
+import UpgradePrompt, { mostUrgent } from "../../../app/components/upgrade/upgrade";
 import router from "../../../app/router/router";
 import rpcService from "../../../app/service/rpc_service";
 import { BuildBuddyError } from "../../../app/util/errors";
@@ -336,6 +337,7 @@ export default class CacheProxiesComponent extends React.Component<Props, State>
                 </div>
                 {activeTab === "status" && (
                   <>
+                    <UpgradePrompt prompt={mostUrgent(this.state.regions.map((r) => r.response.upgradePrompt))} />
                     {!hasProxies && (
                       <div className="empty-state">
                         <h1>No cache proxies are registered.</h1>

--- a/enterprise/app/executors/BUILD
+++ b/enterprise/app/executors/BUILD
@@ -19,6 +19,7 @@ ts_library(
         "//app/components/button:link_button",
         "//app/components/link",
         "//app/components/select",
+        "//app/components/upgrade",
         "//app/router",
         "//app/service:rpc_service",
         "//app/util:errors",

--- a/enterprise/app/executors/executors.css
+++ b/enterprise/app/executors/executors.css
@@ -93,7 +93,7 @@
   margin-top: 16px;
 }
 
-.executors-page .banner {
+.executors-page .self-hosted-executors-banner {
   margin-top: 32px;
   margin-bottom: 32px;
   max-width: 600px;
@@ -113,13 +113,6 @@
 }
 
 .executors-page .pool-size-warning {
-  margin: 0;
   margin-top: 16px;
-  max-width: initial;
   display: inline-flex;
-}
-
-.executors-page .upgrade-prompt-banner {
-  margin: 16px 0;
-  max-width: initial;
 }

--- a/enterprise/app/executors/executors.css
+++ b/enterprise/app/executors/executors.css
@@ -118,3 +118,8 @@
   max-width: initial;
   display: inline-flex;
 }
+
+.executors-page .upgrade-prompt-banner {
+  margin: 16px 0;
+  max-width: initial;
+}

--- a/enterprise/app/executors/executors.tsx
+++ b/enterprise/app/executors/executors.tsx
@@ -402,7 +402,7 @@ export default class ExecutorsComponent extends React.Component<Props, State> {
         {activeTab === "status" && (
           <>
             {allNodes.some((node) => !node.isDefault) && (
-              <Banner type="warning">
+              <Banner type="warning" className="self-hosted-executors-banner">
                 <div>
                   Self-hosted executors are not the default for this organization. To change this, enable "Default to
                   self-hosted executors" in your organization settings.

--- a/enterprise/app/executors/executors.tsx
+++ b/enterprise/app/executors/executors.tsx
@@ -7,6 +7,7 @@ import Breadcrumbs from "../../../app/components/breadcrumbs/breadcrumbs";
 import LinkButton from "../../../app/components/button/link_button";
 import Link, { TextLink } from "../../../app/components/link/link";
 import Select, { Option } from "../../../app/components/select/select";
+import UpgradePrompt, { mostUrgent } from "../../../app/components/upgrade/upgrade";
 import router from "../../../app/router/router";
 import rpcService from "../../../app/service/rpc_service";
 import { BuildBuddyError } from "../../../app/util/errors";
@@ -163,6 +164,7 @@ class ExecutorsList extends React.Component<ExecutorsListProps> {
 
     return (
       <>
+        <UpgradePrompt prompt={mostUrgent(this.props.regions.map((r) => r.response.upgradePrompt))} />
         <div className="executor-cards">
           {keys
             .map((key) => executorsByPool.get(key))


### PR DESCRIPTION
Here's what they look like. Executors are the same, but at the top of the page.

<img width="1205" height="588" alt="Screenshot 2026-07-15 at 1 10 14 PM" src="https://github.com/user-attachments/assets/d9fc5226-70fd-4974-a32d-ffc3435d1f12" />

<img width="1206" height="588" alt="Screenshot 2026-07-15 at 1 10 44 PM" src="https://github.com/user-attachments/assets/7cc263ff-3860-4312-bd87-b5e26bbf6d4d" />

<img width="1209" height="601" alt="Screenshot 2026-07-15 at 1 27 44 PM" src="https://github.com/user-attachments/assets/d9256849-e305-419a-93be-825007138670" />

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7759