### PR TITLE
redis: support extended COMMAND replies

### DIFF
--- a/buildpatches/go_redis_v8_command_info.patch
+++ b/buildpatches/go_redis_v8_command_info.patch
@@ -1,0 +1,47 @@
+diff --git a/command.go b/command.go
+index b523783..a5f059e 100644
+--- a/command.go
++++ b/command.go
+@@ -3231,13 +3231,10 @@ func commandInfoParser(rd *proto.Reader, n int64) (interface{}, error) {
+ 	const numArgRedis5 = 6
+ 	const numArgRedis6 = 7
+ 
+-	switch n {
+-	case numArgRedis5, numArgRedis6:
+-		// continue
+-	default:
+-		return nil, fmt.Errorf("redis: got %d elements in COMMAND reply, wanted 7", n)
++	if n < numArgRedis5 {
++		return nil, fmt.Errorf("redis: got %d elements in COMMAND reply, wanted at least 6", n)
+ 	}
+ 
+ 	var cmd CommandInfo
+ 	var err error
+@@ -3317,10 +3314,27 @@ func commandInfoParser(rd *proto.Reader, n int64) (interface{}, error) {
+ 	if err != nil {
+ 		return nil, err
+ 	}
++
++	// Redis 7 and Valkey 7 append tips, key specifications, and subcommands.
++	// They are not needed for the first-key routing performed by this client.
++	for i := int64(numArgRedis6); i < n; i++ {
++		if _, err := rd.ReadReply(discardCommandMetadata); err != nil {
++			return nil, err
++		}
++	}
+ 
+ 	return &cmd, nil
+ }
+ 
++func discardCommandMetadata(rd *proto.Reader, n int64) (interface{}, error) {
++	for i := int64(0); i < n; i++ {
++		if _, err := rd.ReadReply(discardCommandMetadata); err != nil {
++			return nil, err
++		}
++	}
++	return nil, nil
++}
++
+ //------------------------------------------------------------------------------
+ 
+ type cmdsInfoCache struct {

--- a/deps/go_deps.MODULE.bazel
+++ b/deps/go_deps.MODULE.bazel
@@ -108,6 +108,15 @@ go_deps.module_override(
     ],
     path = "github.com/nishanths/exhaustive",
 )
+go_deps.module_override(
+    patch_strip = 1,
+    patches = [
+        # go-redis/v8 only recognizes the Redis 5 and 6 COMMAND reply shapes.
+        # Redis 7 and Valkey 7 add three trailing metadata fields.
+        "@com_github_buildbuddy_io_buildbuddy//buildpatches:go_redis_v8_command_info.patch",
+    ],
+    path = "github.com/go-redis/redis/v8",
+)
 
 # Go repos with custom directives
 go_deps.gazelle_override(

--- a/enterprise/server/quota/quota_manager_test.go
+++ b/enterprise/server/quota/quota_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/authdb"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/userdb"
@@ -442,6 +443,38 @@ func TestCheckGroupBlocked(t *testing.T) {
 		authedCtx := testauth.WithAuthenticatedUserInfo(ctx, impersonatingClaims)
 		assert.NoError(t, qm.checkGroupBlocked(authedCtx))
 	})
+}
+
+func TestCreateGCRABucket_RateLimit(t *testing.T) {
+	redisHandle := testredis.Start(t)
+	rdb := redisHandle.Client()
+	t.Cleanup(func() { require.NoError(t, rdb.Close()) })
+
+	env := testenv.GetTestEnv(t)
+	env.SetDefaultRedisClient(rdb)
+	bucket, err := createGCRABucket(env, &bucketConfig{
+		namespace:          "test-namespace",
+		name:               "test-bucket",
+		numRequests:        1,
+		periodDurationUsec: int64(time.Hour.Microseconds()),
+		maxBurst:           2,
+	})
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	for range 3 {
+		allowed, err := bucket.Allow(ctx, "key", 1)
+		require.NoError(t, err)
+		require.True(t, allowed)
+	}
+	allowed, err := bucket.Allow(ctx, "key", 1)
+	require.NoError(t, err)
+	require.False(t, allowed)
+
+	// Rate limit state is independent for each key.
+	allowed, err = bucket.Allow(ctx, "other-key", 1)
+	require.NoError(t, err)
+	require.True(t, allowed)
 }
 
 func TestCreateGCRABucket_VeryLargePeriod(t *testing.T) {

--- a/enterprise/server/testutil/testredis/BUILD
+++ b/enterprise/server/testutil/testredis/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -20,5 +20,15 @@ go_library(
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@io_bazel_rules_go//go/runfiles",
+    ],
+)
+
+go_test(
+    name = "testredis_test",
+    srcs = ["testredis_test.go"],
+    embed = [":testredis"],
+    deps = [
+        "@com_github_go_redis_redis_v8//:redis",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/testutil/testredis/testredis_test.go
+++ b/enterprise/server/testutil/testredis/testredis_test.go
@@ -1,0 +1,105 @@
+package testredis
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/stretchr/testify/require"
+)
+
+type deterministicHash struct{}
+
+func (deterministicHash) Get(key string) string {
+	switch key {
+	case "direct", "pipeline", "transaction":
+		return "shard0"
+	default:
+		// Ring's fallback routing hashes a random integer. Sending every
+		// unexpected key to shard1 makes missing command metadata fail
+		// deterministically rather than relying on random distribution.
+		return "shard1"
+	}
+}
+
+func TestCommandInfoCompatibility(t *testing.T) {
+	ctx := context.Background()
+	client := Start(t).Client()
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	info, err := client.Command(ctx).Result()
+	require.NoError(t, err)
+	for _, name := range []string{"get", "hset", "lpush", "sadd", "set", "xadd", "zadd"} {
+		command := info[name]
+		require.NotNil(t, command, "missing COMMAND metadata for %q", name)
+		require.Equal(t, int8(1), command.FirstKeyPos, name)
+		require.Equal(t, int8(1), command.LastKeyPos, name)
+		require.Equal(t, int8(1), command.StepCount, name)
+	}
+}
+
+func TestRingRoutesCommandsByKey(t *testing.T) {
+	ctx := context.Background()
+	shards := StartShardedTCP(t, 2)
+	client := redis.NewRing(&redis.RingOptions{
+		Addrs: map[string]string{
+			"shard0": shards.Shards[0].Target,
+			"shard1": shards.Shards[1].Target,
+		},
+		NewConsistentHash: func([]string) redis.ConsistentHash {
+			return deterministicHash{}
+		},
+	})
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	tests := []struct {
+		name  string
+		write func() error
+	}{
+		{
+			name: "direct",
+			write: func() error {
+				return client.HSet(ctx, "direct", "field", "value").Err()
+			},
+		},
+		{
+			name: "pipeline",
+			write: func() error {
+				pipe := client.Pipeline()
+				pipe.HSet(ctx, "pipeline", "field", "value")
+				_, err := pipe.Exec(ctx)
+				return err
+			},
+		},
+		{
+			name: "transaction",
+			write: func() error {
+				pipe := client.TxPipeline()
+				pipe.HSet(ctx, "transaction", "field", "value")
+				_, err := pipe.Exec(ctx)
+				return err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.NoError(t, test.write())
+		})
+	}
+
+	shard0 := shards.Shards[0].Client()
+	shard1 := shards.Shards[1].Client()
+	t.Cleanup(func() {
+		require.NoError(t, shard0.Close())
+		require.NoError(t, shard1.Close())
+	})
+	for _, test := range tests {
+		value, err := shard0.HGet(ctx, test.name, "field").Result()
+		require.NoError(t, err)
+		require.Equal(t, "value", value)
+
+		_, err = shard1.HGet(ctx, test.name, "field").Result()
+		require.ErrorIs(t, err, redis.Nil)
+	}
+}

--- a/enterprise/server/util/redisutil/redisutil_test.go
+++ b/enterprise/server/util/redisutil/redisutil_test.go
@@ -1,6 +1,7 @@
 package redisutil_test
 
 import (
+	"bufio"
 	"context"
 	"crypto/rand"
 	"crypto/tls"
@@ -30,6 +31,63 @@ const (
 	// should not expire.
 	noExpiration time.Duration = 0
 )
+
+func TestCommandInfoParserExtendedReply(t *testing.T) {
+	commandFields := []string{
+		"$4\r\nhset\r\n",
+		":-4\r\n",
+		"*1\r\n$5\r\nwrite\r\n",
+		":1\r\n",
+		":1\r\n",
+		":1\r\n",
+		"*1\r\n$5\r\nwrite\r\n",
+		"*1\r\n$8\r\nreadonly\r\n",
+		"*1\r\n*2\r\n$5\r\nbegin\r\n:1\r\n",
+		"*0\r\n",
+		"+future-metadata\r\n",
+	}
+
+	for _, fieldCount := range []int{10, 11} {
+		t.Run(fmt.Sprintf("%d fields", fieldCount), func(t *testing.T) {
+			clientConn, serverConn := net.Pipe()
+			serverErr := make(chan error, 1)
+			go func() {
+				defer serverConn.Close()
+				rd := bufio.NewReader(serverConn)
+				for _, want := range []string{"*1\r\n", "$7\r\n", "command\r\n"} {
+					got, err := rd.ReadString('\n')
+					if err != nil {
+						serverErr <- err
+						return
+					}
+					if got != want {
+						serverErr <- fmt.Errorf("got request line %q, want %q", got, want)
+						return
+					}
+				}
+				reply := fmt.Sprintf("*1\r\n*%d\r\n%s", fieldCount, strings.Join(commandFields[:fieldCount], ""))
+				_, err := fmt.Fprint(serverConn, reply)
+				serverErr <- err
+			}()
+
+			client := redis.NewClient(&redis.Options{
+				Addr: "unused",
+				Dialer: func(context.Context, string, string) (net.Conn, error) {
+					return clientConn, nil
+				},
+			})
+			t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+			info, err := client.Command(t.Context()).Result()
+			require.NoError(t, err)
+			require.NoError(t, <-serverErr)
+			require.Contains(t, info, "hset")
+			require.Equal(t, int8(1), info["hset"].FirstKeyPos)
+			require.Equal(t, int8(1), info["hset"].LastKeyPos)
+			require.Equal(t, int8(1), info["hset"].StepCount)
+		})
+	}
+}
 
 func genOptions(scheme, user, password, addr, database string) *redis.Options {
 	if scheme != "redis" && scheme != "rediss" && scheme != "unix" {


### PR DESCRIPTION
When we replaced the sharded Redis setup with Valkey@7.2.13, we
observed `TestActionMerging_LongTask` fail because the scheduler could no
longer find a registered executor.

BuildBuddy uses go-redis/v8.11.5, whose `COMMAND` parser only accepts the
Redis 5 and Redis 6 reply shapes. Valkey 7.2 returns the extended Redis
7 shape, so Ring loses first-key metadata and randomly routes keyed
commands. The scheduler can consequently look on the wrong shard.

Accept replies with at least six fields, preserve the legacy metadata,
and recursively discard trailing fields that v8 does not use. This
retains Redis 5 behavior while supporting Valkey 7.2 and future reply
extensions.

Add synthetic 10- and 11-field parser coverage, deterministic Ring tests
for direct, pipelined, and transactional commands, and a live Redis test
for the GCRA quota path.

Reproducer: [remote execution test invocation](https://app.buildbuddy.io/invocation/a676036e-8112-4dc2-8038-478dc6d35c96?target=%2F%2Fenterprise%2Fserver%2Ftest%2Fintegration%2Fremote_execution%3Aremote_execution_test&targetStatus=6)
