### PR TITLE
proto: use SizeVT when available

### DIFF
--- a/server/util/proto/proto.go
+++ b/server/util/proto/proto.go
@@ -4,7 +4,7 @@ import (
 	gproto "google.golang.org/protobuf/proto"
 )
 
-var Size = gproto.Size
+var Size = size
 var Merge = gproto.Merge
 var Equal = gproto.Equal
 
@@ -27,6 +27,13 @@ type VTProtoMessage interface {
 	// For vtprotoCodecV2
 	MarshalToSizedBufferVT(data []byte) (int, error)
 	SizeVT() int
+}
+
+func size(v Message) int {
+	if vt, ok := v.(VTProtoMessage); ok {
+		return vt.SizeVT()
+	}
+	return gproto.Size(v)
 }
 
 func Marshal(v Message) ([]byte, error) {

--- a/server/util/proto/proto_test.go
+++ b/server/util/proto/proto_test.go
@@ -99,6 +99,7 @@ func generateBytes(t testing.TB, protos []protoMessage) [][]byte {
 type marshalFunc func(v protoMessage) ([]byte, error)
 type unmarshalFunc func([]byte, protoMessage) error
 type cloneFunc func(v proto.Message) proto.Message
+type sizeFunc func(v proto.Message) int
 
 func TestMarshal(t *testing.T) {
 	md := &sgpb.FileMetadata{}
@@ -180,6 +181,30 @@ func TestClone(t *testing.T) {
 	actual := proto.Clone(md)
 	require.NoError(t, err)
 	require.True(t, proto.Equal(md, actual))
+}
+
+func TestSizeVT(t *testing.T) {
+	for name, pbType := range testProtoTypes {
+		t.Run(name, func(t *testing.T) {
+			msg := pbType.providerFn()
+			require.Implements(t, (*proto.VTProtoMessage)(nil), msg)
+			require.NoError(t, faker.FakeData(msg), "unable to fake data")
+			require.Equal(t, gproto.Size(msg), proto.Size(msg))
+		})
+	}
+
+	t.Run("typed nil", func(t *testing.T) {
+		msg := (*sgpb.FileMetadata)(nil)
+		require.Implements(t, (*proto.VTProtoMessage)(nil), msg)
+		require.Equal(t, gproto.Size(msg), proto.Size(msg))
+	})
+
+	t.Run("unknown fields", func(t *testing.T) {
+		msg := &sgpb.FileMetadata{}
+		msg.ProtoReflect().SetUnknown([]byte{0xa0, 0x06, 0x01})
+		require.Implements(t, (*proto.VTProtoMessage)(nil), msg)
+		require.Equal(t, gproto.Size(msg), proto.Size(msg))
+	})
 }
 
 func benchmarkMarshal(b *testing.B, marshalFn marshalFunc, data []protoMessage) {
@@ -305,6 +330,37 @@ func BenchmarkClone(b *testing.B) {
 		for name, fn := range cloneFns {
 			b.Run(fmt.Sprintf("name=%s/pbName=%s", name, pbName), func(b *testing.B) {
 				benchmarkClone(b, fn, protos)
+			})
+		}
+	}
+}
+
+func BenchmarkSize(b *testing.B) {
+	sizeFns := map[string]sizeFunc{
+		"New": func(v proto.Message) int {
+			return proto.Size(v)
+		},
+		"Old": func(v proto.Message) int {
+			return gproto.Size(v)
+		},
+	}
+
+	for pbName, pbType := range testProtoTypes {
+		protos := generateProtos(b, pbType.providerFn)
+		for name, fn := range sizeFns {
+			b.Run(fmt.Sprintf("name=%s/pbName=%s", name, pbName), func(b *testing.B) {
+				b.ReportAllocs()
+				var totalSize int
+				for _, pb := range protos {
+					totalSize += gproto.Size(pb)
+				}
+				b.SetBytes(int64(totalSize / len(protos)))
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+					pb := protos[i%len(protos)]
+					_ = fn(pb)
+				}
 			})
 		}
 	}


### PR DESCRIPTION
Size accounting runs on cache proxy and action-cache request paths.
Use generated VT sizing because reflection adds avoidable CPU cost on
these paths. Preserve the standard fallback and function-variable API.

Local Bazel benchmark on an AMD Ryzen AI MAX+ 395; medians of 20
independent runs at 300 ms per benchmark. All samples report zero
allocations. Generated sizing is faster for all 5 benchmarked message
types.

| Benchmark | proto.Size | SizeVT | Change |
| --- | ---: | ---: | ---: |
| FileMetadata | 104.6 ns | 25.0 ns | -76.1% |
| ReadResponse | 12.9 ns | 5.0 ns | -61.4% |
| ScoreCard | 100.6 us | 71.1 us | -29.3% |
| ScoreCardResult | 490.7 ns | 305.4 ns | -37.8% |
| TreeCache | 16.3 ms | 8.6 ms | -47.3% |
