### PR TITLE
Add builtin metrics to lru.

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -315,7 +315,7 @@ const (
 	LRUOperationLabel = "op"
 
 	// The reason an entry was automatically evicted from an LRU cache:
-	// `size` (evicted to make room for newer entries) or `ttl` (expired).
+	// `size` (evicted because LRU reached max size) or `ttl` (expired).
 	LRUEvictionReasonLabel = "eviction_reason"
 
 	// Distributed cache operation name, such as "FindMissing" or "Get".

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -311,6 +311,13 @@ const (
 	// One of: "expired" or "size"
 	LookasideCacheEvictionReason = "eviction_reason"
 
+	// LRU cache operation: `get` or `contains`.
+	LRUOperationLabel = "op"
+
+	// The reason an entry was automatically evicted from an LRU cache:
+	// `size` (evicted to make room for newer entries) or `ttl` (expired).
+	LRUEvictionReasonLabel = "eviction_reason"
+
 	// Distributed cache operation name, such as "FindMissing" or "Get".
 	DistributedCacheOperation = "op"
 
@@ -2349,6 +2356,32 @@ var (
 		Help:      "The time spent handling each build event in **microseconds**.",
 	}, []string{
 		StatusLabel,
+	})
+
+	// ### In-memory LRU caches
+	//
+	// These metrics are reported by in-memory LRU caches (see
+	// server/util/lru) that are configured with a name.
+
+	LRULookupCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "lru",
+		Name:      "lookup_count",
+		Help:      "Number of LRU cache lookups (`Get` or `Contains` calls), by operation and hit/miss status.",
+	}, []string{
+		CacheNameLabel,
+		LRUOperationLabel,
+		CacheHitMissStatus,
+	})
+
+	LRULastEvictionAgeUsec = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "lru",
+		Name:      "last_eviction_age_usec",
+		Help:      "Age of the entry most recently automatically evicted from an LRU cache (time since the entry was added or last updated), in **microseconds**.",
+	}, []string{
+		CacheNameLabel,
+		LRUEvictionReasonLabel,
 	})
 
 	// ### Usage tracker

--- a/server/util/lru/BUILD
+++ b/server/util/lru/BUILD
@@ -6,8 +6,10 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/lru",
     visibility = ["//visibility:public"],
     deps = [
+        "//server/metrics",
         "//server/util/status",
         "@com_github_jonboulle_clockwork//:clockwork",
+        "@com_github_prometheus_client_golang//prometheus",
     ],
 )
 
@@ -17,7 +19,10 @@ go_test(
     srcs = ["lru_test.go"],
     deps = [
         ":lru",
+        "//server/metrics",
+        "//server/testutil/testmetrics",
         "@com_github_jonboulle_clockwork//:clockwork",
+        "@com_github_prometheus_client_golang//prometheus",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/util/lru/lru.go
+++ b/server/util/lru/lru.go
@@ -87,7 +87,9 @@ type SizeFn[V any] func(value V) int64
 // MaxSize & SizeFn are required.
 type Config[V any] struct {
 	// If set, enables automatic hit/miss and eviction age metrics.
-	// This value is used to identify this LRU instance. Use snake case.
+	// This value is used to identify this LRU instance in metrics.
+	// Use snake case and don't put any dynamic data into the name.
+	// The name must be unique across LRU instances in the same binary.
 	Name string
 
 	// Optional clock implementation used by implementations that need one. If

--- a/server/util/lru/lru.go
+++ b/server/util/lru/lru.go
@@ -5,8 +5,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/jonboulle/clockwork"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // LRU implements a Least Recently Used cache.
@@ -84,6 +86,10 @@ type SizeFn[V any] func(value V) int64
 // Config specifies how the LRU cache is to be constructed.
 // MaxSize & SizeFn are required.
 type Config[V any] struct {
+	// If set, enables automatic hit/miss and eviction age metrics.
+	// This value is used to identify this LRU instance. Use snake case.
+	Name string
+
 	// Optional clock implementation used by implementations that need one. If
 	// not provided a default (real) clock will be used.
 	Clock clockwork.Clock
@@ -134,7 +140,8 @@ type node[V any] struct {
 	value      V
 	prev, next int32
 	size       int64
-	expiresAt  int64 // unix nanos; 0 when TTL is disabled
+	// Unix nanos when the entry was inserted or last updated.
+	addedAt int64
 }
 
 // lru is a fixed-size LRU cache. It is not safe for concurrent use unless
@@ -151,6 +158,41 @@ type lru[V any] struct {
 	updateInPlace bool
 	ttl           time.Duration
 	clock         clockwork.Clock
+	metrics       *lruMetrics // nil when the LRU has no name
+}
+
+type lruMetrics struct {
+	getHit          prometheus.Counter
+	getMiss         prometheus.Counter
+	containsHit     prometheus.Counter
+	containsMiss    prometheus.Counter
+	lastEvictionAge map[EvictionReason]prometheus.Gauge
+}
+
+func newLRUMetrics(name string) *lruMetrics {
+	lookup := func(op, status string) prometheus.Counter {
+		return metrics.LRULookupCount.With(prometheus.Labels{
+			metrics.CacheNameLabel:     name,
+			metrics.LRUOperationLabel:  op,
+			metrics.CacheHitMissStatus: status,
+		})
+	}
+	lastEvictionAge := func(reason EvictionReason) prometheus.Gauge {
+		return metrics.LRULastEvictionAgeUsec.With(prometheus.Labels{
+			metrics.CacheNameLabel:         name,
+			metrics.LRUEvictionReasonLabel: string(reason),
+		})
+	}
+	return &lruMetrics{
+		getHit:       lookup("get", metrics.HitStatusLabel),
+		getMiss:      lookup("get", metrics.MissStatusLabel),
+		containsHit:  lookup("contains", metrics.HitStatusLabel),
+		containsMiss: lookup("contains", metrics.MissStatusLabel),
+		lastEvictionAge: map[EvictionReason]prometheus.Gauge{
+			SizeEviction: lastEvictionAge(SizeEviction),
+			TTLEviction:  lastEvictionAge(TTLEviction),
+		},
+	}
 }
 
 // A thread-safe wrapper around an LRU.
@@ -171,6 +213,10 @@ func New[V any](config *Config[V]) (LRU[V], error) {
 	if clock == nil {
 		clock = clockwork.NewRealClock()
 	}
+	var m *lruMetrics
+	if config.Name != "" {
+		m = newLRUMetrics(config.Name)
+	}
 	var c LRU[V] = &lru[V]{
 		items:         make(map[string]int32),
 		head:          noIndex,
@@ -181,6 +227,7 @@ func New[V any](config *Config[V]) (LRU[V], error) {
 		updateInPlace: config.UpdateInPlace,
 		ttl:           config.TTL,
 		clock:         clock,
+		metrics:       m,
 	}
 	if config.ThreadSafe {
 		c = &threadSafeLRU[V]{inner: c}
@@ -258,9 +305,7 @@ func (c *lru[V]) insert(key string, value V, size int64, front bool) {
 	n.key = key
 	n.value = value
 	n.size = size
-	if c.ttl > 0 {
-		n.expiresAt = c.clock.Now().Add(c.ttl).UnixNano()
-	}
+	n.addedAt = c.clock.Now().UnixNano()
 	if front {
 		c.pushFront(idx)
 	} else {
@@ -273,6 +318,12 @@ func (c *lru[V]) insert(key string, value V, size int64, front bool) {
 func (c *lru[V]) removeIndex(idx int32, reason EvictionReason) {
 	c.unlink(idx)
 	n := &c.nodes[idx]
+	if c.metrics != nil {
+		if g := c.metrics.lastEvictionAge[reason]; g != nil {
+			ageUsec := float64(c.clock.Now().UnixNano()-n.addedAt) / float64(time.Microsecond)
+			g.Set(ageUsec)
+		}
+	}
 	delete(c.items, n.key)
 	c.currentSize -= n.size
 	key, value := n.key, n.value
@@ -284,7 +335,7 @@ func (c *lru[V]) removeIndex(idx int32, reason EvictionReason) {
 }
 
 func (c *lru[V]) expired(idx int32) bool {
-	return c.ttl > 0 && c.clock.Now().UnixNano() >= c.nodes[idx].expiresAt
+	return c.ttl > 0 && c.clock.Now().UnixNano()-c.nodes[idx].addedAt >= int64(c.ttl)
 }
 
 func (c *lru[V]) Add(key string, value V) bool {
@@ -295,9 +346,7 @@ func (c *lru[V]) Add(key string, value V) bool {
 			c.currentSize += size - n.size
 			n.value = value
 			n.size = size
-			if c.ttl > 0 {
-				n.expiresAt = c.clock.Now().Add(c.ttl).UnixNano()
-			}
+			n.addedAt = c.clock.Now().UnixNano()
 			c.moveToFront(idx)
 		} else {
 			// Remove the existing entry (with ConflictEviction) and re-insert.
@@ -331,9 +380,7 @@ func (c *lru[V]) PushBack(key string, value V) bool {
 			n := &c.nodes[idx]
 			n.value = value
 			n.size = size
-			if c.ttl > 0 {
-				n.expiresAt = c.clock.Now().Add(c.ttl).UnixNano()
-			}
+			n.addedAt = c.clock.Now().UnixNano()
 			c.currentSize += sizeDelta
 			return true
 		}
@@ -347,6 +394,30 @@ func (c *lru[V]) PushBack(key string, value V) bool {
 }
 
 func (c *lru[V]) Get(key string) (V, bool) {
+	v, ok := c.get(key)
+	if c.metrics != nil {
+		if ok {
+			c.metrics.getHit.Inc()
+		} else {
+			c.metrics.getMiss.Inc()
+		}
+	}
+	return v, ok
+}
+
+func (c *lru[V]) Contains(key string) bool {
+	_, ok := c.get(key)
+	if c.metrics != nil {
+		if ok {
+			c.metrics.containsHit.Inc()
+		} else {
+			c.metrics.containsMiss.Inc()
+		}
+	}
+	return ok
+}
+
+func (c *lru[V]) get(key string) (V, bool) {
 	if idx, ok := c.items[key]; ok {
 		if c.expired(idx) {
 			c.removeIndex(idx, TTLEviction)
@@ -358,11 +429,6 @@ func (c *lru[V]) Get(key string) (V, bool) {
 	}
 	var zero V
 	return zero, false
-}
-
-func (c *lru[V]) Contains(key string) bool {
-	_, ok := c.Get(key)
-	return ok
 }
 
 func (c *lru[V]) Remove(key string) bool {
@@ -398,7 +464,7 @@ func (c *lru[V]) Keys() []string {
 		now = c.clock.Now().UnixNano()
 	}
 	for idx := c.head; idx != noIndex; idx = c.nodes[idx].next {
-		if c.ttl > 0 && now >= c.nodes[idx].expiresAt {
+		if c.ttl > 0 && now-c.nodes[idx].addedAt >= int64(c.ttl) {
 			// Don't return expired keys.
 			continue
 		}

--- a/server/util/lru/lru_test.go
+++ b/server/util/lru/lru_test.go
@@ -7,8 +7,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/server/metrics"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testmetrics"
 	"github.com/buildbuddy-io/buildbuddy/server/util/lru"
 	"github.com/jonboulle/clockwork"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -497,4 +500,67 @@ func TestLRUMemoryFootprint(t *testing.T) {
 	require.Less(t, objectsPerEntry, 0.5, "expected ~0 heap objects per entry")
 	runtime.KeepAlive(l)
 	runtime.KeepAlive(keys)
+}
+
+func TestMetrics(t *testing.T) {
+	metrics.LRULookupCount.Reset()
+	metrics.LRULastEvictionAgeUsec.Reset()
+
+	clock := clockwork.NewFakeClock()
+	l, err := lru.New[int](&lru.Config[int]{
+		Name:    "test",
+		Clock:   clock,
+		TTL:     time.Hour,
+		MaxSize: 10,
+		SizeFn:  func(value int) int64 { return int64(value) },
+	})
+	require.NoError(t, err)
+
+	lookups := func(op, status string) float64 {
+		return testmetrics.CounterValueForLabels(t, metrics.LRULookupCount, prometheus.Labels{
+			metrics.CacheNameLabel:     "test",
+			metrics.LRUOperationLabel:  op,
+			metrics.CacheHitMissStatus: status,
+		})
+	}
+	lastEvictionAge := func(reason lru.EvictionReason) float64 {
+		return testmetrics.GaugeValueForLabels(t, metrics.LRULastEvictionAgeUsec, prometheus.Labels{
+			metrics.CacheNameLabel:         "test",
+			metrics.LRUEvictionReasonLabel: string(reason),
+		})
+	}
+
+	require.True(t, l.Add("a", 5))
+	_, ok := l.Get("a")
+	require.True(t, ok)
+	_, ok = l.Get("x")
+	require.False(t, ok)
+	require.True(t, l.Contains("a"))
+	require.False(t, l.Contains("x"))
+	require.False(t, l.Contains("y"))
+
+	require.Equal(t, float64(1), lookups("get", metrics.HitStatusLabel))
+	require.Equal(t, float64(1), lookups("get", metrics.MissStatusLabel))
+	require.Equal(t, float64(1), lookups("contains", metrics.HitStatusLabel))
+	require.Equal(t, float64(2), lookups("contains", metrics.MissStatusLabel))
+
+	// Manual removal should not record an eviction age.
+	require.True(t, l.Remove("a"))
+	require.Equal(t, float64(0), lastEvictionAge(lru.SizeEviction))
+	require.Equal(t, float64(0), lastEvictionAge(lru.TTLEviction))
+
+	// Size eviction: re-add "a", then push it out with "b" 10 seconds later;
+	// its recorded age should be 10s.
+	require.True(t, l.Add("a", 5))
+	clock.Advance(10 * time.Second)
+	require.True(t, l.Add("b", 6))
+	require.Equal(t, float64((10 * time.Second).Microseconds()), lastEvictionAge(lru.SizeEviction))
+
+	// TTL eviction: "b" expires an hour after it was added; its recorded age
+	// should be 1h. This should also count as a Get miss.
+	clock.Advance(time.Hour)
+	_, ok = l.Get("b")
+	require.False(t, ok)
+	require.Equal(t, float64(2), lookups("get", metrics.MissStatusLabel))
+	require.Equal(t, float64(time.Hour.Microseconds()), lastEvictionAge(lru.TTLEviction))
 }


### PR DESCRIPTION
The user can specify a Name value in the config to enable some basic hit/miss and eviction age metrics.

To keep the lru simple, switched TTL to use insert time to drive expirely rather than precomputing the expiration time so that the eviction age can be easily be computed.