### PR TITLE
invocation: index compact execution logs

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -149,6 +149,7 @@ ts_library(
         "//app/format",
         "//app/icons:file_icon",
         "//app/invocation:action_compare_button",
+        "//app/invocation:compact_exec_log_index",
         "//app/invocation:execution_status",
         "//app/invocation:invocation_action_tree_node",
         "//app/invocation:invocation_model",
@@ -172,6 +173,27 @@ ts_library(
         "//proto:stored_invocation_ts_proto",
         "//proto:timestamp_ts_proto",
         "//proto:workflow_ts_proto",
+    ],
+)
+
+ts_library(
+    name = "compact_exec_log_index",
+    srcs = ["compact_exec_log_index.ts"],
+    deps = [
+        "//:node_modules/@types/long",
+        "//:node_modules/long",
+        "//proto:spawn_ts_proto",
+    ],
+)
+
+ts_jasmine_node_test(
+    name = "compact_exec_log_index_test",
+    srcs = ["compact_exec_log_index_test.ts"],
+    deps = [
+        ":compact_exec_log_index",
+        "//:node_modules/long",
+        "//:node_modules/tslib",
+        "//proto:spawn_ts_proto",
     ],
 )
 
@@ -490,6 +512,7 @@ ts_library(
         "//app/capabilities",
         "//app/favicon",
         "//app/format",
+        "//app/invocation:compact_exec_log_index",
         "//app/service:rpc_service",
         "//app/util:cache",
         "//app/util:exit_codes",
@@ -519,6 +542,7 @@ ts_jasmine_node_test(
         "//:node_modules/tslib",
         "//proto:build_event_stream_ts_proto",
         "//proto:invocation_ts_proto",
+        "//proto:spawn_ts_proto",
     ],
 )
 
@@ -903,9 +927,7 @@ ts_library(
     name = "invocation_file_card",
     srcs = ["invocation_file_card.tsx"],
     deps = [
-        "//:node_modules/@types/long",
         "//:node_modules/@types/react",
-        "//:node_modules/long",
         "//:node_modules/lucide-react",
         "//:node_modules/react",
         "//app/components/button",
@@ -914,6 +936,7 @@ ts_library(
         "//app/components/select",
         "//app/errors:error_service",
         "//app/format",
+        "//app/invocation:compact_exec_log_index",
         "//app/invocation:invocation_model",
         "//proto:build_event_stream_ts_proto",
         "//proto:spawn_ts_proto",
@@ -935,6 +958,7 @@ ts_library(
         "//app/errors:error_service",
         "//app/format",
         "//app/invocation:action_compare_button",
+        "//app/invocation:compact_exec_log_index",
         "//app/invocation:invocation_model",
         "//app/util:cache",
         "//proto:remote_execution_ts_proto",

--- a/app/invocation/compact_exec_log_index.ts
+++ b/app/invocation/compact_exec_log_index.ts
@@ -1,0 +1,151 @@
+import Long from "long";
+import { tools } from "../../proto/spawn_ts_proto";
+
+export interface CompactExecLogDirectoryEntry {
+  entry: tools.protos.ExecLogEntry;
+  sizeBytes?: Long;
+  hash?: string;
+}
+
+export interface CompactExecLogIndex {
+  entries: tools.protos.ExecLogEntry[];
+  fileEntries: tools.protos.ExecLogEntry[];
+  directoryEntries: CompactExecLogDirectoryEntry[];
+  unresolvedSymlinkEntries: tools.protos.ExecLogEntry[];
+  spawnEntries: tools.protos.ExecLogEntry[];
+  filesById: Map<number, tools.protos.ExecLogEntry.File>;
+  directoriesById: Map<number, tools.protos.ExecLogEntry.Directory>;
+  unresolvedSymlinksById: Map<number, tools.protos.ExecLogEntry.UnresolvedSymlink>;
+  runfilesTreesById: Map<number, tools.protos.ExecLogEntry.RunfilesTree>;
+  inputSetsById: Map<number, tools.protos.ExecLogEntry.InputSet>;
+  symlinkEntrySetsById: Map<number, tools.protos.ExecLogEntry.SymlinkEntrySet>;
+  spawnsById: Map<number, tools.protos.ExecLogEntry.Spawn>;
+  symlinkActionsById: Map<number, tools.protos.ExecLogEntry.SymlinkAction>;
+  spawnEntriesByDigestHash: Map<string, tools.protos.ExecLogEntry[]>;
+  spawnMnemonics: Set<string>;
+  spawnRunners: Set<string>;
+  spawnPlatformPropertyValues: Map<string, Set<string>>;
+}
+
+/** Builds the shared, read-optimized representation of a decoded compact execution log. */
+export function buildCompactExecLogIndex(entries: tools.protos.ExecLogEntry[]): CompactExecLogIndex {
+  const index: CompactExecLogIndex = {
+    entries,
+    fileEntries: [],
+    directoryEntries: [],
+    unresolvedSymlinkEntries: [],
+    spawnEntries: [],
+    filesById: new Map(),
+    directoriesById: new Map(),
+    unresolvedSymlinksById: new Map(),
+    runfilesTreesById: new Map(),
+    inputSetsById: new Map(),
+    symlinkEntrySetsById: new Map(),
+    spawnsById: new Map(),
+    symlinkActionsById: new Map(),
+    spawnEntriesByDigestHash: new Map(),
+    spawnMnemonics: new Set(),
+    spawnRunners: new Set(),
+    spawnPlatformPropertyValues: new Map(),
+  };
+
+  for (const entry of entries) {
+    const id = Number(entry.id || 0);
+    if (entry.file) {
+      index.fileEntries.push(entry);
+      if (id) index.filesById.set(id, entry.file);
+      continue;
+    }
+    if (entry.directory) {
+      index.directoryEntries.push({ entry });
+      if (id) index.directoriesById.set(id, entry.directory);
+      continue;
+    }
+    if (entry.unresolvedSymlink) {
+      index.unresolvedSymlinkEntries.push(entry);
+      if (id) index.unresolvedSymlinksById.set(id, entry.unresolvedSymlink);
+      continue;
+    }
+    if (entry.runfilesTree) {
+      if (id) index.runfilesTreesById.set(id, entry.runfilesTree);
+      continue;
+    }
+    if (entry.inputSet) {
+      if (id) index.inputSetsById.set(id, entry.inputSet);
+      continue;
+    }
+    if (entry.symlinkEntrySet) {
+      if (id) index.symlinkEntrySetsById.set(id, entry.symlinkEntrySet);
+      continue;
+    }
+    if (entry.spawn) {
+      index.spawnEntries.push(entry);
+      if (id) index.spawnsById.set(id, entry.spawn);
+      if (entry.spawn.digest?.hash) {
+        let entriesForDigest = index.spawnEntriesByDigestHash.get(entry.spawn.digest.hash);
+        if (!entriesForDigest) {
+          entriesForDigest = [];
+          index.spawnEntriesByDigestHash.set(entry.spawn.digest.hash, entriesForDigest);
+        }
+        entriesForDigest.push(entry);
+      }
+      if (entry.spawn.mnemonic) index.spawnMnemonics.add(entry.spawn.mnemonic);
+      if (entry.spawn.runner) index.spawnRunners.add(entry.spawn.runner);
+      for (const property of entry.spawn.platform?.properties || []) {
+        if (!property.name || !property.value) continue;
+        let values = index.spawnPlatformPropertyValues.get(property.name);
+        if (!values) {
+          values = new Set();
+          index.spawnPlatformPropertyValues.set(property.name, values);
+        }
+        values.add(property.value);
+      }
+      continue;
+    }
+    if (entry.symlinkAction && id) {
+      index.symlinkActionsById.set(id, entry.symlinkAction);
+    }
+  }
+
+  return index;
+}
+
+export function findSpawnEntryByDigest(
+  index: CompactExecLogIndex,
+  digest: { hash?: string | null; sizeBytes?: unknown } | null | undefined,
+  matchSize: boolean = true
+): tools.protos.ExecLogEntry | undefined {
+  if (!digest?.hash) return undefined;
+  const candidates = index.spawnEntriesByDigestHash.get(digest.hash) || [];
+  if (!matchSize) return candidates[0];
+  const sizeBytes = String(digest.sizeBytes || 0);
+  return candidates.find((entry) => String(entry.spawn?.digest?.sizeBytes || 0) === sizeBytes);
+}
+
+export function getCompactExecLogDirectoryHash(directory: CompactExecLogDirectoryEntry): string {
+  directory.hash ??= hashFileHashes(directory.entry.directory?.files);
+  return directory.hash;
+}
+
+export function getCompactExecLogDirectorySize(directory: CompactExecLogDirectoryEntry): Long {
+  directory.sizeBytes ??= sumFileSizes(directory.entry.directory?.files || []);
+  return directory.sizeBytes;
+}
+
+function sumFileSizes(files: tools.protos.ExecLogEntry.File[]): Long {
+  return files.reduce((sum, file) => sum.add(file.digest?.sizeBytes || 0), Long.ZERO);
+}
+
+function hashFileHashes(files: tools.protos.ExecLogEntry.File[] | undefined): string {
+  // Keep this lightweight synthetic directory digest consistent with the Files tab's existing behavior.
+  return (files || [])
+    .map((file) => file.digest?.hash || "")
+    .reduce((a, b) => {
+      let hash = "";
+      for (let i = 0; i < Math.max(a.length, b.length); i++) {
+        const char = (a.charCodeAt(i) + b.charCodeAt(i)) % 36;
+        hash += String.fromCharCode(char < 26 ? char + 97 : char + 22);
+      }
+      return hash;
+    }, "");
+}

--- a/app/invocation/compact_exec_log_index_test.ts
+++ b/app/invocation/compact_exec_log_index_test.ts
@@ -1,0 +1,104 @@
+import Long from "long";
+import { tools } from "../../proto/spawn_ts_proto";
+import {
+  buildCompactExecLogIndex,
+  findSpawnEntryByDigest,
+  getCompactExecLogDirectoryHash,
+  getCompactExecLogDirectorySize,
+} from "./compact_exec_log_index";
+
+describe("compact execution log index", () => {
+  it("groups entries and builds reusable lookups and spawn facets", () => {
+    const entries = [
+      file(1, "src/input.txt"),
+      directory(2, "tree", [new tools.protos.ExecLogEntry.File({ path: "nested.txt" })]),
+      unresolvedSymlink(3, "link", "target"),
+      inputSet(4, [1]),
+      spawn(5, {
+        digest: digest("compile", 10),
+        mnemonic: "CppCompile",
+        runner: "remote",
+        platform: { properties: [{ name: "cpu", value: "x86_64" }] },
+      }),
+    ];
+
+    const index = buildCompactExecLogIndex(entries);
+
+    expect(index.entries).toBe(entries);
+    expect(index.fileEntries).toEqual([entries[0]]);
+    expect(index.directoryEntries.map((directory) => directory.entry)).toEqual([entries[1]]);
+    expect(index.unresolvedSymlinkEntries).toEqual([entries[2]]);
+    expect(index.spawnEntries).toEqual([entries[4]]);
+    expect(index.filesById.get(1)?.path).toEqual("src/input.txt");
+    expect(index.directoriesById.get(2)?.path).toEqual("tree");
+    expect(index.unresolvedSymlinksById.get(3)?.targetPath).toEqual("target");
+    expect(index.inputSetsById.get(4)?.inputIds).toEqual([1]);
+    expect(index.spawnsById.get(5)?.mnemonic).toEqual("CppCompile");
+    expect(index.spawnMnemonics).toEqual(new Set(["CppCompile"]));
+    expect(index.spawnRunners).toEqual(new Set(["remote"]));
+    expect(index.spawnPlatformPropertyValues.get("cpu")).toEqual(new Set(["x86_64"]));
+  });
+
+  it("precomputes directory sizes without losing Long precision and lazily computes hashes", () => {
+    const index = buildCompactExecLogIndex([
+      directory(1, "large", [
+        new tools.protos.ExecLogEntry.File({ digest: digest("a", "9007199254740992") }),
+        new tools.protos.ExecLogEntry.File({ digest: digest("b", 5) }),
+      ]),
+    ]);
+
+    const directoryEntry = index.directoryEntries[0];
+    expect(directoryEntry.sizeBytes).toBeUndefined();
+    expect(getCompactExecLogDirectorySize(directoryEntry).toString()).toEqual("9007199254740997");
+    expect(directoryEntry.sizeBytes?.toString()).toEqual("9007199254740997");
+    expect(directoryEntry.hash).toBeUndefined();
+    expect(getCompactExecLogDirectoryHash(directoryEntry)).toBeTruthy();
+    expect(directoryEntry.hash).toBeDefined();
+  });
+
+  it("finds spawn entries by digest hash and optionally matches the size", () => {
+    const small = spawn(1, { digest: digest("shared", 1), mnemonic: "Small" });
+    const large = spawn(2, { digest: digest("shared", 2), mnemonic: "Large" });
+    const index = buildCompactExecLogIndex([small, large]);
+
+    expect(findSpawnEntryByDigest(index, digest("shared", 2))).toBe(large);
+    expect(findSpawnEntryByDigest(index, digest("shared", 999))).toBeUndefined();
+    expect(findSpawnEntryByDigest(index, digest("shared", 999), false)).toBe(small);
+  });
+});
+
+function file(id: number, path: string) {
+  return new tools.protos.ExecLogEntry({ id, file: new tools.protos.ExecLogEntry.File({ path }) });
+}
+
+function directory(id: number, path: string, files: tools.protos.ExecLogEntry.File[]) {
+  return new tools.protos.ExecLogEntry({
+    id,
+    directory: new tools.protos.ExecLogEntry.Directory({ path, files }),
+  });
+}
+
+function unresolvedSymlink(id: number, path: string, targetPath: string) {
+  return new tools.protos.ExecLogEntry({
+    id,
+    unresolvedSymlink: new tools.protos.ExecLogEntry.UnresolvedSymlink({ path, targetPath }),
+  });
+}
+
+function inputSet(id: number, inputIds: number[]) {
+  return new tools.protos.ExecLogEntry({
+    id,
+    inputSet: new tools.protos.ExecLogEntry.InputSet({ inputIds }),
+  });
+}
+
+function spawn(id: number, properties: tools.protos.ExecLogEntry.ISpawn) {
+  return new tools.protos.ExecLogEntry({
+    id,
+    spawn: new tools.protos.ExecLogEntry.Spawn(properties),
+  });
+}
+
+function digest(hash: string, sizeBytes: number | string) {
+  return new tools.protos.Digest({ hash, sizeBytes: Long.fromValue(sizeBytes) });
+}

--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -54,6 +54,7 @@ import { MessageClass, timestampToDate } from "../util/proto";
 import { getErrorReason } from "../util/rpc";
 import { quote } from "../util/shlex";
 import ActionCompareButtonComponent from "./action_compare_button";
+import { findSpawnEntryByDigest } from "./compact_exec_log_index";
 import { ExecuteOperation, executionStatusLabel, waitExecution } from "./execution_status";
 import TreeNodeComponent, { TreeNode } from "./invocation_action_tree_node";
 import InvocationModel from "./invocation_model";
@@ -190,18 +191,13 @@ export default class InvocationActionCardComponent extends React.Component<Props
     }
 
     const model = this.props.model;
-    const actionDigestString = digestToString(actionDigest);
     const actionDigestHasSize = actionDigestParam.includes("/");
     model
-      .getExecutionLog()
-      .then((log) => {
+      .getExecutionLogIndex()
+      .then((index) => {
         if (this.props.model !== model || this.props.search.get("actionDigest") !== actionDigestParam) return;
 
-        const spawn = log.find((entry) => {
-          const spawnDigest = entry.spawn?.digest;
-          if (!spawnDigest || spawnDigest.hash !== actionDigest.hash) return false;
-          return !actionDigestHasSize || digestToString(spawnDigest) === actionDigestString;
-        });
+        const spawn = findSpawnEntryByDigest(index, actionDigest, actionDigestHasSize);
         this.setState({
           measuredMemoryPeakBytes: Number(spawn?.spawn?.metrics?.measuredMemoryPeakBytes || 0) || undefined,
         });

--- a/app/invocation/invocation_file_card.tsx
+++ b/app/invocation/invocation_file_card.tsx
@@ -1,4 +1,3 @@
-import Long from "long";
 import { Download, FileIcon, FileSymlink, Folder, FolderOpen } from "lucide-react";
 import React from "react";
 import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
@@ -9,6 +8,12 @@ import Link from "../components/link/link";
 import Select, { Option } from "../components/select/select";
 import error_service from "../errors/error_service";
 import format from "../format/format";
+import {
+  CompactExecLogDirectoryEntry,
+  CompactExecLogIndex,
+  getCompactExecLogDirectoryHash,
+  getCompactExecLogDirectorySize,
+} from "./compact_exec_log_index";
 import InvocationModel from "./invocation_model";
 
 interface Props {
@@ -24,7 +29,7 @@ interface State {
   fileLimit: number;
   directoryLimit: number;
   symlinkLimit: number;
-  log: tools.protos.ExecLogEntry[] | undefined;
+  index: CompactExecLogIndex | undefined;
   directoryToFileLimit: Map<string, number>;
 }
 
@@ -37,11 +42,12 @@ export default class InvocationFileCardComponent extends React.Component<Props, 
     fileLimit: pageSize,
     directoryLimit: pageSize,
     symlinkLimit: pageSize,
-    log: undefined,
+    index: undefined,
     directoryToFileLimit: new Map<string, number>(),
   };
 
   timeoutRef?: number;
+  fetchRequestId = 0;
 
   componentDidMount() {
     this.fetchLog();
@@ -49,11 +55,12 @@ export default class InvocationFileCardComponent extends React.Component<Props, 
 
   componentDidUpdate(prevProps: Props) {
     if (this.props.model !== prevProps.model) {
-      this.fetchLog();
+      this.setState({ index: undefined }, () => this.fetchLog());
     }
   }
 
   componentWillUnmount() {
+    this.fetchRequestId++;
     clearTimeout(this.timeoutRef);
   }
 
@@ -67,20 +74,25 @@ export default class InvocationFileCardComponent extends React.Component<Props, 
   }
 
   fetchLog() {
+    const requestId = ++this.fetchRequestId;
     if (!this.props.model.hasExecutionLog()) {
-      this.setState({ loading: false });
+      this.setState({ index: undefined, loading: false });
+      return;
     }
-
-    // Already fetched
-    if (this.state.log) return;
 
     this.setState({ loading: true });
 
-    this.props.model
-      .getExecutionLog()
-      .then((log) => this.setState({ log: log }))
+    const model = this.props.model;
+    model
+      .getExecutionLogIndex()
+      .then((index) => {
+        if (requestId !== this.fetchRequestId || this.props.model !== model) return;
+        this.setState({ index });
+      })
       .catch((e) => error_service.handleError(e))
-      .finally(() => this.setState({ loading: false }));
+      .finally(() => {
+        if (requestId === this.fetchRequestId) this.setState({ loading: false });
+      });
   }
 
   downloadLog() {
@@ -99,15 +111,15 @@ export default class InvocationFileCardComponent extends React.Component<Props, 
     }
   }
 
-  compareDirectories(a: tools.protos.ExecLogEntry, b: tools.protos.ExecLogEntry): number {
+  compareDirectories(a: CompactExecLogDirectoryEntry, b: CompactExecLogDirectoryEntry): number {
     let first = this.state.direction == "asc" ? a : b;
     let second = this.state.direction == "asc" ? b : a;
 
     switch (this.state.sort) {
       case "size":
-        return +this.sumFileSizes(first?.directory?.files) - +this.sumFileSizes(second?.directory?.files);
+        return getCompactExecLogDirectorySize(first).compare(getCompactExecLogDirectorySize(second));
       default:
-        return (first.directory?.path || "").localeCompare(second.directory?.path || "");
+        return (first.entry.directory?.path || "").localeCompare(second.entry.directory?.path || "");
     }
   }
 
@@ -116,26 +128,6 @@ export default class InvocationFileCardComponent extends React.Component<Props, 
     let second = this.state.direction == "asc" ? b : a;
 
     return (first.unresolvedSymlink?.path || "").localeCompare(second.unresolvedSymlink?.path || "");
-  }
-
-  sumFileSizes(files: Array<tools.protos.ExecLogEntry.File> | undefined) {
-    return (
-      (files || []).map((f) => f.digest?.sizeBytes || 0).reduce((a, b) => new Long(+a + +b), Long.ZERO) || Long.ZERO
-    );
-  }
-
-  hashFileHashes(files: Array<tools.protos.ExecLogEntry.File> | undefined) {
-    // Just do something simple here that gives us a unique string that changes when one file changes.
-    return (files || [])
-      .map((f) => f.digest?.hash || "")
-      .reduce((a, b) => {
-        var hash = "";
-        for (var i = 0; i < Math.max(a.length, b.length); i++) {
-          let char = (a.charCodeAt(i) + b.charCodeAt(i)) % 36;
-          hash += String.fromCharCode(char < 26 ? char + 97 : char + 22);
-        }
-        return hash;
-      }, "");
   }
 
   handleSortDirectionChange(event: React.ChangeEvent<HTMLInputElement>) {
@@ -188,7 +180,7 @@ export default class InvocationFileCardComponent extends React.Component<Props, 
     if (this.state.loading) {
       return <div className="loading" />;
     }
-    if (!this.state.log?.length) {
+    if (!this.state.index?.entries.length) {
       return (
         <div className="invocation-execution-empty-state">
           No files for this invocation{this.props.model.isInProgress() && <span> yet</span>}.
@@ -196,7 +188,7 @@ export default class InvocationFileCardComponent extends React.Component<Props, 
       );
     }
 
-    const files = this.state.log
+    const files = this.state.index.fileEntries
       .filter((l) => {
         if (l.type != "file") {
           return false;
@@ -213,8 +205,8 @@ export default class InvocationFileCardComponent extends React.Component<Props, 
       })
       .sort(this.compareFiles.bind(this));
 
-    const directories = this.state.log
-      .filter((l) => {
+    const directories = this.state.index.directoryEntries
+      .filter(({ entry: l }) => {
         if (l.type != "directory") {
           return false;
         }
@@ -233,7 +225,7 @@ export default class InvocationFileCardComponent extends React.Component<Props, 
       })
       .sort(this.compareDirectories.bind(this));
 
-    const symlinks = this.state.log
+    const symlinks = this.state.index.unresolvedSymlinkEntries
       .filter((l) => {
         if (l.type != "unresolvedSymlink") {
           return false;
@@ -361,7 +353,8 @@ export default class InvocationFileCardComponent extends React.Component<Props, 
             </div>
             <div>
               <div className="invocation-execution-table">
-                {directories.slice(0, this.state.directoryLimit).map((entry) => {
+                {directories.slice(0, this.state.directoryLimit).map((directory) => {
+                  const entry = directory.entry;
                   let path = entry.directory?.path || "";
                   let fileLimit = this.state.directoryToFileLimit.get(path) || 0;
                   return (
@@ -378,8 +371,8 @@ export default class InvocationFileCardComponent extends React.Component<Props, 
                             <div>
                               <DigestComponent
                                 digest={{
-                                  sizeBytes: this.sumFileSizes(entry.directory?.files),
-                                  hash: this.hashFileHashes(entry.directory?.files),
+                                  sizeBytes: getCompactExecLogDirectorySize(directory),
+                                  hash: getCompactExecLogDirectoryHash(directory),
                                 }}
                                 expanded={true}
                               />

--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -24,6 +24,7 @@ import { resourceNameToString } from "../util/cache";
 import { exitCode } from "../util/exit_codes";
 import { durationToMillisWithFallback, timestampToDateWithFallback } from "../util/proto";
 import { quote } from "../util/shlex";
+import { buildCompactExecLogIndex, CompactExecLogIndex } from "./compact_exec_log_index";
 
 export const CI_RUNNER_ROLE = "CI_RUNNER";
 export const HOSTED_BAZEL_ROLE = "HOSTED_BAZEL";
@@ -79,6 +80,7 @@ export default class InvocationModel {
   rootCauseTargetLabels: Set<String> = new Set<String>();
 
   execLogEntryPromise: Promise<tools.protos.ExecLogEntry[]> | undefined;
+  execLogIndexPromise: Promise<CompactExecLogIndex> | undefined;
 
   private targetConfigurations: build_event_stream.Configuration[] = [];
   private fileSetIDToFilesMap: Map<string, build_event_stream.File[]> = new Map();
@@ -1153,11 +1155,21 @@ export default class InvocationModel {
           entries.push(tools.protos.ExecLogEntry.decode(byteArray.subarray(offset, offset + length)));
           offset += length;
         }
-        console.log(entries);
+        if (rpcService.debuggingEnabled()) {
+          console.debug("Decoded execution log", {
+            bytes: body.byteLength,
+            entries: entries.length,
+          });
+        }
         return entries;
       });
 
     return this.execLogEntryPromise;
+  }
+
+  getExecutionLogIndex() {
+    this.execLogIndexPromise ??= this.getExecutionLog().then(buildCompactExecLogIndex);
+    return this.execLogIndexPromise;
   }
 
   downloadExecutionLog() {

--- a/app/invocation/invocation_model_test.ts
+++ b/app/invocation/invocation_model_test.ts
@@ -1,5 +1,6 @@
 import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
 import { invocation } from "../../proto/invocation_ts_proto";
+import { tools } from "../../proto/spawn_ts_proto";
 import InvocationModel from "./invocation_model";
 
 function newInvocationModelWithBuildMetadata(metadata: Record<string, string>) {
@@ -83,5 +84,25 @@ describe("InvocationModel.getMode", () => {
     model.optionsMap.set("compilation_mode", "opt");
 
     expect(model.getMode()).toBe("opt");
+  });
+});
+
+describe("InvocationModel.getExecutionLogIndex", () => {
+  it("builds and caches one shared index for the decoded execution log", async () => {
+    const model = new InvocationModel(new invocation.Invocation());
+    const entries = [
+      new tools.protos.ExecLogEntry({
+        id: 1,
+        file: new tools.protos.ExecLogEntry.File({ path: "input.txt" }),
+      }),
+    ];
+    model.execLogEntryPromise = Promise.resolve(entries);
+
+    const first = await model.getExecutionLogIndex();
+    const second = await model.getExecutionLogIndex();
+
+    expect(second).toBe(first);
+    expect(first.entries).toBe(entries);
+    expect(first.filesById.get(1)?.path).toEqual("input.txt");
   });
 });

--- a/app/invocation/invocation_spawn_card.tsx
+++ b/app/invocation/invocation_spawn_card.tsx
@@ -10,6 +10,7 @@ import error_service from "../errors/error_service";
 import format from "../format/format";
 import { digestToString } from "../util/cache";
 import ActionCompareButtonComponent from "./action_compare_button";
+import { CompactExecLogIndex } from "./compact_exec_log_index";
 import InvocationModel from "./invocation_model";
 
 interface Props {
@@ -26,7 +27,7 @@ interface State {
   runnerFilter: string;
   platformPropertyFilters: Map<string, string>;
   limit: number;
-  log: tools.protos.ExecLogEntry[] | undefined;
+  index: CompactExecLogIndex | undefined;
 }
 
 const ExecutionStage = build.bazel.remote.execution.v2.ExecutionStage;
@@ -40,10 +41,11 @@ export default class InvocationExecLogCardComponent extends React.Component<Prop
     runnerFilter: "",
     platformPropertyFilters: new Map<string, string>(),
     limit: 100,
-    log: undefined,
+    index: undefined,
   };
 
   timeoutRef?: number;
+  fetchRequestId = 0;
 
   componentDidMount() {
     this.fetchLog();
@@ -51,29 +53,35 @@ export default class InvocationExecLogCardComponent extends React.Component<Prop
 
   componentDidUpdate(prevProps: Props) {
     if (this.props.model !== prevProps.model) {
-      this.fetchLog();
+      this.setState({ index: undefined }, () => this.fetchLog());
     }
   }
 
   componentWillUnmount() {
+    this.fetchRequestId++;
     clearTimeout(this.timeoutRef);
   }
 
   fetchLog() {
+    const requestId = ++this.fetchRequestId;
     if (!this.props.model.hasExecutionLog()) {
-      this.setState({ loading: false });
+      this.setState({ index: undefined, loading: false });
+      return;
     }
-
-    // Already fetched
-    if (this.state.log) return;
 
     this.setState({ loading: true });
 
-    this.props.model
-      .getExecutionLog()
-      .then((log) => this.setState({ log: log }))
+    const model = this.props.model;
+    model
+      .getExecutionLogIndex()
+      .then((index) => {
+        if (requestId !== this.fetchRequestId || this.props.model !== model) return;
+        this.setState({ index });
+      })
       .catch((e) => error_service.handleError(e))
-      .finally(() => this.setState({ loading: false }));
+      .finally(() => {
+        if (requestId === this.fetchRequestId) this.setState({ loading: false });
+      });
   }
 
   downloadLog() {
@@ -181,7 +189,7 @@ export default class InvocationExecLogCardComponent extends React.Component<Prop
     if (this.state.loading) {
       return <div className="loading" />;
     }
-    if (!this.state.log?.length) {
+    if (!this.state.index?.entries.length) {
       return (
         <div className="invocation-execution-empty-state">
           No execution log actions for this invocation{this.props.model.isInProgress() && <span> yet</span>}.
@@ -189,29 +197,12 @@ export default class InvocationExecLogCardComponent extends React.Component<Prop
       );
     }
 
-    const mnemonics = new Set<string>();
-    const runners = new Set<string>();
-    const platformPropertyValues = new Map<string, Set<string>>();
+    const mnemonics = this.state.index.spawnMnemonics;
+    const runners = this.state.index.spawnRunners;
+    const platformPropertyValues = this.state.index.spawnPlatformPropertyValues;
 
-    const spawns = this.state.log
+    const spawns = this.state.index.spawnEntries
       .filter((l) => {
-        if (l.spawn?.mnemonic) {
-          mnemonics.add(l.spawn.mnemonic);
-        }
-        if (l.spawn?.runner) {
-          runners.add(l.spawn.runner);
-        }
-        const platformProps = this.getPlatformProperties(l.spawn?.platform);
-        for (const [propName, propValue] of platformProps) {
-          if (!platformPropertyValues.has(propName)) {
-            platformPropertyValues.set(propName, new Set<string>());
-          }
-          platformPropertyValues.get(propName)!.add(propValue);
-        }
-
-        if (l.type != "spawn") {
-          return false;
-        }
         if (this.state.mnemonicFilter != "" && l.spawn?.mnemonic != this.state.mnemonicFilter) {
           return false;
         }


### PR DESCRIPTION
Large compact execution logs are decoded once, but each invocation view
still scans and analyzes the full entry array independently. This slows
navigation because the Files tab also recomputes directory sizes while
sorting, which took over seven seconds for one reported invocation.

Build one reusable index per InvocationModel with typed entry groups,
ID and digest lookups, and spawn filter facets. Compute directory size
and hash metadata lazily so non-File views do not pay that cost, while
ensuring each directory is analyzed at most once.

Use the shared index in the Files and Spawns tabs and for Action detail
spawn lookup. Guard async component updates against stale models, and
keep large decoded entry arrays out of the console unless debug logging
is enabled.

This provides the foundation for compact-log action edges without
coupling the index to that UI.
