### PR TITLE
Add git trace processor util

### DIFF
--- a/enterprise/server/util/git_trace2/BUILD
+++ b/enterprise/server/util/git_trace2/BUILD
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "git_trace2",
+    srcs = ["git_trace2.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/git_trace2",
+    deps = ["//server/util/log"],
+)
+
+go_test(
+    name = "git_trace2_test",
+    size = "small",
+    srcs = ["git_trace2_test.go"],
+    deps = [
+        ":git_trace2",
+        "//server/testutil/testfs",
+        "//server/testutil/testgit",
+        "//server/testutil/testshell",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/server/util/git_trace2/git_trace2.go
+++ b/enterprise/server/util/git_trace2/git_trace2.go
@@ -1,0 +1,151 @@
+// Package git_trace2 provides utilities for processing Git Trace2 events in
+// real time.
+package git_trace2
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+)
+
+const (
+	// maxEventSize limits the memory allocated for a single newline-delimited
+	// Trace2 JSON event.
+	maxEventSize = 1024 * 1024 // 1 MiB
+
+	// drainTimeout limits how long Stop waits for lingering Trace2 writers,
+	// such as detached background maintenance processes that inherited the
+	// pipe and outlived the Git command.
+	drainTimeout = time.Second
+)
+
+// Event is a decoded Git Trace2 event.
+type Event struct {
+	// Type identifies the Trace2 event type, such as data or region_enter.
+	Type string `json:"event"`
+	// SessionID identifies the Git process and its ancestry.
+	SessionID string `json:"sid"`
+	// Category groups related data and region events.
+	Category string `json:"category"`
+	// Label identifies a Trace2 region.
+	Label string `json:"label"`
+	// Key identifies a Trace2 data value.
+	Key string `json:"key"`
+	// Value contains the raw JSON value of a Trace2 data value: a JSON
+	// string for data events, or an arbitrary JSON value for data_json
+	// events.
+	Value json.RawMessage `json:"value"`
+}
+
+// StringValue returns the event's value decoded as a JSON string, or an empty
+// string if the value is absent or not a string (e.g. for data_json events).
+func (e *Event) StringValue() string {
+	var s string
+	if err := json.Unmarshal(e.Value, &s); err != nil {
+		return ""
+	}
+	return s
+}
+
+// Handler processes a decoded Trace2 event. Events are delivered from a
+// single goroutine in the order they are received. Handlers must not block
+// (Stop waits for the event stream to drain) and must not panic (a panic
+// unwinds the processing goroutine and crashes the process).
+type Handler func(*Event)
+
+// Processor reads Trace2 events that a Git process tree writes to a shared
+// pipe.
+type Processor struct {
+	r        *os.File
+	w        *os.File
+	handler  Handler
+	done     chan struct{}
+	stopped  atomic.Bool
+	stopOnce sync.Once
+}
+
+// StartProcessor starts a processor that calls handler for each valid Trace2
+// event written by attached Git commands.
+func StartProcessor(handler Handler) (*Processor, error) {
+	if handler == nil {
+		return nil, errors.New("handler is required")
+	}
+	r, w, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("create trace2 pipe: %w", err)
+	}
+	p := &Processor{r: r, w: w, handler: handler, done: make(chan struct{})}
+	go p.process()
+	return p, nil
+}
+
+// Attach configures a Git command to stream Trace2 events to the processor.
+// The command and its descendant processes (including submodule fetches)
+// inherit the pipe and write their events to it. Attach must be called
+// before the command starts and before Stop; it may be called on several
+// commands in turn.
+func (p *Processor) Attach(cmd *exec.Cmd) error {
+	if p.stopped.Load() {
+		return errors.New("processor is stopped")
+	}
+	// ExtraFiles[i] becomes descriptor 3+i in the child.
+	fd := 3 + len(cmd.ExtraFiles)
+	if fd > 9 {
+		return fmt.Errorf("descriptor %d exceeds git's single-digit trace2 target limit", fd)
+	}
+	cmd.ExtraFiles = append(cmd.ExtraFiles, p.w)
+	cmd.Env = append(cmd.Environ(),
+		"GIT_TRACE2_EVENT="+strconv.Itoa(fd),
+		// Data events such as fetch progress can be nested inside other
+		// trace2 regions; raise the nesting limit (default 2) so they aren't
+		// dropped.
+		"GIT_TRACE2_EVENT_NESTING=5",
+	)
+	return nil
+}
+
+func (p *Processor) process() {
+	defer close(p.done)
+	scanner := bufio.NewScanner(p.r)
+	scanner.Buffer(nil, maxEventSize)
+	for scanner.Scan() {
+		var event Event
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			log.Debugf("Ignoring unparseable Trace2 event: %s", err)
+			continue
+		}
+		p.handler(&event)
+	}
+	if err := scanner.Err(); err != nil {
+		log.Warningf("Git Trace2 event stream ended early: %s", err)
+		// Keep consuming the pipe so that attached Git processes are never
+		// blocked writing trace2 events to a full pipe.
+		_, _ = io.Copy(io.Discard, p.r)
+	}
+}
+
+// Stop drains the remaining Trace2 events and releases the pipe. Call it
+// after the Git command exits; it is safe to call more than once.
+func (p *Processor) Stop() {
+	p.stopped.Store(true)
+	p.stopOnce.Do(func() {
+		// Close this process's copy of the write end so that the processing
+		// goroutine sees EOF once every Git process has exited.
+		_ = p.w.Close()
+		// Time out reads so that a lingering writer cannot block shutdown
+		// indefinitely.
+		_ = p.r.SetReadDeadline(time.Now().Add(drainTimeout))
+		<-p.done
+		_ = p.r.Close()
+	})
+}

--- a/enterprise/server/util/git_trace2/git_trace2_test.go
+++ b/enterprise/server/util/git_trace2/git_trace2_test.go
@@ -1,0 +1,116 @@
+package git_trace2_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/git_trace2"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testgit"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testshell"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessorHandlesEventsFromMultipleWriters(t *testing.T) {
+	// Attached processes share the trace2 pipe, each writing whole event
+	// lines to the inherited descriptor. Verify that events from separate
+	// processes are all delivered, that a malformed line does not prevent
+	// subsequent events from being processed, and that Stop drains buffered
+	// events.
+	var events []*git_trace2.Event
+	processor, err := git_trace2.StartProcessor(func(event *git_trace2.Event) {
+		events = append(events, event)
+	})
+	require.NoError(t, err)
+	t.Cleanup(processor.Stop)
+
+	for _, script := range []string{
+		`printf '%s\n' 'not json' '{"event":"start","sid":"parent"}' >&3`,
+		`printf '%s\n' '{"event":"data","sid":"parent/child","category":"progress","key":"total_bytes","value":"123"}' >&3`,
+		`printf '%s\n' '{"event":"data_json","sid":"parent/child2","key":"argv","value":["git","fetch"]}' >&3`,
+	} {
+		cmd := exec.CommandContext(t.Context(), "sh", "-c", script)
+		require.NoError(t, processor.Attach(cmd))
+		require.NoError(t, cmd.Run())
+	}
+
+	// Attach fails when the trace2 target descriptor would exceed git's
+	// single-digit limit.
+	overLimit := exec.CommandContext(t.Context(), "sh", "-c", "true")
+	overLimit.ExtraFiles = make([]*os.File, 7)
+	require.Error(t, processor.Attach(overLimit))
+
+	// Stop is documented to be safe to call more than once; the cleanup hook
+	// registered above exercises that by calling Stop again after the test
+	// body.
+	processor.Stop()
+
+	// Attach fails once the processor is stopped.
+	require.Error(t, processor.Attach(exec.CommandContext(t.Context(), "sh", "-c", "true")))
+
+	// Stop waits for the processing goroutine, so events is safe to read
+	// afterwards. The data_json event's non-string value should not prevent
+	// the rest of the event from being delivered.
+	var sessionIDs, stringValues []string
+	for _, event := range events {
+		sessionIDs = append(sessionIDs, event.SessionID)
+		stringValues = append(stringValues, event.StringValue())
+	}
+	require.Equal(t, []string{"parent", "parent/child", "parent/child2"}, sessionIDs)
+	require.Equal(t, []string{"", "123", ""}, stringValues)
+}
+
+func TestProcessorReceivesSubmoduleFetchEvents(t *testing.T) {
+	// Create a submodule repo and a superproject that references it.
+	// protocol.file.allow=always is needed because Git disallows file-based
+	// submodule URLs by default.
+	subRepoPath, _ := testgit.MakeTempRepo(t, map[string]string{"sub.txt": "A"})
+	superRepoPath, _ := testgit.MakeTempRepo(t, map[string]string{"super.txt": "A"})
+	testshell.Run(t, superRepoPath, `
+		git -c protocol.file.allow=always submodule add `+subRepoPath+` sub
+		git commit -m "Add submodule"
+	`)
+
+	// Clone the superproject with the submodule populated, so that a fetch
+	// with --recurse-submodules=yes spawns a child Git process for the
+	// submodule.
+	workDir := testfs.MakeTempDir(t)
+	testshell.Run(t, workDir, `git -c protocol.file.allow=always clone --recurse-submodules `+superRepoPath+` work`)
+
+	// Add a new commit to the submodule remote so the submodule fetch has
+	// objects to transfer.
+	testgit.CommitFiles(t, subRepoPath, map[string]string{"sub.txt": "B"})
+
+	var sessionIDs []string
+	processor, err := git_trace2.StartProcessor(func(event *git_trace2.Event) {
+		sessionIDs = append(sessionIDs, event.SessionID)
+	})
+	require.NoError(t, err)
+	t.Cleanup(processor.Stop)
+
+	// Run the fetch attached to the processor, so the whole Git process tree
+	// streams Trace2 events to the shared pipe.
+	cmd := exec.CommandContext(t.Context(), "git", "-c", "protocol.file.allow=always", "fetch", "--recurse-submodules=yes")
+	cmd.Dir = filepath.Join(workDir, "work")
+	require.NoError(t, processor.Attach(cmd))
+	b, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git fetch: %s", string(b))
+	processor.Stop()
+
+	// Session IDs are slash-separated ancestry chains. Expect an event from
+	// the top-level fetch, and an event from a grandchild process: the
+	// submodule fetch is a child of the top-level fetch, and the processes it
+	// spawns to transfer submodule objects are grandchildren. Without
+	// submodule recursion the process tree is only two levels deep.
+	var sawTopLevel, sawGrandchild bool
+	for _, sid := range sessionIDs {
+		depth := strings.Count(sid, "/")
+		sawTopLevel = sawTopLevel || depth == 0
+		sawGrandchild = sawGrandchild || depth >= 2
+	}
+	require.True(t, sawTopLevel, "expected events from the top-level fetch; got session IDs: %v", sessionIDs)
+	require.True(t, sawGrandchild, "expected events from submodule fetch descendants; got session IDs: %v", sessionIDs)
+}


### PR DESCRIPTION
Adds a generic git trace processor util.

- The initial use case is detecting slow fetches and auto-retrying them: https://buildbuddy-corp.slack.com/archives/C05GBMP463D/p1784038685622369
- In the future it'd be neat if we could show these traces in the timing profile, by having the handler convert them to Google's trace event format.

Example usage:

```go
// Create a processor, handling events with a callback
traceProcessor, _ := git_trace2.StartProcessor(func(e *git_trace2.Event) {
  doSomethingWith(e)
})
defer traceProcessor.Stop()

// Attach configures the command to stream trace2 events to the processor
// over an inherited pipe. The whole git process tree writes to it,
// including submodule fetches.
cmd := exec.Command("git", "fetch")
if err := traceProcessor.Attach(cmd); err != nil {
  return err
}
_ = cmd.Run()

// After git exits, drain any remaining events
traceProcessor.Stop()
```