### PR TITLE
codesearch: add tree-sitter code navigation library

### DIFF
--- a/codesearch/annotations/BUILD
+++ b/codesearch/annotations/BUILD
@@ -7,6 +7,7 @@ go_library(
         "cpp.go",
         "golang.go",
         "java.go",
+        "nav.go",
         "python.go",
         "rust.go",
         "typescript.go",
@@ -34,12 +35,14 @@ go_test(
     srcs = [
         "annotations_test.go",
         "cpp_test.go",
+        "nav_test.go",
+        "nav_ts_test.go",
         "python_test.go",
         "rust_test.go",
         "typescript_test.go",
     ],
+    embed = [":annotations"],
     deps = [
-        ":annotations",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/codesearch/annotations/golang.go
+++ b/codesearch/annotations/golang.go
@@ -151,3 +151,300 @@ func goImportPaths(tree *sitter.Tree, content []byte) []string {
 	}
 	return paths
 }
+
+// Code navigation (decorateGo / goDefinitions) for Go. These reuse the same
+// identity vocabulary as extraction (goTerm / goPackageImportPath) so nav
+// tickets join against the `import_id` terms the index already stores.
+
+// GoSelfImportID returns the import_id term for the package containing the
+// repo-relative file relPath in a module rooted at modulePath, or "" when it
+// can't be determined (no module path, a path outside the module, or a test
+// file — test files aren't part of a package's importable surface, mirroring
+// the extractor's `import_id` rule). It's a convenience for callers that have
+// module context; the server instead reads the term from the index.
+func GoSelfImportID(modulePath, relPath string) string {
+	if modulePath == "" || relPath == "" || strings.HasSuffix(relPath, "_test.go") {
+		return ""
+	}
+	return goTerm(goPackageImportPath(modulePath, relPath))
+}
+
+// GoModuleInRepo returns a NavOptions.InRepo predicate that accepts import
+// paths within the module rooted at modulePath. It returns nil for an empty
+// module path, which Decorate treats as "accept everything".
+func GoModuleInRepo(modulePath string) func(string) bool {
+	if modulePath == "" {
+		return nil
+	}
+	return func(imp string) bool {
+		return imp == modulePath || strings.HasPrefix(imp, modulePath+"/")
+	}
+}
+
+// goImportMap maps each imported package's local name (its alias, or the last
+// path element by default) to its import path. Blank and dot imports are
+// skipped — neither yields a usable package selector.
+func goImportMap(root *sitter.Node, content []byte) map[string]string {
+	out := make(map[string]string)
+	var visit func(n *sitter.Node)
+	visit = func(n *sitter.Node) {
+		if n.Type() == "import_spec" {
+			pathNode := n.ChildByFieldName("path")
+			if pathNode == nil {
+				return
+			}
+			imp, err := strconv.Unquote(pathNode.Content(content))
+			if err != nil || imp == "" {
+				return
+			}
+			local := path.Base(imp)
+			if nameNode := n.ChildByFieldName("name"); nameNode != nil {
+				name := nameNode.Content(content)
+				if name == "_" || name == "." {
+					return // blank/dot import: no usable selector
+				}
+				local = name
+			}
+			out[local] = imp
+			return
+		}
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			visit(n.NamedChild(i))
+		}
+	}
+	for i := 0; i < int(root.NamedChildCount()); i++ {
+		if child := root.NamedChild(i); child.Type() == "import_declaration" {
+			visit(child)
+		}
+	}
+	return out
+}
+
+// decorateGo parses a Go file and returns the clickable references in it. It
+// produces two kinds of reference, all sharing the tree-sitter://symbol ticket
+// shape so they resolve through one path:
+//
+//   - package selectors (`log.Infof`): the field is decorated, targeting the
+//     imported package's identity. opts.InRepo limits these to resolvable
+//     packages; with no predicate, external selectors are still decorated but
+//     resolve to nothing on click.
+//   - same-package names: a bare identifier whose name matches a file-scope
+//     declaration in this file, targeting this file's own package
+//     (opts.SelfImportID). Disabled when SelfImportID is empty.
+//
+// This is name-based, like GitHub's syntactic nav: it does not perform scope
+// resolution, so a local variable shadowing a declared name still decorates.
+func decorateGo(ctx context.Context, content []byte, opts NavOptions) ([]Ref, error) {
+	parser := sitter.NewParser()
+	// Close the parser only after the tree: the binding keeps the parser
+	// alive for the tree's lifetime (defers run LIFO).
+	defer parser.Close()
+	parser.SetLanguage(golang.GetLanguage())
+	tree, err := parser.ParseCtx(ctx, nil, content)
+	if err != nil {
+		return nil, err
+	}
+	defer tree.Close()
+	root := tree.RootNode()
+
+	importMap := goImportMap(root, content)
+	selfID := opts.SelfImportID
+	inRepo := opts.InRepo
+	if inRepo == nil {
+		inRepo = func(string) bool { return true }
+	}
+
+	// File-scope declaration names (lowercased) and the byte offsets of the
+	// declaration name tokens themselves, so a declaration site isn't also
+	// decorated as a reference to itself.
+	declNames := make(map[string]struct{})
+	declSites := make(map[uint32]struct{})
+	defs, err := goDefinitions(ctx, content)
+	if err != nil {
+		return nil, err
+	}
+	for _, d := range defs {
+		declNames[strings.ToLower(d.Name)] = struct{}{}
+		declSites[d.Start.Byte] = struct{}{}
+	}
+
+	// consumed marks byte offsets handled as part of a package selector (the
+	// operand and field tokens), so the same tokens aren't reconsidered as
+	// same-package references.
+	consumed := make(map[uint32]struct{})
+	var refs []Ref
+
+	var walk func(n *sitter.Node)
+	walk = func(n *sitter.Node) {
+		switch n.Type() {
+		case "selector_expression":
+			operand := n.ChildByFieldName("operand")
+			field := n.ChildByFieldName("field")
+			if operand != nil && operand.Type() == "identifier" && field != nil {
+				consumed[operand.StartByte()] = struct{}{}
+				if imp, ok := importMap[operand.Content(content)]; ok && inRepo(imp) {
+					consumed[field.StartByte()] = struct{}{}
+					refs = append(refs, Ref{
+						Start:        nodeStart(field),
+						End:          nodeEnd(field),
+						Kind:         refEdgeKind,
+						TargetTicket: symbolTicket(goTerm(imp), field.Content(content)),
+					})
+				}
+			}
+		case "identifier", "type_identifier":
+			if selfID == "" {
+				break
+			}
+			if _, skip := consumed[n.StartByte()]; skip {
+				break
+			}
+			if _, isDecl := declSites[n.StartByte()]; isDecl {
+				break
+			}
+			name := n.Content(content)
+			if _, ok := declNames[strings.ToLower(name)]; ok {
+				refs = append(refs, Ref{
+					Start:        nodeStart(n),
+					End:          nodeEnd(n),
+					Kind:         refEdgeKind,
+					TargetTicket: symbolTicket(selfID, name),
+				})
+			}
+		}
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			walk(n.NamedChild(i))
+		}
+	}
+	walk(root)
+
+	return refs, nil
+}
+
+// goDefSpecQuery captures file-scope declarations: functions, methods, types
+// (incl. aliases), and package-level consts/vars. Each match binds @sym (the
+// name token, for the span) and @decl (the enclosing declaration node, for
+// kind/signature/doc). Const/var captures are anchored to source_file so
+// function-local declarations are excluded.
+var goDefSpecQuery = mustCompileQuery(`
+	(function_declaration name: (identifier) @sym) @decl
+	(method_declaration name: (field_identifier) @sym) @decl
+	(type_spec name: (type_identifier) @sym) @decl
+	(type_alias name: (type_identifier) @sym) @decl
+	(source_file (const_declaration (const_spec name: (identifier) @sym) @decl))
+	(source_file (var_declaration (var_spec name: (identifier) @sym) @decl))
+`, golang.GetLanguage())
+
+// goDefinitions returns the file-scope declarations in a Go file, each with its
+// original-case name, the span of the name token, and documentation metadata
+// (kind, one-line signature, leading doc comment).
+func goDefinitions(ctx context.Context, content []byte) ([]Def, error) {
+	parser := sitter.NewParser()
+	defer parser.Close()
+	parser.SetLanguage(golang.GetLanguage())
+	tree, err := parser.ParseCtx(ctx, nil, content)
+	if err != nil {
+		return nil, err
+	}
+	defer tree.Close()
+
+	qc := sitter.NewQueryCursor()
+	defer qc.Close()
+	qc.Exec(goDefSpecQuery, tree.RootNode())
+
+	var defs []Def
+	for {
+		m, ok := qc.NextMatch()
+		if !ok {
+			break
+		}
+		var nameNode, declNode *sitter.Node
+		for _, c := range m.Captures {
+			switch goDefSpecQuery.CaptureNameForId(c.Index) {
+			case "sym":
+				nameNode = c.Node
+			case "decl":
+				declNode = c.Node
+			}
+		}
+		if nameNode == nil {
+			continue
+		}
+		name := nameNode.Content(content)
+		if name == "" {
+			continue
+		}
+		d := Def{Name: name, Start: nodeStart(nameNode), End: nodeEnd(nameNode)}
+		if declNode != nil {
+			d.Kind = goDeclKind(declNode)
+			d.Signature = goSignature(declNode, content)
+			d.Doc = goLeadingComment(declNode, content)
+		}
+		defs = append(defs, d)
+	}
+	return defs, nil
+}
+
+// goDeclKind classifies a declaration node.
+func goDeclKind(decl *sitter.Node) string {
+	switch decl.Type() {
+	case "function_declaration":
+		return "func"
+	case "method_declaration":
+		return "method"
+	case "type_alias":
+		return "type"
+	case "type_spec":
+		if t := decl.ChildByFieldName("type"); t != nil {
+			switch t.Type() {
+			case "struct_type":
+				return "struct"
+			case "interface_type":
+				return "interface"
+			}
+		}
+		return "type"
+	case "const_spec":
+		return "const"
+	case "var_spec":
+		return "var"
+	}
+	return ""
+}
+
+// goSignature renders a declaration as a single line: for funcs/methods, the
+// text up to the body; for others, the first line, with the leading keyword
+// restored (the spec nodes don't include it).
+func goSignature(decl *sitter.Node, content []byte) string {
+	switch decl.Type() {
+	case "function_declaration", "method_declaration":
+		if body := decl.ChildByFieldName("body"); body != nil {
+			sig := string(content[decl.StartByte():body.StartByte()])
+			return strings.Join(strings.Fields(sig), " ")
+		}
+		return firstLine(decl.Content(content))
+	case "type_spec", "type_alias":
+		return "type " + firstLine(decl.Content(content))
+	case "const_spec":
+		return "const " + firstLine(decl.Content(content))
+	case "var_spec":
+		return "var " + firstLine(decl.Content(content))
+	}
+	return firstLine(decl.Content(content))
+}
+
+// goLeadingComment returns the contiguous doc-comment lines immediately above a
+// declaration, with comment markers stripped. For const/var specs the comment
+// often sits above the enclosing declaration, so that is tried as a fallback.
+func goLeadingComment(decl *sitter.Node, content []byte) string {
+	doc := collectComments(decl, content)
+	if doc == "" {
+		switch decl.Type() {
+		case "const_spec", "var_spec":
+			if parent := decl.Parent(); parent != nil {
+				doc = collectComments(parent, content)
+			}
+		}
+	}
+	return doc
+}

--- a/codesearch/annotations/nav.go
+++ b/codesearch/annotations/nav.go
@@ -1,0 +1,429 @@
+// Click-through code navigation ("go to definition", hover, find references)
+// derived on demand from tree-sitter — the syntactic, kythe-free nav tier.
+// Given a file's contents it produces the clickable references in that file
+// (Decorate, per language); given the index's existing `symbols`/`import_id`
+// posting lists (via DefLookup/RefLookup) it resolves a clicked reference to
+// the file+span that defines it (Resolve), to documentation (Describe), or to
+// every use site (FindReferences).
+//
+// The model is deliberately name-based, the same approach GitHub ships as its
+// default "search-based" navigation: a reference is an identifier occurrence
+// whose name matches a declared symbol. It needs no compilation and no
+// semantic type resolution, so it works on any indexed snapshot of a repo.
+//
+// References carry an opaque target ticket under the tree-sitter:// scheme (see
+// Scheme) encoding a definition's package import_id term and symbol name. The
+// package half is exactly an `import_id` term as produced by extraction (e.g.
+// `go:<lowercased import path>`). Resolution is then a single posting-list
+// intersection — "files whose import_id is this package and whose symbols
+// contain this name" — followed by a re-parse of those files to recover the
+// declaration. The scheme also drives serving: the server routes a request to
+// tree-sitter nav, instead of kythe, precisely when its ticket(s) carry the
+// tree-sitter:// scheme, with no enabling flag. This layer is free of kythe and
+// proto dependencies; the server maps these types to the kythe reply protos the
+// frontend consumes.
+
+package annotations
+
+import (
+	"context"
+	"net/url"
+	"slices"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// Scheme is the URI scheme of every nav ticket. The server routes
+// Decorations/CrossReferences/Docs/Xrefs requests to tree-sitter nav (rather
+// than kythe) by this scheme alone — a request carrying tree-sitter:// tickets
+// is served here; a kythe:// request goes to kythe. There is no global flag.
+const Scheme = "tree-sitter"
+
+const schemePrefix = Scheme + "://"
+
+// HasScheme reports whether a ticket is a tree-sitter nav ticket (a file ticket
+// like "tree-sitter://buildbuddy?path=..." or a symbol ticket from
+// symbolTicket). The server uses it as the sole routing signal.
+func HasScheme(ticket string) bool {
+	return strings.HasPrefix(ticket, schemePrefix)
+}
+
+// Pos is a position in a file. Line is 1-based; Col is a 0-based byte offset
+// within the line; Byte is the 0-based byte offset within the file. These match
+// the conventions the code frontend expects (it adds 1 to Col to build a
+// 1-based Monaco column, and reads Line directly as the 1-based line).
+type Pos struct {
+	Byte uint32
+	Line uint32
+	Col  uint32
+}
+
+// Ref is a clickable identifier occurrence within a file: the span to decorate
+// plus the opaque ticket that resolves to its definition.
+type Ref struct {
+	Start Pos
+	End   Pos
+	// Kind is a kythe edge-kind string the frontend recognizes; references use
+	// "/kythe/edge/ref".
+	Kind string
+	// TargetTicket is an opaque tree-sitter://symbol ticket. The frontend echoes
+	// it back to Resolve and uses it as a highlight key, so every occurrence of
+	// the same symbol shares one ticket.
+	TargetTicket string
+}
+
+// Def is a top-level declaration: the symbol name and the span of the name
+// token (the span navigation jumps to), plus documentation metadata for hover.
+type Def struct {
+	Name  string
+	Start Pos
+	End   Pos
+	// Kind is the declaration kind: "func", "method", "type", "struct",
+	// "interface", "const", or "var".
+	Kind string
+	// Signature is a one-line rendering of the declaration (e.g.
+	// "func Infof(format string, args ...any)").
+	Signature string
+	// Doc is the leading doc comment, with comment markers stripped.
+	Doc string
+}
+
+// Location is a resolved definition site: a repo-relative file path and the
+// span of the declared name within it.
+type Location struct {
+	Path  string
+	Start Pos
+	End   Pos
+}
+
+// Definition is a resolved definition with documentation metadata, for hover.
+type Definition struct {
+	Path      string
+	Start     Pos
+	End       Pos
+	Kind      string
+	Signature string
+	Doc       string
+}
+
+// DefFile is a candidate file that may declare a looked-up symbol, returned by
+// a DefLookup.
+type DefFile struct {
+	Path    string
+	Content []byte
+	// Lang is the file's lowercase enry language name (as stored in the index's
+	// language field), used to dispatch the right definition finder.
+	Lang string
+}
+
+// DefLookup finds indexed files that may declare a symbol in a package. The
+// server implements it over the codesearch index's `symbols`/`import_id`
+// posting lists; tests implement it in memory.
+type DefLookup interface {
+	// FindDefs returns the files whose import_id term is importID and whose
+	// symbols field contains symbolLower (already lowercased to match the
+	// keyword tokenizer's normalization).
+	FindDefs(ctx context.Context, importID, symbolLower string) ([]DefFile, error)
+}
+
+// RefFile is a candidate file that may reference a symbol, with the inputs
+// needed to decorate it (the same inputs Decorate takes).
+type RefFile struct {
+	Path         string
+	Content      []byte
+	Lang         string
+	SelfImportID string
+	InRepo       func(importPath string) bool
+}
+
+// RefLookup finds candidate files that may reference symbols in a package:
+// files that import the package (cross-package uses) and files belonging to it
+// (same-package uses). The server implements it over the `imports`/`import_id`
+// posting lists.
+type RefLookup interface {
+	FindReferencingFiles(ctx context.Context, importID string) ([]RefFile, error)
+}
+
+// Reference is a use site of a symbol: its span plus the source line it sits
+// on, for display in the references panel.
+type Reference struct {
+	Path    string
+	Start   Pos
+	End     Pos
+	Snippet string
+}
+
+const refEdgeKind = "/kythe/edge/ref"
+
+// EdgeKindRef is the kythe edge kind the frontend renders for a reference.
+const EdgeKindRef = refEdgeKind
+
+// NavOptions controls reference extraction. Its fields are sourced from the
+// viewed file's own indexed document, so no module/checkout context is needed.
+type NavOptions struct {
+	// SelfImportID is the viewed file's own import_id term (e.g.
+	// "go:example.com/repo/svc"), as stored in the index. It is used to mint
+	// same-package reference tickets; empty disables same-package references
+	// (e.g. for a test file, which has no import_id).
+	SelfImportID string
+
+	// Path is the file's repo-relative path. Languages with path-based identity
+	// (TS/JS) need it to resolve relative imports against the file's directory —
+	// the directory can't be recovered from SelfImportID once an `index`
+	// basename is collapsed. Go ignores it (its identities are module-based).
+	Path string
+
+	// InRepo reports whether an import path is resolvable within the indexed
+	// corpus; package-selector references are emitted only for paths it accepts.
+	// A nil predicate accepts everything — best effort, at the cost of
+	// unresolvable selectors (e.g. stdlib) becoming clickable no-ops. Used by
+	// Go; TS resolves relative specifiers directly and ignores it.
+	InRepo func(importPath string) bool
+}
+
+// symbolTicket builds an opaque target ticket identifying a definition by its
+// package's import_id term and symbol name, e.g.
+//
+//	tree-sitter://symbol?pkg=go%3Aexample.com%2Frepo%2Futil%2Flog&sym=Infof
+//
+// The frontend treats it as opaque (it echoes it back to CrossReferences and
+// uses it as a per-symbol highlight key); url.Values.Encode sorts its keys, so
+// the same (pkg, symbol) always yields the identical string. The format is
+// language-neutral: pkg is any family's import_id term, sym any symbol name.
+func symbolTicket(importTerm, symbol string) string {
+	v := url.Values{}
+	v.Set("pkg", importTerm)
+	v.Set("sym", symbol)
+	return schemePrefix + "symbol?" + v.Encode()
+}
+
+// parseSymbolTicket extracts the import_id term and symbol from a symbol
+// ticket. ok is false for tickets this layer did not mint (e.g. a kythe ticket,
+// or a tree-sitter file ticket).
+func parseSymbolTicket(ticket string) (importID, symbol string, ok bool) {
+	u, err := url.Parse(ticket)
+	if err != nil || u.Scheme != Scheme {
+		return "", "", false
+	}
+	q := u.Query()
+	importID, symbol = q.Get("pkg"), q.Get("sym")
+	if importID == "" || symbol == "" {
+		return "", "", false
+	}
+	return importID, symbol, true
+}
+
+// Decorate parses a file of the given language and returns its clickable
+// references. lang is the lowercase enry language name (as stored in the
+// index's language field). Unsupported languages return no references and no
+// error, so a mixed-language repo degrades to "only supported files decorate".
+func Decorate(ctx context.Context, lang string, content []byte, opts NavOptions) ([]Ref, error) {
+	switch lang {
+	case "go":
+		return decorateGo(ctx, content, opts)
+	case "typescript", "tsx", "javascript", "jsx":
+		return decorateTS(ctx, lang, content, opts)
+	}
+	return nil, nil
+}
+
+// definitions returns the top-level declarations in a file of the given
+// language, for resolution (span) and hover (kind/signature/doc). Unsupported
+// languages return nothing.
+func definitions(ctx context.Context, lang string, content []byte) ([]Def, error) {
+	switch lang {
+	case "go":
+		return goDefinitions(ctx, content)
+	case "typescript", "tsx", "javascript", "jsx":
+		return tsDefinitions(ctx, lang, content)
+	}
+	return nil, nil
+}
+
+// resolvedDef pairs a matched declaration with the file it was found in.
+type resolvedDef struct {
+	Path string
+	Def  Def
+}
+
+// resolve decodes a target ticket, looks up candidate files via lk, and
+// re-parses each (in its own language) to recover the matching declarations
+// (the posting list tells us which file declares the name, not where or what).
+// Tickets this layer did not mint resolve to nothing and no error.
+func resolve(ctx context.Context, lk DefLookup, ticket string) ([]resolvedDef, error) {
+	importID, sym, ok := parseSymbolTicket(ticket)
+	if !ok {
+		return nil, nil
+	}
+	symLower := strings.ToLower(sym)
+	files, err := lk.FindDefs(ctx, importID, symLower)
+	if err != nil {
+		return nil, err
+	}
+	var out []resolvedDef
+	for _, f := range files {
+		defs, err := definitions(ctx, f.Lang, f.Content)
+		if err != nil {
+			continue // tolerate a single unparseable candidate
+		}
+		for _, d := range defs {
+			if strings.ToLower(d.Name) == symLower {
+				out = append(out, resolvedDef{Path: f.Path, Def: d})
+			}
+		}
+	}
+	return out, nil
+}
+
+// Resolve returns every definition site for a target ticket (the
+// go-to-definition / CrossReferences path).
+func Resolve(ctx context.Context, lk DefLookup, ticket string) ([]Location, error) {
+	rs, err := resolve(ctx, lk, ticket)
+	if err != nil || len(rs) == 0 {
+		return nil, err
+	}
+	locs := make([]Location, 0, len(rs))
+	for _, r := range rs {
+		locs = append(locs, Location{Path: r.Path, Start: r.Def.Start, End: r.Def.End})
+	}
+	return locs, nil
+}
+
+// Describe returns every definition site for a target ticket with documentation
+// metadata (kind, signature, doc comment) for hover.
+func Describe(ctx context.Context, lk DefLookup, ticket string) ([]Definition, error) {
+	rs, err := resolve(ctx, lk, ticket)
+	if err != nil || len(rs) == 0 {
+		return nil, err
+	}
+	defs := make([]Definition, 0, len(rs))
+	for _, r := range rs {
+		defs = append(defs, Definition{
+			Path:      r.Path,
+			Start:     r.Def.Start,
+			End:       r.Def.End,
+			Kind:      r.Def.Kind,
+			Signature: r.Def.Signature,
+			Doc:       r.Def.Doc,
+		})
+	}
+	return defs, nil
+}
+
+// FindReferences returns every use site of a ticket's symbol across files that
+// import its package or belong to it. It decorates each candidate file and
+// keeps the references whose target ticket matches — exactly the occurrences
+// the editor would make clickable and point back at this symbol. Tickets this
+// layer did not mint return nothing.
+func FindReferences(ctx context.Context, rl RefLookup, ticket string) ([]Reference, error) {
+	importID, _, ok := parseSymbolTicket(ticket)
+	if !ok {
+		return nil, nil
+	}
+	files, err := rl.FindReferencingFiles(ctx, importID)
+	if err != nil {
+		return nil, err
+	}
+	var refs []Reference
+	for _, f := range files {
+		decs, err := Decorate(ctx, f.Lang, f.Content, NavOptions{SelfImportID: f.SelfImportID, Path: f.Path, InRepo: f.InRepo})
+		if err != nil {
+			continue // tolerate a single unparseable candidate
+		}
+		for _, d := range decs {
+			if d.TargetTicket != ticket {
+				continue
+			}
+			refs = append(refs, Reference{
+				Path:    f.Path,
+				Start:   d.Start,
+				End:     d.End,
+				Snippet: lineAt(f.Content, d.Start.Byte),
+			})
+		}
+	}
+	return refs, nil
+}
+
+// lineAt returns the trimmed source line containing the byte offset.
+func lineAt(content []byte, offset uint32) string {
+	if int(offset) > len(content) {
+		return ""
+	}
+	start := 0
+	for i := int(offset) - 1; i >= 0; i-- {
+		if content[i] == '\n' {
+			start = i + 1
+			break
+		}
+	}
+	end := len(content)
+	for i := int(offset); i < len(content); i++ {
+		if content[i] == '\n' {
+			end = i
+			break
+		}
+	}
+	return strings.TrimSpace(string(content[start:end]))
+}
+
+// firstLine returns the first line of s, trimmed and with a trailing brace (the
+// start of a body/struct/class block) dropped.
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = s[:i]
+	}
+	return strings.TrimSpace(strings.TrimRight(strings.TrimSpace(s), "{"))
+}
+
+// collectComments gathers comment nodes directly above node, each on the line
+// immediately above the previous, in source order. Works for any grammar whose
+// comments are named nodes of type "comment" (Go, TS/JS, C/C++, ...).
+func collectComments(node *sitter.Node, content []byte) string {
+	var lines []string
+	target := node
+	for {
+		prev := target.PrevNamedSibling()
+		if prev == nil || prev.Type() != "comment" {
+			break
+		}
+		if prev.EndPoint().Row+1 != target.StartPoint().Row {
+			break // a blank line breaks the doc-comment block
+		}
+		lines = append(lines, cleanComment(prev.Content(content)))
+		target = prev
+	}
+	slices.Reverse(lines)
+	return strings.TrimSpace(strings.Join(lines, "\n"))
+}
+
+// cleanComment strips comment markers from a comment node's text: a `//` line
+// prefix, or `/* */` block delimiters with a leading `*` removed from each
+// line (so JSDoc `/** * foo */` blocks read cleanly).
+func cleanComment(s string) string {
+	s = strings.TrimSpace(s)
+	if rest, ok := strings.CutPrefix(s, "//"); ok {
+		return strings.TrimSpace(rest)
+	}
+	s = strings.TrimSuffix(strings.TrimPrefix(s, "/*"), "*/")
+	var out []string
+	for line := range strings.SplitSeq(s, "\n") {
+		line = strings.TrimSpace(line)
+		line = strings.TrimPrefix(line, "*")
+		out = append(out, strings.TrimSpace(line))
+	}
+	return strings.TrimSpace(strings.Join(out, "\n"))
+}
+
+// nodeStart returns the start position of a tree-sitter node.
+func nodeStart(n *sitter.Node) Pos {
+	p := n.StartPoint()
+	return Pos{Byte: n.StartByte(), Line: p.Row + 1, Col: p.Column}
+}
+
+// nodeEnd returns the end position of a tree-sitter node.
+func nodeEnd(n *sitter.Node) Pos {
+	p := n.EndPoint()
+	return Pos{Byte: n.EndByte(), Line: p.Row + 1, Col: p.Column}
+}

--- a/codesearch/annotations/nav_test.go
+++ b/codesearch/annotations/nav_test.go
@@ -1,0 +1,300 @@
+package annotations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testModule = "example.com/repo"
+
+// refByTicket returns the first ref with the given target ticket, or nil.
+func refByTicket(refs []Ref, ticket string) *Ref {
+	for i := range refs {
+		if refs[i].TargetTicket == ticket {
+			return &refs[i]
+		}
+	}
+	return nil
+}
+
+func tickets(refs []Ref) []string {
+	out := make([]string, 0, len(refs))
+	for _, r := range refs {
+		out = append(out, r.TargetTicket)
+	}
+	return out
+}
+
+func TestDecorateSelector(t *testing.T) {
+	src := []byte(`package main
+
+import (
+	"fmt"
+	"example.com/repo/util/log"
+	lg "example.com/repo/util/altlog"
+)
+
+func main() {
+	log.Infof("hi")
+	lg.Warn("yo")
+	fmt.Println("external")
+}
+`)
+	refs, err := Decorate(context.Background(), "go", src, NavOptions{
+		SelfImportID: GoSelfImportID(testModule, "cmd/main.go"),
+		InRepo:       GoModuleInRepo(testModule),
+	})
+	require.NoError(t, err)
+
+	// In-repo selector, default local name.
+	logRef := refByTicket(refs, symbolTicket("go:example.com/repo/util/log", "Infof"))
+	require.NotNil(t, logRef, "expected ref for log.Infof; got %v", tickets(refs))
+	assert.Equal(t, EdgeKindRef, logRef.Kind)
+	assert.Equal(t, uint32(10), logRef.Start.Line)
+	// The decorated span covers only the symbol token, not "log.".
+	assert.Equal(t, "Infof", string(src[logRef.Start.Byte:logRef.End.Byte]))
+
+	// In-repo selector via an import alias resolves to the real import path.
+	assert.NotNil(t, refByTicket(refs, symbolTicket("go:example.com/repo/util/altlog", "Warn")),
+		"expected aliased ref; got %v", tickets(refs))
+
+	// External package (fmt) is not in the repo, so it is not decorated.
+	for _, r := range refs {
+		_, sym, _ := parseSymbolTicket(r.TargetTicket)
+		assert.NotEqual(t, "Println", sym, "fmt.Println should not be decorated")
+	}
+}
+
+func TestDecorateLocal(t *testing.T) {
+	src := []byte(`package svc
+
+type Greeter struct{}
+
+func Greet(g Greeter) string {
+	return helper()
+}
+
+func helper() string {
+	return "hi"
+}
+`)
+	refs, err := Decorate(context.Background(), "go", src, NavOptions{
+		SelfImportID: GoSelfImportID(testModule, "svc/svc.go"),
+	})
+	require.NoError(t, err)
+
+	selfID := "go:example.com/repo/svc"
+
+	// Use of the file-scope func `helper` is decorated, targeting this package.
+	helperRef := refByTicket(refs, symbolTicket(selfID, "helper"))
+	require.NotNil(t, helperRef, "expected local ref to helper; got %v", tickets(refs))
+	assert.Equal(t, uint32(6), helperRef.Start.Line) // the call site, not the decl
+
+	// Use of the file-scope type `Greeter` (the parameter type) is decorated.
+	assert.NotNil(t, refByTicket(refs, symbolTicket(selfID, "Greeter")),
+		"expected local ref to Greeter; got %v", tickets(refs))
+
+	// A declaration site is never decorated as a reference to itself: there is
+	// exactly one occurrence of `helper` decorated (the call on line 6), not
+	// the declaration on line 9.
+	count := 0
+	for _, r := range refs {
+		if r.TargetTicket == symbolTicket(selfID, "helper") {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "only the call site should be decorated")
+}
+
+func TestDecorateNoSelfIDForTestFile(t *testing.T) {
+	src := []byte(`package svc
+
+func helper() string { return "" }
+
+func use() string { return helper() }
+`)
+	// _test.go files have no import_id, so same-package references can't be
+	// minted (nothing to resolve against).
+	refs, err := Decorate(context.Background(), "go", src, NavOptions{
+		SelfImportID: GoSelfImportID(testModule, "svc/svc_test.go"),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, refs)
+}
+
+func TestGoDefinitions(t *testing.T) {
+	src := []byte(`package svc
+
+type Greeter struct{}
+
+const Version = "1"
+
+func (g Greeter) Greet() {}
+
+func Helper() {}
+`)
+	defs, err := goDefinitions(context.Background(), src)
+	require.NoError(t, err)
+
+	byName := make(map[string]Def)
+	for _, d := range defs {
+		byName[d.Name] = d
+	}
+	require.Contains(t, byName, "Greeter")
+	require.Contains(t, byName, "Version")
+	require.Contains(t, byName, "Greet")
+	require.Contains(t, byName, "Helper")
+
+	assert.Equal(t, uint32(3), byName["Greeter"].Start.Line)
+	assert.Equal(t, uint32(9), byName["Helper"].Start.Line)
+	// Span covers exactly the name token.
+	g := byName["Greeter"]
+	assert.Equal(t, "Greeter", string(src[g.Start.Byte:g.End.Byte]))
+}
+
+// fakeLookup resolves an import_id to a fixed set of files, ignoring the
+// symbol filter (Resolve re-parses and filters by symbol itself).
+type fakeLookup map[string][]DefFile
+
+func (f fakeLookup) FindDefs(_ context.Context, importID, _ string) ([]DefFile, error) {
+	return f[importID], nil
+}
+
+func TestResolve(t *testing.T) {
+	defFile := DefFile{
+		Path: "util/log/log.go",
+		Lang: "go",
+		Content: []byte(`package log
+
+func Debugf(string) {}
+
+func Infof(format string) {}
+`),
+	}
+	lk := fakeLookup{"go:example.com/repo/util/log": {defFile}}
+
+	locs, err := Resolve(context.Background(), lk, symbolTicket("go:example.com/repo/util/log", "Infof"))
+	require.NoError(t, err)
+	require.Len(t, locs, 1)
+	assert.Equal(t, "util/log/log.go", locs[0].Path)
+	assert.Equal(t, uint32(5), locs[0].Start.Line)
+
+	// A symbol the file doesn't declare resolves to nothing.
+	locs, err = Resolve(context.Background(), lk, symbolTicket("go:example.com/repo/util/log", "Missing"))
+	require.NoError(t, err)
+	assert.Empty(t, locs)
+}
+
+func TestDescribe(t *testing.T) {
+	defFile := DefFile{
+		Path: "util/log/log.go",
+		Lang: "go",
+		Content: []byte(`package log
+
+// Infof logs a formatted message.
+// It is safe for concurrent use.
+func Infof(format string, args ...any) {}
+
+type Greeter struct{}
+`),
+	}
+	lk := fakeLookup{"go:example.com/repo/util/log": {defFile}}
+
+	defs, err := Describe(context.Background(), lk, symbolTicket("go:example.com/repo/util/log", "Infof"))
+	require.NoError(t, err)
+	require.Len(t, defs, 1)
+	assert.Equal(t, "func", defs[0].Kind)
+	assert.Equal(t, "func Infof(format string, args ...any)", defs[0].Signature)
+	assert.Equal(t, "Infof logs a formatted message.\nIt is safe for concurrent use.", defs[0].Doc)
+	assert.Equal(t, uint32(5), defs[0].Start.Line)
+
+	// A struct type with no doc comment.
+	defs, err = Describe(context.Background(), lk, symbolTicket("go:example.com/repo/util/log", "Greeter"))
+	require.NoError(t, err)
+	require.Len(t, defs, 1)
+	assert.Equal(t, "struct", defs[0].Kind)
+	assert.Equal(t, "type Greeter struct{}", defs[0].Signature)
+	assert.Empty(t, defs[0].Doc)
+}
+
+// fakeRefLookup returns a fixed set of candidate files for any import_id.
+type fakeRefLookup map[string][]RefFile
+
+func (f fakeRefLookup) FindReferencingFiles(_ context.Context, importID string) ([]RefFile, error) {
+	return f[importID], nil
+}
+
+func TestFindReferences(t *testing.T) {
+	// A cross-package importer using log.Print twice.
+	mainFile := RefFile{
+		Path: "app/main.go",
+		Lang: "go",
+		Content: []byte(`package main
+
+import "example.com/repo/util/log"
+
+func main() {
+	log.Print()
+	log.Print()
+}
+`),
+		SelfImportID: "go:example.com/repo/app",
+		InRepo:       func(imp string) bool { return imp == "example.com/repo/util/log" },
+	}
+	// The declaring file, which also uses Print within itself.
+	defFile := RefFile{
+		Path: "util/log/log.go",
+		Lang: "go",
+		Content: []byte(`package log
+
+func Print() {}
+
+func reprint() { Print() }
+`),
+		SelfImportID: "go:example.com/repo/util/log",
+		InRepo:       func(string) bool { return false },
+	}
+	rl := fakeRefLookup{"go:example.com/repo/util/log": {mainFile, defFile}}
+
+	refs, err := FindReferences(context.Background(), rl, symbolTicket("go:example.com/repo/util/log", "Print"))
+	require.NoError(t, err)
+	// Two cross-package uses in main.go + one same-file use in log.go. The
+	// Print declaration itself is not a reference.
+	require.Len(t, refs, 3)
+
+	byPath := map[string][]string{}
+	for _, r := range refs {
+		byPath[r.Path] = append(byPath[r.Path], r.Snippet)
+	}
+	assert.Equal(t, []string{"log.Print()", "log.Print()"}, byPath["app/main.go"])
+	assert.Equal(t, []string{"func reprint() { Print() }"}, byPath["util/log/log.go"])
+}
+
+func TestResolveIgnoresForeignTickets(t *testing.T) {
+	locs, err := Resolve(context.Background(), fakeLookup{}, "kythe://buildbuddy?path=x.go")
+	require.NoError(t, err)
+	assert.Nil(t, locs)
+}
+
+func TestTicketRoundTrip(t *testing.T) {
+	ticket := symbolTicket("go:example.com/repo/util/log", "Infof")
+	assert.True(t, HasScheme(ticket), "minted ticket carries the scheme: %s", ticket)
+
+	id, sym, ok := parseSymbolTicket(ticket)
+	require.True(t, ok)
+	assert.Equal(t, "go:example.com/repo/util/log", id)
+	assert.Equal(t, "Infof", sym)
+
+	// Non-tree-sitter and non-symbol tickets are rejected.
+	_, _, ok = parseSymbolTicket("kythe://buildbuddy?path=x.go")
+	assert.False(t, ok, "kythe ticket")
+	_, _, ok = parseSymbolTicket("tree-sitter://buildbuddy?path=x.go")
+	assert.False(t, ok, "file ticket has no pkg/sym")
+
+	// HasScheme accepts file tickets too (used for request routing).
+	assert.True(t, HasScheme("tree-sitter://buildbuddy?path=x.go"))
+	assert.False(t, HasScheme("kythe://buildbuddy?path=x.go"))
+}

--- a/codesearch/annotations/nav_ts_test.go
+++ b/codesearch/annotations/nav_ts_test.go
@@ -1,0 +1,128 @@
+package annotations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fileByName is a DefLookup/RefLookup over in-memory TS files keyed by their
+// import_id term. FindDefs/FindReferencingFiles return the same candidate set;
+// resolve/decorate filter by symbol themselves.
+type tsFiles struct {
+	byID  map[string][]DefFile // importID -> files declaring (used for FindDefs)
+	byMod map[string][]RefFile // moduleID -> files importing/owning it
+}
+
+func (f tsFiles) FindDefs(_ context.Context, importID, _ string) ([]DefFile, error) {
+	return f.byID[importID], nil
+}
+func (f tsFiles) FindReferencingFiles(_ context.Context, importID string) ([]RefFile, error) {
+	return f.byMod[importID], nil
+}
+
+// log.ts declares Print and a helper; app.ts imports Print (aliased) and a
+// namespace, and uses a same-module declaration.
+const tsLog = `// Print writes a greeting.
+export function Print(): void {}
+
+export const VERSION = "1";
+`
+
+const tsApp = `import { Print as P } from "./util/log";
+import * as log from "./util/log";
+
+function greet(): void {
+  P();
+  log.Print();
+  helper();
+}
+
+function helper(): void {}
+`
+
+func tsAppRefFile() RefFile {
+	return RefFile{
+		Path:         "src/app.ts",
+		Content:      []byte(tsApp),
+		Lang:         "typescript",
+		SelfImportID: "ts:src/app",
+	}
+}
+
+func TestDecorateTS(t *testing.T) {
+	refs, err := Decorate(context.Background(), "typescript", []byte(tsApp), NavOptions{
+		SelfImportID: "ts:src/app",
+		Path:         "src/app.ts",
+	})
+	require.NoError(t, err)
+
+	got := map[string]bool{}
+	for _, r := range refs {
+		assert.Equal(t, EdgeKindRef, r.Kind)
+		got[r.TargetTicket] = true
+	}
+	logMod := "ts:src/util/log"
+	// Named import `P` (alias of Print) -> module log, original name Print.
+	assert.True(t, got[symbolTicket(logMod, "Print")],
+		"aliased named import P() should target log#Print; got %v", keys(got))
+	// Namespace member `log.Print` -> same ticket.
+	// (both P() and log.Print() produce the same ticket, deduped in the map)
+	// Same-module use of `helper` -> self.
+	assert.True(t, got[symbolTicket("ts:src/app", "helper")],
+		"same-module helper() should target app#helper; got %v", keys(got))
+}
+
+func TestTSDefinitions(t *testing.T) {
+	defs, err := tsDefinitions(context.Background(), "typescript", []byte(tsLog))
+	require.NoError(t, err)
+	byName := map[string]Def{}
+	for _, d := range defs {
+		byName[d.Name] = d
+	}
+	require.Contains(t, byName, "Print")
+	require.Contains(t, byName, "VERSION")
+	assert.Equal(t, "func", byName["Print"].Kind)
+	// The function_declaration node excludes the `export` keyword wrapper.
+	assert.Equal(t, "function Print(): void", byName["Print"].Signature)
+	assert.Equal(t, "Print writes a greeting.", byName["Print"].Doc)
+	assert.Equal(t, "const", byName["VERSION"].Kind)
+}
+
+func TestResolveAndFindReferencesTS(t *testing.T) {
+	logFile := DefFile{Path: "src/util/log.ts", Content: []byte(tsLog), Lang: "typescript"}
+	logRef := RefFile{Path: "src/util/log.ts", Content: []byte(tsLog), Lang: "typescript", SelfImportID: "ts:src/util/log"}
+	lk := tsFiles{
+		byID:  map[string][]DefFile{"ts:src/util/log": {logFile}},
+		byMod: map[string][]RefFile{"ts:src/util/log": {logRef, tsAppRefFile()}},
+	}
+
+	// Resolve the Print ticket -> its declaration in log.ts (line 2).
+	locs, err := Resolve(context.Background(), lk, symbolTicket("ts:src/util/log", "Print"))
+	require.NoError(t, err)
+	require.Len(t, locs, 1)
+	assert.Equal(t, "src/util/log.ts", locs[0].Path)
+	assert.Equal(t, uint32(2), locs[0].Start.Line)
+
+	// Find references to Print across the importing app.ts: the aliased P() and
+	// the namespace log.Print() are both uses. log.ts itself doesn't use Print.
+	refs, err := FindReferences(context.Background(), lk, symbolTicket("ts:src/util/log", "Print"))
+	require.NoError(t, err)
+	lines := map[uint32]string{}
+	for _, r := range refs {
+		assert.Equal(t, "src/app.ts", r.Path)
+		lines[r.Start.Line] = r.Snippet
+	}
+	assert.Contains(t, lines, uint32(5), "P() use; got %v", lines)         // P();
+	assert.Contains(t, lines, uint32(6), "log.Print() use; got %v", lines) // log.Print();
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/codesearch/annotations/typescript.go
+++ b/codesearch/annotations/typescript.go
@@ -257,3 +257,317 @@ func extractTypeScript(ctx context.Context, lang, filename string, content []byt
 	}
 	return ann, nil
 }
+
+// ── Code navigation ──────────────────────────────────────────────────────────
+//
+// TS/JS resolve imported symbols by their local binding, not a package
+// qualifier: `import {foo as f} from "./m"` makes a bare `f` a reference to
+// foo in module m. So decoration builds a local-name -> (module, symbol) map
+// from the import statements (mirroring the extractor's relative-path
+// resolution so tickets join against stored import_id terms), then walks uses.
+
+// tsDefPatternCommon binds @sym (the declared name) and @decl (the declaration
+// node, for kind/signature/doc) for declarations shared by both grammars.
+// Variable declarators are scoped to top-level/exported, matching the symbol
+// query, so locals don't become navigable definitions.
+const tsDefPatternCommon = `
+	(function_declaration name: (identifier) @sym) @decl
+	(program (lexical_declaration (variable_declarator name: (identifier) @sym)) @decl)
+	(program (variable_declaration (variable_declarator name: (identifier) @sym)) @decl)
+	(export_statement (lexical_declaration (variable_declarator name: (identifier) @sym)) @decl)
+	(export_statement (variable_declaration (variable_declarator name: (identifier) @sym)) @decl)
+`
+
+const tsDefPatternJS = tsDefPatternCommon + `
+	(class_declaration name: (identifier) @sym) @decl
+`
+
+const tsDefPatternTS = tsDefPatternCommon + `
+	(class_declaration name: (type_identifier) @sym) @decl
+	(interface_declaration name: (type_identifier) @sym) @decl
+	(type_alias_declaration name: (type_identifier) @sym) @decl
+	(enum_declaration name: (identifier) @sym) @decl
+`
+
+var (
+	tsxDefQuery = mustCompileQuery(tsDefPatternTS, tsx.GetLanguage())
+	tsDefQuery  = mustCompileQuery(tsDefPatternTS, typescript.GetLanguage())
+	jsDefQuery  = mustCompileQuery(tsDefPatternJS, javascript.GetLanguage())
+)
+
+// tsNavGrammar returns the grammar and definition query for the enry language.
+func tsNavGrammar(lang string) (*sitter.Language, *sitter.Query) {
+	switch lang {
+	case "tsx":
+		return tsx.GetLanguage(), tsxDefQuery
+	case "typescript":
+		return typescript.GetLanguage(), tsDefQuery
+	default: // "javascript", "jsx"
+		return javascript.GetLanguage(), jsDefQuery
+	}
+}
+
+// tsModuleTerm resolves a relative import specifier against the importing
+// file's directory to the imported module's identity term, matching how
+// extraction derives import_id. ok is false for bare (external) specifiers.
+func tsModuleTerm(selfDir, spec string) (string, bool) {
+	if !strings.HasPrefix(spec, "./") && !strings.HasPrefix(spec, "../") {
+		return "", false
+	}
+	resolved := path.Clean(path.Join(selfDir, spec))
+	return tsTerm(tsNormalize(resolved)), true
+}
+
+// tsBinding is an imported symbol's target: its module identity term and its
+// name in that module (the original name, not the local alias).
+type tsBinding struct {
+	module string
+	sym    string
+}
+
+// tsImportBindings builds, from a file's import statements, the maps used to
+// resolve uses: named bindings (local name -> module+symbol, for bare
+// identifier uses) and namespace bindings (local name -> module, for `ns.foo`
+// member uses). Only relative (in-repo) imports are recorded; default imports
+// are skipped (a module's default export has no indexed symbol identity).
+func tsImportBindings(root *sitter.Node, content []byte, selfDir string) (named map[string]tsBinding, ns map[string]string) {
+	named = map[string]tsBinding{}
+	ns = map[string]string{}
+	for i := 0; i < int(root.NamedChildCount()); i++ {
+		stmt := root.NamedChild(i)
+		if stmt.Type() != "import_statement" {
+			continue
+		}
+		src := stmt.ChildByFieldName("source")
+		if src == nil {
+			continue
+		}
+		module, ok := tsModuleTerm(selfDir, tsStringLiteral(src.Content(content)))
+		if !ok {
+			continue
+		}
+		for j := 0; j < int(stmt.NamedChildCount()); j++ {
+			clause := stmt.NamedChild(j)
+			if clause.Type() != "import_clause" {
+				continue
+			}
+			for k := 0; k < int(clause.NamedChildCount()); k++ {
+				c := clause.NamedChild(k)
+				switch c.Type() {
+				case "named_imports":
+					for s := 0; s < int(c.NamedChildCount()); s++ {
+						spec := c.NamedChild(s)
+						if spec.Type() != "import_specifier" {
+							continue
+						}
+						nameNode := spec.ChildByFieldName("name")
+						if nameNode == nil {
+							continue
+						}
+						local := nameNode
+						if alias := spec.ChildByFieldName("alias"); alias != nil {
+							local = alias
+						}
+						named[local.Content(content)] = tsBinding{module: module, sym: nameNode.Content(content)}
+					}
+				case "namespace_import":
+					// `* as ns`: the binding is the identifier child.
+					for s := 0; s < int(c.NamedChildCount()); s++ {
+						if id := c.NamedChild(s); id.Type() == "identifier" {
+							ns[id.Content(content)] = module
+						}
+					}
+				}
+				// A bare (identifier) child is a default import — skipped.
+			}
+		}
+	}
+	return named, ns
+}
+
+// decorateTS parses a TS/JS file and returns its clickable references: uses of
+// named imports (resolved to their source module + original name), uses of
+// namespace members (`ns.foo`), and uses of this file's own top-level
+// declarations (same-module refs, via opts.SelfImportID).
+func decorateTS(ctx context.Context, lang string, content []byte, opts NavOptions) ([]Ref, error) {
+	grammar, _ := tsNavGrammar(lang)
+	parser := sitter.NewParser()
+	defer parser.Close()
+	parser.SetLanguage(grammar)
+	tree, err := parser.ParseCtx(ctx, nil, content)
+	if err != nil {
+		return nil, err
+	}
+	defer tree.Close()
+	root := tree.RootNode()
+
+	named, ns := tsImportBindings(root, content, path.Dir(opts.Path))
+	selfID := opts.SelfImportID
+
+	declNames := make(map[string]struct{})
+	declSites := make(map[uint32]struct{})
+	defs, err := tsDefinitions(ctx, lang, content)
+	if err != nil {
+		return nil, err
+	}
+	for _, d := range defs {
+		declNames[d.Name] = struct{}{}
+		declSites[d.Start.Byte] = struct{}{}
+	}
+
+	consumed := make(map[uint32]struct{})
+	var refs []Ref
+
+	var walk func(n *sitter.Node)
+	walk = func(n *sitter.Node) {
+		switch n.Type() {
+		case "import_statement":
+			return // bindings handled above; don't decorate the import clause
+		case "member_expression":
+			object := n.ChildByFieldName("object")
+			property := n.ChildByFieldName("property")
+			if object != nil && object.Type() == "identifier" && property != nil {
+				consumed[object.StartByte()] = struct{}{}
+				if module, ok := ns[object.Content(content)]; ok {
+					consumed[property.StartByte()] = struct{}{}
+					refs = append(refs, Ref{
+						Start:        nodeStart(property),
+						End:          nodeEnd(property),
+						Kind:         refEdgeKind,
+						TargetTicket: symbolTicket(module, property.Content(content)),
+					})
+				}
+			}
+		case "identifier", "type_identifier":
+			if _, skip := consumed[n.StartByte()]; skip {
+				break
+			}
+			if _, isDecl := declSites[n.StartByte()]; isDecl {
+				break
+			}
+			name := n.Content(content)
+			if b, ok := named[name]; ok {
+				refs = append(refs, Ref{
+					Start:        nodeStart(n),
+					End:          nodeEnd(n),
+					Kind:         refEdgeKind,
+					TargetTicket: symbolTicket(b.module, b.sym),
+				})
+			} else if selfID != "" {
+				if _, ok := declNames[name]; ok {
+					refs = append(refs, Ref{
+						Start:        nodeStart(n),
+						End:          nodeEnd(n),
+						Kind:         refEdgeKind,
+						TargetTicket: symbolTicket(selfID, name),
+					})
+				}
+			}
+		}
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			walk(n.NamedChild(i))
+		}
+	}
+	walk(root)
+
+	return refs, nil
+}
+
+// tsDefinitions returns the top-level declarations in a TS/JS file, each with
+// its name, name-token span, and documentation metadata.
+func tsDefinitions(ctx context.Context, lang string, content []byte) ([]Def, error) {
+	grammar, defQuery := tsNavGrammar(lang)
+	parser := sitter.NewParser()
+	defer parser.Close()
+	parser.SetLanguage(grammar)
+	tree, err := parser.ParseCtx(ctx, nil, content)
+	if err != nil {
+		return nil, err
+	}
+	defer tree.Close()
+
+	qc := sitter.NewQueryCursor()
+	defer qc.Close()
+	qc.Exec(defQuery, tree.RootNode())
+
+	var defs []Def
+	for {
+		m, ok := qc.NextMatch()
+		if !ok {
+			break
+		}
+		var nameNode, declNode *sitter.Node
+		for _, c := range m.Captures {
+			switch defQuery.CaptureNameForId(c.Index) {
+			case "sym":
+				nameNode = c.Node
+			case "decl":
+				declNode = c.Node
+			}
+		}
+		if nameNode == nil {
+			continue
+		}
+		name := nameNode.Content(content)
+		if name == "" {
+			continue
+		}
+		d := Def{Name: name, Start: nodeStart(nameNode), End: nodeEnd(nameNode)}
+		if declNode != nil {
+			d.Kind = tsDeclKind(declNode, content)
+			d.Signature = tsSignature(declNode, content)
+			d.Doc = tsLeadingComment(declNode, content)
+		}
+		defs = append(defs, d)
+	}
+	return defs, nil
+}
+
+// tsDeclKind classifies a TS/JS declaration node.
+func tsDeclKind(decl *sitter.Node, content []byte) string {
+	switch decl.Type() {
+	case "function_declaration":
+		return "func"
+	case "class_declaration":
+		return "class"
+	case "interface_declaration":
+		return "interface"
+	case "type_alias_declaration":
+		return "type"
+	case "enum_declaration":
+		return "enum"
+	case "variable_declaration":
+		return "var"
+	case "lexical_declaration":
+		if decl.NamedChildCount() > 0 && strings.HasPrefix(decl.Content(content), "let") {
+			return "var"
+		}
+		return "const"
+	}
+	return ""
+}
+
+// tsSignature renders a TS/JS declaration as a single line: for declarations
+// with a body block, the text up to the body; otherwise the first line.
+func tsSignature(decl *sitter.Node, content []byte) string {
+	switch decl.Type() {
+	case "function_declaration", "class_declaration", "interface_declaration", "enum_declaration":
+		if body := decl.ChildByFieldName("body"); body != nil {
+			return strings.Join(strings.Fields(string(content[decl.StartByte():body.StartByte()])), " ")
+		}
+	}
+	return firstLine(decl.Content(content))
+}
+
+// tsLeadingComment returns the doc comment above a declaration, falling back to
+// the comment above the enclosing export_statement for exported declarations
+// (where the comment sits above `export`, not the declaration itself).
+func tsLeadingComment(decl *sitter.Node, content []byte) string {
+	doc := collectComments(decl, content)
+	if doc == "" {
+		if p := decl.Parent(); p != nil && p.Type() == "export_statement" {
+			doc = collectComments(p, content)
+		}
+	}
+	return doc
+}


### PR DESCRIPTION
Add on-demand click-through navigation primitives to the annotations package. (Go and TypeScript/JS to start)

