### PR TITLE
Add conflict and manual eviction to LRU metrics

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1932,15 +1932,15 @@ func (p *PebbleCache) findMissing(ctx context.Context, db pebble.IPebbleDB, grou
 		return err
 	}
 
+	unlockFn := p.locker.RLock(key.LockID())
+	defer unlockFn()
+
 	// Avoid expensive pebble op if key is in the presence cache.
 	// We don't update the atime on hit because we expect the cache TTL to be
 	// configured below the atime update threshold.
 	if p.presence.Contains(key) {
 		return nil
 	}
-
-	unlockFn := p.locker.RLock(key.LockID())
-	defer unlockFn()
 
 	buf, closer, err := p.lookupFileMetadataBytes(db, key)
 	if err != nil {

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1932,15 +1932,15 @@ func (p *PebbleCache) findMissing(ctx context.Context, db pebble.IPebbleDB, grou
 		return err
 	}
 
-	unlockFn := p.locker.RLock(key.LockID())
-	defer unlockFn()
-
 	// Avoid expensive pebble op if key is in the presence cache.
 	// We don't update the atime on hit because we expect the cache TTL to be
 	// configured below the atime update threshold.
 	if p.presence.Contains(key) {
 		return nil
 	}
+
+	unlockFn := p.locker.RLock(key.LockID())
+	defer unlockFn()
 
 	buf, closer, err := p.lookupFileMetadataBytes(db, key)
 	if err != nil {

--- a/server/util/lru/lru.go
+++ b/server/util/lru/lru.go
@@ -195,8 +195,10 @@ func newLRUMetrics(name string) *lruMetrics {
 		containsHit:  lookup("contains", metrics.HitStatusLabel),
 		containsMiss: lookup("contains", metrics.MissStatusLabel),
 		lastEvictionAge: map[EvictionReason]prometheus.Gauge{
-			SizeEviction: lastEvictionAge(SizeEviction),
-			TTLEviction:  lastEvictionAge(TTLEviction),
+			SizeEviction:     lastEvictionAge(SizeEviction),
+			TTLEviction:      lastEvictionAge(TTLEviction),
+			ConflictEviction: lastEvictionAge(ConflictEviction),
+			ManualEviction:   lastEvictionAge(ManualEviction),
 		},
 	}
 }


### PR DESCRIPTION
While the latency of these might not matter that much, having the counts can be useful.