### PR TITLE
oom killer: don't count active_file usage as unreclaimable

### DIFF
--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -503,6 +503,13 @@ func ReadMemoryStatField(dir, field string) (int64, error) {
 	return readCgroupInt64Field(filepath.Join(dir, "memory.stat"), field)
 }
 
+// ReadMemoryStat reads the "memory.stat" file under the given cgroup directory
+// and returns the field values as a map. The directory should be an absolute
+// path, including the /sys/fs/cgroup prefix.
+func ReadMemoryStat(dir string) (map[string]int64, error) {
+	return readAllInt64Fields(filepath.Join(dir, "memory.stat"))
+}
+
 // ReadPidsEvents reads the "pids.events" file under the given cgroup
 // directory and returns the counter values as a map. The directory should be an
 // absolute path, including the /sys/fs/cgroup prefix.

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux.go
@@ -67,7 +67,7 @@ type cgroupMemoryMonitor struct {
 }
 
 func (m *cgroupMemoryMonitor) Snapshot(_ context.Context) (*MemorySnapshot, error) {
-	usedBytes, err := getCgroupWorkingSetMemoryBytes(m.dir)
+	usedBytes, err := getCgroupUnreclaimableMemoryBytes(m.dir)
 	if err != nil {
 		return nil, fmt.Errorf("read executor cgroup memory: %w", err)
 	}
@@ -78,12 +78,22 @@ func (m *cgroupMemoryMonitor) Snapshot(_ context.Context) (*MemorySnapshot, erro
 	}, nil
 }
 
-// getCgroupWorkingSetMemoryBytes returns the memory usage of the cgroup at the
-// given cgroupfs directory, excluding inactive page cache, which the kernel
-// reclaims under memory pressure instead of OOM killing. This matches the
-// "working set" definition that the kubelet uses for eviction decisions. See
-// https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#memory-signals
-func getCgroupWorkingSetMemoryBytes(dir string) (int64, error) {
+// getCgroupUnreclaimableMemoryBytes returns the memory usage of the cgroup at
+// the given cgroupfs directory, excluding file page cache, which the kernel
+// reclaims under memory pressure instead of OOM killing.
+//
+// Everything else is counted: anon memory, shmem/tmpfs pages (which are tracked
+// by the anon LRU lists, not the file lists), unevictable pages, and kernel
+// memory. Without swap enabled (which for now we assume is the case), the
+// kernel cannot reclaim any of these, so they determine how close the cgroup is
+// to a kernel OOM kill.
+//
+// The exception is reclaimable slab (dentry and inode caches), which the kernel
+// can shrink under memory pressure but which is deliberately still counted:
+// slab reclaim only frees pages when whole slabs empty out, making it less
+// dependable than dropping clean file pages, and counting it errs toward
+// killing tasks early instead of letting the kernel OOM kill the executor.
+func getCgroupUnreclaimableMemoryBytes(dir string) (int64, error) {
 	currentBytes, err := cgroup.ReadMemoryCurrent(dir)
 	if err != nil {
 		return 0, err
@@ -91,11 +101,19 @@ func getCgroupWorkingSetMemoryBytes(dir string) (int64, error) {
 	if currentBytes < 0 {
 		return 0, fmt.Errorf("cgroup memory.current is negative (%d)", currentBytes)
 	}
-	inactiveFileBytes, err := cgroup.ReadMemoryStatField(dir, "inactive_file")
+	memoryStat, err := cgroup.ReadMemoryStat(dir)
 	if err != nil {
 		return 0, fmt.Errorf("read memory stats: %w", err)
 	}
+	var fileBytes int64
+	for _, field := range []string{"inactive_file", "active_file"} {
+		value, ok := memoryStat[field]
+		if !ok {
+			return 0, fmt.Errorf("memory.stat is missing field %q", field)
+		}
+		fileBytes += value
+	}
 	// memory.current and memory.stat are read separately, so the subtraction
 	// can skew slightly negative under concurrent cache growth.
-	return max(int64(0), currentBytes-inactiveFileBytes), nil
+	return max(int64(0), currentBytes-fileBytes), nil
 }

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux_test.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux_test.go
@@ -13,30 +13,54 @@ import (
 func TestCgroupMemoryMonitorSnapshot(t *testing.T) {
 	cgroupDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.current"), []byte("750"), 0644))
-	require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.stat"), []byte("anon 500\ninactive_file 200\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.stat"), []byte("anon 500\ninactive_file 120\nactive_file 80\n"), 0644))
 	monitor := &cgroupMemoryMonitor{dir: cgroupDir, limitBytes: 1000}
 
-	// The monitor should report usage from the executor cgroup, excluding
-	// inactive page cache since the kernel reclaims it under memory pressure,
-	// and calculate the remaining headroom relative to the cgroup memory
-	// limit.
+	// The monitor should report usage from the executor cgroup, excluding both
+	// the inactive and active file page cache since the kernel reclaims file
+	// pages under memory pressure, and calculate the remaining headroom
+	// relative to the cgroup memory limit.
 	snapshot, err := monitor.Snapshot(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, &MemorySnapshot{UsedBytes: 550, LimitBytes: 1000, AvailableBytes: 450}, snapshot)
 }
 
-func TestCgroupMemoryMonitorSnapshot_InactiveFileAboveCurrent(t *testing.T) {
+func TestCgroupMemoryMonitorSnapshot_FileCacheAboveCurrent(t *testing.T) {
 	cgroupDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.current"), []byte("100"), 0644))
-	require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.stat"), []byte("inactive_file 150\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.stat"), []byte("inactive_file 90\nactive_file 60\n"), 0644))
 	monitor := &cgroupMemoryMonitor{dir: cgroupDir, limitBytes: 1000}
 
-	// memory.current and memory.stat are read separately, so inactive page
+	// memory.current and memory.stat are read separately, so the file page
 	// cache can momentarily exceed the earlier memory.current reading. Clamp
 	// the reported usage to zero instead of going negative.
 	snapshot, err := monitor.Snapshot(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, &MemorySnapshot{UsedBytes: 0, LimitBytes: 1000, AvailableBytes: 1000}, snapshot)
+}
+
+func TestCgroupMemoryMonitorSnapshot_MissingFileFields(t *testing.T) {
+	for _, testCase := range []struct {
+		name         string
+		memoryStat   string
+		missingField string
+	}{
+		{name: "missing inactive_file", memoryStat: "anon 500\nactive_file 80\n", missingField: "inactive_file"},
+		{name: "missing active_file", memoryStat: "anon 500\ninactive_file 120\n", missingField: "active_file"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			cgroupDir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.current"), []byte("750"), 0644))
+			require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.stat"), []byte(testCase.memoryStat), 0644))
+			monitor := &cgroupMemoryMonitor{dir: cgroupDir, limitBytes: 1000}
+
+			// The kernel always reports both file LRU fields, so a missing field
+			// means the read went wrong somehow. Report an error instead of
+			// silently treating the missing cache as used.
+			_, err := monitor.Snapshot(t.Context())
+			require.ErrorContains(t, err, testCase.missingField)
+		})
+	}
 }
 
 func TestCgroupMemoryMonitorSnapshot_NegativeUsage(t *testing.T) {
@@ -54,7 +78,7 @@ func TestCgroupMemoryMonitorSnapshot_NegativeUsage(t *testing.T) {
 func TestCgroupMemoryMonitorSnapshot_UsageAboveLimit(t *testing.T) {
 	cgroupDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.current"), []byte("1250"), 0644))
-	require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.stat"), []byte("inactive_file 100\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.stat"), []byte("inactive_file 60\nactive_file 40\n"), 0644))
 	monitor := &cgroupMemoryMonitor{dir: cgroupDir, limitBytes: 1000}
 
 	// If usage somehow exceeds the memory limit, preserve the observed usage

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux_vm_test.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux_vm_test.go
@@ -82,6 +82,39 @@ func TestVMCgroupMemoryMonitorExcludesPageCache(t *testing.T) {
 	require.Less(t, snapshot.UsedBytes, int64(50<<20))
 }
 
+func TestVMCgroupMemoryMonitorExcludesActiveFileCache(t *testing.T) {
+	cgroupDir := setupTestCgroup(t)
+
+	// This test needs a disk-backed scratch directory so that file writes
+	// produce page cache rather than tmpfs memory.
+	scratchDir := t.TempDir()
+	var st unix.Statfs_t
+	require.NoError(t, unix.Statfs(scratchDir, &st))
+	require.NotEqual(t, int64(unix.TMPFS_MAGIC), st.Type, "scratch dir %s is on tmpfs; expected a disk-backed filesystem", scratchDir)
+
+	// Write a 100MB file to disk from inside the cgroup, syncing so the cached
+	// pages are clean, then continuously re-read the file so the kernel
+	// promotes the pages to the active file LRU list and keeps them there.
+	cacheFile := filepath.Join(scratchDir, "f")
+	cmd, _ := startBashInCgroup(t, cgroupDir, fmt.Sprintf("dd if=/dev/zero of=%s bs=1M count=100 conv=fsync", cacheFile))
+	require.NoError(t, cmd.Wait())
+	startBashInCgroup(t, cgroupDir, fmt.Sprintf("while true; do cat %s >/dev/null; done", cacheFile))
+	require.Eventually(t, func() bool {
+		activeFileBytes, err := cgroup.ReadMemoryStatField(cgroupDir, "active_file")
+		return err == nil && activeFileBytes >= 90<<20
+	}, 30*time.Second, 100*time.Millisecond, "active file cache did not reach 90MB")
+
+	// Active file pages are still reclaimable under memory pressure, so the
+	// monitor should exclude them from the reported usage. The kernel only
+	// moves pages back to the inactive list when reclaim runs, so a monitor
+	// that only excludes inactive_file would count this cache as used and
+	// cause false OOM kills.
+	monitor := &cgroupMemoryMonitor{dir: cgroupDir, limitBytes: 1 << 30}
+	snapshot, err := monitor.Snapshot(t.Context())
+	require.NoError(t, err)
+	require.Less(t, snapshot.UsedBytes, int64(50<<20))
+}
+
 func TestVMKillerKillsTaskWhenCgroupMemoryIsExhausted(t *testing.T) {
 	cgroupDir := setupTestCgroup(t)
 	ctx := t.Context()


### PR DESCRIPTION
The executor OOM killer is intended to only start killing processes once "unreclaimable" memory used by the executor cgroup reaches 95% of the total memory available to the cgroup. This includes, for example, anonymous memory allocated by `malloc()` - the kernel cannot reclaim this memory except by swapping it to disk, but we do not have (or want) swap enabled.

Currently, the "unreclaimable" calculation includes `active_file` memory, because I had mistaken `active_file` memory to mean "currently in-use / hot memory pages that the kernel will not evict from cache." In actuality, a memory page being `active` just means "this page was accessed twice, at some point" and not much more than that[^1]. Technically the kernel will not evict from the `active_file` list, but it *will* demote pages from this list to `inactive` if there's memory pressure, and then evict from the `inactive` list.

Because the `active` part of the page cache can keep growing if there's no memory pressure, and we're counting it as "unreclaimable" memory, this can lead to a bad situation where we start prematurely killing processes even if they are using very little memory in total.

This PR fixes that potential bad situation by not counting `active` memory as unreclaimable. However, the tradeoff is that we are allowing more memory to be used for process memory, and less memory to be used for the page cache. As a result, this increases the risk of thrashing. As a future improvement, we could combat this risk by incorporating memory pressure signals into the OOM killer's decisions, if we see processes spending too much time waiting for memory, we could kill a process to free up more memory for other processes.

[^1]: [This comment](https://github.com/torvalds/linux/blob/b95f03f04d475aa6719d15a636ddf32222d55657/mm/workingset.c#L22-L182) in the kernel source explains how the kernel manages the "working set," via two LRU structures (`inactive` and `active` cache slots). The queue is essentially a low-fi blend of an LRU and an LFU, where there is only 1 bit for recording frequency of access ("inactive" or "active").
