### PR TITLE
[WF] Fix webhook parsing for annotated tags

### DIFF
--- a/enterprise/server/webhooks/github/github.go
+++ b/enterprise/server/webhooks/github/github.go
@@ -126,11 +126,14 @@ func ParseWebhookData(event interface{}) (*interfaces.WebhookData, error) {
 		ref := event.GetRef()
 		if after, ok := strings.CutPrefix(ref, "refs/tags/"); ok {
 			tag := after
-			// For all tag pushes, head_commit is the commit the tag points
-			// to. Prefer it over the "after" SHA: for lightweight tags the
-			// two are identical, but for annotated tags "after" identifies
-			// the tag object rather than a commit, and can't be used to
-			// report commit statuses.
+			// For tag pushes, prefer head_commit, which identifies the commit the tag
+			// resolves to. For lightweight tags it is the same as "after". For annotated
+			// tags, "after" identifies the tag object while head_commit.ID identifies
+			// the underlying commit. A commit SHA is needed for commit status reporting
+			// and commit-based repository API calls.
+			//
+			// GitHub documents that head_commit is populated for tag pushes. However, the
+			// field is nullable, so defensively fall back to "after".
 			sha := event.GetHeadCommit().GetID()
 			if sha == "" {
 				sha = event.GetAfter()

--- a/enterprise/server/webhooks/github/github.go
+++ b/enterprise/server/webhooks/github/github.go
@@ -126,11 +126,20 @@ func ParseWebhookData(event interface{}) (*interfaces.WebhookData, error) {
 		ref := event.GetRef()
 		if after, ok := strings.CutPrefix(ref, "refs/tags/"); ok {
 			tag := after
+			// For all tag pushes, head_commit is the commit the tag points
+			// to. Prefer it over the "after" SHA: for lightweight tags the
+			// two are identical, but for annotated tags "after" identifies
+			// the tag object rather than a commit, and can't be used to
+			// report commit statuses.
+			sha := event.GetHeadCommit().GetID()
+			if sha == "" {
+				sha = event.GetAfter()
+			}
 			return &interfaces.WebhookData{
 				EventName:               webhook_data.EventName.Push,
 				PushedRepoURL:           event.GetRepo().GetCloneURL(),
 				PushedTag:               tag,
-				SHA:                     event.GetAfter(),
+				SHA:                     sha,
 				TargetRepoURL:           event.GetRepo().GetCloneURL(),
 				TargetRepoDefaultBranch: event.GetRepo().GetDefaultBranch(),
 				IsTargetRepoPublic:      !event.GetRepo().GetPrivate(),

--- a/enterprise/server/webhooks/github/github_test.go
+++ b/enterprise/server/webhooks/github/github_test.go
@@ -60,6 +60,23 @@ func TestParseRequest_ValidTagPushEvent_Success(t *testing.T) {
 	}, data)
 }
 
+func TestParseRequest_ValidAnnotatedTagPushEvent_UsesDereferencedCommitSHA(t *testing.T) {
+	env := testenv.GetTestEnv(t)
+	req := webhookRequest(t, "push", test_data.PushAnnotatedTagEvent)
+
+	data, err := github.NewProvider(env).ParseWebhookData(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, &interfaces.WebhookData{
+		EventName:               "push",
+		PushedRepoURL:           "https://github.com/test/hello_bb_ci.git",
+		PushedTag:               "v1.1.0",
+		SHA:                     "258044d28288d5f6f1c5928b0e22580296fec666",
+		TargetRepoURL:           "https://github.com/test/hello_bb_ci.git",
+		TargetRepoDefaultBranch: "main",
+	}, data)
+}
+
 func TestParseRequest_TagDeletionEvent_ReturnsNil(t *testing.T) {
 	env := testenv.GetTestEnv(t)
 	req := webhookRequest(t, "push", test_data.DeleteTagEvent)

--- a/enterprise/server/webhooks/github/test_data/BUILD
+++ b/enterprise/server/webhooks/github/test_data/BUILD
@@ -12,6 +12,7 @@ go_library(
         "delete_tag_event.json",
         "pull_request_event.json",
         "pull_request_approved_review_event.json",
+        "push_annotated_tag_event.json",
         "push_event.json",
         "push_tag_event.json",
     ],

--- a/enterprise/server/webhooks/github/test_data/push_annotated_tag_event.json
+++ b/enterprise/server/webhooks/github/test_data/push_annotated_tag_event.json
@@ -1,0 +1,66 @@
+{
+  "ref": "refs/tags/v1.1.0",
+  "before": "0000000000000000000000000000000000000000",
+  "after": "b8ec69cbb0a4c521d84f6bff2b8788c343e2a9de",
+  "repository": {
+    "id": 338160417,
+    "node_id": "MDEwOlJlcG9zaXRvcnkzMzgxNjA0MTc=",
+    "name": "hello_bb_ci",
+    "full_name": "test/hello_bb_ci",
+    "private": true,
+    "owner": {
+      "name": "test",
+      "email": "test@buildbuddy.io",
+      "login": "test",
+      "id": 2414826,
+      "node_id": "MDQ6VXNlcjI0MTQ4MjY=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2414826?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/test",
+      "html_url": "https://github.com/test",
+      "type": "User",
+      "site_admin": false
+    },
+    "html_url": "https://github.com/test/hello_bb_ci",
+    "description": null,
+    "fork": false,
+    "url": "https://github.com/test/hello_bb_ci",
+    "clone_url": "https://github.com/test/hello_bb_ci.git",
+    "default_branch": "main",
+    "master_branch": "main"
+  },
+  "pusher": { "name": "test", "email": "test@buildbuddy.io" },
+  "sender": {
+    "login": "test",
+    "id": 2414826,
+    "type": "User",
+    "site_admin": false
+  },
+  "created": true,
+  "deleted": false,
+  "forced": false,
+  "base_ref": null,
+  "compare": "https://github.com/test/hello_bb_ci/compare/v1.1.0",
+  "commits": [],
+  "head_commit": {
+    "id": "258044d28288d5f6f1c5928b0e22580296fec666",
+    "tree_id": "e6ad10f38a3e6a04f102cfda25b1ab8890e1959e",
+    "distinct": true,
+    "message": "Update BUILD",
+    "timestamp": "2021-02-12T13:26:23-05:00",
+    "url": "https://github.com/test/hello_bb_ci/commit/258044d28288d5f6f1c5928b0e22580296fec666",
+    "author": {
+      "name": "test",
+      "email": "test@buildbuddy.io",
+      "username": "test"
+    },
+    "committer": {
+      "name": "GitHub",
+      "email": "noreply@github.com",
+      "username": "web-flow"
+    },
+    "added": [],
+    "removed": [],
+    "modified": ["BUILD"]
+  }
+}

--- a/enterprise/server/webhooks/github/test_data/push_tag_event.json
+++ b/enterprise/server/webhooks/github/test_data/push_tag_event.json
@@ -42,5 +42,17 @@
   "base_ref": null,
   "compare": "https://github.com/test/hello_bb_ci/compare/v1.0.0",
   "commits": [],
-  "head_commit": null
+  "head_commit": {
+    "id": "258044d28288d5f6f1c5928b0e22580296fec666",
+    "tree_id": "e3797121ccacedf40c13872df15102a5e602b267",
+    "distinct": true,
+    "message": "Add+another+useless+diff.",
+    "timestamp": "2021-02-12T14:09:40-05:00",
+    "url": "https://github.com/test/hello_bb_ci/commit/258044d28288d5f6f1c5928b0e22580296fec666",
+    "author": { "name": "Test", "email": "test@buildbuddy.io", "username": "test" },
+    "committer": { "name": "Test", "email": "test@buildbuddy.io", "username": "test" },
+    "added": [],
+    "removed": [],
+    "modified": ["BUILD"]
+  }
 }

--- a/enterprise/server/webhooks/github/test_data/test_data.go
+++ b/enterprise/server/webhooks/github/test_data/test_data.go
@@ -8,6 +8,9 @@ var PushEvent []byte
 //go:embed push_tag_event.json
 var PushTagEvent []byte
 
+//go:embed push_annotated_tag_event.json
+var PushAnnotatedTagEvent []byte
+
 //go:embed delete_tag_event.json
 var DeleteTagEvent []byte
 


### PR DESCRIPTION
Previously, if someone pushed an annotated tag, `event.GetAfter()` referred to the SHA of the tag object, as opposed to the SHA of the commit.

A tag object SHA doesn't resolve as a commit in GitHub's contents API, so when we try to fetch the buildbuddy.yaml to determine whether a trigger matches, nothing is returned and the workflow will never start

[[Bug report]](https://buildbuddy-corp.slack.com/archives/C0777L0C2UW/p1784080187828479)