### PR TITLE
docs: add Cache Proxy deployment guidance

### DIFF
--- a/docs/enterprise-helm.md
+++ b/docs/enterprise-helm.md
@@ -10,6 +10,8 @@ They have options to deploy everything necessary to use all of BuildBuddy's bell
 
 The official BuildBuddy charts live in our [buildbuddy-helm repo](https://github.com/buildbuddy-io/buildbuddy-helm).
 
+For guidance on deploying and sizing self-hosted Cache Proxies, see the [Enterprise Cache Proxy documentation](enterprise-proxy.md).
+
 ## TL;DR
 
 ```bash

--- a/docs/enterprise-proxy.md
+++ b/docs/enterprise-proxy.md
@@ -38,18 +38,45 @@ This will return an IP address that you can ping to verify that your installatio
 
 ## Configuration
 
-You may want to configure your deployment's size by editing the number of replicas and the CPU and memory allocation for your pods:
+### Deployment topology and storage
+
+The Helm chart runs Cache Proxy replicas as a distributed cache. Consistent hashing assigns each cached artifact to an owning proxy pod. With the default replication factor of one, that pod stores the artifact's local copy and other proxies route reads and writes to it. The upstream BuildBuddy Remote Cache remains the authoritative copy.
+
+Use local SSD-backed storage for Cache Proxy data when possible. Proxy storage performance is generally less sensitive than executor scratch storage, but disk latency and throughput can still become bottlenecks under heavy cache traffic. Prefer fewer, larger proxies to reduce coordination and per-pod overhead, while retaining enough replicas for maintenance and failure tolerance.
+
+### Initial sizing
+
+As a starting point, size the proxy deployment relative to the executor capacity in the same cluster:
+
+| Resource | Executor-to-proxy ratio |
+| -------- | ----------------------- |
+| CPU      | 20:1 to 30:1            |
+| Memory   | 4:1 to 5:1              |
+
+For example, a cluster with 1,000 executor CPUs and 2 TB (approximately 1.82 TiB) of executor memory should start with approximately 33 to 50 proxy CPUs and 400 to 500 GB (approximately 373 to 466 GiB) of proxy memory, divided across the proxy replicas.
+
+One possible starting configuration for that example is:
 
 ```yaml title="values.yaml"
-replicas: 6
+replicas: 3
 resources:
   limits:
-    cpu: "8"
-    memory: "32Gi"
+    cpu: "16"
+    memory: "140Gi"
   requests:
-    cpu: "7"
-    memory: "30Gi"
+    cpu: "16"
+    memory: "140Gi"
 ```
+
+This allocates 48 CPUs and 420 GiB of memory across three Cache Proxy replicas.
+
+The example sets requests equal to limits so scheduler reservations match the sizing calculation. Clusters that intentionally overcommit CPU can lower the CPU requests separately.
+
+These ratios are rules of thumb rather than fixed requirements. Monitor proxy CPU, memory, disk utilization, cache hit rate, request latency, evictions, and upstream traffic, then tune the replica count and per-pod resources for your cache traffic and enabled features.
+
+### Scaling executors
+
+When Cache Proxies and executors run in the same cluster, the executor fleet can autoscale independently while the proxy fleet retains its local cache. Newly started executors can read cached artifacts over the cluster network instead of fetching those artifacts across clusters during scale-up.
 
 ## Usage
 

--- a/docs/enterprise-proxy.md
+++ b/docs/enterprise-proxy.md
@@ -38,18 +38,45 @@ This will return an IP address that you can ping to verify that your installatio
 
 ## Configuration
 
-You may want to configure your deployment's size by editing the number of replicas and the CPU and memory allocation for your pods:
+### Deployment topology and storage
+
+The Helm chart runs Cache Proxy replicas as a distributed cache. Consistent hashing assigns each cached artifact to an owning proxy pod. With the default replication factor of one, one proxy pod within the cluster stores each artifact, and other proxies route reads and writes to it. The upstream BuildBuddy Remote Cache remains the authoritative copy.
+
+Use SSD-backed storage within the cluster for Cache Proxy data when possible. Proxy storage performance is generally less sensitive than executor scratch storage, but disk latency and throughput can still become bottlenecks under heavy cache traffic. Prefer fewer, larger proxies to reduce coordination and per-pod overhead, while retaining enough replicas for maintenance and failure tolerance.
+
+### Initial sizing
+
+As a starting point, size the proxy deployment relative to the executor capacity in the same cluster:
+
+| Resource | Executor-to-proxy ratio |
+| -------- | ----------------------- |
+| CPU      | 20:1 to 30:1            |
+| Memory   | 4:1 to 5:1              |
+
+For example, a cluster with 1,000 executor CPUs and 2 TB (approximately 1.82 TiB) of executor memory should start with approximately 33 to 50 proxy CPUs and 400 to 500 GB (approximately 373 to 466 GiB) of proxy memory, divided across the proxy replicas.
+
+One possible starting configuration for that example is:
 
 ```yaml title="values.yaml"
-replicas: 6
+replicas: 3
 resources:
   limits:
-    cpu: "8"
-    memory: "32Gi"
+    cpu: "16"
+    memory: "140Gi"
   requests:
-    cpu: "7"
-    memory: "30Gi"
+    cpu: "16"
+    memory: "140Gi"
 ```
+
+This allocates 48 CPUs and 420 GiB of memory across three Cache Proxy replicas.
+
+The example sets requests equal to limits so scheduler reservations match the sizing calculation. Clusters that intentionally overcommit CPU can lower the CPU requests separately.
+
+These ratios are rules of thumb rather than fixed requirements. Monitor proxy CPU, memory, disk utilization, cache hit rate, request latency, evictions, and upstream traffic, then tune the replica count and per-pod resources for your cache traffic and enabled features.
+
+### Scaling executors
+
+When Cache Proxies and executors run in the same cluster, the executor fleet can autoscale independently while the proxy fleet retains its cache within the cluster. Newly started executors can read cached artifacts over the cluster network instead of fetching those artifacts across clusters during scale-up.
 
 ## Usage
 

--- a/docs/enterprise-proxy.md
+++ b/docs/enterprise-proxy.md
@@ -40,9 +40,9 @@ This will return an IP address that you can ping to verify that your installatio
 
 ### Deployment topology and storage
 
-The Helm chart runs Cache Proxy replicas as a distributed cache. Consistent hashing assigns each cached artifact to an owning proxy pod. With the default replication factor of one, one proxy pod within the cluster stores each artifact, and other proxies route reads and writes to it. The upstream BuildBuddy Remote Cache remains the authoritative copy.
+The Helm chart runs Cache Proxies replicas as a distributed cache. Consistent hashing assigns cache artifacts to one or more proxy pods. With the default replication factor of one, each artifact is stored on one proxy pod in the cluster, and other proxy pods route reads and writes to the pod that owns the artifact. The upstream BuildBuddy Remote Cache remains the authoritative source of all cache artifacts.
 
-Use SSD-backed storage within the cluster for Cache Proxy data when possible. Proxy storage performance is generally less sensitive than executor scratch storage, but disk latency and throughput can still become bottlenecks under heavy cache traffic. Prefer fewer, larger proxies to reduce coordination and per-pod overhead, while retaining enough replicas for maintenance and failure tolerance.
+Use SSD-backed storage for Cache Proxy data when possible. Proxy storage performance is generally less sensitive than executor scratch storage, but disk latency and throughput can become bottlenecks under heavy load. Prefer fewer, larger proxies to reduce coordination and per-pod overhead, while retaining enough replicas for maintenance and failure tolerance.
 
 ### Initial sizing
 
@@ -53,7 +53,7 @@ As a starting point, size the proxy deployment relative to the executor capacity
 | CPU      | 20:1 to 30:1            |
 | Memory   | 4:1 to 5:1              |
 
-For example, a cluster with 1,000 executor CPUs and 2 TB (approximately 1.82 TiB) of executor memory should start with approximately 33 to 50 proxy CPUs and 400 to 500 GB (approximately 373 to 466 GiB) of proxy memory, divided across the proxy replicas.
+For example, an executor cluster with 1,000 CPUs and 2 TB (approximately 1.82 TiB) of memory should start with approximately 33 to 50 proxy CPUs and 400 to 500 GB (approximately 373 to 466 GiB) of proxy memory total, divided across the proxy replicas.
 
 One possible starting configuration for that example is:
 
@@ -72,7 +72,7 @@ This allocates 48 CPUs and 420 GiB of memory across three Cache Proxy replicas.
 
 The example sets requests equal to limits so scheduler reservations match the sizing calculation. Clusters that intentionally overcommit CPU can lower the CPU requests separately.
 
-These ratios are rules of thumb rather than fixed requirements. Monitor proxy CPU, memory, disk utilization, cache hit rate, request latency, evictions, and upstream traffic, then tune the replica count and per-pod resources for your cache traffic and enabled features.
+These ratios are rules of thumb rather than fixed requirements. Monitor proxy CPU, memory, disk utilization, cache hit rate, request latency, evictions, and upstream traffic, then tune the replica count and per-pod resources based on observed performance.
 
 ### Scaling executors
 

--- a/docs/enterprise-rbe.md
+++ b/docs/enterprise-rbe.md
@@ -114,6 +114,8 @@ The default values support both memory hungry Java tests and CPU-intensive Tenso
 
 For a full overview of what can be configured via our enterprise Helm charts, see the [buildbuddy-enterprise values.yaml file](https://github.com/buildbuddy-io/buildbuddy-helm/blob/master/charts/buildbuddy-enterprise/values.yaml), and the [buildbuddy-executor values.yaml file](https://github.com/buildbuddy-io/buildbuddy-helm/blob/master/charts/buildbuddy-executor/values.yaml). Values for the executor deployment are nested in the `executor:` block of the buildbuddy-enterprise yaml file.
 
+If you deploy Cache Proxies alongside your executors, see the [Cache Proxy sizing, storage, and scaling guidance](enterprise-proxy.md#configuration).
+
 ## More configuration
 
 For more configuration options beyond RBE, like authentication and storage options, see our [configuration docs](config.md) and our [enterprise configuration guide](enterprise-config.md).


### PR DESCRIPTION
Operators currently have to ask support how to size and place
self-hosted Cache Proxies because the docs do not explain how the
resource example relates to executor capacity.

Document the distributed-cache topology, local SSD recommendation,
starting CPU and memory ratios, and a ratio-derived YAML example with
explicit unit conversions and resource reservations. Add the monitoring
caveat and same-cluster autoscaling benefit, and link the guidance from
the RBE and Helm pages.
