### PR TITLE
Move presence check before locking the pebble row

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1932,15 +1932,15 @@ func (p *PebbleCache) findMissing(ctx context.Context, db pebble.IPebbleDB, grou
 		return err
 	}
 
-	unlockFn := p.locker.RLock(key.LockID())
-	defer unlockFn()
-
 	// Avoid expensive pebble op if key is in the presence cache.
 	// We don't update the atime on hit because we expect the cache TTL to be
 	// configured below the atime update threshold.
 	if p.presence.Contains(key) {
 		return nil
 	}
+
+	unlockFn := p.locker.RLock(key.LockID())
+	defer unlockFn()
 
 	buf, closer, err := p.lookupFileMetadataBytes(db, key)
 	if err != nil {

--- a/enterprise/server/test/performance/cache/cache_test.go
+++ b/enterprise/server/test/performance/cache/cache_test.go
@@ -3,6 +3,7 @@ package cache_test
 import (
 	"bytes"
 	"context"
+	"flag"
 	"fmt"
 	"io"
 	"runtime"
@@ -49,6 +50,8 @@ const (
 	numDigests   = 100
 )
 
+var enablePebblePresenceCache = flag.Bool("enable_pebble_presence_cache", false, "If true, configure the pebble presence cache for benchmarks.")
+
 func init() {
 	*log.LogLevel = "error"
 	*log.IncludeShortFileName = true
@@ -56,7 +59,7 @@ func init() {
 }
 
 func setExperimentProvider(b *testing.B, te *real_environment.RealEnv) {
-	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+	flags := map[string]memprovider.InMemoryFlag{
 		migration_cache.MigrationCacheConfigFlag: {
 			State:          memprovider.Enabled,
 			DefaultVariant: "singleton",
@@ -67,7 +70,18 @@ func setExperimentProvider(b *testing.B, te *real_environment.RealEnv) {
 				migration_cache.DecompressReadPercentageField: 0.0,
 			}},
 		},
-	})
+	}
+	if *enablePebblePresenceCache {
+		flags[pebble_cache.PresenceCacheConfigExperiment] = memprovider.InMemoryFlag{
+			State:          memprovider.Enabled,
+			DefaultVariant: "on",
+			Variants: map[string]any{"on": map[string]any{
+				"max_entries": 1000,
+				"ttl":         "1h",
+			}},
+		}
+	}
+	testProvider := memprovider.NewInMemoryProvider(flags)
 	require.NoError(b, openfeature.SetProviderAndWait(testProvider))
 	fp, err := experiments.NewFlagProvider("")
 	require.NoError(b, err)

--- a/enterprise/server/test/performance/cache/cache_test.go
+++ b/enterprise/server/test/performance/cache/cache_test.go
@@ -76,7 +76,7 @@ func setExperimentProvider(b *testing.B, te *real_environment.RealEnv) {
 			State:          memprovider.Enabled,
 			DefaultVariant: "on",
 			Variants: map[string]any{"on": map[string]any{
-				"max_entries": 1000,
+				"max_entries": numDigests,
 				"ttl":         "1h",
 			}},
 		}


### PR DESCRIPTION
25% faster in (pretty synthetic) benchmarks:

```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor
                                │  /tmp/base   │             /tmp/lock              │
                                │    sec/op    │   sec/op     vs base               │
FindMissing/LocalPebble10-24      55.00µ ± 10%   42.06µ ± 7%  -23.53% (p=0.001 n=7)
FindMissing/LocalPebble100-24     51.45µ ±  2%   37.57µ ± 7%  -26.98% (p=0.001 n=7)
FindMissing/LocalPebble1000-24    51.28µ ±  5%   37.91µ ± 3%  -26.07% (p=0.001 n=7)
FindMissing/LocalPebble10000-24   51.55µ ±  4%   37.29µ ± 2%  -27.65% (p=0.001 n=7)
geomean                           52.30µ         38.66µ       -26.07%

                                │  /tmp/base   │              /tmp/lock              │
                                │     B/op     │     B/op      vs base               │
FindMissing/LocalPebble10-24      59.18Ki ± 0%   44.33Ki ± 0%  -25.10% (p=0.001 n=7)
FindMissing/LocalPebble100-24     59.17Ki ± 0%   44.31Ki ± 0%  -25.11% (p=0.001 n=7)
FindMissing/LocalPebble1000-24    59.17Ki ± 0%   44.32Ki ± 0%  -25.10% (p=0.001 n=7)
FindMissing/LocalPebble10000-24   59.17Ki ± 0%   44.31Ki ± 0%  -25.11% (p=0.001 n=7)
geomean                           59.17Ki        44.32Ki       -25.10%

                                │ /tmp/base  │             /tmp/lock             │
                                │ allocs/op  │ allocs/op   vs base               │
FindMissing/LocalPebble10-24      910.0 ± 0%   510.0 ± 0%  -43.96% (p=0.001 n=7)
FindMissing/LocalPebble100-24     910.0 ± 0%   510.0 ± 0%  -43.96% (p=0.001 n=7)
FindMissing/LocalPebble1000-24    910.0 ± 0%   510.0 ± 0%  -43.96% (p=0.001 n=7)
FindMissing/LocalPebble10000-24   910.0 ± 0%   510.0 ± 0%  -43.96% (p=0.001 n=7)
geomean                           910.0        510.0       -43.96%
```