### PR TITLE
Pool distributed_cache.WriteRequest protos on the server

### DIFF
--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -388,10 +388,9 @@ func (c *Proxy) Write(stream dcpb.DistributedCache_WriteServer) error {
 				return err
 			}
 			if req.GetHandoffPeer() != "" && c.hintedHandoffCallback != nil {
-				// Because the hinted handoff callback might hold on to the
-				// handoff peer in a queue, and we're pooling WriteRequest
-				// protos, clone the string.
-				c.hintedHandoffCallback(ctx, strings.Clone(req.GetHandoffPeer()), rn)
+				// Because the hinted handoff callback might hold on to `rn` in
+				// a queue, and we're pooling WriteRequest protos, clone it.
+				c.hintedHandoffCallback(ctx, req.GetHandoffPeer(), rn.CloneVT())
 			}
 			c.log.Debugf("Write(%q) succeeded (user prefix: %s)", ResourceIsolationString(rn), up)
 			return stream.SendAndClose(&dcpb.WriteResponse{

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -337,12 +337,6 @@ func (c *Proxy) Read(req *dcpb.ReadRequest, stream dcpb.DistributedCache_ReadSer
 	return nil
 }
 
-func (c *Proxy) callHintedHandoffCB(ctx context.Context, peer string, r *rspb.ResourceName) {
-	if c.hintedHandoffCallback != nil {
-		c.hintedHandoffCallback(ctx, peer, r)
-	}
-}
-
 func (c *Proxy) Write(stream dcpb.DistributedCache_WriteServer) error {
 	ctx, err := c.readWriteContext(stream.Context())
 	if err != nil {
@@ -358,7 +352,7 @@ func (c *Proxy) Write(stream dcpb.DistributedCache_WriteServer) error {
 			req = dcpb.WriteRequestFromVTPool()
 			defer req.ReturnToVTPool()
 		} else {
-			// VT unmarshall doesn't reset, so we need to reset manually.
+			// VT unmarshal doesn't reset, so we need to reset manually.
 			req.ResetVT()
 		}
 		err := stream.RecvMsg(req)
@@ -393,8 +387,11 @@ func (c *Proxy) Write(stream dcpb.DistributedCache_WriteServer) error {
 			if err := writeCloser.Commit(); err != nil {
 				return err
 			}
-			if req.GetHandoffPeer() != "" {
-				c.callHintedHandoffCB(ctx, req.GetHandoffPeer(), rn)
+			if req.GetHandoffPeer() != "" && c.hintedHandoffCallback != nil {
+				// Because the hinted handoff callback might hold on to the
+				// handoff peer in a queue, and we're pooling WriteRequest
+				// protos, clone the string.
+				c.hintedHandoffCallback(ctx, strings.Clone(req.GetHandoffPeer()), rn)
 			}
 			c.log.Debugf("Write(%q) succeeded (user prefix: %s)", ResourceIsolationString(rn), up)
 			return stream.SendAndClose(&dcpb.WriteResponse{

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -352,8 +352,16 @@ func (c *Proxy) Write(stream dcpb.DistributedCache_WriteServer) error {
 
 	var bytesWritten int64
 	var writeCloser interfaces.CommittedWriteCloser
+	var req *dcpb.WriteRequest
 	for {
-		req, err := stream.Recv()
+		if req == nil {
+			req = dcpb.WriteRequestFromVTPool()
+			defer req.ReturnToVTPool()
+		} else {
+			// VT unmarshall doesn't reset, so we need to reset manually.
+			req.ResetVT()
+		}
+		err := stream.RecvMsg(req)
 		if err == io.EOF {
 			break
 		}
@@ -376,12 +384,12 @@ func (c *Proxy) Write(stream dcpb.DistributedCache_WriteServer) error {
 			defer wc.Close()
 			writeCloser = wc
 		}
-		n, err := writeCloser.Write(req.Data)
+		n, err := writeCloser.Write(req.GetData())
 		if err != nil {
 			return err
 		}
 		bytesWritten += int64(n)
-		if req.FinishWrite {
+		if req.GetFinishWrite() {
 			if err := writeCloser.Commit(); err != nil {
 				return err
 			}

--- a/enterprise/server/util/distributed_client/distributed_client_test.go
+++ b/enterprise/server/util/distributed_client/distributed_client_test.go
@@ -1085,29 +1085,25 @@ func BenchmarkWrite(b *testing.B) {
 	flags.Set(b, "app.log_level", "error")
 	log.Configure()
 
-	digestSizes := []int64{
-		128, 16384, 16_777_216,
-	}
+	digestSizes := []int64{128, 16384, 16_777_216}
+
+	ctx := context.Background()
+	te := getTestEnv(b, emptyUserMap)
+
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(b, err)
+
+	peer := fmt.Sprintf("localhost:%d", testport.FindFree(b))
+	c := distributed_client.New(te, te.GetCache(), peer)
+	err = c.StartListening()
+	require.NoError(b, err)
+	waitUntilServerIsAlive(peer)
 
 	for _, digestSize := range digestSizes {
 		for chunkSize := digestSize / 4; chunkSize <= digestSize; chunkSize += digestSize / 4 {
 			b.Run(fmt.Sprintf("digest%s_chunk%s", units.BytesSize(float64(digestSize)), units.BytesSize(float64(chunkSize))), func(b *testing.B) {
 				b.ReportAllocs()
-				ctx := context.Background()
-				te := getTestEnv(b, emptyUserMap)
-
-				ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
-				require.NoError(b, err)
-
-				peer := fmt.Sprintf("localhost:%d", testport.FindFree(b))
-				c := distributed_client.New(te, te.GetCache(), peer)
-				err = c.StartListening()
-				require.NoError(b, err)
-
-				waitUntilServerIsAlive(peer)
-
-				b.ResetTimer()
-				for n := 0; n < b.N; n++ {
+				for b.Loop() {
 					b.StopTimer()
 					rn, buf := testdigest.RandomCASResourceBuf(b, digestSize)
 					b.StartTimer()
@@ -1115,6 +1111,12 @@ func BenchmarkWrite(b *testing.B) {
 					require.NoError(b, err)
 					copyChunked(b, wc, buf, chunkSize)
 					require.NoError(b, err)
+					b.StopTimer()
+					// Delete the resource so that background eviction doesn't
+					// affect performance. This also ensures that we don't get
+					// any accidental collisions with existing resources.
+					require.NoError(b, c.RemoteDelete(ctx, peer, rn))
+					b.StartTimer()
 				}
 			})
 		}

--- a/proto/distributed_cache.proto
+++ b/proto/distributed_cache.proto
@@ -25,6 +25,7 @@ message ReadResponse {
 
 // Next Tag: 9
 message WriteRequest {
+  option (vtproto.mempool) = true;
   reserved 1, 2, 6;
   bool finish_write = 3;
 


### PR DESCRIPTION
This saves a bunch of memory when unmarshalling WriteRequest protos.

---
The distributed_client_test benchmarks show a large reduction in allocated bytes and a slight regression in wall time, but the regression is only present for unrealistically large chunk sizes. Results from `bazel build -c opt //enterprise/server/util/distributed_client:distributed_client_test && bazel-bin/enterprise/server/util/distributed_client/distributed_client_test_/distributed_client_test -test.skip=^Test -test.bench="BenchmarkWrite" -test.benchmem -test.count=7`
```
                                │  /tmp/base   │             /tmp/pool              │
                                │    sec/op    │   sec/op     vs base               │
Write/digest128B_chunk32B-24      95.24µ ±  2%   98.06µ ± 1%   +2.96% (p=0.001 n=7)
Write/digest128B_chunk64B-24      95.33µ ±  4%   95.34µ ± 2%        ~ (p=0.805 n=7)
Write/digest128B_chunk96B-24      94.61µ ±  2%   95.20µ ± 4%        ~ (p=1.000 n=7)
Write/digest128B_chunk128B-24     93.86µ ±  3%   94.59µ ± 2%        ~ (p=0.535 n=7)
Write/digest16KiB_chunk4KiB-24    104.3µ ±  5%   102.4µ ± 2%        ~ (p=0.128 n=7)
Write/digest16KiB_chunk8KiB-24    105.4µ ±  4%   101.0µ ± 4%   -4.15% (p=0.007 n=7)
Write/digest16KiB_chunk12KiB-24   102.1µ ±  7%   105.0µ ± 4%        ~ (p=0.535 n=7)
Write/digest16KiB_chunk16KiB-24   104.7µ ±  4%   104.2µ ± 4%        ~ (p=0.165 n=7)
Write/digest16MiB_chunk4MiB-24    8.416m ±  7%   9.354m ± 9%  +11.14% (p=0.001 n=7)
Write/digest16MiB_chunk8MiB-24    8.308m ± 10%   8.949m ± 2%   +7.72% (p=0.026 n=7)
Write/digest16MiB_chunk12MiB-24   8.717m ±  8%   8.903m ± 2%        ~ (p=0.073 n=7)
Write/digest16MiB_chunk16MiB-24   7.837m ±  5%   8.994m ± 3%  +14.76% (p=0.001 n=7)
geomean                           434.5µ         447.1µ        +2.91%

                                │  /tmp/base   │              /tmp/pool              │
                                │     B/op     │     B/op      vs base               │
Write/digest128B_chunk32B-24      26.74Ki ± 0%   26.46Ki ± 0%   -1.04% (p=0.001 n=7)
Write/digest128B_chunk64B-24      26.69Ki ± 0%   26.41Ki ± 0%   -1.06% (p=0.001 n=7)
Write/digest128B_chunk96B-24      26.69Ki ± 0%   26.39Ki ± 0%   -1.09% (p=0.001 n=7)
Write/digest128B_chunk128B-24     26.67Ki ± 0%   26.46Ki ± 0%   -0.77% (p=0.001 n=7)
Write/digest16KiB_chunk4KiB-24    61.14Ki ± 0%   45.04Ki ± 0%  -26.34% (p=0.001 n=7)
Write/digest16KiB_chunk8KiB-24    61.09Ki ± 0%   44.98Ki ± 0%  -26.37% (p=0.001 n=7)
Write/digest16KiB_chunk12KiB-24   61.02Ki ± 0%   45.15Ki ± 0%  -26.00% (p=0.001 n=7)
Write/digest16KiB_chunk16KiB-24   61.15Ki ± 0%   45.07Ki ± 1%  -26.30% (p=0.001 n=7)
Write/digest16MiB_chunk4MiB-24    54.27Mi ± 1%   37.93Mi ± 1%  -30.12% (p=0.001 n=7)
Write/digest16MiB_chunk8MiB-24    54.45Mi ± 1%   37.84Mi ± 1%  -30.51% (p=0.001 n=7)
Write/digest16MiB_chunk12MiB-24   54.59Mi ± 1%   37.87Mi ± 1%  -30.63% (p=0.001 n=7)
Write/digest16MiB_chunk16MiB-24   54.15Mi ± 1%   37.73Mi ± 1%  -30.32% (p=0.001 n=7)
geomean                           449.5Ki        358.7Ki       -20.20%

                                │  /tmp/base   │              /tmp/pool              │
                                │  allocs/op   │  allocs/op    vs base               │
Write/digest128B_chunk32B-24       415.0 ±  0%    413.0 ±  0%   -0.48% (p=0.001 n=7)
Write/digest128B_chunk64B-24       415.0 ±  0%    413.0 ±  0%   -0.48% (p=0.001 n=7)
Write/digest128B_chunk96B-24       415.0 ±  0%    413.0 ±  0%   -0.48% (p=0.001 n=7)
Write/digest128B_chunk128B-24      415.0 ±  0%    413.0 ±  0%   -0.48% (p=0.001 n=7)
Write/digest16KiB_chunk4KiB-24     409.0 ±  0%    407.0 ±  0%   -0.49% (p=0.001 n=7)
Write/digest16KiB_chunk8KiB-24     409.0 ±  0%    407.0 ±  0%   -0.49% (p=0.001 n=7)
Write/digest16KiB_chunk12KiB-24    409.0 ±  0%    407.0 ±  0%   -0.49% (p=0.001 n=7)
Write/digest16KiB_chunk16KiB-24    409.0 ±  0%    407.0 ±  0%   -0.49% (p=0.001 n=7)
Write/digest16MiB_chunk4MiB-24    1.943k ± 11%   1.748k ± 12%  -10.04% (p=0.017 n=7)
Write/digest16MiB_chunk8MiB-24    1.946k ±  1%   1.669k ±  4%  -14.23% (p=0.001 n=7)
Write/digest16MiB_chunk12MiB-24   1.953k ±  2%   1.657k ±  1%  -15.16% (p=0.001 n=7)
Write/digest16MiB_chunk16MiB-24   1.773k ±  1%   1.661k ±  1%   -6.32% (p=0.001 n=7)
geomean                            686.0          656.5         -4.30%
```

---
The cache benchmarks show an even bigger reduction in allocated bytes and a slight reduction in wall time. Results from `bazel build -c opt //enterprise/server/test/performance/cache:cache_test && bazel-bin/enterprise/server/test/performance/cache/cache_test_/cache_test -test.skip=^Test -test.bench="BenchmarkSet/DistPebble" -test.benchmem -test.count=7`
```
                             │ /tmp/cachebase │          /tmp/cachepool           │
                             │     sec/op     │   sec/op     vs base              │
Set/DistPebble10/AC-24            113.3µ ± 4%   116.9µ ± 2%  +3.24% (p=0.026 n=7)
Set/DistPebble10/CAS-24           98.92µ ± 1%   99.56µ ± 3%       ~ (p=0.073 n=7)
Set/DistPebble100/AC-24           128.1µ ± 3%   126.1µ ± 4%       ~ (p=0.053 n=7)
Set/DistPebble100/CAS-24          96.53µ ± 2%   95.83µ ± 1%  -0.72% (p=0.011 n=7)
Set/DistPebble1000/AC-24          144.6µ ± 2%   143.0µ ± 1%       ~ (p=0.383 n=7)
Set/DistPebble1000/CAS-24         96.41µ ± 1%   96.95µ ± 0%  +0.56% (p=0.004 n=7)
Set/DistPebble10000/AC-24         258.1µ ± 2%   259.4µ ± 2%       ~ (p=0.710 n=7)
Set/DistPebble10000/CAS-24       100.80µ ± 1%   99.59µ ± 2%  -1.20% (p=0.026 n=7)
Set/DistPebble1000000/AC-24       3.794m ± 8%   3.767m ± 1%       ~ (p=0.097 n=7)
Set/DistPebble1000000/CAS-24      564.2µ ± 1%   515.1µ ± 7%  -8.70% (p=0.001 n=7)
geomean                           201.0µ        199.1µ       -0.96%

                             │ /tmp/cachebase │             /tmp/cachepool             │
                             │      B/s       │      B/s        vs base                │
Set/DistPebble10/AC-24           87.89Ki ± 0%    87.89Ki ± 11%       ~ (p=1.000 n=7)
Set/DistPebble10/CAS-24          97.66Ki ± 0%    97.66Ki ±  0%       ~ (p=1.000 n=7) ¹
Set/DistPebble100/AC-24          761.7Ki ± 3%    771.5Ki ±  4%  +1.28% (p=0.027 n=7)
Set/DistPebble100/CAS-24        1015.6Ki ± 3%   1015.6Ki ±  1%       ~ (p=0.486 n=7)
Set/DistPebble1000/AC-24         6.590Mi ± 2%    6.666Mi ±  1%       ~ (p=0.335 n=7)
Set/DistPebble1000/CAS-24        9.890Mi ± 1%    9.832Mi ±  0%  -0.58% (p=0.003 n=7)
Set/DistPebble10000/AC-24        36.95Mi ± 2%    36.76Mi ±  2%       ~ (p=0.710 n=7)
Set/DistPebble10000/CAS-24       94.61Mi ± 1%    95.76Mi ±  2%  +1.21% (p=0.026 n=7)
Set/DistPebble1000000/AC-24      251.4Mi ± 7%    253.2Mi ±  1%       ~ (p=0.097 n=7)
Set/DistPebble1000000/CAS-24     1.651Gi ± 1%    1.808Gi ±  6%  +9.53% (p=0.001 n=7)
geomean                          7.528Mi         7.622Mi        +1.24%
¹ all samples are equal

                             │  /tmp/cachebase  │             /tmp/cachepool             │
                             │       B/op       │      B/op        vs base               │
Set/DistPebble10/AC-24           37.48Ki ±   1%   37.42Ki ±    0%        ~ (p=0.175 n=7)
Set/DistPebble10/CAS-24          32.86Ki ±   0%   32.86Ki ±    0%        ~ (p=0.736 n=7)
Set/DistPebble100/AC-24          38.08Ki ±  12%   37.81Ki ±   12%   -0.69% (p=0.017 n=7)
Set/DistPebble100/CAS-24         32.75Ki ±   0%   32.55Ki ±    0%   -0.63% (p=0.001 n=7)
Set/DistPebble1000/AC-24         40.13Ki ±   0%   38.97Ki ±    0%   -2.89% (p=0.001 n=7)
Set/DistPebble1000/CAS-24        33.52Ki ±   0%   32.44Ki ±    0%   -3.23% (p=0.001 n=7)
Set/DistPebble10000/AC-24        50.30Ki ±   0%   40.06Ki ±    1%  -20.36% (p=0.001 n=7)
Set/DistPebble10000/CAS-24       42.42Ki ±   0%   32.29Ki ±    0%  -23.87% (p=0.001 n=7)
Set/DistPebble1000000/AC-24    1062.67Ki ± 147%   76.63Ki ± 1872%  -92.79% (p=0.017 n=7)
Set/DistPebble1000000/CAS-24     932.5Ki ±   1%   324.6Ki ±    6%  -65.19% (p=0.001 n=7)
geomean                          73.12Ki          47.74Ki          -34.70%

                             │ /tmp/cachebase │          /tmp/cachepool          │
                             │   allocs/op    │ allocs/op   vs base              │
Set/DistPebble10/AC-24             533.0 ± 0%   531.0 ± 0%  -0.38% (p=0.001 n=7)
Set/DistPebble10/CAS-24            448.0 ± 0%   447.0 ± 0%  -0.22% (p=0.001 n=7)
Set/DistPebble100/AC-24            542.0 ± 0%   540.0 ± 0%  -0.37% (p=0.001 n=7)
Set/DistPebble100/CAS-24           448.0 ± 0%   447.0 ± 0%  -0.22% (p=0.004 n=7)
Set/DistPebble1000/AC-24           537.0 ± 0%   535.0 ± 0%  -0.37% (p=0.001 n=7)
Set/DistPebble1000/CAS-24          443.0 ± 0%   442.0 ± 0%  -0.23% (p=0.001 n=7)
Set/DistPebble10000/AC-24          570.0 ± 0%   568.0 ± 0%  -0.35% (p=0.001 n=7)
Set/DistPebble10000/CAS-24         443.0 ± 0%   442.0 ± 0%  -0.23% (p=0.001 n=7)
Set/DistPebble1000000/AC-24        641.0 ± 2%   636.0 ± 1%  -0.78% (p=0.012 n=7)
Set/DistPebble1000000/CAS-24       558.0 ± 1%   546.0 ± 1%  -2.15% (p=0.001 n=7)
geomean                            512.3        509.6       -0.53%
```