### PR TITLE
ci_runner: fix partial clone remote config

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -2278,6 +2278,8 @@ func configurePartialClone(ctx context.Context) error {
 		}
 	}
 
+	// A failed lazy fetch creates only these two config entries for the
+	// synthetic promisor remote.
 	for _, key := range []string{"remote.true.promisor", "remote.true.partialCloneFilter"} {
 		if _, err := git(ctx, io.Discard, "config", "--unset-all", key); err != nil {
 			if getExitCode(err) == 5 {

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -2209,10 +2209,6 @@ func (ws *workspace) config(ctx context.Context) error {
 		{"user.name", "BuildBuddy"},
 		{"advice.detachedHead", "false"},
 		{"credential.interactive", "false"},
-		// With the version of git that we have installed in the CI runner
-		// image, --filter=blob:none requires the partialClone extension to be
-		// enabled.
-		{"extensions.partialClone", "true"},
 		// Disable this check for `git fetch` performance improvements
 		{"fetch.showForcedUpdates", "false"},
 		// Disable automatic gc - it can interfere with running `rm -rf .git` in
@@ -2235,6 +2231,9 @@ func (ws *workspace) config(ctx context.Context) error {
 			return err
 		}
 	}
+	if err := configurePartialClone(ctx); err != nil {
+		return err
+	}
 
 	// Set up global config (~/.gitconfig) but only on Linux for now since Linux
 	// workflows are isolated.
@@ -2250,6 +2249,43 @@ func (ws *workspace) config(ctx context.Context) error {
 		}
 	}
 
+	return nil
+}
+
+// configurePartialClone sets the promisor remote needed for filtered fetches
+// and repairs invalid partial clone configuration written by older versions of
+// ci_runner. extensions.partialClone contains the name of a promisor remote,
+// but ci_runner previously set it to "true", causing Git to try to fetch
+// missing objects from a remote named "true".
+func configurePartialClone(ctx context.Context) error {
+	trueRemoteURL, err := git(ctx, io.Discard, "config", "--get", "remote.true.url")
+	if err != nil && getExitCode(err) != 1 {
+		return fmt.Errorf("get remote.true.url: %w", err)
+	}
+	if strings.TrimSpace(trueRemoteURL) != "" {
+		// Preserve a legitimate remote named "true".
+		return nil
+	}
+
+	partialCloneRemote, err := git(ctx, io.Discard, "config", "--get", "extensions.partialClone")
+	if err != nil && getExitCode(err) != 1 {
+		return fmt.Errorf("get extensions.partialClone: %w", err)
+	}
+	partialCloneRemote = strings.TrimSpace(partialCloneRemote)
+	if partialCloneRemote == "true" || (partialCloneRemote == "" && len(*gitFetchFilters) > 0) {
+		if _, err := git(ctx, io.Discard, "config", "extensions.partialClone", gitRemoteName(*pushedRepoURL)); err != nil {
+			return fmt.Errorf("set extensions.partialClone: %w", err)
+		}
+	}
+
+	for _, key := range []string{"remote.true.promisor", "remote.true.partialCloneFilter"} {
+		if _, err := git(ctx, io.Discard, "config", "--unset-all", key); err != nil {
+			if getExitCode(err) == 5 {
+				continue
+			}
+			return fmt.Errorf("unset %s: %w", key, err)
+		}
+	}
 	return nil
 }
 

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -2322,6 +2322,10 @@ func (ws *workspace) config(ctx context.Context) error {
 		{"user.name", "BuildBuddy"},
 		{"advice.detachedHead", "false"},
 		{"credential.interactive", "false"},
+		// With the version of git that we have installed in the CI runner
+		// image, --filter=blob:none requires the partialClone extension to be
+		// enabled. Its value is the promisor remote name, not a boolean.
+		{"extensions.partialClone", gitRemoteName(*pushedRepoURL)},
 		// Disable this check for `git fetch` performance improvements
 		{"fetch.showForcedUpdates", "false"},
 		// Disable automatic gc - it can interfere with running `rm -rf .git` in
@@ -2344,9 +2348,6 @@ func (ws *workspace) config(ctx context.Context) error {
 			return err
 		}
 	}
-	if err := configurePartialClone(ctx); err != nil {
-		return err
-	}
 
 	// Set up global config (~/.gitconfig) but only on Linux for now since Linux
 	// workflows are isolated.
@@ -2362,45 +2363,6 @@ func (ws *workspace) config(ctx context.Context) error {
 		}
 	}
 
-	return nil
-}
-
-// configurePartialClone sets the promisor remote needed for filtered fetches
-// and repairs invalid partial clone configuration written by older versions of
-// ci_runner. extensions.partialClone contains the name of a promisor remote,
-// but ci_runner previously set it to "true", causing Git to try to fetch
-// missing objects from a remote named "true".
-func configurePartialClone(ctx context.Context) error {
-	trueRemoteURL, err := git(ctx, io.Discard, "config", "--get", "remote.true.url")
-	if err != nil && getExitCode(err) != 1 {
-		return fmt.Errorf("get remote.true.url: %w", err)
-	}
-	if strings.TrimSpace(trueRemoteURL) != "" {
-		// Preserve a legitimate remote named "true".
-		return nil
-	}
-
-	partialCloneRemote, err := git(ctx, io.Discard, "config", "--get", "extensions.partialClone")
-	if err != nil && getExitCode(err) != 1 {
-		return fmt.Errorf("get extensions.partialClone: %w", err)
-	}
-	partialCloneRemote = strings.TrimSpace(partialCloneRemote)
-	if partialCloneRemote == "true" || (partialCloneRemote == "" && len(*gitFetchFilters) > 0) {
-		if _, err := git(ctx, io.Discard, "config", "extensions.partialClone", gitRemoteName(*pushedRepoURL)); err != nil {
-			return fmt.Errorf("set extensions.partialClone: %w", err)
-		}
-	}
-
-	// A failed lazy fetch creates only these two config entries for the
-	// synthetic promisor remote.
-	for _, key := range []string{"remote.true.promisor", "remote.true.partialCloneFilter"} {
-		if _, err := git(ctx, io.Discard, "config", "--unset-all", key); err != nil {
-			if getExitCode(err) == 5 {
-				continue
-			}
-			return fmt.Errorf("unset %s: %w", key, err)
-		}
-	}
 	return nil
 }
 

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -2322,10 +2322,6 @@ func (ws *workspace) config(ctx context.Context) error {
 		{"user.name", "BuildBuddy"},
 		{"advice.detachedHead", "false"},
 		{"credential.interactive", "false"},
-		// With the version of git that we have installed in the CI runner
-		// image, --filter=blob:none requires the partialClone extension to be
-		// enabled.
-		{"extensions.partialClone", "true"},
 		// Disable this check for `git fetch` performance improvements
 		{"fetch.showForcedUpdates", "false"},
 		// Disable automatic gc - it can interfere with running `rm -rf .git` in
@@ -2348,6 +2344,9 @@ func (ws *workspace) config(ctx context.Context) error {
 			return err
 		}
 	}
+	if err := configurePartialClone(ctx); err != nil {
+		return err
+	}
 
 	// Set up global config (~/.gitconfig) but only on Linux for now since Linux
 	// workflows are isolated.
@@ -2363,6 +2362,43 @@ func (ws *workspace) config(ctx context.Context) error {
 		}
 	}
 
+	return nil
+}
+
+// configurePartialClone sets the promisor remote needed for filtered fetches
+// and repairs invalid partial clone configuration written by older versions of
+// ci_runner. extensions.partialClone contains the name of a promisor remote,
+// but ci_runner previously set it to "true", causing Git to try to fetch
+// missing objects from a remote named "true".
+func configurePartialClone(ctx context.Context) error {
+	trueRemoteURL, err := git(ctx, io.Discard, "config", "--get", "remote.true.url")
+	if err != nil && getExitCode(err) != 1 {
+		return fmt.Errorf("get remote.true.url: %w", err)
+	}
+	if strings.TrimSpace(trueRemoteURL) != "" {
+		// Preserve a legitimate remote named "true".
+		return nil
+	}
+
+	partialCloneRemote, err := git(ctx, io.Discard, "config", "--get", "extensions.partialClone")
+	if err != nil && getExitCode(err) != 1 {
+		return fmt.Errorf("get extensions.partialClone: %w", err)
+	}
+	partialCloneRemote = strings.TrimSpace(partialCloneRemote)
+	if partialCloneRemote == "true" || (partialCloneRemote == "" && len(*gitFetchFilters) > 0) {
+		if _, err := git(ctx, io.Discard, "config", "extensions.partialClone", gitRemoteName(*pushedRepoURL)); err != nil {
+			return fmt.Errorf("set extensions.partialClone: %w", err)
+		}
+	}
+
+	for _, key := range []string{"remote.true.promisor", "remote.true.partialCloneFilter"} {
+		if _, err := git(ctx, io.Discard, "config", "--unset-all", key); err != nil {
+			if getExitCode(err) == 5 {
+				continue
+			}
+			return fmt.Errorf("unset %s: %w", key, err)
+		}
+	}
 	return nil
 }
 

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -2391,6 +2391,8 @@ func configurePartialClone(ctx context.Context) error {
 		}
 	}
 
+	// A failed lazy fetch creates only these two config entries for the
+	// synthetic promisor remote.
 	for _, key := range []string{"remote.true.promisor", "remote.true.partialCloneFilter"} {
 		if _, err := git(ctx, io.Discard, "config", "--unset-all", key); err != nil {
 			if getExitCode(err) == 5 {

--- a/enterprise/server/cmd/ci_runner/main_test.go
+++ b/enterprise/server/cmd/ci_runner/main_test.go
@@ -124,6 +124,87 @@ func TestGitFetchRetriesSlowTransfer(t *testing.T) {
 	require.Equal(t, wantCommitSHA, strings.TrimSpace(fetchedCommitSHA))
 }
 
+func TestWorkspaceConfig_InvalidPartialCloneRemoteFailsLazyFetch(t *testing.T) {
+	ctx := t.Context()
+	runGit := func(repoDir string, args ...string) string {
+		args = append([]string{"-C", repoDir}, args...)
+		output, gitErr := git(ctx, io.Discard, args...)
+		if gitErr != nil {
+			t.Fatalf("git %v failed: %s", args, gitErr.Output)
+		}
+		return strings.TrimSpace(output)
+	}
+
+	sourceDir, _ := testgit.MakeTempRepo(t, map[string]string{
+		"lazy.txt": "lazy contents\n",
+	})
+	runGit(sourceDir, "config", "uploadpack.allowFilter", "true")
+	// Disable path-walk packing because it does not support object filters.
+	runGit(sourceDir, "config", "pack.usePathWalk", "false")
+	blobOID := runGit(sourceDir, "rev-parse", "HEAD:lazy.txt")
+
+	remoteURL := "file://" + sourceDir
+	checkoutDir := filepath.Join(t.TempDir(), "repo-root")
+	_, gitErr := git(
+		ctx,
+		io.Discard,
+		"clone", "--no-checkout", "--filter=blob:none", remoteURL, checkoutDir,
+	)
+	if gitErr != nil {
+		t.Fatalf("partial clone failed: %s", gitErr.Output)
+	}
+
+	missingObjects := runGit(checkoutDir, "rev-list", "--objects", "--all", "--missing=print")
+	require.Contains(t, missingObjects, "?"+blobOID, "expected blob to be omitted from the partial clone")
+
+	// Recreate the invalid configuration found in recycled runner snapshots.
+	// The partialClone extension value is a remote name, so the boolean-looking
+	// value below makes Git try to fetch missing objects from a remote named
+	// "true".
+	runGit(checkoutDir, "config", "--unset-all", "remote.origin.promisor")
+	runGit(checkoutDir, "config", "--unset-all", "remote.origin.partialCloneFilter")
+	runGit(checkoutDir, "config", "extensions.partialClone", "true")
+
+	// Verify that the fixture reproduces the reported failure.
+	_, gitErr = git(ctx, io.Discard, "-C", checkoutDir, "cat-file", "blob", blobOID)
+	require.NotNil(t, gitErr)
+	require.Contains(t, gitErr.Output, "'true' does not appear to be a git repository")
+
+	// Some Git versions persist this filter after the failed lazy fetch. Add it
+	// explicitly so the test deterministically matches the stale state observed
+	// in affected snapshots.
+	runGit(checkoutDir, "config", "remote.true.partialCloneFilter", "blob:none")
+	require.Equal(t, "blob:none", runGit(checkoutDir, "config", "--get", "remote.true.partialCloneFilter"))
+	require.Contains(t, strings.Fields(runGit(checkoutDir, "remote")), "true")
+
+	flags.Set(t, "pushed_repo_url", remoteURL)
+	flags.Set(t, "target_repo_url", remoteURL)
+	flags.Set(t, "git_fetch_filters", []string{"blob:none"})
+	t.Setenv("USE_SYSTEM_GIT_CREDENTIALS", "1")
+
+	originalWorkingDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(checkoutDir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(originalWorkingDir))
+	})
+
+	invocationLog := newInvocationLog(nil)
+	invocationLog.writer = io.Discard
+	ws := &workspace{
+		rootDir: checkoutDir,
+		log:     &buildEventReporter{log: invocationLog},
+	}
+	require.NoError(t, ws.config(ctx))
+
+	// Configuring an existing workspace currently leaves the invalid promisor
+	// remote in place, so lazy fetches continue to fail.
+	_, gitErr = git(ctx, io.Discard, "cat-file", "blob", blobOID)
+	require.NotNil(t, gitErr)
+	require.Contains(t, gitErr.Output, "'true' does not appear to be a git repository")
+	require.Contains(t, strings.Fields(runGit(checkoutDir, "remote")), "true")
+}
+
 func TestIsTransferTooSlow(t *testing.T) {
 	// Serve a git HTTP endpoint that starts a ref advertisement and then
 	// stalls, so that git's low-speed check aborts the transfer.

--- a/enterprise/server/cmd/ci_runner/main_test.go
+++ b/enterprise/server/cmd/ci_runner/main_test.go
@@ -173,7 +173,6 @@ func TestWorkspaceConfigRepairsInvalidPartialCloneRemote(t *testing.T) {
 	// Verify that the fixture reproduces the reported failure.
 	_, gitErr = git(ctx, io.Discard, "-C", checkoutDir, "cat-file", "blob", blobOID)
 	require.NotNil(t, gitErr)
-	require.Contains(t, gitErr.Output, "'true' does not appear to be a git repository")
 
 	// Some Git versions persist this filter after the failed lazy fetch. Add it
 	// explicitly so the test deterministically matches the stale state observed
@@ -202,18 +201,14 @@ func TestWorkspaceConfigRepairsInvalidPartialCloneRemote(t *testing.T) {
 		rootDir: checkoutDir,
 		log:     &buildEventReporter{log: invocationLog},
 	}
-	configCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	require.NoError(t, ws.config(configCtx))
+	require.NoError(t, ws.config(ctx))
 
 	// Configuring an existing workspace should point the extension at the
 	// actual remote and remove the stale synthetic remote.
 	require.Equal(t, "origin", runGit(checkoutDir, "config", "--get", "extensions.partialClone"))
 	require.NotContains(t, strings.Fields(runGit(checkoutDir, "remote")), "true")
 
-	fetchCtx, cancelFetch := context.WithTimeout(ctx, 5*time.Second)
-	defer cancelFetch()
-	blobContents, gitErr := git(fetchCtx, io.Discard, "cat-file", "blob", blobOID)
+	blobContents, gitErr := git(ctx, io.Discard, "cat-file", "blob", blobOID)
 	require.Nil(t, gitErr)
 	require.Contains(t, blobContents, "lazy contents")
 }

--- a/enterprise/server/cmd/ci_runner/main_test.go
+++ b/enterprise/server/cmd/ci_runner/main_test.go
@@ -124,7 +124,7 @@ func TestGitFetchRetriesSlowTransfer(t *testing.T) {
 	require.Equal(t, wantCommitSHA, strings.TrimSpace(fetchedCommitSHA))
 }
 
-func TestWorkspaceConfig_InvalidPartialCloneRemoteFailsLazyFetch(t *testing.T) {
+func TestWorkspaceConfigRepairsInvalidPartialCloneRemote(t *testing.T) {
 	ctx := t.Context()
 	runGit := func(repoDir string, args ...string) string {
 		args = append([]string{"-C", repoDir}, args...)
@@ -138,12 +138,17 @@ func TestWorkspaceConfig_InvalidPartialCloneRemoteFailsLazyFetch(t *testing.T) {
 	sourceDir, _ := testgit.MakeTempRepo(t, map[string]string{
 		"lazy.txt": "lazy contents\n",
 	})
-	runGit(sourceDir, "config", "uploadpack.allowFilter", "true")
-	// Disable path-walk packing because it does not support object filters.
-	runGit(sourceDir, "config", "pack.usePathWalk", "false")
 	blobOID := runGit(sourceDir, "rev-parse", "HEAD:lazy.txt")
 
-	remoteURL := "file://" + sourceDir
+	remote := testgit.StartServer(t, testgit.ServerOptions{LogWriter: io.Discard})
+	remote.CreateProject("test-org", "test-repo", &testgit.ProjectSettings{Public: true})
+	remote.SetProjectConfig("test-org", "test-repo", "uploadpack.allowFilter", "true")
+	// Lazy fetching requests the missing blob directly by object ID.
+	remote.SetProjectConfig("test-org", "test-repo", "uploadpack.allowAnySHA1InWant", "true")
+	// Disable path-walk packing because it does not support object filters.
+	remote.SetProjectConfig("test-org", "test-repo", "pack.usePathWalk", "false")
+	remote.Push("test-org", "test-repo", remote.AccessToken(), sourceDir)
+	remoteURL := remote.RepoURL("test-org", "test-repo", "")
 	checkoutDir := filepath.Join(t.TempDir(), "repo-root")
 	_, gitErr := git(
 		ctx,
@@ -173,7 +178,9 @@ func TestWorkspaceConfig_InvalidPartialCloneRemoteFailsLazyFetch(t *testing.T) {
 	// Some Git versions persist this filter after the failed lazy fetch. Add it
 	// explicitly so the test deterministically matches the stale state observed
 	// in affected snapshots.
+	runGit(checkoutDir, "config", "remote.true.promisor", "true")
 	runGit(checkoutDir, "config", "remote.true.partialCloneFilter", "blob:none")
+	require.Equal(t, "true", runGit(checkoutDir, "config", "--get", "remote.true.promisor"))
 	require.Equal(t, "blob:none", runGit(checkoutDir, "config", "--get", "remote.true.partialCloneFilter"))
 	require.Contains(t, strings.Fields(runGit(checkoutDir, "remote")), "true")
 
@@ -195,14 +202,20 @@ func TestWorkspaceConfig_InvalidPartialCloneRemoteFailsLazyFetch(t *testing.T) {
 		rootDir: checkoutDir,
 		log:     &buildEventReporter{log: invocationLog},
 	}
-	require.NoError(t, ws.config(ctx))
+	configCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	require.NoError(t, ws.config(configCtx))
 
-	// Configuring an existing workspace currently leaves the invalid promisor
-	// remote in place, so lazy fetches continue to fail.
-	_, gitErr = git(ctx, io.Discard, "cat-file", "blob", blobOID)
-	require.NotNil(t, gitErr)
-	require.Contains(t, gitErr.Output, "'true' does not appear to be a git repository")
-	require.Contains(t, strings.Fields(runGit(checkoutDir, "remote")), "true")
+	// Configuring an existing workspace should point the extension at the
+	// actual remote and remove the stale synthetic remote.
+	require.Equal(t, "origin", runGit(checkoutDir, "config", "--get", "extensions.partialClone"))
+	require.NotContains(t, strings.Fields(runGit(checkoutDir, "remote")), "true")
+
+	fetchCtx, cancelFetch := context.WithTimeout(ctx, 5*time.Second)
+	defer cancelFetch()
+	blobContents, gitErr := git(fetchCtx, io.Discard, "cat-file", "blob", blobOID)
+	require.Nil(t, gitErr)
+	require.Contains(t, blobContents, "lazy contents")
 }
 
 func TestIsTransferTooSlow(t *testing.T) {

--- a/enterprise/server/cmd/ci_runner/main_test.go
+++ b/enterprise/server/cmd/ci_runner/main_test.go
@@ -282,7 +282,7 @@ func TestGitCheckoutRetriesSlowLazyFetch(t *testing.T) {
 	require.NoError(t, ws.init(t.Context()))
 	// Filtered fetches require the partialClone extension, which the runner
 	// normally enables while configuring the repository.
-	_, gitErr := git(t.Context(), io.Discard, "config", "extensions.partialClone", "true")
+	_, gitErr := git(t.Context(), io.Discard, "config", "extensions.partialClone", "origin")
 	require.Nil(t, gitErr)
 
 	// Fetch the pushed branch without blobs. This fetch is not stalled, so
@@ -414,7 +414,7 @@ func TestGitMergeRetriesSlowLazyFetch(t *testing.T) {
 	// commit needs a committer identity. The runner normally sets both while
 	// configuring the repository.
 	for _, kv := range [][2]string{
-		{"extensions.partialClone", "true"},
+		{"extensions.partialClone", "origin"},
 		{"user.email", "ci-runner@buildbuddy.io"},
 		{"user.name", "BuildBuddy"},
 	} {
@@ -451,93 +451,60 @@ func TestGitMergeRetriesSlowLazyFetch(t *testing.T) {
 	require.Nil(t, gitErr, "expected HEAD to be a merge commit")
 }
 
-func TestWorkspaceConfigRepairsInvalidPartialCloneRemote(t *testing.T) {
-	ctx := t.Context()
-	runGit := func(repoDir string, args ...string) string {
-		args = append([]string{"-C", repoDir}, args...)
-		output, gitErr := git(ctx, io.Discard, args...)
-		if gitErr != nil {
-			t.Fatalf("git %v failed: %s", args, gitErr.Output)
-		}
-		return strings.TrimSpace(output)
+func TestWorkspaceConfigPartialCloneRemote(t *testing.T) {
+	for _, remoteName := range []string{"origin", "fork"} {
+		t.Run(remoteName, func(t *testing.T) {
+			ctx := t.Context()
+			runGit := func(repoDir string, args ...string) string {
+				args = append([]string{"-C", repoDir}, args...)
+				output, gitErr := git(ctx, io.Discard, args...)
+				if gitErr != nil {
+					t.Fatalf("git %v failed: %s", args, gitErr.Output)
+				}
+				return strings.TrimSpace(output)
+			}
+
+			sourceDir, _ := testgit.MakeTempRepo(t, map[string]string{
+				"lazy.txt": "lazy contents\n",
+			})
+			blobOID := runGit(sourceDir, "rev-parse", "HEAD:lazy.txt")
+			remote := testgit.StartServer(t, testgit.ServerOptions{LogWriter: io.Discard})
+			remote.CreateProject("test-org", "test-repo", &testgit.ProjectSettings{Public: true})
+			// Disable path-walk packing because it does not support object filters.
+			remote.SetProjectConfig("test-org", "test-repo", "pack.usePathWalk", "false")
+			remote.Push("test-org", "test-repo", remote.AccessToken(), sourceDir)
+			remoteURL := remote.RepoURL("test-org", "test-repo", "")
+
+			flags.Set(t, "pushed_repo_url", remoteURL)
+			if remoteName == "fork" {
+				flags.Set(t, "target_repo_url", remote.RepoURL("test-org", "upstream", ""))
+			} else {
+				flags.Set(t, "target_repo_url", remoteURL)
+			}
+			flags.Set(t, "git_fetch_filters", []string{"blob:none"})
+			t.Setenv("USE_SYSTEM_GIT_CREDENTIALS", "1")
+			checkoutDir := t.TempDir()
+			t.Chdir(checkoutDir)
+			invocationLog := newInvocationLog(nil)
+			invocationLog.writer = io.Discard
+			ws := &workspace{
+				rootDir: checkoutDir,
+				log:     &buildEventReporter{log: invocationLog},
+			}
+			require.NoError(t, ws.init(ctx))
+			require.NoError(t, ws.config(ctx))
+			// The extension must name the remote used for the pushed repository,
+			// including when the pushed branch belongs to a fork.
+			require.Equal(t, remoteName, runGit(checkoutDir, "config", "--get", "extensions.partialClone"))
+			require.NoError(t, ws.fetch(ctx, remoteURL, []string{"refs/heads/master"}, 1))
+
+			missingObjects := runGit(checkoutDir, "rev-list", "--objects", "--all", "--missing=print")
+			require.Contains(t, missingObjects, "?"+blobOID, "expected blob to be omitted from the filtered fetch")
+			// Reading the missing blob must lazily retrieve it from the real remote.
+			require.Contains(t, runGit(checkoutDir, "cat-file", "blob", blobOID), "lazy contents")
+			require.NotContains(t, strings.Fields(runGit(checkoutDir, "remote")), "true")
+		})
 	}
-
-	sourceDir, _ := testgit.MakeTempRepo(t, map[string]string{
-		"lazy.txt": "lazy contents\n",
-	})
-	blobOID := runGit(sourceDir, "rev-parse", "HEAD:lazy.txt")
-
-	remote := testgit.StartServer(t, testgit.ServerOptions{LogWriter: io.Discard})
-	remote.CreateProject("test-org", "test-repo", &testgit.ProjectSettings{Public: true})
-	remote.SetProjectConfig("test-org", "test-repo", "uploadpack.allowFilter", "true")
-	// Lazy fetching requests the missing blob directly by object ID.
-	remote.SetProjectConfig("test-org", "test-repo", "uploadpack.allowAnySHA1InWant", "true")
-	// Disable path-walk packing because it does not support object filters.
-	remote.SetProjectConfig("test-org", "test-repo", "pack.usePathWalk", "false")
-	remote.Push("test-org", "test-repo", remote.AccessToken(), sourceDir)
-	remoteURL := remote.RepoURL("test-org", "test-repo", "")
-	checkoutDir := filepath.Join(t.TempDir(), "repo-root")
-	_, gitErr := git(
-		ctx,
-		io.Discard,
-		"clone", "--no-checkout", "--filter=blob:none", remoteURL, checkoutDir,
-	)
-	if gitErr != nil {
-		t.Fatalf("partial clone failed: %s", gitErr.Output)
-	}
-
-	missingObjects := runGit(checkoutDir, "rev-list", "--objects", "--all", "--missing=print")
-	require.Contains(t, missingObjects, "?"+blobOID, "expected blob to be omitted from the partial clone")
-
-	// Recreate the invalid configuration found in recycled runner snapshots.
-	// The partialClone extension value is a remote name, so the boolean-looking
-	// value below makes Git try to fetch missing objects from a remote named
-	// "true".
-	runGit(checkoutDir, "config", "--unset-all", "remote.origin.promisor")
-	runGit(checkoutDir, "config", "--unset-all", "remote.origin.partialCloneFilter")
-	runGit(checkoutDir, "config", "extensions.partialClone", "true")
-
-	// Verify that the fixture reproduces the reported failure.
-	_, gitErr = git(ctx, io.Discard, "-C", checkoutDir, "cat-file", "blob", blobOID)
-	require.NotNil(t, gitErr)
-
-	// Some Git versions persist this filter after the failed lazy fetch. Add it
-	// explicitly so the test deterministically matches the stale state observed
-	// in affected snapshots.
-	runGit(checkoutDir, "config", "remote.true.promisor", "true")
-	runGit(checkoutDir, "config", "remote.true.partialCloneFilter", "blob:none")
-	require.Equal(t, "true", runGit(checkoutDir, "config", "--get", "remote.true.promisor"))
-	require.Equal(t, "blob:none", runGit(checkoutDir, "config", "--get", "remote.true.partialCloneFilter"))
-	require.Contains(t, strings.Fields(runGit(checkoutDir, "remote")), "true")
-
-	flags.Set(t, "pushed_repo_url", remoteURL)
-	flags.Set(t, "target_repo_url", remoteURL)
-	flags.Set(t, "git_fetch_filters", []string{"blob:none"})
-	t.Setenv("USE_SYSTEM_GIT_CREDENTIALS", "1")
-
-	originalWorkingDir, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(checkoutDir))
-	t.Cleanup(func() {
-		require.NoError(t, os.Chdir(originalWorkingDir))
-	})
-
-	invocationLog := newInvocationLog(nil)
-	invocationLog.writer = io.Discard
-	ws := &workspace{
-		rootDir: checkoutDir,
-		log:     &buildEventReporter{log: invocationLog},
-	}
-	require.NoError(t, ws.config(ctx))
-
-	// Configuring an existing workspace should point the extension at the
-	// actual remote and remove the stale synthetic remote.
-	require.Equal(t, "origin", runGit(checkoutDir, "config", "--get", "extensions.partialClone"))
-	require.NotContains(t, strings.Fields(runGit(checkoutDir, "remote")), "true")
-
-	blobContents, gitErr := git(ctx, io.Discard, "cat-file", "blob", blobOID)
-	require.Nil(t, gitErr)
-	require.Contains(t, blobContents, "lazy contents")
 }
 
 func TestIsTransferTooSlow(t *testing.T) {

--- a/enterprise/server/cmd/ci_runner/main_test.go
+++ b/enterprise/server/cmd/ci_runner/main_test.go
@@ -451,6 +451,87 @@ func TestGitMergeRetriesSlowLazyFetch(t *testing.T) {
 	require.Nil(t, gitErr, "expected HEAD to be a merge commit")
 }
 
+func TestWorkspaceConfig_InvalidPartialCloneRemoteFailsLazyFetch(t *testing.T) {
+	ctx := t.Context()
+	runGit := func(repoDir string, args ...string) string {
+		args = append([]string{"-C", repoDir}, args...)
+		output, gitErr := git(ctx, io.Discard, args...)
+		if gitErr != nil {
+			t.Fatalf("git %v failed: %s", args, gitErr.Output)
+		}
+		return strings.TrimSpace(output)
+	}
+
+	sourceDir, _ := testgit.MakeTempRepo(t, map[string]string{
+		"lazy.txt": "lazy contents\n",
+	})
+	runGit(sourceDir, "config", "uploadpack.allowFilter", "true")
+	// Disable path-walk packing because it does not support object filters.
+	runGit(sourceDir, "config", "pack.usePathWalk", "false")
+	blobOID := runGit(sourceDir, "rev-parse", "HEAD:lazy.txt")
+
+	remoteURL := "file://" + sourceDir
+	checkoutDir := filepath.Join(t.TempDir(), "repo-root")
+	_, gitErr := git(
+		ctx,
+		io.Discard,
+		"clone", "--no-checkout", "--filter=blob:none", remoteURL, checkoutDir,
+	)
+	if gitErr != nil {
+		t.Fatalf("partial clone failed: %s", gitErr.Output)
+	}
+
+	missingObjects := runGit(checkoutDir, "rev-list", "--objects", "--all", "--missing=print")
+	require.Contains(t, missingObjects, "?"+blobOID, "expected blob to be omitted from the partial clone")
+
+	// Recreate the invalid configuration found in recycled runner snapshots.
+	// The partialClone extension value is a remote name, so the boolean-looking
+	// value below makes Git try to fetch missing objects from a remote named
+	// "true".
+	runGit(checkoutDir, "config", "--unset-all", "remote.origin.promisor")
+	runGit(checkoutDir, "config", "--unset-all", "remote.origin.partialCloneFilter")
+	runGit(checkoutDir, "config", "extensions.partialClone", "true")
+
+	// Verify that the fixture reproduces the reported failure.
+	_, gitErr = git(ctx, io.Discard, "-C", checkoutDir, "cat-file", "blob", blobOID)
+	require.NotNil(t, gitErr)
+	require.Contains(t, gitErr.Output, "'true' does not appear to be a git repository")
+
+	// Some Git versions persist this filter after the failed lazy fetch. Add it
+	// explicitly so the test deterministically matches the stale state observed
+	// in affected snapshots.
+	runGit(checkoutDir, "config", "remote.true.partialCloneFilter", "blob:none")
+	require.Equal(t, "blob:none", runGit(checkoutDir, "config", "--get", "remote.true.partialCloneFilter"))
+	require.Contains(t, strings.Fields(runGit(checkoutDir, "remote")), "true")
+
+	flags.Set(t, "pushed_repo_url", remoteURL)
+	flags.Set(t, "target_repo_url", remoteURL)
+	flags.Set(t, "git_fetch_filters", []string{"blob:none"})
+	t.Setenv("USE_SYSTEM_GIT_CREDENTIALS", "1")
+
+	originalWorkingDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(checkoutDir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(originalWorkingDir))
+	})
+
+	invocationLog := newInvocationLog(nil)
+	invocationLog.writer = io.Discard
+	ws := &workspace{
+		rootDir: checkoutDir,
+		log:     &buildEventReporter{log: invocationLog},
+	}
+	require.NoError(t, ws.config(ctx))
+
+	// Configuring an existing workspace currently leaves the invalid promisor
+	// remote in place, so lazy fetches continue to fail.
+	_, gitErr = git(ctx, io.Discard, "cat-file", "blob", blobOID)
+	require.NotNil(t, gitErr)
+	require.Contains(t, gitErr.Output, "'true' does not appear to be a git repository")
+	require.Contains(t, strings.Fields(runGit(checkoutDir, "remote")), "true")
+}
+
 func TestIsTransferTooSlow(t *testing.T) {
 	// Serve a git HTTP endpoint that starts a ref advertisement and then
 	// stalls, so that git's low-speed check aborts the transfer.

--- a/enterprise/server/cmd/ci_runner/main_test.go
+++ b/enterprise/server/cmd/ci_runner/main_test.go
@@ -451,7 +451,7 @@ func TestGitMergeRetriesSlowLazyFetch(t *testing.T) {
 	require.Nil(t, gitErr, "expected HEAD to be a merge commit")
 }
 
-func TestWorkspaceConfig_InvalidPartialCloneRemoteFailsLazyFetch(t *testing.T) {
+func TestWorkspaceConfigRepairsInvalidPartialCloneRemote(t *testing.T) {
 	ctx := t.Context()
 	runGit := func(repoDir string, args ...string) string {
 		args = append([]string{"-C", repoDir}, args...)
@@ -465,12 +465,17 @@ func TestWorkspaceConfig_InvalidPartialCloneRemoteFailsLazyFetch(t *testing.T) {
 	sourceDir, _ := testgit.MakeTempRepo(t, map[string]string{
 		"lazy.txt": "lazy contents\n",
 	})
-	runGit(sourceDir, "config", "uploadpack.allowFilter", "true")
-	// Disable path-walk packing because it does not support object filters.
-	runGit(sourceDir, "config", "pack.usePathWalk", "false")
 	blobOID := runGit(sourceDir, "rev-parse", "HEAD:lazy.txt")
 
-	remoteURL := "file://" + sourceDir
+	remote := testgit.StartServer(t, testgit.ServerOptions{LogWriter: io.Discard})
+	remote.CreateProject("test-org", "test-repo", &testgit.ProjectSettings{Public: true})
+	remote.SetProjectConfig("test-org", "test-repo", "uploadpack.allowFilter", "true")
+	// Lazy fetching requests the missing blob directly by object ID.
+	remote.SetProjectConfig("test-org", "test-repo", "uploadpack.allowAnySHA1InWant", "true")
+	// Disable path-walk packing because it does not support object filters.
+	remote.SetProjectConfig("test-org", "test-repo", "pack.usePathWalk", "false")
+	remote.Push("test-org", "test-repo", remote.AccessToken(), sourceDir)
+	remoteURL := remote.RepoURL("test-org", "test-repo", "")
 	checkoutDir := filepath.Join(t.TempDir(), "repo-root")
 	_, gitErr := git(
 		ctx,
@@ -500,7 +505,9 @@ func TestWorkspaceConfig_InvalidPartialCloneRemoteFailsLazyFetch(t *testing.T) {
 	// Some Git versions persist this filter after the failed lazy fetch. Add it
 	// explicitly so the test deterministically matches the stale state observed
 	// in affected snapshots.
+	runGit(checkoutDir, "config", "remote.true.promisor", "true")
 	runGit(checkoutDir, "config", "remote.true.partialCloneFilter", "blob:none")
+	require.Equal(t, "true", runGit(checkoutDir, "config", "--get", "remote.true.promisor"))
 	require.Equal(t, "blob:none", runGit(checkoutDir, "config", "--get", "remote.true.partialCloneFilter"))
 	require.Contains(t, strings.Fields(runGit(checkoutDir, "remote")), "true")
 
@@ -522,14 +529,20 @@ func TestWorkspaceConfig_InvalidPartialCloneRemoteFailsLazyFetch(t *testing.T) {
 		rootDir: checkoutDir,
 		log:     &buildEventReporter{log: invocationLog},
 	}
-	require.NoError(t, ws.config(ctx))
+	configCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	require.NoError(t, ws.config(configCtx))
 
-	// Configuring an existing workspace currently leaves the invalid promisor
-	// remote in place, so lazy fetches continue to fail.
-	_, gitErr = git(ctx, io.Discard, "cat-file", "blob", blobOID)
-	require.NotNil(t, gitErr)
-	require.Contains(t, gitErr.Output, "'true' does not appear to be a git repository")
-	require.Contains(t, strings.Fields(runGit(checkoutDir, "remote")), "true")
+	// Configuring an existing workspace should point the extension at the
+	// actual remote and remove the stale synthetic remote.
+	require.Equal(t, "origin", runGit(checkoutDir, "config", "--get", "extensions.partialClone"))
+	require.NotContains(t, strings.Fields(runGit(checkoutDir, "remote")), "true")
+
+	fetchCtx, cancelFetch := context.WithTimeout(ctx, 5*time.Second)
+	defer cancelFetch()
+	blobContents, gitErr := git(fetchCtx, io.Discard, "cat-file", "blob", blobOID)
+	require.Nil(t, gitErr)
+	require.Contains(t, blobContents, "lazy contents")
 }
 
 func TestIsTransferTooSlow(t *testing.T) {

--- a/enterprise/server/cmd/ci_runner/main_test.go
+++ b/enterprise/server/cmd/ci_runner/main_test.go
@@ -500,7 +500,6 @@ func TestWorkspaceConfigRepairsInvalidPartialCloneRemote(t *testing.T) {
 	// Verify that the fixture reproduces the reported failure.
 	_, gitErr = git(ctx, io.Discard, "-C", checkoutDir, "cat-file", "blob", blobOID)
 	require.NotNil(t, gitErr)
-	require.Contains(t, gitErr.Output, "'true' does not appear to be a git repository")
 
 	// Some Git versions persist this filter after the failed lazy fetch. Add it
 	// explicitly so the test deterministically matches the stale state observed
@@ -529,18 +528,14 @@ func TestWorkspaceConfigRepairsInvalidPartialCloneRemote(t *testing.T) {
 		rootDir: checkoutDir,
 		log:     &buildEventReporter{log: invocationLog},
 	}
-	configCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	require.NoError(t, ws.config(configCtx))
+	require.NoError(t, ws.config(ctx))
 
 	// Configuring an existing workspace should point the extension at the
 	// actual remote and remove the stale synthetic remote.
 	require.Equal(t, "origin", runGit(checkoutDir, "config", "--get", "extensions.partialClone"))
 	require.NotContains(t, strings.Fields(runGit(checkoutDir, "remote")), "true")
 
-	fetchCtx, cancelFetch := context.WithTimeout(ctx, 5*time.Second)
-	defer cancelFetch()
-	blobContents, gitErr := git(fetchCtx, io.Discard, "cat-file", "blob", blobOID)
+	blobContents, gitErr := git(ctx, io.Discard, "cat-file", "blob", blobOID)
 	require.Nil(t, gitErr)
 	require.Contains(t, blobContents, "lazy contents")
 }

--- a/server/testutil/testgit/testgit.go
+++ b/server/testutil/testgit/testgit.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"slices"
@@ -253,6 +254,15 @@ func (s *Server) AccessToken() string {
 func (s *Server) CreateProject(owner, repo string, settings *ProjectSettings) {
 	err := mockgitserver.CreateProject(s.gitProjectRoot, owner, repo, settings)
 	require.NoError(s.t, err)
+}
+
+// SetProjectConfig sets a Git config value in a project repository.
+func (s *Server) SetProjectConfig(owner, repo, key, value string) {
+	repoPath := filepath.Join(s.gitProjectRoot, owner, repo)
+	cmd := exec.Command("git", "config", key, value)
+	cmd.Dir = repoPath
+	output, err := cmd.CombinedOutput()
+	require.NoError(s.t, err, "git config failed: %s", output)
 }
 
 // Push pushes the local repo to a project created with CreateProject.


### PR DESCRIPTION
Remote Bazel jobs can fail to lazily fetch missing Git objects because
ci_runner sets extensions.partialClone=true. Git interprets that value
as a promisor remote name and can try to fetch from a remote named true.

Set the extension to the pushed repository's actual remote, origin
or fork, using the same remote-selection logic as fetch. Keep this
in the existing repository configuration loop. Existing snapshots
containing stale remote.true metadata are not migrated; affected
users must clear their snapshots after the change has fully rolled out.

Cover filtered fetches and lazy retrieval of missing blobs over HTTP
for both origin and fork, and align the checkout and merge retry
fixtures with the corrected configuration.
