### PR TITLE
Remove NewestAvailableVersion from upgrade proto

### DIFF
--- a/enterprise/server/cache_proxy_registry_server/cache_proxy_registry_server_test.go
+++ b/enterprise/server/cache_proxy_registry_server/cache_proxy_registry_server_test.go
@@ -201,7 +201,6 @@ func TestGetCacheProxies_UpgradePrompt(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, resp.GetCacheProxy(), 1)
 	require.NotNil(t, resp.GetUpgradePrompt())
-	assert.Equal(t, "v2.153.0", resp.GetUpgradePrompt().GetNewestAvailableVersion())
 	assert.Equal(t, uppb.Prompt_LOW, resp.GetUpgradePrompt().GetUrgency())
 	assert.Equal(t, upgradePromptMessage, resp.GetUpgradePrompt().GetMessage())
 }

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -1533,7 +1533,6 @@ func TestGetExecutionNodes_UpgradePrompt(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rsp.GetExecutor(), 2)
 	require.NotNil(t, rsp.GetUpgradePrompt())
-	require.Equal(t, "v2.153.0", rsp.GetUpgradePrompt().GetNewestAvailableVersion())
 	require.Equal(t, uppb.Prompt_LOW, rsp.GetUpgradePrompt().GetUrgency())
 	require.Equal(t, upgradePromptMessage, rsp.GetUpgradePrompt().GetMessage())
 }

--- a/proto/upgrade.proto
+++ b/proto/upgrade.proto
@@ -12,8 +12,7 @@ message Prompt {
     CRITICAL = 4;
   }
   Urgency urgency = 1;
-  string newest_available_version = 2;
 
   // The message that should be displayed in the UI upgrade prompt.
-  string message = 3;
+  string message = 2;
 }

--- a/server/util/upgrade/upgrade.go
+++ b/server/util/upgrade/upgrade.go
@@ -112,9 +112,8 @@ func (d *Detector) Detect(newest *semver.Version, versions []string, message str
 		return nil
 	}
 	return &uppb.Prompt{
-		NewestAvailableVersion: newest.Original(),
-		Urgency:                urgency,
-		Message:                message,
+		Urgency: urgency,
+		Message: message,
 	}
 }
 

--- a/server/util/upgrade/upgrade_test.go
+++ b/server/util/upgrade/upgrade_test.go
@@ -117,7 +117,6 @@ func TestDetect(t *testing.T) {
 	// skipped.
 	prompt := d.Detect(newest, []string{"v2.153.0", "unknown", "v2.132.0"}, message)
 	require.NotNil(t, prompt)
-	assert.Equal(t, "v2.153.0", prompt.GetNewestAvailableVersion())
 	assert.Equal(t, uppb.Prompt_MEDIUM, prompt.GetUrgency())
 	assert.Equal(t, message, prompt.GetMessage())
 


### PR DESCRIPTION
This necessitates a bunch of null checks in the client-side rendering code that I don't want to worry about right now.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7759