### PR TITLE
Pin pnpm version via packageManager field

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -544,7 +544,7 @@
           "REPO_MAPPING:,com_github_buildbuddy_io_buildbuddy ",
           "REPO_MAPPING:aspect_rules_ts+,aspect_rules_ts aspect_rules_ts+",
           "REPO_MAPPING:aspect_rules_ts+,bazel_tools bazel_tools",
-          "FILE:@@//package.json 2f8f40a2feff3c366b5693b25ce07b31296bf97eab405e2ec942b388204f5a96"
+          "FILE:@@//package.json 934ef254d8dd8c05a10ca23ce38efb91e5d98710a7b1ed7612d4fab2959d93b7"
         ],
         "generatedRepoSpecs": {
           "npm_typescript": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "uuid": "^14.0.0",
     "varint": "^6.0.0"
   },
+  "packageManager": "pnpm@11.8.0",
   "devEngines": {
     "packageManager": {
       "name": "pnpm",

--- a/website/package.json
+++ b/website/package.json
@@ -40,6 +40,7 @@
       "last 1 safari version"
     ]
   },
+  "packageManager": "pnpm@11.8.0",
   "devEngines": {
     "packageManager": {
       "name": "pnpm",


### PR DESCRIPTION
Without a top-level `packageManager` field, corepack ignores `devEngines.packageManager` and runs whatever pnpm version is cached on the machine (usually the latest). pnpm then fails the devEngines check, since it can't switch versions when running under corepack:

    [ERROR] This project is configured to use 11.8.0 of pnpm. Your current pnpm is v11.13.0

- Pin `packageManager: pnpm@11.8.0` (matching `devEngines`) in the root and website `package.json` so corepack always runs the pinned version.
- Tested: `bb build //website:website`