### PR TITLE
ociruntime: upgrade crun to 1.28

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -313,19 +313,17 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         sha256 = PODMAN_STATIC_SHA256_ARM64,
     )
 
-    # NOTE: crun 1.16.1 has a double-free bug. Before upgrading, be sure the
-    # release includes a fix for https://github.com/containers/crun/issues/1537
     http_file(
         name = "com_github_containers_crun_crun-linux-amd64",
-        urls = ["https://github.com/containers/crun/releases/download/1.15/crun-1.15-linux-amd64-disable-systemd"],
-        sha256 = "03fd3ec6a7799183eaeefba5ebd3f66f9b5fb41a5b080c196285879631ff5dc1",
+        urls = ["https://github.com/containers/crun/releases/download/1.28/crun-1.28-linux-amd64-disable-systemd"],
+        sha256 = "137bce17e4a102683e9b6974f4141cf6c30da61c8ade43c8f2b2d6961a8b858b",
         downloaded_file_path = "crun",
         executable = True,
     )
     http_file(
         name = "com_github_containers_crun_crun-linux-arm64",
-        urls = ["https://github.com/containers/crun/releases/download/1.15/crun-1.15-linux-arm64-disable-systemd"],
-        sha256 = "1bd840c95e9ae8edc25654dcf2481309724b9ff18ce95dbcd2535da9b026a47d",
+        urls = ["https://github.com/containers/crun/releases/download/1.28/crun-1.28-linux-arm64-disable-systemd"],
+        sha256 = "decac16cacbc570a1d7739d2ba47da4ffe0d3918adb10e47712bd1da0a110a78",
         downloaded_file_path = "crun",
         executable = True,
     )

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -795,13 +795,6 @@ func (c *ociContainer) Create(ctx context.Context, workDir string) error {
 
 func (c *ociContainer) Exec(ctx context.Context, cmd *repb.Command, stdio *interfaces.Stdio) *interfaces.CommandResult {
 	args := []string{"exec", "--cwd=" + filepath.Join(c.execrootPath, cmd.GetWorkingDirectory())}
-	// Respect command env. Note, when setting any --env vars at all, it
-	// completely overrides the env from the bundle, rather than just adding
-	// to it. So we specify the complete env here, including the base env,
-	// image env, and command env.
-	for _, e := range baseEnv {
-		args = append(args, "--env="+e)
-	}
 	if c.lockedImage == nil {
 		return commandutil.ErrorResult(status.UnavailableError("exec called before pulling image"))
 	}
@@ -811,11 +804,14 @@ func (c *ociContainer) Exec(ctx context.Context, cmd *repb.Command, stdio *inter
 	}
 	args = append(args, fmt.Sprintf("--user=%d:%d", user.UID, user.GID))
 
+	commandEnv := cmd.GetEnvironmentVariables()
 	cmd, err = withImageConfig(cmd, c.lockedImage.Image)
 	if err != nil {
 		return commandutil.ErrorResult(status.UnavailableErrorf("apply image config: %s", err))
 	}
-	for _, e := range cmd.GetEnvironmentVariables() {
+	// The bundle already contains the base and image environments. Pass only
+	// command env here; crun merges it with the bundle env and gives it precedence.
+	for _, e := range commandEnv {
 		args = append(args, fmt.Sprintf("--env=%s=%s", e.GetName(), e.GetValue()))
 	}
 	args = append(args, c.cid)

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -782,6 +782,7 @@ func TestPullCreateExecRemove(t *testing.T) {
 		`},
 		EnvironmentVariables: []*repb.Command_EnvironmentVariable{
 			{Name: "GREETING", Value: "Hello"},
+			{Name: "TEST_ENV_VAR", Value: "overridden"},
 		},
 	}
 	stdio := interfaces.Stdio{}
@@ -797,7 +798,7 @@ HOSTNAME=localhost
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/test/bin
 PWD=/buildbuddy-execroot
 SHLVL=1
-TEST_ENV_VAR=foo
+TEST_ENV_VAR=overridden
 `, string(res.Stdout))
 
 	// Make sure that no cached images were modified.


### PR DESCRIPTION
The bundled OCI runtime remains pinned to crun 1.15, which predates
current security and compatibility fixes. Upgrade it so that proposed
changes to executor mount protections are evaluated against current
isolation behavior.

Upgrade the amd64 and arm64 static binaries to 1.28 and refresh their
checksums. Remove the obsolete warning about crun 1.16.1's double-free
bug, which was fixed upstream.

crun 1.28 merges exec environment entries with the bundle environment.
Rely on the bundle's base and image variables during exec, and pass only
command-specific values so they override bundle entries.
