### PR TITLE
Allow disabling FMB cache using flagd

### DIFF
--- a/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
+++ b/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
@@ -38,6 +38,7 @@ var (
 type CASServerProxy struct {
 	supportsEncryption func(context.Context) bool
 	authenticator      interfaces.Authenticator
+	efp                interfaces.ExperimentFlagProvider
 	local              repb.ContentAddressableStorageServer
 	remote             repb.ContentAddressableStorageClient
 	localCache         interfaces.Cache
@@ -85,9 +86,14 @@ func New(env environment.Env) (*CASServerProxy, error) {
 	if remote == nil {
 		return nil, fmt.Errorf("A remote ContentAddressableStorageClient is required to enable the ContentAddressableStorageServerProxy")
 	}
+	efp := env.GetExperimentFlagProvider()
+	if efp == nil {
+		log.Warning("No experiment flag provider configured; ContentAddressableStorageServerProxy experiment flags will not take effect")
+	}
 	proxy := CASServerProxy{
 		supportsEncryption: remote_crypter.SupportsEncryption(env),
 		authenticator:      authenticator,
+		efp:                efp,
 		local:              local,
 		remote:             remote,
 		localCache:         env.GetCache(),
@@ -209,7 +215,7 @@ func (s *CASServerProxy) FindMissingBlobs(ctx context.Context, req *repb.FindMis
 	defer spn.End()
 	tracing.AddStringAttributeToCurrentSpan(ctx, "requested-blobs", strconv.Itoa(len(req.BlobDigests)))
 
-	if s.findMissingCache == nil {
+	if s.findMissingCache == nil || s.efp != nil && s.efp.Boolean(ctx, "cache_proxy.bypass_find_missing_cache", false) {
 		return s.remote.FindMissingBlobs(ctx, req)
 	}
 

--- a/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy_test.go
+++ b/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy_test.go
@@ -369,6 +369,41 @@ func TestFindMissingBlobs_Caching(t *testing.T) {
 	require.Equal(t, int32(6), requestCount.Load())
 }
 
+func TestFindMissingBlobs_BypassCache(t *testing.T) {
+	flags.Set(t, "cache_proxy.find_missing_blobs_cache_ttl", 30*time.Second)
+	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		"cache_proxy.bypass_find_missing_cache": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "true",
+			Variants: map[string]any{
+				"true": true,
+			},
+		},
+	})
+	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
+	fp, err := experiments.NewFlagProvider(t.Name())
+	require.NoError(t, err)
+
+	ctx := testContext()
+	conn, requestCount, _ := runRemoteCASS(ctx, testenv.GetTestEnv(t), t)
+	proxyEnv := testenv.GetTestEnv(t)
+	proxyEnv.SetAuthenticator(testauth.NewTestAuthenticator(t, testauth.TestUsers("US1", "GR1")))
+	proxyEnv.SetExperimentFlagProvider(fp)
+	proxyEnv.SetContentAddressableStorageClient(repb.NewContentAddressableStorageClient(conn))
+	require.NoError(t, atime_updater.Register(proxyEnv))
+	proxyConn := runCASProxy(ctx, conn, proxyEnv, t)
+	proxy := repb.NewContentAddressableStorageClient(proxyConn)
+	ctx = metadata.AppendToOutgoingContext(ctx, authutil.APIKeyHeader, "US1")
+
+	barDigestProto := digestProto(barDigest, 3)
+	update(ctx, proxy, map[*repb.Digest]string{barDigestProto: "bar"}, t)
+	requestCount.Store(0)
+
+	findMissing(ctx, proxy, []*repb.Digest{barDigestProto}, []*repb.Digest{}, t)
+	findMissing(ctx, proxy, []*repb.Digest{barDigestProto}, []*repb.Digest{}, t)
+	require.Equal(t, int32(2), requestCount.Load())
+}
+
 func TestFindMissingBlobs_CachingIsolatedByGroup(t *testing.T) {
 	flags.Set(t, "cache_proxy.find_missing_blobs_cache_ttl", 30*time.Second)
 	ctx := testContext()


### PR DESCRIPTION
When changing chunking parameters, we need an authoritative check based on current configuration whether something is missing. Therefore, we need to bypass any existence caching. 

This PR adds it to flagd so we can disable it per group.