### PR TITLE
Add experiment to detect + retry slow git fetches

### DIFF
--- a/enterprise/server/cmd/ci_runner/BUILD
+++ b/enterprise/server/cmd/ci_runner/BUILD
@@ -79,5 +79,10 @@ go_test(
     name = "ci_runner_test",
     srcs = ["main_test.go"],
     embed = [":ci_runner_lib"],
-    deps = ["@com_github_stretchr_testify//assert"],
+    deps = [
+        "//server/testutil/testgit",
+        "//server/util/testing/flags",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math"
 	"net/url"
 	"os"
 	"os/exec"
@@ -108,6 +109,9 @@ const (
 	// depth required.
 	smartFetchDepth = -1
 
+	// maxGitFetchLowSpeedRetries caps --git_fetch_low_speed_retries.
+	maxGitFetchLowSpeedRetries = 3
+
 	// Env vars set by workflow runner
 	// NOTE: These env vars are not populated for non-private repos.
 
@@ -192,9 +196,15 @@ var (
 	commitSHA             = flag.String("commit_sha", "", "Commit SHA to report statuses for.")
 	prNumber              = flag.Int64("pull_request_number", 0, "PR number, if applicable (0 if not triggered by a PR).")
 	patchURIs             = flag.Slice("patch_uri", []string{}, "URIs of patches to apply to the repo after checkout. Can be specified multiple times to apply multiple patches.")
-	gitCleanExclude       = flag.Slice("git_clean_exclude", []string{}, "Directories to exclude from `git clean` while setting up the repo.")
-	gitFetchFilters       = flag.Slice("git_fetch_filters", []string{}, "Filters to apply to `git fetch` commands.")
-	gitFetchDepth         = flag.Int("git_fetch_depth", smartFetchDepth, "Depth to use for `git fetch` commands.")
+	gitCleanExclude       = flag.Slice("git_clean_exclude", []string{}, "Directories to exclude from git clean while setting up the repo.")
+
+	// Flags to configure git fetch behavior
+	gitFetchFilters         = flag.Slice("git_fetch_filters", []string{}, "Filters to apply to git fetch commands.")
+	gitFetchDepth           = flag.Int("git_fetch_depth", smartFetchDepth, "Depth to use for git fetch commands.")
+	gitFetchLowSpeedRetries = flag.Int("git_fetch_low_speed_retries", 0, "Number of times to retry git fetch commands that were aborted because the transfer rate was too slow.")
+	gitFetchLowSpeedLimit   = flag.Int64("git_fetch_low_speed_limit", 1024, "Transfer rate in bytes per second below which a git fetch transfer is considered too slow. Only applies if git_fetch_low_speed_retries is set.")
+	gitFetchLowSpeedTime    = flag.Duration("git_fetch_low_speed_time", 30*time.Second, "How long a git fetch transfer must stay below git_fetch_low_speed_limit before it is aborted. Only applies if git_fetch_low_speed_retries is set.")
+
 	// Flags to configure merge-with-base behavior
 	targetRepoURL = flag.String("target_repo_url", "", "If different from pushed_repo_url, indicates a fork (`pushed_repo_url`) is being merged into this repo.")
 	targetBranch  = flag.String("target_branch", "", "If different from pushed_branch, pushed_branch should be merged into this branch in the target repo.")
@@ -281,6 +291,9 @@ type workspace struct {
 
 	// Total time spent running git fetch commands during setup.
 	gitFetchDuration time.Duration
+
+	// Total number of git fetch retries after low-speed aborts during setup.
+	gitFetchRetryCount int64
 
 	// The start time of the setup phase.
 	startTime time.Time
@@ -1107,6 +1120,7 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 			Payload: &bespb.BuildEvent_GitFetchCompleted{GitFetchCompleted: &bespb.GitFetchCompleted{
 				TotalBytes: ws.gitFetchTotalBytes,
 				Duration:   durationpb.New(ws.gitFetchDuration),
+				RetryCount: ws.gitFetchRetryCount,
 			}},
 		}
 		publishErr := ar.reporter.Publish(gitFetchEvent)
@@ -2321,12 +2335,41 @@ func (ws *workspace) fetch(ctx context.Context, remoteURL string, refs []string,
 		fetchEnv["GIT_TRACE2_EVENT_NESTING"] = "5"
 	}
 
-	fetchStart := time.Now()
-	_, fetchErr := gitWithEnv(ctx, ws.log, fetchEnv, fetchArgs...)
-	ws.gitFetchDuration += time.Since(fetchStart)
+	lowSpeedRetries := 0
+	if *gitFetchLowSpeedRetries > 0 {
+		lowSpeedRetries = *gitFetchLowSpeedRetries
+		if lowSpeedRetries > maxGitFetchLowSpeedRetries {
+			writeCommandSummary(ws.log, "Warning: --git_fetch_low_speed_retries=%d exceeds the maximum of %d; using %d.", lowSpeedRetries, maxGitFetchLowSpeedRetries, maxGitFetchLowSpeedRetries)
+			lowSpeedRetries = maxGitFetchLowSpeedRetries
+		}
+		// Respect low-speed settings that are already present in the
+		// environment (e.g. set on the image or in the action env).
+		if os.Getenv("GIT_HTTP_LOW_SPEED_LIMIT") == "" {
+			fetchEnv["GIT_HTTP_LOW_SPEED_LIMIT"] = strconv.FormatInt(*gitFetchLowSpeedLimit, 10)
+		}
+		if os.Getenv("GIT_HTTP_LOW_SPEED_TIME") == "" {
+			// Git configures the low-speed window in whole seconds; round up
+			// so that a sub-second value doesn't truncate to 0, which would
+			// disable the low-speed check entirely.
+			fetchEnv["GIT_HTTP_LOW_SPEED_TIME"] = strconv.Itoa(int(math.Ceil(gitFetchLowSpeedTime.Seconds())))
+		}
+	}
+
+	var fetchErr *commandError
+	for attempt := 0; ; attempt++ {
+		fetchStart := time.Now()
+		_, fetchErr = gitWithEnv(ctx, ws.log, fetchEnv, fetchArgs...)
+		ws.gitFetchDuration += time.Since(fetchStart)
+		if fetchErr == nil || attempt >= lowSpeedRetries || !isTransferTooSlow(fetchErr) {
+			break
+		}
+		ws.gitFetchRetryCount++
+		writeCommandSummary(ws.log, "The fetch was aborted because the transfer rate was too slow. Retrying (attempt %d of %d)...", attempt+1, lowSpeedRetries)
+	}
 	// Count fetched bytes even if the fetch failed, since a failed fetch may
 	// be retried (e.g. with a different depth) and we want the total to
-	// reflect all data transferred.
+	// reflect all data transferred. Retried attempts append to the same log,
+	// so any bytes they recorded before being aborted are counted too.
 	if fetchEnv["GIT_TRACE2_EVENT"] != "" {
 		if f, err := os.Open(trace2Path); err != nil {
 			backendLog.Warningf("Could not open the git trace2 event log; git fetch stats may be undercounted: %s", err)
@@ -2449,6 +2492,15 @@ func isBranchNotFound(err error) bool {
 func isAlreadyUpToDate(err error) bool {
 	gitErr, ok := err.(*commandError)
 	return ok && strings.Contains(gitErr.Output, "up to date")
+}
+
+// isTransferTooSlow returns whether git aborted a transfer because its rate
+// stayed below GIT_HTTP_LOW_SPEED_LIMIT for longer than
+// GIT_HTTP_LOW_SPEED_TIME. The message is libcurl's error string for a
+// low-speed abort (curl error 28).
+func isTransferTooSlow(err error) bool {
+	gitErr, ok := err.(*commandError)
+	return ok && strings.Contains(gitErr.Output, "Operation too slow. Less than")
 }
 
 func git(ctx context.Context, out io.Writer, args ...string) (string, *commandError) {

--- a/enterprise/server/cmd/ci_runner/main_test.go
+++ b/enterprise/server/cmd/ci_runner/main_test.go
@@ -1,12 +1,23 @@
 package main
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testgit"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCollectRunfiles_RelativeDirectorySymlink(t *testing.T) {
@@ -25,6 +36,119 @@ func TestCollectRunfiles_RelativeDirectorySymlink(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, files)
 	assert.Equal(t, map[string]string{linkPath: targetDir}, dirs)
+}
+
+type stallingReadCloser struct {
+	ctx context.Context
+	io.ReadCloser
+	started bool
+}
+
+func (r *stallingReadCloser) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if !r.started {
+		r.started = true
+		return r.ReadCloser.Read(p[:1])
+	}
+	<-r.ctx.Done()
+	return 0, r.ctx.Err()
+}
+
+func TestGitFetchRetriesSlowTransfer(t *testing.T) {
+	flags.Set(t, "git_fetch_low_speed_retries", 1)
+	flags.Set(t, "git_fetch_low_speed_limit", 1)
+	// Git and libcurl configure the low-speed window in whole seconds, so one
+	// second is the shortest interval and gives the fastest possible check.
+	flags.Set(t, "git_fetch_low_speed_time", time.Second)
+	for _, envVar := range []string{"GIT_HTTP_LOW_SPEED_LIMIT", "GIT_HTTP_LOW_SPEED_TIME"} {
+		originalValue, wasSet := os.LookupEnv(envVar)
+		require.NoError(t, os.Unsetenv(envVar))
+		t.Cleanup(func() {
+			if wasSet {
+				require.NoError(t, os.Setenv(envVar, originalValue))
+				return
+			}
+			require.NoError(t, os.Unsetenv(envVar))
+		})
+	}
+	// Fetch from the proxy URL as-is. Otherwise fetch() embeds the REPO_USER
+	// and REPO_TOKEN credentials in the URL if they are set, which they are
+	// when this test itself runs in a BuildBuddy workflow.
+	t.Setenv("USE_SYSTEM_GIT_CREDENTIALS", "1")
+
+	// Serve a real repository over HTTP.
+	remote := testgit.StartServer(t, testgit.ServerOptions{LogWriter: io.Discard})
+	remote.CreateProject("test-org", "test-repo", &testgit.ProjectSettings{Public: true})
+	sourceDir, wantCommitSHA := testgit.MakeTempRepo(t, map[string]string{"README.md": "test repo"})
+	remote.Push("test-org", "test-repo", remote.AccessToken(), sourceDir)
+
+	// Proxy the Git server and leave the first upload-pack response hanging
+	// after its first byte until Git aborts it. Later responses pass through.
+	upstreamURL, err := url.Parse(remote.RepoURL("test-org", "test-repo", ""))
+	require.NoError(t, err)
+	var stalledFirstFetch atomic.Bool
+	proxy := httputil.NewSingleHostReverseProxy(upstreamURL)
+	proxy.ModifyResponse = func(response *http.Response) error {
+		if response.Request.Method == http.MethodPost && strings.HasSuffix(response.Request.URL.Path, "/git-upload-pack") && stalledFirstFetch.CompareAndSwap(false, true) {
+			response.Body = &stallingReadCloser{ctx: response.Request.Context(), ReadCloser: response.Body}
+		}
+		return nil
+	}
+	proxyServer := httptest.NewServer(proxy)
+	t.Cleanup(proxyServer.Close)
+
+	checkoutDir := t.TempDir()
+	originalWorkingDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(checkoutDir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(originalWorkingDir))
+	})
+	invocationLog := newInvocationLog(nil)
+	invocationLog.writer = io.Discard
+	ws := &workspace{
+		rootDir: checkoutDir,
+		log:     &buildEventReporter{log: invocationLog},
+	}
+	require.NoError(t, ws.init(t.Context()))
+
+	// The initial fetch should be aborted by Git's low-speed check. Verify the
+	// runner retries it and the second real fetch retrieves the expected ref.
+	err = ws.fetch(t.Context(), proxyServer.URL, []string{"refs/heads/master"}, 1)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), ws.gitFetchRetryCount)
+	fetchedCommitSHA, gitErr := git(t.Context(), io.Discard, "rev-parse", "FETCH_HEAD")
+	require.Nil(t, gitErr)
+	require.Equal(t, wantCommitSHA, strings.TrimSpace(fetchedCommitSHA))
+}
+
+func TestIsTransferTooSlow(t *testing.T) {
+	// Serve a git HTTP endpoint that starts a ref advertisement and then
+	// stalls, so that git's low-speed check aborts the transfer.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+		io.WriteString(w, "001e# service=git-upload-pack\n")
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+
+	// List the stalled remote with the low-speed check configured to trip
+	// after one second (the shortest window git supports). Expect
+	// isTransferTooSlow to match the error that git reports.
+	_, err := gitWithEnv(t.Context(), io.Discard, map[string]string{
+		"GIT_HTTP_LOW_SPEED_LIMIT": "1024",
+		"GIT_HTTP_LOW_SPEED_TIME":  "1",
+	}, "ls-remote", server.URL)
+	require.NotNil(t, err)
+	assert.True(t, isTransferTooSlow(err), "expected a low-speed abort, got: %s", err.Output)
+
+	// A git error unrelated to transfer speed should not match.
+	_, err = git(t.Context(), io.Discard, "ls-remote", filepath.Join(t.TempDir(), "nonexistent"))
+	require.NotNil(t, err)
+	assert.False(t, isTransferTooSlow(err), "unexpected low-speed abort: %s", err.Output)
 }
 
 func TestParseGitFetchedBytes(t *testing.T) {

--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -235,6 +235,7 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 		if bazelCommandOverride != "" {
 			args = append(args, "--bazel_command="+bazelCommandOverride)
 		}
+		args = append(args, ci_runner_util.GitFetchLowSpeedRetryFlags(ctx, efp, experiments.WithContext("workflow_action_name", "remote_bazel"))...)
 	}
 	args = append(args, req.GetRunnerFlags()...)
 

--- a/enterprise/server/util/ci_runner_util/ci_runner_util.go
+++ b/enterprise/server/util/ci_runner_util/ci_runner_util.go
@@ -2,11 +2,13 @@ package ci_runner_util
 
 import (
 	"context"
-	_ "embed"
 	"flag"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"time"
+
+	_ "embed"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/cmd/ci_runner/bundle"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/experiments"
@@ -29,6 +31,7 @@ import (
 const ExecutableName = "buildbuddy_ci_runner"
 const CLIBinaryName = "bb"
 const DefaultTimeoutExperimentName = "remote_execution.remote_runner_default_timeout"
+const LowSpeedRetryConfigExperimentName = "remote_execution.ci_runner.low_speed_retry_config"
 const FreeTierTimeoutReason = "free_tier_limit"
 
 type RunnerTimeoutResult struct {
@@ -71,6 +74,59 @@ func RunnerTimeout(ctx context.Context, efp interfaces.ExperimentFlagProvider, r
 		return &RunnerTimeoutResult{Duration: *requestedTimeout}, nil
 	}
 	return &RunnerTimeoutResult{Duration: *CIRunnerDefaultTimeout}, nil
+}
+
+// LowSpeedRetryConfig is the value of the LowSpeedRetryConfigExperimentName
+// experiment, which configures the ci_runner to abort git fetches whose
+// transfer rate stays below Rate for Duration, and retry them up to Retries
+// times.
+type LowSpeedRetryConfig struct {
+	// Retries is the number of times to retry an aborted fetch.
+	Retries int `json:"retries"`
+	// Duration is how long the transfer rate must stay below Rate before the
+	// fetch is aborted, in time.Duration format (e.g. "30s"). If empty, the
+	// ci_runner default applies.
+	Duration string `json:"duration"`
+	// Rate is the transfer rate in bytes per second below which the fetch is
+	// considered too slow. If zero, the ci_runner default applies.
+	Rate int64 `json:"rate"`
+}
+
+// GitFetchLowSpeedRetryFlags returns the ci_runner git fetch retry flags
+// configured by the LowSpeedRetryConfigExperimentName experiment, or nil if
+// the experiment is not configured.
+func GitFetchLowSpeedRetryFlags(ctx context.Context, efp interfaces.ExperimentFlagProvider, opts ...any) []string {
+	if efp == nil {
+		return nil
+	}
+	object := efp.Object(ctx, LowSpeedRetryConfigExperimentName, nil, opts...)
+	if len(object) == 0 {
+		return nil
+	}
+	config := &LowSpeedRetryConfig{}
+	if err := experiments.ObjectToStruct(object, config); err != nil {
+		log.CtxErrorf(ctx, "Could not parse the %s experiment value: %s", LowSpeedRetryConfigExperimentName, err)
+		return nil
+	}
+	if config.Duration != "" {
+		duration, err := time.ParseDuration(config.Duration)
+		if err != nil {
+			log.CtxErrorf(ctx, "Could not parse the %s experiment duration %q: %s", LowSpeedRetryConfigExperimentName, config.Duration, err)
+			return nil
+		}
+		if duration <= 0 {
+			log.CtxWarningf(ctx, "Ignoring the %s experiment duration %q because it is not positive.", LowSpeedRetryConfigExperimentName, config.Duration)
+			config.Duration = ""
+		}
+	}
+	flags := []string{fmt.Sprintf("--git_fetch_low_speed_retries=%d", config.Retries)}
+	if config.Rate > 0 {
+		flags = append(flags, fmt.Sprintf("--git_fetch_low_speed_limit=%d", config.Rate))
+	}
+	if config.Duration != "" {
+		flags = append(flags, "--git_fetch_low_speed_time="+config.Duration)
+	}
+	return flags
 }
 
 // CanInitFromCache The apps are built for linux/amd64. If the ci_runner will run on linux/amd64

--- a/enterprise/server/util/ci_runner_util/ci_runner_util_test.go
+++ b/enterprise/server/util/ci_runner_util/ci_runner_util_test.go
@@ -219,3 +219,81 @@ func newRemoteRunnerTask(repoURL, apiKey, repoToken string) *repb.ExecutionTask 
 		},
 	}
 }
+
+func TestGitFetchLowSpeedRetryFlags(t *testing.T) {
+	tests := []struct {
+		name          string
+		experiment    map[string]any
+		expectedFlags []string
+	}{
+		{
+			// With no experiment configured, no flags should be returned, so
+			// the ci_runner falls back to its flag defaults (retries disabled).
+			name:          "not configured",
+			experiment:    nil,
+			expectedFlags: nil,
+		},
+		{
+			// A fully specified config should produce all three fetch flags.
+			name:          "all fields set",
+			experiment:    map[string]any{"retries": 2, "duration": "45s", "rate": 2048},
+			expectedFlags: []string{"--git_fetch_low_speed_retries=2", "--git_fetch_low_speed_limit=2048", "--git_fetch_low_speed_time=45s"},
+		},
+		{
+			// If only retries is set, the rate and duration should be left to
+			// the ci_runner's flag defaults.
+			name:          "only retries set",
+			experiment:    map[string]any{"retries": 1},
+			expectedFlags: []string{"--git_fetch_low_speed_retries=1"},
+		},
+		{
+			// A duration the ci_runner would fail to parse should disable the
+			// experiment entirely rather than produce partial flags.
+			name:          "invalid duration",
+			experiment:    map[string]any{"retries": 1, "duration": "not-a-duration"},
+			expectedFlags: nil,
+		},
+		{
+			// A zero duration disables Git's low-speed check, so it should be
+			// omitted to let the ci_runner use its default duration.
+			name:          "zero duration",
+			experiment:    map[string]any{"retries": 1, "duration": "0s"},
+			expectedFlags: []string{"--git_fetch_low_speed_retries=1"},
+		},
+		{
+			// A negative duration is not meaningful, so it should be omitted to
+			// let the ci_runner use its default duration.
+			name:          "negative duration",
+			experiment:    map[string]any{"retries": 1, "duration": "-1s"},
+			expectedFlags: []string{"--git_fetch_low_speed_retries=1"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := enterprise_testenv.New(t)
+			configureLowSpeedRetryExperiment(t, env, tc.experiment)
+			flags := GitFetchLowSpeedRetryFlags(t.Context(), env.GetExperimentFlagProvider())
+			require.Equal(t, tc.expectedFlags, flags)
+		})
+	}
+}
+
+func configureLowSpeedRetryExperiment(t *testing.T, env *testenv.TestEnv, config map[string]any) {
+	memFlags := map[string]memprovider.InMemoryFlag{}
+	if config != nil {
+		memFlags[LowSpeedRetryConfigExperimentName] = memprovider.InMemoryFlag{
+			State:          memprovider.Enabled,
+			DefaultVariant: "on",
+			Variants: map[string]any{
+				"on": config,
+			},
+		}
+	}
+	testProvider := memprovider.NewInMemoryProvider(memFlags)
+	require.NoError(t, openfeature.SetProviderAndWait(testProvider))
+
+	fp, err := experiments.NewFlagProvider("test")
+	require.NoError(t, err)
+	env.SetExperimentFlagProvider(fp)
+}

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1205,6 +1205,7 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 	if workflowAction.GitFetchDepth != nil {
 		args = append(args, fmt.Sprintf("--git_fetch_depth=%d", *workflowAction.GitFetchDepth))
 	}
+	args = append(args, ci_runner_util.GitFetchLowSpeedRetryFlags(ctx, ws.env.GetExperimentFlagProvider(), experiments.WithContext("workflow_action_name", workflowAction.Name))...)
 	for _, path := range workflowAction.GitCleanExclude {
 		args = append(args, "--git_clean_exclude="+path)
 	}

--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -1682,6 +1682,9 @@ message GitFetchCompleted {
 
   // Total time spent running git fetch commands.
   google.protobuf.Duration duration = 2;
+
+  // Total number of git fetch retries after low-speed aborts.
+  int64 retry_count = 3;
 }
 
 // Message describing a build event. Events will have an identifier that

--- a/server/build_event_protocol/accumulator/accumulator.go
+++ b/server/build_event_protocol/accumulator/accumulator.go
@@ -91,6 +91,7 @@ type BEValues struct {
 	profileName               string
 	gitFetchTotalBytes        int64
 	gitFetchDuration          time.Duration
+	gitFetchRetryCount        int64
 
 	failedTestOutputURIs []*url.URL
 	passedTestOutputURIs []*url.URL
@@ -172,6 +173,7 @@ func (v *BEValues) AddEvent(event *build_event_stream.BuildEvent) error {
 		// The remote runner reports cumulative totals, so the last event wins.
 		v.gitFetchTotalBytes = p.GitFetchCompleted.GetTotalBytes()
 		v.gitFetchDuration = p.GitFetchCompleted.GetDuration().AsDuration()
+		v.gitFetchRetryCount = p.GitFetchCompleted.GetRetryCount()
 	case *build_event_stream.BuildEvent_Finished:
 		v.sawFinishedEvent = true
 	case *build_event_stream.BuildEvent_BuildToolLogs:
@@ -253,6 +255,12 @@ func (v *BEValues) GitFetchTotalBytes() int64 {
 // fetch commands, or 0 if not reported.
 func (v *BEValues) GitFetchDuration() time.Duration {
 	return v.gitFetchDuration
+}
+
+// GitFetchRetryCount returns the number of git fetch retries a remote runner
+// made after low-speed aborts, or 0 if not reported.
+func (v *BEValues) GitFetchRetryCount() int64 {
+	return v.gitFetchRetryCount
 }
 
 func (v *BEValues) DisableCommitStatusReporting() bool {

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -256,6 +256,7 @@ type recordStatsTask struct {
 	// the primary DB at flush time.
 	gitFetchTotalBytes   int64
 	gitFetchDurationUsec int64
+	gitFetchRetryCount   int64
 }
 
 // statsRecorder listens for finalized invocations and copies cache stats from
@@ -321,6 +322,7 @@ func (r *statsRecorder) Enqueue(ctx context.Context, beValues *accumulator.BEVal
 		kytheSSTableResourceName: beValues.KytheSSTableResourceName(),
 		gitFetchTotalBytes:       beValues.GitFetchTotalBytes(),
 		gitFetchDurationUsec:     beValues.GitFetchDuration().Microseconds(),
+		gitFetchRetryCount:       beValues.GitFetchRetryCount(),
 	}
 	select {
 	case r.tasks <- req:
@@ -363,6 +365,7 @@ func (r *statsRecorder) flushInvocationStatsToOLAPDB(ctx context.Context, task *
 	// the task instead of being read back from the primary DB.
 	inv.GitFetchTotalBytes = task.gitFetchTotalBytes
 	inv.GitFetchDurationUsec = task.gitFetchDurationUsec
+	inv.GitFetchRetryCount = task.gitFetchRetryCount
 
 	err = r.env.GetOLAPDBHandle().FlushInvocationStats(ctx, inv)
 	if err != nil {

--- a/server/build_event_protocol/build_event_handler/build_event_handler_test.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 
@@ -37,7 +38,6 @@ import (
 	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
 	inspb "github.com/buildbuddy-io/buildbuddy/proto/invocation_status"
 	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
-	"google.golang.org/protobuf/testing/protocmp"
 )
 
 func streamRequest(anyEvent *anypb.Any, iid string, sequenceNumer int64) *pepb.PublishBuildToolEventStreamRequest {
@@ -280,13 +280,14 @@ func finishedEvent() *anypb.Any {
 	return finishedAny
 }
 
-func gitFetchCompletedEvent(totalBytes int64, duration time.Duration) *anypb.Any {
+func gitFetchCompletedEvent(totalBytes int64, duration time.Duration, retryCount int64) *anypb.Any {
 	gitFetchAny := &anypb.Any{}
 	gitFetchAny.MarshalFrom(&bspb.BuildEvent{
 		Payload: &bspb.BuildEvent_GitFetchCompleted{
 			GitFetchCompleted: &bspb.GitFetchCompleted{
 				TotalBytes: totalBytes,
 				Duration:   durationpb.New(duration),
+				RetryCount: retryCount,
 			},
 		},
 		Id: &bspb.BuildEventId{Id: &bspb.BuildEventId_GitFetchCompleted{}},
@@ -981,7 +982,7 @@ func TestGitFetchStatsFlushedToOLAPDB(t *testing.T) {
 
 	// Send a GitFetchCompleted event reporting git fetch stats, as published
 	// by the remote runner after setting up the git repo.
-	request = streamRequest(gitFetchCompletedEvent(9_000_000, 3*time.Second), testInvocationID, 3)
+	request = streamRequest(gitFetchCompletedEvent(9_000_000, 3*time.Second, 2), testInvocationID, 3)
 	err = channel.HandleEvent(request)
 	require.NoError(t, err)
 
@@ -1002,6 +1003,7 @@ func TestGitFetchStatsFlushedToOLAPDB(t *testing.T) {
 	}, 30*time.Second, 50*time.Millisecond)
 	assert.Equal(t, int64(9_000_000), inv.GitFetchTotalBytes)
 	assert.Equal(t, (3 * time.Second).Microseconds(), inv.GitFetchDurationUsec)
+	assert.Equal(t, int64(2), inv.GitFetchRetryCount)
 }
 
 func TestUnfinishedFinalizeWithCanceledContext(t *testing.T) {

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -190,6 +190,7 @@ type Invocation struct {
 	// flushing the invocation to the OLAP DB.
 	GitFetchTotalBytes   int64 `gorm:"-"`
 	GitFetchDurationUsec int64 `gorm:"-"`
+	GitFetchRetryCount   int64 `gorm:"-"`
 }
 
 func (i *Invocation) TableName() string {

--- a/server/testutil/testgit/testgit.go
+++ b/server/testutil/testgit/testgit.go
@@ -257,10 +257,15 @@ func (s *Server) CreateProject(owner, repo string, settings *ProjectSettings) {
 
 // Push pushes the local repo to a project created with CreateProject.
 func (s *Server) Push(owner, repo, accessToken, localPath string) {
+	// Disable credential helpers (an empty helper value resets the helper
+	// list) so that git does not store the pushed credentials after
+	// authenticating. On macOS, the system gitconfig enables the osxkeychain
+	// helper, which hangs forever on unattended hosts waiting for keychain
+	// access.
 	testshell.Run(s.t, localPath, `
 		git remote add origin `+s.RepoURL(owner, repo, accessToken)+`
 		export GIT_ASKPASS=/usr/bin/true
-		git push --set-upstream origin "$(git branch --show-current)"
+		git -c credential.helper= push --set-upstream origin "$(git branch --show-current)"
 	`)
 }
 

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -141,6 +141,7 @@ type Invocation struct {
 	// bazel), if any.
 	GitFetchTotalBytes   int64
 	GitFetchDurationUsec int64
+	GitFetchRetryCount   int64
 }
 
 func (i *Invocation) ExcludedFields() []string {
@@ -818,5 +819,6 @@ func ToInvocationFromPrimaryDB(ti *tables.Invocation) *Invocation {
 		RunStatus:                         ti.RunStatus,
 		GitFetchTotalBytes:                ti.GitFetchTotalBytes,
 		GitFetchDurationUsec:              ti.GitFetchDurationUsec,
+		GitFetchRetryCount:                ti.GitFetchRetryCount,
 	}
 }


### PR DESCRIPTION
Git fetches on the remote runners occasionally slow to a crawl, due to some issue with GitHub that we haven't yet root-caused, causing runs to take way longer than they would otherwise.

As a workaround, add a `--git_fetch_low_speed_retries` flag to the CI runner. When set, the runner configures git with `GIT_HTTP_LOW_SPEED_LIMIT`/`GIT_HTTP_LOW_SPEED_TIME` so that git itself aborts a fetch whose transfer rate stays below `--git_fetch_low_speed_limit` (default 1024 bytes/sec) for `--git_fetch_low_speed_time` (default 30s), then retries the fetch.

The flag is set via the `remote_execution.ci_runner.low_speed_retry_config` experiment, which applies to both workflows and remote bazel. The experiment config allows setting the number of retries as well as the low speed limit + low speed time. Everything is off by default.