### PR TITLE
Improve OOM kill logs and metrics

### DIFF
--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller.go
@@ -75,6 +75,12 @@ type TaskState struct {
 	EstimatedMemoryBytes int64
 	// GroupID identifies the group that owns an active task.
 	GroupID string
+	// ExecutionID identifies the execution ID associated with the task,
+	// or "" if the runner is not active.
+	ExecutionID string
+	// InvocationID identifies the invocation associated with the task,
+	// or "" if the runner is not active.
+	InvocationID string
 	// RemoteExecutionPriority is the task's remote execution priority. Positive
 	// values mark low priority tasks, and larger values are lower priority.
 	// This field is only comparable among active tasks with the same non-empty
@@ -280,7 +286,7 @@ func (k *killer) pollWhileTasks(ctx context.Context) {
 }
 
 func (k *killer) check(ctx context.Context) error {
-	snapshot, err := k.monitor.Snapshot(ctx)
+	hostMem, err := k.monitor.Snapshot(ctx)
 	if err != nil {
 		return err
 	}
@@ -290,9 +296,9 @@ func (k *killer) check(ctx context.Context) error {
 	// victim's memory isn't reclaimed instantly, so we can't re-snapshot after
 	// each kill; instead we optimistically subtract each victim's observed
 	// memory from the projected usage.
-	projectedUsedBytes := snapshot.UsedBytes
+	projectedUsedBytes := hostMem.UsedBytes
 	killedCount := 0
-	for k.shouldKill(ctx, projectedUsedBytes, snapshot.LimitBytes) {
+	for k.shouldKill(ctx, projectedUsedBytes, hostMem.LimitBytes) {
 		victim := k.chooseVictim(ctx)
 		if victim == nil {
 			if killedCount == 0 {
@@ -309,8 +315,19 @@ func (k *killer) check(ctx context.Context) error {
 			// instead of waiting for the next poll.
 			continue
 		}
-		log.CtxWarningf(ctx, "Executor OOM killer terminating victim %s: executor memory used=%d projected_remaining=%d limit=%d available=%d victim memory=%d estimated=%d active=%t", taskName(victim.task), snapshot.UsedBytes, projectedUsedBytes, snapshot.LimitBytes, snapshot.AvailableBytes, victim.observedMemoryBytes, victim.state.EstimatedMemoryBytes, victim.state.Active)
-		metrics.RemoteExecutionOOMKillerTargetedTaskMemoryBytes.Observe(float64(victim.observedMemoryBytes))
+
+		ctx := log.EnrichContext(ctx, log.ExecutionIDKey, victim.state.ExecutionID)
+		ctx = log.EnrichContext(ctx, log.InvocationIDKey, victim.state.InvocationID)
+		log.CtxWarningf(
+			ctx,
+			"Executor OOM killer terminating victim %s: "+
+				"Executor{Used:%d ProjectedUsed:%d Limit:%d Avail:%d} "+
+				"Victim{Memory:%d Estimated:%d Active:%t}",
+			taskName(victim.task),
+			hostMem.UsedBytes, projectedUsedBytes, hostMem.LimitBytes, hostMem.AvailableBytes,
+			victim.observedMemoryBytes, victim.state.EstimatedMemoryBytes, victim.state.Active,
+		)
+		metrics.RemoteExecutionOOMKillerTargetedTaskMemoryBytes.WithLabelValues(victim.state.GroupID).Observe(float64(victim.observedMemoryBytes))
 		oomErr := oom.Error(oom.Details{
 			EstimatedMemoryBytes: victim.state.EstimatedMemoryBytes,
 			ObservedMemoryBytes:  victim.observedMemoryBytes,

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -360,6 +360,8 @@ func (k *killableTask) State(ctx context.Context) (*oomkiller.TaskState, error) 
 	return &oomkiller.TaskState{
 		EstimatedMemoryBytes:    k.r.schedulingMetadata.GetTaskSize().GetEstimatedMemoryBytes(),
 		GroupID:                 k.r.schedulingMetadata.GetTaskGroupId(),
+		InvocationID:            k.r.task.GetInvocationId(),
+		ExecutionID:             k.r.task.GetExecutionId(),
 		RemoteExecutionPriority: k.r.schedulingMetadata.GetPriority(),
 		StartedAt:               k.startedAt,
 		UsageStats:              &repb.UsageStats{MemoryBytes: stats.GetMemoryBytes()},
@@ -369,6 +371,10 @@ func (k *killableTask) State(ctx context.Context) (*oomkiller.TaskState, error) 
 
 func (k *killableTask) Kill(ctx context.Context, err error) {
 	k.cancel(err)
+}
+
+func (k *killableTask) String() string {
+	return k.r.String()
 }
 
 // Run runs the task that is currently bound to the command runner.

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1348,12 +1348,14 @@ var (
 		Buckets:   exponentialBucketRange(1, 1024*1024*1024*1024 /*1 TB*/, 1.5),
 	})
 
-	RemoteExecutionOOMKillerTargetedTaskMemoryBytes = promauto.NewHistogram(prometheus.HistogramOpts{
+	RemoteExecutionOOMKillerTargetedTaskMemoryBytes = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",
 		Name:      "oom_killer_targeted_task_memory_bytes",
 		Help:      "Observed task memory in bytes targeted by the executor OOM killer.",
 		Buckets:   exponentialBucketRange(1, 1024*1024*1024*1024 /*1 TB*/, 1.5),
+	}, []string{
+		GroupID,
 	})
 
 	RemoteExecutionWaitingExecutionResult = promauto.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
- Ensure `execution_id` and `invocation_id` are in the logging context for victim tasks
- Add group_id to prometheus metrics
- Tweak formatting of memory numbers to make the structure a bit clearer
- Implement `killableTask.String()` so that we show the runner debug ID instead of `*runner.killableTask`