### PR TITLE
Refine FMB existence cache metrics

### DIFF
--- a/enterprise/server/content_addressable_storage_server_proxy/BUILD
+++ b/enterprise/server/content_addressable_storage_server_proxy/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//server/real_environment",
         "//server/remote_cache/digest",
         "//server/util/authutil",
+        "//server/util/cdc",
         "//server/util/log",
         "//server/util/lru",
         "//server/util/proto",

--- a/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
+++ b/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
@@ -15,6 +15,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
+	"github.com/buildbuddy-io/buildbuddy/server/util/cdc"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/lru"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
@@ -52,9 +53,7 @@ type CASServerProxy struct {
 	//    remote-return path (local cache didn't have the digest, remote cache
 	//    did).
 	// TODO(go/b/7780): fix those issues.
-	findMissingCache       lru.LRU[struct{}]
-	findMissingCacheHits   prometheus.Counter
-	findMissingCacheMisses prometheus.Counter
+	findMissingCache lru.LRU[struct{}]
 }
 
 func Register(env *real_environment.RealEnv) error {
@@ -98,10 +97,6 @@ func New(env environment.Env) (*CASServerProxy, error) {
 			return nil, status.InvalidArgumentErrorf("Error initializing FindMissingBlobs cache: %s", err)
 		}
 		proxy.findMissingCache = cache
-		proxy.findMissingCacheHits = metrics.FindMissingBlobsCacheLookups.With(
-			prometheus.Labels{metrics.CacheHitMissStatus: metrics.HitStatusLabel})
-		proxy.findMissingCacheMisses = metrics.FindMissingBlobsCacheLookups.With(
-			prometheus.Labels{metrics.CacheHitMissStatus: metrics.MissStatusLabel})
 	}
 	return &proxy, nil
 }
@@ -227,8 +222,8 @@ func (s *CASServerProxy) FindMissingBlobs(ctx context.Context, req *repb.FindMis
 	}
 
 	hits := len(req.GetBlobDigests()) - len(misses)
-	s.findMissingCacheHits.Add(float64(hits))
-	s.findMissingCacheMisses.Add(float64(len(misses)))
+	chunked := cdc.IsChunked(ctx)
+	findMissingBlobsCacheLookups(metrics.HitStatusLabel, chunked).Add(float64(hits))
 
 	// All digests were found in the FindMissingBlobs cache, return.
 	if len(misses) == 0 {
@@ -251,13 +246,24 @@ func (s *CASServerProxy) FindMissingBlobs(ctx context.Context, req *repb.FindMis
 	for _, d := range rsp.GetMissingBlobDigests() {
 		missing[cacheKeys[digestKey(d)]] = struct{}{}
 	}
+	presentRemotely := 0
 	for _, d := range remoteReq.GetBlobDigests() {
 		key := cacheKeys[digestKey(d)]
 		if _, ok := missing[key]; !ok {
+			presentRemotely++
 			s.findMissingCache.Add(key, struct{}{})
 		}
 	}
+	findMissingBlobsCacheLookups(metrics.MissStatusLabel, chunked).Add(float64(presentRemotely))
+	findMissingBlobsCacheLookups(metrics.UncacheableStatusLabel, chunked).Add(float64(len(remoteReq.GetBlobDigests()) - presentRemotely))
 	return rsp, nil
+}
+
+func findMissingBlobsCacheLookups(status string, chunked bool) prometheus.Counter {
+	return metrics.FindMissingBlobsCacheLookups.With(prometheus.Labels{
+		metrics.CacheHitMissStatus: status,
+		metrics.ChunkedLabel:       strconv.FormatBool(chunked),
+	})
 }
 
 // digestKey identifies a digest within a single FindMissingBlobs request.

--- a/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
+++ b/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
@@ -53,7 +53,14 @@ type CASServerProxy struct {
 	//    remote-return path (local cache didn't have the digest, remote cache
 	//    did).
 	// TODO(go/b/7780): fix those issues.
-	findMissingCache lru.LRU[struct{}]
+	findMissingCache                  lru.LRU[struct{}]
+	findMissingCacheCountersByChunked map[bool]findMissingCacheCounters
+}
+
+type findMissingCacheCounters struct {
+	hits        prometheus.Counter
+	misses      prometheus.Counter
+	uncacheable prometheus.Counter
 }
 
 func Register(env *real_environment.RealEnv) error {
@@ -97,6 +104,14 @@ func New(env environment.Env) (*CASServerProxy, error) {
 			return nil, status.InvalidArgumentErrorf("Error initializing FindMissingBlobs cache: %s", err)
 		}
 		proxy.findMissingCache = cache
+		proxy.findMissingCacheCountersByChunked = make(map[bool]findMissingCacheCounters, 2)
+		for _, chunked := range []bool{false, true} {
+			proxy.findMissingCacheCountersByChunked[chunked] = findMissingCacheCounters{
+				hits:        findMissingBlobsCacheLookups(metrics.HitStatusLabel, chunked),
+				misses:      findMissingBlobsCacheLookups(metrics.MissStatusLabel, chunked),
+				uncacheable: findMissingBlobsCacheLookups(metrics.UncacheableStatusLabel, chunked),
+			}
+		}
 	}
 	return &proxy, nil
 }
@@ -222,8 +237,8 @@ func (s *CASServerProxy) FindMissingBlobs(ctx context.Context, req *repb.FindMis
 	}
 
 	hits := len(req.GetBlobDigests()) - len(misses)
-	chunked := cdc.IsChunked(ctx)
-	findMissingBlobsCacheLookups(metrics.HitStatusLabel, chunked).Add(float64(hits))
+	counters := s.findMissingCacheCountersByChunked[cdc.IsChunked(ctx)]
+	counters.hits.Add(float64(hits))
 
 	// All digests were found in the FindMissingBlobs cache, return.
 	if len(misses) == 0 {
@@ -254,8 +269,8 @@ func (s *CASServerProxy) FindMissingBlobs(ctx context.Context, req *repb.FindMis
 			s.findMissingCache.Add(key, struct{}{})
 		}
 	}
-	findMissingBlobsCacheLookups(metrics.MissStatusLabel, chunked).Add(float64(presentRemotely))
-	findMissingBlobsCacheLookups(metrics.UncacheableStatusLabel, chunked).Add(float64(len(remoteReq.GetBlobDigests()) - presentRemotely))
+	counters.misses.Add(float64(presentRemotely))
+	counters.uncacheable.Add(float64(len(remoteReq.GetBlobDigests()) - presentRemotely))
 	return rsp, nil
 }
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -4237,9 +4237,10 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "proxy",
 		Name:      "find_missing_blobs_cache_lookups",
-		Help:      "The number of digests looked up in the Cache Proxy's local FindMissingBlobs cache by cache hit/miss status.",
+		Help:      "The number of digests looked up in the Cache Proxy's local FindMissingBlobs cache, by lookup status and whether the digests are CDC chunks. 'hit': served from the local cache. 'miss': the remote reported the digest present, so the lookup could have been a hit. 'uncacheable': the remote reported the digest missing; absence is never cached, so these lookups always require a remote check.",
 	}, []string{
 		CacheHitMissStatus,
+		ChunkedLabel,
 	})
 
 	RemoteAtimeUpdates = promauto.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
A metrics fix here is that a "miss" only is useful if the remote reported the blob as not missing. If the remote reports the blobs as missing still, this is "uncachable" since a subsequent look needs to check again (i.e. we can't read through this value). Also lets add the "chunked" label.