### PR TITLE
task_router: prefer two affinity nodes

### DIFF
--- a/enterprise/server/scheduling/task_router/task_router.go
+++ b/enterprise/server/scheduling/task_router/task_router.go
@@ -38,6 +38,10 @@ const (
 	// probes per task (for load balancing purposes).
 	defaultPreferredNodeLimit = 1
 
+	// The preferred node limit for non-default affinity-key experiments. This
+	// leaves one of the three probes available for load balancing.
+	experimentPreferredNodeLimit = 2
+
 	// The preferred node limit for ci_runner tasks.
 	// This is set higher than the default limit since we strongly prefer
 	// these tasks to hit a node with a warm bazel workspace, but it is
@@ -513,7 +517,13 @@ func (*affinityRouter) Applies(_ context.Context, params routingParams) bool {
 	return getAffinityRoutingHint(params) != ""
 }
 
-func (*affinityRouter) preferredNodeLimit(_ routingParams) int {
+func (*affinityRouter) preferredNodeLimit(params routingParams) int {
+	// Keep the whole experiment cohort at two preferred nodes, including
+	// actions that fall back to a first-output hint when target metadata is
+	// unavailable.
+	if params.affinityRouterKey != affinityRouterKeyFirstOutput {
+		return experimentPreferredNodeLimit
+	}
 	return defaultPreferredNodeLimit
 }
 

--- a/enterprise/server/scheduling/task_router/task_router_test.go
+++ b/enterprise/server/scheduling/task_router/task_router_test.go
@@ -273,9 +273,15 @@ func TestTaskRouter_RankNodes_AffinityRouting_UsesExperimentSelectedKey(t *testi
 	selectedOrgPackageCtx := withRequestMetadata(withAuthUser(t, context.Background(), env, "US1"), "//foo/bar", "TestRunner")
 	selectedOrgOtherPackageCtx := withRequestMetadata(withAuthUser(t, context.Background(), env, "US1"), "//foo/baz:foo_test", "TestRunner")
 	router.MarkSucceeded(selectedOrgCtx, nil, firstCmd, instanceName, executorHostID1)
+	router.MarkSucceeded(selectedOrgCtx, nil, firstCmd, instanceName, executorHostID2)
 
 	ranked := router.RankNodes(selectedOrgSameTargetCtx, nil, secondCmd, instanceName, nodes)
-	require.Equal(t, executorHostID1, ranked[0].GetExecutionNode().GetExecutorHostId())
+	require.Equal(t, executorHostID2, ranked[0].GetExecutionNode().GetExecutorHostId())
+	require.True(t, ranked[0].IsPreferred())
+	require.Equal(t, executorHostID1, ranked[1].GetExecutionNode().GetExecutorHostId())
+	require.True(t, ranked[1].IsPreferred())
+	requireNumPreferred(t, 2, ranked)
+	requireNonSequential(t, ranked[2:])
 	requireNotAlwaysRanked(0, executorHostID1, t, router, selectedOrgOtherTargetCtx, secondCmd, instanceName)
 	requireNotAlwaysRanked(0, executorHostID1, t, router, selectedOrgPackageCtx, secondCmd, instanceName)
 	requireNotAlwaysRanked(0, executorHostID1, t, router, selectedOrgOtherPackageCtx, secondCmd, instanceName)
@@ -285,17 +291,27 @@ func TestTaskRouter_RankNodes_AffinityRouting_UsesExperimentSelectedKey(t *testi
 	packageOrgPackageCtx := withRequestMetadata(withAuthUser(t, context.Background(), env, "US2"), "//foo/bar", "TestRunner")
 	packageOrgOtherPackageCtx := withRequestMetadata(withAuthUser(t, context.Background(), env, "US2"), "//foo/baz:foo_test", "TestRunner")
 	router.MarkSucceeded(packageOrgCtx, nil, firstCmd, instanceName, executorHostID1)
+	router.MarkSucceeded(packageOrgCtx, nil, firstCmd, instanceName, executorHostID2)
 
 	ranked = router.RankNodes(packageOrgOtherTargetCtx, nil, secondCmd, instanceName, nodes)
-	require.Equal(t, executorHostID1, ranked[0].GetExecutionNode().GetExecutorHostId())
+	require.Equal(t, executorHostID2, ranked[0].GetExecutionNode().GetExecutorHostId())
+	require.True(t, ranked[0].IsPreferred())
+	require.Equal(t, executorHostID1, ranked[1].GetExecutionNode().GetExecutorHostId())
+	require.True(t, ranked[1].IsPreferred())
+	requireNumPreferred(t, 2, ranked)
 	ranked = router.RankNodes(packageOrgPackageCtx, nil, secondCmd, instanceName, nodes)
-	require.Equal(t, executorHostID1, ranked[0].GetExecutionNode().GetExecutorHostId())
+	require.Equal(t, executorHostID2, ranked[0].GetExecutionNode().GetExecutorHostId())
+	require.Equal(t, executorHostID1, ranked[1].GetExecutionNode().GetExecutorHostId())
 	requireNotAlwaysRanked(0, executorHostID1, t, router, packageOrgOtherPackageCtx, secondCmd, instanceName)
 
 	controlOrgCtx := withRequestMetadata(context.Background(), "//foo/bar:foo_lib", "GoLink")
 	controlOrgOtherTargetCtx := withRequestMetadata(context.Background(), "//foo/bar:foo_test", "TestRunner")
 	router.MarkSucceeded(controlOrgCtx, nil, firstCmd, instanceName, executorHostID1)
+	router.MarkSucceeded(controlOrgCtx, nil, firstCmd, instanceName, executorHostID2)
 
+	ranked = router.RankNodes(controlOrgCtx, nil, firstCmd, instanceName, nodes)
+	require.Equal(t, executorHostID2, ranked[0].GetExecutionNode().GetExecutorHostId())
+	requireNumPreferred(t, 1, ranked)
 	requireNotAlwaysRanked(0, executorHostID1, t, router, controlOrgOtherTargetCtx, secondCmd, instanceName)
 }
 
@@ -332,10 +348,13 @@ func TestTaskRouter_RankNodes_AffinityRouting_TargetKeyFallsBackToFirstOutput(t 
 	}
 
 	router.MarkSucceeded(ctx, nil, firstCmd, instanceName, executorHostID1)
+	router.MarkSucceeded(ctx, nil, firstCmd, instanceName, executorHostID2)
 
 	nodes := sequentiallyNumberedNodes(100)
 	ranked := router.RankNodes(ctx, nil, secondCmd, instanceName, nodes)
-	require.Equal(t, executorHostID1, ranked[0].GetExecutionNode().GetExecutorHostId())
+	require.Equal(t, executorHostID2, ranked[0].GetExecutionNode().GetExecutorHostId())
+	require.Equal(t, executorHostID1, ranked[1].GetExecutionNode().GetExecutorHostId())
+	requireNumPreferred(t, 2, ranked)
 	requireNotAlwaysRanked(0, executorHostID1, t, router, ctx, thirdCmd, instanceName)
 }
 
@@ -682,6 +701,17 @@ func requireNonePreferred(t *testing.T, rankedNodes []interfaces.RankedExecution
 	for i := 1; i < len(rankedNodes); i++ {
 		require.False(t, rankedNodes[i].IsPreferred())
 	}
+}
+
+func requireNumPreferred(t *testing.T, expected int, rankedNodes []interfaces.RankedExecutionNode) {
+	t.Helper()
+	actual := 0
+	for _, node := range rankedNodes {
+		if node.IsPreferred() {
+			actual++
+		}
+	}
+	require.Equal(t, expected, actual)
 }
 
 func requireSameExecutionNodes(t *testing.T, nodes []interfaces.ExecutionNode, ranked []interfaces.RankedExecutionNode) {


### PR DESCRIPTION
Two affinity nodes are needed because non-default routing remembers only
the most recent successful executor. When a randomized fallback wins,
the previous warm executor immediately drops out of the preferred set.

Remember two executors for package- and target-key routing, including
actions that fall back to a first-output hint when target metadata is
unavailable.
The scheduler still sends three probes. One probe remains randomized and
CPU-weighted for load balancing. The default first-output variant keeps
one node.

