### PR TITLE
fix(cli): mirror ignored user.bazelrc files for remote Bazel

### DIFF
--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -591,18 +591,32 @@ func generatePatches(baseCommit string) ([][]byte, error) {
 		}
 	}
 
-	// Generate patches for non-tracked files
+	// Generate patches for non-tracked files. Include ignored user.bazelrc files
+	// since they are commonly imported by the workspace .bazelrc and need to be
+	// available on the remote runner.
 	untrackedFiles, err := runGit("ls-files", "--others", "--exclude-standard")
 	if err != nil {
 		return nil, status.WrapError(err, "get untracked files")
 	}
-	untrackedFiles = strings.Trim(untrackedFiles, "\n")
-	if untrackedFiles != "" {
-		for uf := range strings.SplitSeq(untrackedFiles, "\n") {
-			if strings.HasPrefix(uf, BuildBuddyArtifactDir+"/") {
+	ignoredUserBazelrcFiles, err := runGit(
+		"ls-files", "--others", "--ignored", "--exclude-standard", "--", ":(glob)**/user.bazelrc")
+	if err != nil {
+		return nil, status.WrapError(err, "get ignored user.bazelrc files")
+	}
+	filesToPatch := strings.Trim(untrackedFiles, "\n")
+	ignoredUserBazelrcFiles = strings.Trim(ignoredUserBazelrcFiles, "\n")
+	if ignoredUserBazelrcFiles != "" {
+		if filesToPatch != "" {
+			filesToPatch += "\n"
+		}
+		filesToPatch += ignoredUserBazelrcFiles
+	}
+	if filesToPatch != "" {
+		for path := range strings.SplitSeq(filesToPatch, "\n") {
+			if strings.HasPrefix(path, BuildBuddyArtifactDir+"/") {
 				continue
 			}
-			patch, err := diffUntrackedFile(uf)
+			patch, err := diffUntrackedFile(path)
 			if err != nil {
 				return nil, status.WrapError(err, "diff untracked file")
 			}

--- a/cli/remotebazel/remotebazel_test.go
+++ b/cli/remotebazel/remotebazel_test.go
@@ -582,8 +582,10 @@ func TestGitConfig_FetchURL(t *testing.T) {
 func TestGeneratingPatches(t *testing.T) {
 	// Setup the "remote" repo
 	remoteRepoPath, _ := testgit.MakeTempRepo(t, map[string]string{
-		"hello.txt": "echo HI",
-		"b.bin":     "",
+		"hello.txt":  "echo HI",
+		"b.bin":      "",
+		".bazelrc":   "try-import %workspace%/user.bazelrc\n",
+		".gitignore": "user.bazelrc\n",
 	})
 
 	// Setup a "local" repo
@@ -606,12 +608,15 @@ func TestGeneratingPatches(t *testing.T) {
 
 		# Generate a binary diff on an untracked file
 		echo -ne '\x00\x01\x02\x03\x04' > b2.bin
+
+		# Generate a diff for an ignored user-specific bazelrc
+		echo "build --remote_header=x-user-config=1" > user.bazelrc
 `)
 
 	config, err := Config()
 	require.NoError(t, err)
 
-	require.Equal(t, 4, len(config.Patches))
+	require.Equal(t, 5, len(config.Patches))
 	for _, patchBytes := range config.Patches {
 		p := string(patchBytes)
 		if strings.Contains(p, "hello.txt") {
@@ -622,6 +627,8 @@ func TestGeneratingPatches(t *testing.T) {
 			require.Contains(t, p, "GIT binary patch")
 		} else if strings.Contains(p, "b2.bin") {
 			require.Contains(t, p, "GIT binary patch")
+		} else if strings.Contains(p, "user.bazelrc") {
+			require.Contains(t, p, "x-user-config=1")
 		} else {
 			require.FailNowf(t, "unexpected patch %s", p)
 		}


### PR DESCRIPTION
## What changed

- Include ignored files named `user.bazelrc` in the patchset mirrored to remote Bazel runners.
- Add regression coverage for a workspace `.bazelrc` that imports a gitignored `user.bazelrc`.

## Why

Remote Bazel currently collects untracked files with `git ls-files --others --exclude-standard`, which deliberately omits gitignored user configuration. As a result, a common `try-import %workspace%/user.bazelrc` setup works locally but loses those options remotely.

Fixes #11846

## Tests

- `bazel test //cli/remotebazel:remotebazel_test --test_filter=TestGeneratingPatches`
- `bazel test //cli/remotebazel:remotebazel_test`
- `bazel run //tools/lint -- --diff_base=origin/master`