### PR TITLE
Add Xcode Simulator Runtimes metadata

### DIFF
--- a/enterprise/app/executors/executor_card.tsx
+++ b/enterprise/app/executors/executor_card.tsx
@@ -96,6 +96,12 @@ export default class ExecutorCardComponent extends React.Component<Props> {
                 <div>{this.props.node.xcodeVersions.join(", ")}</div>
               </div>
             )}
+            {this.props.node.xcodeSimulatorRuntimes && this.props.node.xcodeSimulatorRuntimes.length > 0 && (
+              <div className="executor-section">
+                <div className="executor-section-title">Xcode Simulator Runtimes:</div>
+                <div>{this.props.node.xcodeSimulatorRuntimes.join(", ")}</div>
+              </div>
+            )}
             {this.props.node.supportedIsolationTypes && this.props.node.supportedIsolationTypes.length > 0 && (
               <div className="executor-section">
                 <div className="executor-section-title">Isolation Types:</div>

--- a/enterprise/server/scheduling/scheduler_client/scheduler_client.go
+++ b/enterprise/server/scheduling/scheduler_client/scheduler_client.go
@@ -35,7 +35,7 @@ import (
 var (
 	pool                         = flag.String("executor.pool", "", "Executor pool name. Only one of this config option or the MY_POOL environment variable should be specified.")
 	labels                       = flag.Map[string, string]("executor.labels", map[string]string{}, "Optional labels identifying this executor, similar to Kubernetes labels (e.g. 'canary=true,experiment-ramfs=control,region=us-east1'). Reported to the scheduler at registration and used for server-side debug routing via the 'debug-executor-labels' platform property.")
-	xcodeSimulatorRuntimes       = flag.Slice("executor.xcode_simulator_runtimes", []string{}, "Optional Xcode Simulator runtime labels to report in executor metadata.")
+	xcodeSimulatorRuntimes       = flag.Slice("executor.xcode_simulator_runtimes", []string{}, "Optional Xcode Simulator Runtime strings to report in executor metadata.")
 	proactiveCancellationEnabled = flag.Bool("executor.proactive_cancellation_enabled", false, "Whether the executor supports proactive task cancellation.", flag.Internal)
 )
 

--- a/enterprise/server/scheduling/scheduler_client/scheduler_client.go
+++ b/enterprise/server/scheduling/scheduler_client/scheduler_client.go
@@ -35,6 +35,7 @@ import (
 var (
 	pool                         = flag.String("executor.pool", "", "Executor pool name. Only one of this config option or the MY_POOL environment variable should be specified.")
 	labels                       = flag.Map[string, string]("executor.labels", map[string]string{}, "Optional labels identifying this executor, similar to Kubernetes labels (e.g. 'canary=true,experiment-ramfs=control,region=us-east1'). Reported to the scheduler at registration and used for server-side debug routing via the 'debug-executor-labels' platform property.")
+	xcodeSimulatorRuntimes       = flag.Slice("executor.xcode_simulator_runtimes", []string{}, "Optional Xcode Simulator runtime labels to report in executor metadata.")
 	proactiveCancellationEnabled = flag.Bool("executor.proactive_cancellation_enabled", false, "Whether the executor supports proactive task cancellation.", flag.Internal)
 )
 
@@ -125,6 +126,7 @@ func makeExecutionNode(pool, executorID, executorHostID string, xcodeLocator int
 		SupportedIsolationTypes:   supportedTypes,
 		CurrentQueueLength:        0,
 		XcodeVersions:             xcodeLocator.Versions(),
+		XcodeSimulatorRuntimes:    *xcodeSimulatorRuntimes,
 		// TODO: hard-code this to true once it's battle-tested.
 		SupportsProactiveCancellation: *proactiveCancellationEnabled,
 		WarmupImages:                  options.WarmupImages,

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -612,6 +612,9 @@ message ExecutionNode {
 
   // Optional set of key-value labels identifying this executor.
   map<string, string> labels = 22;
+
+  // The Xcode Simulator runtimes installed on this executor.
+  repeated string xcode_simulator_runtimes = 23;
 }
 
 message GetExecutionNodesRequest {


### PR DESCRIPTION
This shows up on the executors page if it is set. This must be passed in
because calculating this in the executor would require running some CLIs
that have complex failure modes.
