### PR TITLE
Let users label commit checks

### DIFF
--- a/docs/guide-metadata.md
+++ b/docs/guide-metadata.md
@@ -104,6 +104,22 @@ build:ci --build_metadata=ROLE=CI
 
 This role will automatically be populated if the environment variable `CI` is set, which it is in most CI systems like Github Actions, CircleCI, Travis, Gitlab CI, BuildKite, Bitrise, and others.
 
+## Commit statuses
+
+By default, BuildBuddy names the commit status for a CI invocation after the Bazel command and target pattern, such as `bazel test //...`. Set `COMMIT_STATUS_LABEL` to use a name that reflects the logical CI step instead:
+
+```bash
+bazel test //... --build_metadata=COMMIT_STATUS_LABEL="Unit tests"
+```
+
+This is useful when a CI workflow runs multiple Bazel invocations. The label only changes the name of the commit status; its details link still points to the BuildBuddy invocation.
+
+To prevent BuildBuddy from publishing a commit status for a particular invocation, set `DISABLE_COMMIT_STATUS_REPORTING`:
+
+```bash
+bazel test //... --build_metadata=DISABLE_COMMIT_STATUS_REPORTING=true
+```
+
 ## Test groups
 
 If using Github commit status reporting, you can use the test groups metadata field to specify how tests are grouped in your Github commit statuses. Test groups are specified as a comma separated list of test path prefixes that should be grouped together.

--- a/docs/rbe-github-actions.md
+++ b/docs/rbe-github-actions.md
@@ -78,6 +78,15 @@ Add your BuildBuddy API Key as GitHub Secret named `BUILDBUDDY_ORG_API_KEY`. For
 
 If you'd like BuildBuddy to publish commit statuses to your repo, you can do so by [logging in](https://app.buildbuddy.io) and clicking `Link Github Account` in the user menu in the top right.
 
+By default, each status is named after its Bazel command and target pattern. You can assign a name that matches the logical GitHub Actions step with build metadata:
+
+```yaml
+- name: Run unit tests
+  run: bazel test //... --config=ci --build_metadata=COMMIT_STATUS_LABEL="Unit tests"
+```
+
+To keep a Bazel invocation from publishing a BuildBuddy status, set `--build_metadata=DISABLE_COMMIT_STATUS_REPORTING=true`. This only disables the status reported by BuildBuddy, not the GitHub Actions job status.
+
 ### Visibility
 
 By default, authenticated builds are only visible to members of your BuildBuddy organization. If you'd like your BuildBuddy results pages to be visible to members outside of your organization, you can add the following line to your `.bazelrc`:

--- a/server/build_event_protocol/accumulator/accumulator.go
+++ b/server/build_event_protocol/accumulator/accumulator.go
@@ -22,6 +22,7 @@ import (
 const (
 	workflowIDFieldName                   = "workflowID"
 	actionNameFieldName                   = "actionName"
+	commitStatusLabelFieldName            = "commitStatusLabel"
 	disableCommitStatusReportingFieldName = "disableCommitStatusReporting"
 	disableTargetTrackingFieldName        = "disableTargetTracking"
 
@@ -39,6 +40,7 @@ var (
 	buildMetadataFieldMapping = map[string]string{
 		"DISABLE_COMMIT_STATUS_REPORTING": disableCommitStatusReportingFieldName,
 		"DISABLE_TARGET_TRACKING":         disableTargetTrackingFieldName,
+		"COMMIT_STATUS_LABEL":             commitStatusLabelFieldName,
 	}
 	bytestreamURIPattern = regexp.MustCompile(`^bytestream://.*/blobs/([a-z0-9]{64})/\d+$`)
 )
@@ -62,6 +64,7 @@ type Accumulator interface {
 	DisableTargetTracking() bool
 	WorkflowID() string
 	ActionName() string
+	CommitStatusLabel() string
 	Pattern() string
 
 	BuildFinished() bool
@@ -270,6 +273,10 @@ func (v *BEValues) WorkflowID() string {
 
 func (v *BEValues) ActionName() string {
 	return v.getStringValue(actionNameFieldName)
+}
+
+func (v *BEValues) CommitStatusLabel() string {
+	return v.getStringValue(commitStatusLabelFieldName)
 }
 
 func (v *BEValues) BuildFinished() bool {

--- a/server/build_event_protocol/build_event_handler/build_event_handler_test.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler_test.go
@@ -1699,9 +1699,11 @@ func TestBuildStatusReporting(t *testing.T) {
 	for _, test := range []struct {
 		name           string
 		metadataEvents []*bspb.BuildEvent
+		statusContext  string
 	}{
 		{
-			name: "BuildMetadataThenWorkspaceStatus",
+			name:          "BuildMetadataThenWorkspaceStatus",
+			statusContext: "bazel build //...",
 			metadataEvents: []*bspb.BuildEvent{
 				&bspb.BuildEvent{
 					Id: &bspb.BuildEventId{Id: &bspb.BuildEventId_Pattern{Pattern: &bspb.BuildEventId_PatternExpandedId{
@@ -1727,7 +1729,8 @@ func TestBuildStatusReporting(t *testing.T) {
 			},
 		},
 		{
-			name: "WorkspaceStatusThenBuildMetadata",
+			name:          "WorkspaceStatusThenBuildMetadataWithCommitStatusLabel",
+			statusContext: "Build and test",
 			metadataEvents: []*bspb.BuildEvent{
 				&bspb.BuildEvent{
 					Id: &bspb.BuildEventId{Id: &bspb.BuildEventId_Pattern{Pattern: &bspb.BuildEventId_PatternExpandedId{
@@ -1747,7 +1750,10 @@ func TestBuildStatusReporting(t *testing.T) {
 					Id: &bspb.BuildEventId{Id: &bspb.BuildEventId_BuildMetadata{}},
 					Payload: &bspb.BuildEvent_BuildMetadata{BuildMetadata: &bspb.BuildMetadata{
 						// Status reporting is only enabled for CI builds.
-						Metadata: map[string]string{"ROLE": "CI"},
+						Metadata: map[string]string{
+							"ROLE":                "CI",
+							"COMMIT_STATUS_LABEL": "Build and test",
+						},
 					}},
 				},
 			},
@@ -1828,7 +1834,7 @@ func TestBuildStatusReporting(t *testing.T) {
 						TargetURL:   pointer("http://localhost:8080/invocation/" + seq.InvocationID),
 						State:       pointer("pending"),
 						Description: pointer("Running..."),
-						Context:     pointer("bazel build //..."),
+						Context:     pointer(test.statusContext),
 					},
 				},
 			}, client.ConsumeStatuses())
@@ -1853,7 +1859,7 @@ func TestBuildStatusReporting(t *testing.T) {
 						TargetURL:   pointer("http://localhost:8080/invocation/" + seq.InvocationID),
 						State:       pointer("success"),
 						Description: pointer("Success"),
-						Context:     pointer("bazel build //..."),
+						Context:     pointer(test.statusContext),
 					},
 				},
 			}, client.ConsumeStatuses())

--- a/server/build_event_protocol/build_status_reporter/build_status_reporter.go
+++ b/server/build_event_protocol/build_status_reporter/build_status_reporter.go
@@ -285,6 +285,9 @@ func (r *BuildStatusReporter) invocationLabel() string {
 	if r.buildEventAccumulator.ActionName() != "" {
 		return r.buildEventAccumulator.ActionName()
 	}
+	if r.buildEventAccumulator.CommitStatusLabel() != "" {
+		return r.buildEventAccumulator.CommitStatusLabel()
+	}
 
 	command := r.buildEventAccumulator.Invocation().GetCommand()
 	pattern := r.buildEventAccumulator.Pattern()

--- a/server/build_event_protocol/target_tracker/target_tracker_test.go
+++ b/server/build_event_protocol/target_tracker/target_tracker_test.go
@@ -126,6 +126,10 @@ func (a *fakeAccumulator) ActionName() string {
 	return ""
 }
 
+func (a *fakeAccumulator) CommitStatusLabel() string {
+	return ""
+}
+
 func (a *fakeAccumulator) MetadataIsLoaded() bool {
 	return true
 }


### PR DESCRIPTION
Users may want to see specifically named things. For example `bazel run ci/tooling/gazelle` might be too much for users, it could be more helpful to see "Check BUILD file tidyness" or something like that.

This PR adds a build_metadata which enables setting the label, this defaults to the bazel command run.