### PR TITLE
ci_runner: resolve relative runfiles links

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1441,12 +1441,16 @@ func collectRunfiles(runfilesDir string) (map[digest.Key]string, map[string]stri
 			if err != nil {
 				return err
 			}
-			fi, err := os.Stat(t)
+			targetPath := t
+			if !filepath.IsAbs(targetPath) {
+				targetPath = filepath.Join(filepath.Dir(path), targetPath)
+			}
+			fi, err := os.Stat(targetPath)
 			if err != nil {
 				return err
 			}
 			if fi.IsDir() {
-				dirsToUpload[path] = t
+				dirsToUpload[path] = targetPath
 				return nil
 			}
 		}

--- a/enterprise/server/cmd/ci_runner/main_test.go
+++ b/enterprise/server/cmd/ci_runner/main_test.go
@@ -1,11 +1,29 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestCollectRunfiles_RelativeDirectorySymlink(t *testing.T) {
+	rootDir := t.TempDir()
+	targetDir := filepath.Join(rootDir, "target")
+	assert.NoError(t, os.Mkdir(targetDir, 0755))
+
+	runfilesDir := filepath.Join(rootDir, "binary.runfiles")
+	assert.NoError(t, os.Mkdir(runfilesDir, 0755))
+	linkPath := filepath.Join(runfilesDir, "relative-directory")
+	linkTarget, err := filepath.Rel(filepath.Dir(linkPath), targetDir)
+	assert.NoError(t, err)
+	assert.NoError(t, os.Symlink(linkTarget, linkPath))
+
+	_, _, err = collectRunfiles(runfilesDir)
+	assert.ErrorContains(t, err, "no such file or directory")
+}
 
 func TestParseGitFetchedBytes(t *testing.T) {
 	for _, tc := range []struct {

--- a/enterprise/server/cmd/ci_runner/main_test.go
+++ b/enterprise/server/cmd/ci_runner/main_test.go
@@ -21,8 +21,10 @@ func TestCollectRunfiles_RelativeDirectorySymlink(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, os.Symlink(linkTarget, linkPath))
 
-	_, _, err = collectRunfiles(runfilesDir)
-	assert.ErrorContains(t, err, "no such file or directory")
+	files, dirs, err := collectRunfiles(runfilesDir)
+	assert.NoError(t, err)
+	assert.Empty(t, files)
+	assert.Equal(t, map[string]string{linkPath: targetDir}, dirs)
 }
 
 func TestParseGitFetchedBytes(t *testing.T) {


### PR DESCRIPTION
Remote Bazel can finish its inner Bazel invocation successfully and then
fail while the CI runner collects runfiles. This matters because users
see the overall remote action fail even though the Bazel invocation
succeeded, and the error points to a valid runfiles link.

The CI runner currently passes the raw link target from os.Readlink to
os.Stat, which resolves relative targets from the runner's working
directory. Resolve non-absolute targets from the symlink's parent,
preserve absolute targets, and use the resolved path for CAS directory
uploads.

Add regression coverage that records the original failure before the fix
and then requires successful collection with the correctly resolved
target path.
