### PR TITLE
Add ConfigurationID to clickhouse Executions table

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -303,6 +303,7 @@ func (s *ExecutionServer) insertExecution(ctx context.Context, executionID, invo
 		rmd := bazel_request.GetRequestMetadata(ctx)
 		executionProto.TargetLabel = rmd.GetTargetId()
 		executionProto.ActionMnemonic = rmd.GetActionMnemonic()
+		executionProto.ConfigurationId = rmd.GetConfigurationId()
 		executionProto.OutputPath = primaryOutputPath(command)
 		executionProto.RequestedPool = requestedPool
 		executionProto.ClientIp = clientip.Get(ctx)
@@ -442,6 +443,7 @@ func (s *ExecutionServer) updateExecution(ctx context.Context, executionID strin
 			rmd := bazel_request.GetRequestMetadata(ctx)
 			executionProto.TargetLabel = rmd.GetTargetId()
 			executionProto.ActionMnemonic = rmd.GetActionMnemonic()
+			executionProto.ConfigurationId = rmd.GetConfigurationId()
 			if value, ok := rexec.LookupEnv(cmd.GetEnvironmentVariables(), "TEST_SIZE"); ok {
 				if testSize, ok := bespb.TestSize_value[strings.ToUpper(value)]; ok && testSize != int32(bespb.TestSize_UNKNOWN) {
 					executionProto.TestSize = strings.ToLower(bespb.TestSize(testSize).String())

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -868,6 +868,7 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 		ToolInvocationId: invocationID,
 		TargetId:         "//some:test",
 		ActionMnemonic:   "TestRunner",
+		ConfigurationId:  "26b4b27c1032c7df9ed4ffe75e295384222c5464200cf73616ef1beeb8f8028d",
 	})
 	require.NoError(t, err)
 	for k, v := range test.platformOverrides {
@@ -1199,6 +1200,7 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 		RequestedTimeoutUsec:         10000000,
 		TargetLabel:                  "//some:test",
 		ActionMnemonic:               "TestRunner",
+		ConfigurationId:              "26b4b27c1032c7df9ed4ffe75e295384222c5464200cf73616ef1beeb8f8028d",
 		TestSize:                     wantTestSize,
 		TestShardIndex:               2,
 		TestTotalShards:              6,

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -3095,9 +3095,9 @@ message StoredExecution {
   string status_message = 32;
   string command_snippet = 62;
 
-  // TODO(sluongng): add configuration.
   string target_label = 33;
   string action_mnemonic = 57;
+  string configuration_id = 92;
 
   // Experiments used by this execution.
   repeated string experiments = 61;

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -451,6 +451,7 @@ func ExecutionFromProto(in *repb.StoredExecution, inv *sipb.StoredInvocation) (*
 		Tags:                               invocation_format.ConvertDBTagsToOLAP(inv.GetTags()),
 		TargetLabel:                        in.GetTargetLabel(),
 		ActionMnemonic:                     in.GetActionMnemonic(),
+		ConfigurationID:                    in.GetConfigurationId(),
 		TestSize:                           in.GetTestSize(),
 		TestShardIndex:                     in.GetTestShardIndex(),
 		TestTotalShards:                    in.GetTestTotalShards(),

--- a/server/util/clickhouse/clickhouse_test.go
+++ b/server/util/clickhouse/clickhouse_test.go
@@ -92,14 +92,20 @@ func TestExecutionFromProto(t *testing.T) {
 			},
 		},
 		{
-			name: "TestMetadata",
+			name: "RequestAndTestMetadata",
 			in: &repb.StoredExecution{
 				ExecutionId:     executionID,
+				TargetLabel:     "//some:test",
+				ActionMnemonic:  "TestRunner",
+				ConfigurationId: "26b4b27c1032c7df9ed4ffe75e295384222c5464200cf73616ef1beeb8f8028d",
 				TestSize:        "large",
 				TestShardIndex:  2,
 				TestTotalShards: 6,
 			},
 			want: &schema.Execution{
+				TargetLabel:     "//some:test",
+				ActionMnemonic:  "TestRunner",
+				ConfigurationID: "26b4b27c1032c7df9ed4ffe75e295384222c5464200cf73616ef1beeb8f8028d",
 				TestSize:        "large",
 				TestShardIndex:  2,
 				TestTotalShards: 6,
@@ -114,6 +120,9 @@ func TestExecutionFromProto(t *testing.T) {
 			// The row should preserve direct proto fields while also parsing
 			// the execution ID resource fields.
 			require.Equal(t, testCase.want.RecycleRunner, execution.RecycleRunner)
+			require.Equal(t, testCase.want.TargetLabel, execution.TargetLabel)
+			require.Equal(t, testCase.want.ActionMnemonic, execution.ActionMnemonic)
+			require.Equal(t, testCase.want.ConfigurationID, execution.ConfigurationID)
 			require.Equal(t, testCase.want.TestSize, execution.TestSize)
 			require.Equal(t, testCase.want.TestShardIndex, execution.TestShardIndex)
 			require.Equal(t, testCase.want.TestTotalShards, execution.TestTotalShards)
@@ -163,6 +172,7 @@ func TestFlushExecutionStats_SkipsMalformedExecutionIDs(t *testing.T) {
 			InvocationUuid:  invocationUUID,
 			UpdatedAtUsec:   nowUsec,
 			CreatedAtUsec:   nowUsec,
+			ConfigurationId: "26b4b27c1032c7df9ed4ffe75e295384222c5464200cf73616ef1beeb8f8028d",
 			TestSize:        "enormous",
 			TestShardIndex:  3,
 			TestTotalShards: 8,
@@ -190,6 +200,7 @@ func TestFlushExecutionStats_SkipsMalformedExecutionIDs(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	require.Equal(t, validExecutionID, reconstructExecutionID(t, &rows[0]))
+	require.Equal(t, "26b4b27c1032c7df9ed4ffe75e295384222c5464200cf73616ef1beeb8f8028d", rows[0].ConfigurationID)
 	require.Equal(t, "enormous", rows[0].TestSize)
 	require.Equal(t, uint32(3), rows[0].TestShardIndex)
 	require.Equal(t, uint32(8), rows[0].TestTotalShards)

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -203,6 +203,8 @@ type Execution struct {
 	// RequestMetadata
 	TargetLabel    string `gorm:"codec:ZSTD(1)"`
 	ActionMnemonic string `gorm:"codec:ZSTD(1)"`
+	// ConfigurationID identifies the configuration in which the target was built.
+	ConfigurationID string `gorm:"codec:ZSTD(1)"`
 
 	// Test metadata
 	TestSize        string `gorm:"type:LowCardinality(String)"`
@@ -364,6 +366,7 @@ func (e *Execution) AdditionalFields() []string {
 		"OutputPath",
 		"TargetLabel",
 		"ActionMnemonic",
+		"ConfigurationID",
 		"TestSize",
 		"TestShardIndex",
 		"TestTotalShards",


### PR DESCRIPTION
These are long-ish hashes like `26b4b27c1032c7df9ed4ffe75e295384222c5464200cf73616ef1beeb8f8028d`, but they are low-cardinality so I expect them to compress pretty well. For example in [this invocation](https://buildbuddy.buildbuddy.io/invocation/9b08b3bf-2f3b-4cdd-a9e5-d00981f4a327), we only have 2 configuration IDs total, across 500+ executions.

Context https://buildbuddy-corp.slack.com/archives/C01TGNZKYMP/p1784216060962789

This should allow joining with the `Configuration` events in the BES stream, allowing us to show a nice configuration mnemonic for each execution.