### PR TITLE
Fix and consolidate bytestream URI parsing

### DIFF
--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -845,16 +844,11 @@ func lookupBazelInvocationOutputs(ctx context.Context, bbClient bbspb.BuildBuddy
 }
 
 func bytestreamURIToResourceName(uri string) (*digest.CASResourceName, error) {
-	u, err := url.Parse(uri)
+	parsedURI, err := digest.ParseByteStreamURI(uri)
 	if err != nil {
-		return nil, fmt.Errorf("parse bytestream uri %q: %w", uri, err)
+		return nil, fmt.Errorf("parse ByteStream URI %q: %w", uri, err)
 	}
-	r := strings.TrimPrefix(u.RequestURI(), "/")
-	rn, err := digest.ParseDownloadResourceName(r)
-	if err != nil {
-		return nil, fmt.Errorf("parse bytestream resource name %q: %w", r, err)
-	}
-	return rn, nil
+	return &parsedURI.CASResourceName, nil
 }
 
 // TODO(vadim): add interactive progress bar for downloads

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -843,14 +843,6 @@ func lookupBazelInvocationOutputs(ctx context.Context, bbClient bbspb.BuildBuddy
 	return outputs, nil
 }
 
-func bytestreamURIToResourceName(uri string) (*digest.CASResourceName, error) {
-	parsedURI, err := digest.ParseByteStreamURI(uri)
-	if err != nil {
-		return nil, fmt.Errorf("parse ByteStream URI %q: %w", uri, err)
-	}
-	return &parsedURI.CASResourceName, nil
-}
-
 // TODO(vadim): add interactive progress bar for downloads
 // TODO(vadim): parallelize downloads
 func downloadOutputs(ctx context.Context, env environment.Env, mainOutputs []*bespb.File, supportingOutputs []*bespb.File, supportingDirs []*bespb.Tree, outputBaseDir string) ([]string, error) {
@@ -858,7 +850,7 @@ func downloadOutputs(ctx context.Context, env environment.Env, mainOutputs []*be
 
 	var mainLocalArtifacts []string
 	download := func(f *bespb.File) (string, error) {
-		r, err := bytestreamURIToResourceName(f.GetUri())
+		uri, err := digest.ParseByteStreamURI(f.GetUri())
 		if err != nil {
 			return "", fmt.Errorf("resolve output uri for %q: %w", f.GetName(), err)
 		}
@@ -867,7 +859,7 @@ func downloadOutputs(ctx context.Context, env environment.Env, mainOutputs []*be
 			outFile = filepath.Join(outFile, p)
 		}
 		outFile = filepath.Join(outFile, f.GetName())
-		if err := downloadFile(ctx, bsClient, r, outFile); err != nil {
+		if err := downloadFile(ctx, bsClient, &uri.CASResourceName, outFile); err != nil {
 			return "", fmt.Errorf("download output %q: %w", f.GetName(), err)
 		}
 		return outFile, nil
@@ -886,19 +878,19 @@ func downloadOutputs(ctx context.Context, env environment.Env, mainOutputs []*be
 		}
 	}
 	for _, d := range supportingDirs {
-		rn, err := bytestreamURIToResourceName(d.GetUri())
+		uri, err := digest.ParseByteStreamURI(d.GetUri())
 		if err != nil {
 			return nil, fmt.Errorf("resolve supporting output dir uri %q: %w", d.GetName(), err)
 		}
 		tree := &repb.Tree{}
-		if err := cachetools.GetBlobAsProto(ctx, bsClient, rn, tree); err != nil {
+		if err := cachetools.GetBlobAsProto(ctx, bsClient, &uri.CASResourceName, tree); err != nil {
 			return nil, fmt.Errorf("download supporting output dir metadata %q: %w", d.GetName(), err)
 		}
 		outDir := filepath.Join(outputBaseDir, BuildBuddyArtifactDir, d.GetName())
 		if err := os.MkdirAll(outDir, 0755); err != nil {
 			return nil, fmt.Errorf("create supporting output dir %q: %w", outDir, err)
 		}
-		if _, err := dirtools.DownloadTree(ctx, env, rn.GetInstanceName(), rn.GetDigestFunction(), tree, &dirtools.DownloadTreeOpts{RootDir: outDir}); err != nil {
+		if _, err := dirtools.DownloadTree(ctx, env, uri.GetInstanceName(), uri.GetDigestFunction(), tree, &dirtools.DownloadTreeOpts{RootDir: outDir}); err != nil {
 			return nil, fmt.Errorf("download supporting output dir %q: %w", d.GetName(), err)
 		}
 	}

--- a/cli/util/download/download.go
+++ b/cli/util/download/download.go
@@ -80,11 +80,11 @@ func getInvocationResource(ctx context.Context, bbClient bbspb.BuildBuddyService
 	if file == nil {
 		return nil, fmt.Errorf("no %s found for invocation %s", description, invocationID)
 	}
-	resource, err := parseBytestreamURI(file.GetUri())
+	uri, err := digest.ParseByteStreamURI(file.GetUri())
 	if err != nil {
 		return nil, fmt.Errorf("invalid %s URI for %q: %w", description, file.GetName(), err)
 	}
-	return resource, nil
+	return &uri.CASResourceName, nil
 }
 
 func (d *byteStreamDownloader) GetBytestreamFile(ctx context.Context, uri string, w io.Writer) error {
@@ -93,21 +93,12 @@ func (d *byteStreamDownloader) GetBytestreamFile(ctx context.Context, uri string
 
 // GetBytestreamFile downloads the contents of a bytestream:// URI.
 func GetBytestreamFile(ctx context.Context, bsClient bspb.ByteStreamClient, uri string, w io.Writer) error {
-	resource, err := parseBytestreamURI(uri)
+	parsedURI, err := digest.ParseByteStreamURI(uri)
 	if err != nil {
 		return err
 	}
-	if err := cachetools.GetBlob(ctx, bsClient, resource, w); err != nil {
-		return fmt.Errorf("failed to download %s: %w", resource.DownloadString(), err)
+	if err := cachetools.GetBlob(ctx, bsClient, &parsedURI.CASResourceName, w); err != nil {
+		return fmt.Errorf("failed to download %s: %w", parsedURI.DownloadString(), err)
 	}
 	return nil
-}
-
-// parseBytestreamURI parses a bytestream:// URI into a CAS resource name.
-func parseBytestreamURI(uri string) (*digest.CASResourceName, error) {
-	parsedURI, err := digest.ParseByteStreamURI(uri)
-	if err != nil {
-		return nil, err
-	}
-	return &parsedURI.CASResourceName, nil
 }

--- a/cli/util/download/download.go
+++ b/cli/util/download/download.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/url"
-	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/flaghistory"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
@@ -107,12 +105,9 @@ func GetBytestreamFile(ctx context.Context, bsClient bspb.ByteStreamClient, uri 
 
 // parseBytestreamURI parses a bytestream:// URI into a CAS resource name.
 func parseBytestreamURI(uri string) (*digest.CASResourceName, error) {
-	if !strings.HasPrefix(uri, "bytestream://") {
-		return nil, fmt.Errorf("unsupported bytestream URI: %s", uri)
-	}
-	u, err := url.Parse(uri)
+	parsedURI, err := digest.ParseByteStreamURI(uri)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse bytestream URI: %w", err)
+		return nil, err
 	}
-	return digest.ParseDownloadResourceName(u.Path)
+	return &parsedURI.CASResourceName, nil
 }

--- a/enterprise/server/api/api_server.go
+++ b/enterprise/server/api/api_server.go
@@ -567,35 +567,20 @@ func (gfs *getFileWriter) Write(data []byte) (int, error) {
 	return len(data), err
 }
 
-func parseBytestreamCASURI(uri string) (*url.URL, *digest.CASResourceName, error) {
-	parsedURL, err := url.Parse(uri)
-	if err != nil {
-		return nil, nil, status.InvalidArgumentErrorf("Invalid URL")
-	}
-	if parsedURL.Scheme != "bytestream" {
-		return nil, nil, status.InvalidArgumentError("only bytestream:// URIs are supported")
-	}
-	rn, err := digest.ParseDownloadResourceName(strings.TrimPrefix(parsedURL.RequestURI(), "/"))
-	if err != nil {
-		return nil, nil, status.InvalidArgumentErrorf("Invalid URL")
-	}
-	return parsedURL, rn, nil
-}
-
 func (s *APIServer) GetFile(req *apipb.GetFileRequest, server apipb.ApiService_GetFileServer) error {
 	ctx := server.Context()
 	if _, err := s.env.GetAuthenticator().AuthenticatedUser(ctx); err != nil {
 		return err
 	}
 
-	parsedURL, err := url.Parse(req.GetUri())
+	parsedURI, err := digest.ParseByteStreamURI(req.GetUri())
 	if err != nil {
-		return status.InvalidArgumentErrorf("Invalid URL")
+		return err
 	}
 
 	writer := &getFileWriter{s: server}
 
-	return s.env.GetPooledByteStreamClient().StreamBytestreamFile(ctx, parsedURL, writer)
+	return s.env.GetPooledByteStreamClient().StreamBytestreamFile(ctx, &parsedURI.URL, writer)
 }
 
 func (s *APIServer) GetFileRange(ctx context.Context, req *apipb.GetFileRangeRequest) (*apipb.GetFileRangeResponse, error) {
@@ -615,11 +600,11 @@ func (s *APIServer) GetFileRange(ctx context.Context, req *apipb.GetFileRangeReq
 		return nil, status.InvalidArgumentError("end must be greater than start")
 	}
 
-	_, rn, err := parseBytestreamCASURI(req.GetUri())
+	parsedURI, err := digest.ParseByteStreamURI(req.GetUri())
 	if err != nil {
 		return nil, err
 	}
-	if end > rn.GetDigest().GetSizeBytes() {
+	if end > parsedURI.GetDigest().GetSizeBytes() {
 		return nil, status.InvalidArgumentError("end must not exceed digest size_bytes")
 	}
 
@@ -633,7 +618,7 @@ func (s *APIServer) GetFileRange(ctx context.Context, req *apipb.GetFileRangeReq
 		return nil, err
 	}
 
-	reader, err := s.env.GetCache().Reader(ctx, rn.ToProto(), start, limit)
+	reader, err := s.env.GetCache().Reader(ctx, parsedURI.ToProto(), start, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -709,13 +694,13 @@ func (s *APIServer) handleGetFileRequest(w http.ResponseWriter, r *http.Request)
 	req := apipb.GetFileRequest{}
 	protolet.ReadRequestToProto(r, &req)
 
-	parsedURL, err := url.Parse(req.GetUri())
+	parsedURI, err := digest.ParseByteStreamURI(req.GetUri())
 	if err != nil {
 		http.Error(w, "Invalid URI", http.StatusBadRequest)
 		return
 	}
 
-	err = s.env.GetPooledByteStreamClient().StreamBytestreamFile(r.Context(), parsedURL, w)
+	err = s.env.GetPooledByteStreamClient().StreamBytestreamFile(r.Context(), &parsedURI.URL, w)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 	}

--- a/enterprise/server/api/api_server.go
+++ b/enterprise/server/api/api_server.go
@@ -580,7 +580,7 @@ func (s *APIServer) GetFile(req *apipb.GetFileRequest, server apipb.ApiService_G
 
 	writer := &getFileWriter{s: server}
 
-	return s.env.GetPooledByteStreamClient().StreamBytestreamFile(ctx, &parsedURI.URL, writer)
+	return s.env.GetPooledByteStreamClient().StreamBytestreamFile(ctx, parsedURI, writer)
 }
 
 func (s *APIServer) GetFileRange(ctx context.Context, req *apipb.GetFileRangeRequest) (*apipb.GetFileRangeResponse, error) {
@@ -700,7 +700,7 @@ func (s *APIServer) handleGetFileRequest(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	err = s.env.GetPooledByteStreamClient().StreamBytestreamFile(r.Context(), &parsedURI.URL, w)
+	err = s.env.GetPooledByteStreamClient().StreamBytestreamFile(r.Context(), parsedURI, w)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 	}

--- a/server/api/common/common.go
+++ b/server/api/common/common.go
@@ -3,7 +3,6 @@ package common
 import (
 	"encoding/base64"
 	"fmt"
-	"net/url"
 	"slices"
 	"strings"
 
@@ -55,11 +54,9 @@ func FileFromBESFile(besFile *bespb.File) *apipb.File {
 }
 
 func fillFileDigestFromURI(f *apipb.File) {
-	if u, err := url.Parse(f.Uri); err == nil {
-		if r, err := digest.ParseDownloadResourceName(u.Path); err == nil {
-			f.Hash = r.GetDigest().GetHash()
-			f.SizeBytes = r.GetDigest().GetSizeBytes()
-		}
+	if parsedURI, err := digest.ParseByteStreamURI(f.Uri); err == nil {
+		f.Hash = parsedURI.GetDigest().GetHash()
+		f.SizeBytes = parsedURI.GetDigest().GetSizeBytes()
 	}
 }
 

--- a/server/build_event_protocol/accumulator/BUILD
+++ b/server/build_event_protocol/accumulator/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "accumulator",
@@ -16,5 +16,17 @@ go_library(
         "//server/util/log",
         "//server/util/proto",
         "//server/util/timeutil",
+    ],
+)
+
+go_test(
+    name = "accumulator_test",
+    srcs = ["accumulator_test.go"],
+    deps = [
+        ":accumulator",
+        "//proto:build_event_stream_go_proto",
+        "//proto:invocation_go_proto",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/build_event_protocol/accumulator/accumulator.go
+++ b/server/build_event_protocol/accumulator/accumulator.go
@@ -2,7 +2,7 @@ package accumulator
 
 import (
 	"context"
-	"net/url"
+	"strings"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
@@ -81,7 +81,7 @@ type BEValues struct {
 	sawStartedEvent           bool
 	sawFinishedEvent          bool
 	buildStartTime            time.Time
-	buildToolLogURIs          []*url.URL
+	buildToolLogURIs          []*digest.ByteStreamURI
 	outputFilesMap            map[string]*build_event_stream.File
 	kytheSSTableResourceName  *rspb.ResourceName
 	profileName               string
@@ -89,8 +89,8 @@ type BEValues struct {
 	gitFetchDuration          time.Duration
 	gitFetchRetryCount        int64
 
-	failedTestOutputURIs []*url.URL
-	passedTestOutputURIs []*url.URL
+	failedTestOutputURIs []*digest.ByteStreamURI
+	passedTestOutputURIs []*digest.ByteStreamURI
 	// TODO(bduffany): Migrate all parser functionality directly into the
 	// accumulator. The parser is a separate entity only for historical reasons.
 	parser *event_parser.StreamingEventParser
@@ -170,46 +170,34 @@ func (v *BEValues) AddEvent(event *build_event_stream.BuildEvent) error {
 		v.maybeExtractOutputFile(p.BuildToolLogs.GetLog()...)
 		for _, toolLog := range p.BuildToolLogs.GetLog() {
 			if uri := toolLog.GetUri(); uri != "" {
-				parsedURL, err := url.Parse(uri)
-				if err != nil {
-					log.Warningf("Error parsing uri from BuildToolLogs: %s", uri)
-					continue
-				}
-				if parsedURL.Scheme != "bytestream" {
-					continue
-				}
 				parsedURI, err := digest.ParseByteStreamURI(uri)
 				if err != nil {
-					log.Warningf("Error parsing uri from BuildToolLogs: %s", uri)
+					if strings.HasPrefix(uri, "bytestream://") {
+						log.Warningf("Error parsing uri from BuildToolLogs: %s", uri)
+					}
 					continue
 				}
-				v.buildToolLogURIs = append(v.buildToolLogURIs, &parsedURI.URL)
+				v.buildToolLogURIs = append(v.buildToolLogURIs, parsedURI)
 			}
 		}
 	case *build_event_stream.BuildEvent_TestResult:
 		v.maybeExtractOutputFile(p.TestResult.GetTestActionOutput()...)
 		for _, f := range p.TestResult.GetTestActionOutput() {
-			u, err := url.Parse(f.GetUri())
-			if err != nil {
-				log.Warningf("Error parsing uri from TestResult: %s", f.GetUri())
-				continue
-			}
-			if u.Scheme != "bytestream" {
-				continue
-			}
 			parsedURI, err := digest.ParseByteStreamURI(f.GetUri())
 			if err != nil {
-				log.Warningf("Error parsing uri from TestResult: %s", f.GetUri())
+				if strings.HasPrefix(f.GetUri(), "bytestream://") {
+					log.Warningf("Error parsing uri from TestResult: %s", f.GetUri())
+				}
 				continue
 			}
 			if p.TestResult.GetStatus() == build_event_stream.TestStatus_PASSED {
 				if len(v.passedTestOutputURIs) < maxPersistableTestArtifacts {
-					v.passedTestOutputURIs = append(v.passedTestOutputURIs, &parsedURI.URL)
+					v.passedTestOutputURIs = append(v.passedTestOutputURIs, parsedURI)
 				}
 				continue
 			}
 			if len(v.failedTestOutputURIs) < maxPersistableTestArtifacts {
-				v.failedTestOutputURIs = append(v.failedTestOutputURIs, &parsedURI.URL)
+				v.failedTestOutputURIs = append(v.failedTestOutputURIs, parsedURI)
 			}
 		}
 	}
@@ -295,15 +283,15 @@ func (v *BEValues) BuildFinished() bool {
 	return v.sawFinishedEvent
 }
 
-func (v *BEValues) BuildToolLogURIs() []*url.URL {
+func (v *BEValues) BuildToolLogURIs() []*digest.ByteStreamURI {
 	return v.buildToolLogURIs
 }
 
-func (v *BEValues) PassedTestOutputURIs() []*url.URL {
+func (v *BEValues) PassedTestOutputURIs() []*digest.ByteStreamURI {
 	return v.passedTestOutputURIs
 }
 
-func (v *BEValues) FailedTestOutputURIs() []*url.URL {
+func (v *BEValues) FailedTestOutputURIs() []*digest.ByteStreamURI {
 	return v.failedTestOutputURIs
 }
 

--- a/server/build_event_protocol/accumulator/accumulator.go
+++ b/server/build_event_protocol/accumulator/accumulator.go
@@ -3,7 +3,6 @@ package accumulator
 import (
 	"context"
 	"net/url"
-	"regexp"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
@@ -36,14 +35,11 @@ const (
 	KytheOutputName = "kythe_serving.sst"
 )
 
-var (
-	buildMetadataFieldMapping = map[string]string{
-		"DISABLE_COMMIT_STATUS_REPORTING": disableCommitStatusReportingFieldName,
-		"DISABLE_TARGET_TRACKING":         disableTargetTrackingFieldName,
-		"COMMIT_STATUS_LABEL":             commitStatusLabelFieldName,
-	}
-	bytestreamURIPattern = regexp.MustCompile(`^bytestream://.*/blobs/([a-z0-9]{64})/\d+$`)
-)
+var buildMetadataFieldMapping = map[string]string{
+	"DISABLE_COMMIT_STATUS_REPORTING": disableCommitStatusReportingFieldName,
+	"DISABLE_TARGET_TRACKING":         disableTargetTrackingFieldName,
+	"COMMIT_STATUS_LABEL":             commitStatusLabelFieldName,
+}
 
 type Accumulator interface {
 	// Invocation returns the accumulated invocation proto. Not all fields may
@@ -118,21 +114,15 @@ func (v *BEValues) maybeExtractOutputFile(files ...*build_event_stream.File) {
 		if file.GetName() == "" {
 			continue
 		}
-		if m := bytestreamURIPattern.FindStringSubmatch(file.GetUri()); len(m) >= 1 {
-			digestHash := m[1]
-			v.outputFilesMap[digestHash] = proto.Clone(file).(*build_event_stream.File)
+		parsedURI, err := digest.ParseByteStreamURI(file.GetUri())
+		if err != nil {
+			continue
 		}
+		digestHash := parsedURI.GetDigest().GetHash()
+		v.outputFilesMap[digestHash] = proto.Clone(file).(*build_event_stream.File)
 		// Special case: check for kythe output files.
 		if file.GetName() == KytheOutputName {
-			uri, err := url.Parse(file.GetUri())
-			if err != nil {
-				continue
-			}
-			rn, err := digest.ParseDownloadResourceName(uri.Path)
-			if err != nil {
-				continue
-			}
-			v.kytheSSTableResourceName = rn.ToProto()
+			v.kytheSSTableResourceName = parsedURI.ToProto()
 		}
 	}
 }
@@ -180,11 +170,20 @@ func (v *BEValues) AddEvent(event *build_event_stream.BuildEvent) error {
 		v.maybeExtractOutputFile(p.BuildToolLogs.GetLog()...)
 		for _, toolLog := range p.BuildToolLogs.GetLog() {
 			if uri := toolLog.GetUri(); uri != "" {
-				if url, err := url.Parse(uri); err != nil {
+				parsedURL, err := url.Parse(uri)
+				if err != nil {
 					log.Warningf("Error parsing uri from BuildToolLogs: %s", uri)
-				} else if url.Scheme == "bytestream" {
-					v.buildToolLogURIs = append(v.buildToolLogURIs, url)
+					continue
 				}
+				if parsedURL.Scheme != "bytestream" {
+					continue
+				}
+				parsedURI, err := digest.ParseByteStreamURI(uri)
+				if err != nil {
+					log.Warningf("Error parsing uri from BuildToolLogs: %s", uri)
+					continue
+				}
+				v.buildToolLogURIs = append(v.buildToolLogURIs, &parsedURI.URL)
 			}
 		}
 	case *build_event_stream.BuildEvent_TestResult:
@@ -198,14 +197,19 @@ func (v *BEValues) AddEvent(event *build_event_stream.BuildEvent) error {
 			if u.Scheme != "bytestream" {
 				continue
 			}
+			parsedURI, err := digest.ParseByteStreamURI(f.GetUri())
+			if err != nil {
+				log.Warningf("Error parsing uri from TestResult: %s", f.GetUri())
+				continue
+			}
 			if p.TestResult.GetStatus() == build_event_stream.TestStatus_PASSED {
 				if len(v.passedTestOutputURIs) < maxPersistableTestArtifacts {
-					v.passedTestOutputURIs = append(v.passedTestOutputURIs, u)
+					v.passedTestOutputURIs = append(v.passedTestOutputURIs, &parsedURI.URL)
 				}
 				continue
 			}
 			if len(v.failedTestOutputURIs) < maxPersistableTestArtifacts {
-				v.failedTestOutputURIs = append(v.failedTestOutputURIs, u)
+				v.failedTestOutputURIs = append(v.failedTestOutputURIs, &parsedURI.URL)
 			}
 		}
 	}

--- a/server/build_event_protocol/accumulator/accumulator_test.go
+++ b/server/build_event_protocol/accumulator/accumulator_test.go
@@ -1,0 +1,40 @@
+package accumulator_test
+
+import (
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/accumulator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	bespb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
+	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
+)
+
+func TestAddEvent_IndexesBLAKE3TestOutput(t *testing.T) {
+	const hash = "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d"
+	file := &bespb.File{
+		Name: "test.log",
+		File: &bespb.File_Uri{Uri: "bytestream://remote.buildbuddy.io/blobs/blake3/" + hash + "/1234"},
+	}
+	event := &bespb.BuildEvent{
+		Payload: &bespb.BuildEvent_TestResult{
+			TestResult: &bespb.TestResult{
+				Status:           bespb.TestStatus_PASSED,
+				TestActionOutput: []*bespb.File{file},
+			},
+		},
+	}
+
+	// Add a BLAKE3 test output so it is eligible for artifact persistence and
+	// can also be discovered when replaying the invocation.
+	values := accumulator.NewBEValues(&inpb.Invocation{})
+	require.NoError(t, values.AddEvent(event))
+	require.Len(t, values.PassedTestOutputURIs(), 1)
+
+	// The output file should be indexed by its digest regardless of the digest
+	// function segment in the ByteStream URI.
+	indexedFile, ok := values.OutputFiles()[hash]
+	require.True(t, ok)
+	assert.Equal(t, file, indexedFile)
+}

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -528,7 +528,7 @@ func (r *statsRecorder) handleTask(ctx context.Context, task *recordStatsTask) {
 		if cache_api_url.String() != "" && urlutil.GetDomain(uri.Hostname()) != urlutil.GetDomain(cache_api_url.WithPath("").Hostname()) {
 			continue
 		}
-		rn, err := digest.ParseDownloadResourceName(uri.Path)
+		rn, err := digest.ParseByteStreamURI(uri.String())
 		if err != nil {
 			log.CtxErrorf(ctx, "Unparseable artifact URI: %s", err)
 			continue

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -121,7 +121,7 @@ var (
 var cacheArtifactsBlobstorePath = path.Join("artifacts", "cache")
 
 type PersistArtifacts struct {
-	URIs              []*url.URL
+	URIs              []*digest.ByteStreamURI
 	TestActionOutputs bool
 }
 
@@ -525,27 +525,23 @@ func (r *statsRecorder) handleTask(ctx context.Context, task *recordStatsTask) {
 	for _, uri := range task.persist.URIs {
 		// Only persist artifacts from caches that are hosted on the BuildBuddy
 		// domain (but only if we know it).
-		if cache_api_url.String() != "" && urlutil.GetDomain(uri.Hostname()) != urlutil.GetDomain(cache_api_url.WithPath("").Hostname()) {
+		hostname := (&url.URL{Host: uri.GetHost()}).Hostname()
+		if cache_api_url.String() != "" && urlutil.GetDomain(hostname) != urlutil.GetDomain(cache_api_url.WithPath("").Hostname()) {
 			continue
 		}
-		rn, err := digest.ParseByteStreamURI(uri.String())
-		if err != nil {
-			log.CtxErrorf(ctx, "Unparseable artifact URI: %s", err)
+		if uri.IsEmpty() {
 			continue
 		}
-		if rn.IsEmpty() {
+		if _, seen := artifactsUploaded[uri.GetDigest().GetHash()]; seen {
 			continue
 		}
-		if _, seen := artifactsUploaded[rn.GetDigest().GetHash()]; seen {
-			continue
-		}
-		artifactsUploaded[rn.GetDigest().GetHash()] = struct{}{}
+		artifactsUploaded[uri.GetDigest().GetHash()] = struct{}{}
 		eg.Go(func() error {
 			// When persisting artifacts, make sure we associate the cache
 			// requests with the app, not bazel.
 			ctx := usageutil.WithLocalServerLabels(ctx)
 
-			fullPath := path.Join(task.invocationInfo.id, cacheArtifactsBlobstorePath, uri.Path)
+			fullPath := path.Join(task.invocationInfo.id, cacheArtifactsBlobstorePath, uri.DownloadString())
 			if err := persistArtifact(ctx, r.env, uri, fullPath); err != nil {
 				log.CtxError(ctx, err.Error())
 			}
@@ -580,7 +576,7 @@ func (r *statsRecorder) Stop() {
 	close(r.onStatsRecorded)
 }
 
-func persistArtifact(ctx context.Context, env environment.Env, uri *url.URL, path string) error {
+func persistArtifact(ctx context.Context, env environment.Env, uri *digest.ByteStreamURI, path string) error {
 	w, err := env.GetBlobstore().Writer(ctx, path)
 	if err != nil {
 		return status.WrapErrorf(

--- a/server/buildbuddy_server/BUILD
+++ b/server/buildbuddy_server/BUILD
@@ -56,6 +56,7 @@ go_library(
         "//server/interfaces",
         "//server/metrics",
         "//server/real_environment",
+        "//server/remote_cache/digest",
         "//server/remote_cache/directory_size",
         "//server/remote_cache/scorecard",
         "//server/remote_execution/config",

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/directory_size"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/scorecard"
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
@@ -297,11 +298,11 @@ func (s *BuildBuddyServer) DeleteInvocation(ctx context.Context, req *inpb.Delet
 }
 
 func (s *BuildBuddyServer) GetZipManifest(ctx context.Context, req *zipb.GetZipManifestRequest) (*zipb.GetZipManifestResponse, error) {
-	u, err := url.Parse(req.GetUri())
+	parsedURI, err := digest.ParseByteStreamURI(req.GetUri())
 	if err != nil {
 		return nil, err
 	}
-	man, err := s.env.GetPooledByteStreamClient().FetchBytestreamZipManifest(ctx, u)
+	man, err := s.env.GetPooledByteStreamClient().FetchBytestreamZipManifest(ctx, &parsedURI.URL)
 	if err != nil {
 		return nil, err
 	}
@@ -2421,7 +2422,17 @@ func getBestFilename(filename, blobname string) string {
 }
 
 func parseByteStreamURL(bsURL, filename string) (*bsLookup, error) {
-	if strings.HasPrefix(bsURL, bytestreamProtocolPrefix) || strings.HasPrefix(bsURL, actioncacheProtocolPrefix) {
+	if strings.HasPrefix(bsURL, bytestreamProtocolPrefix) {
+		parsedURI, err := digest.ParseByteStreamURI(bsURL)
+		if err != nil {
+			return nil, err
+		}
+		return &bsLookup{
+			URL:      &parsedURI.URL,
+			Filename: getBestFilename(filename, parsedURI.RequestURI()),
+		}, nil
+	}
+	if strings.HasPrefix(bsURL, actioncacheProtocolPrefix) {
 		u, err := url.Parse(bsURL)
 		if err != nil {
 			return nil, err

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -302,7 +302,7 @@ func (s *BuildBuddyServer) GetZipManifest(ctx context.Context, req *zipb.GetZipM
 	if err != nil {
 		return nil, err
 	}
-	man, err := s.env.GetPooledByteStreamClient().FetchBytestreamZipManifest(ctx, &parsedURI.URL)
+	man, err := s.env.GetPooledByteStreamClient().FetchBytestreamZipManifest(ctx, parsedURI)
 	if err != nil {
 		return nil, err
 	}
@@ -2401,8 +2401,10 @@ func (s *BuildBuddyServer) DeleteSecret(ctx context.Context, req *skpb.DeleteSec
 }
 
 type bsLookup struct {
-	URL      *url.URL
-	Filename string
+	ByteStreamURI  *digest.ByteStreamURI
+	ActionCacheURL *url.URL
+	Filename       string
+	ResourcePath   string
 }
 
 func getBestFilename(filename, blobname string) string {
@@ -2428,8 +2430,9 @@ func parseByteStreamURL(bsURL, filename string) (*bsLookup, error) {
 			return nil, err
 		}
 		return &bsLookup{
-			URL:      &parsedURI.URL,
-			Filename: getBestFilename(filename, parsedURI.RequestURI()),
+			ByteStreamURI: parsedURI,
+			Filename:      getBestFilename(filename, parsedURI.DownloadString()),
+			ResourcePath:  parsedURI.DownloadString(),
 		}, nil
 	}
 	if strings.HasPrefix(bsURL, actioncacheProtocolPrefix) {
@@ -2438,8 +2441,9 @@ func parseByteStreamURL(bsURL, filename string) (*bsLookup, error) {
 			return nil, err
 		}
 		return &bsLookup{
-			URL:      u,
-			Filename: getBestFilename(filename, u.RequestURI()),
+			ActionCacheURL: u,
+			Filename:       getBestFilename(filename, u.RequestURI()),
+			ResourcePath:   u.Path,
 		}, nil
 	}
 	return nil, fmt.Errorf("unparsable bytestream URL: '%s'", bsURL)
@@ -2556,7 +2560,7 @@ func (s *BuildBuddyServer) serveArtifact(ctx context.Context, w http.ResponseWri
 		if err != nil {
 			return http.StatusBadRequest, status.FailedPreconditionErrorf("Could not parse bytestream_url '%s' for cache artifact.", params.Get("bytestream_url"))
 		}
-		b, err := s.env.GetBlobstore().ReadBlob(ctx, path.Join(iid, "artifacts", "cache", lookup.URL.Path))
+		b, err := s.env.GetBlobstore().ReadBlob(ctx, path.Join(iid, "artifacts", "cache", lookup.ResourcePath))
 		if err != nil {
 			if status.IsNotFoundError(err) {
 				return http.StatusNotFound, status.NotFoundError("File not found.")
@@ -2646,7 +2650,13 @@ func (s *BuildBuddyServer) serveBytestream(ctx context.Context, w http.ResponseW
 			return http.StatusBadRequest, status.FailedPreconditionErrorf("\"%s\" does not represent a valid ManifestEntry proto when base64 decoded.", zipReference)
 		}
 		setContentHeaders(w, entry.GetName(), download)
-		err = s.env.GetPooledByteStreamClient().StreamSingleFileFromBytestreamZip(ctx, lookup.URL, entry, w)
+		if lookup.ByteStreamURI != nil {
+			err = s.env.GetPooledByteStreamClient().StreamSingleFileFromBytestreamZip(ctx, lookup.ByteStreamURI, entry, w)
+		} else {
+			// Keep the complete actioncache:// URL so its /blobs/ac/... resource
+			// name is parsed by the action-cache streaming path.
+			err = s.env.GetPooledByteStreamClient().StreamSingleFileFromActionCacheZip(ctx, lookup.ActionCacheURL, entry, w)
+		}
 		if err != nil {
 			if status.IsInvalidArgumentError(err) {
 				return http.StatusBadRequest, err
@@ -2658,7 +2668,13 @@ func (s *BuildBuddyServer) serveBytestream(ctx context.Context, w http.ResponseW
 
 	// Stream the file back to our client
 	setContentHeaders(w, lookup.Filename, download)
-	err = s.env.GetPooledByteStreamClient().StreamBytestreamFile(ctx, lookup.URL, w)
+	if lookup.ByteStreamURI != nil {
+		err = s.env.GetPooledByteStreamClient().StreamBytestreamFile(ctx, lookup.ByteStreamURI, w)
+	} else {
+		// Keep the complete actioncache:// URL so its /blobs/ac/... resource
+		// name is parsed by the action-cache streaming path.
+		err = s.env.GetPooledByteStreamClient().StreamActionCacheFile(ctx, lookup.ActionCacheURL, w)
+	}
 
 	if err != nil {
 		if status.IsInvalidArgumentError(err) {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -326,9 +326,11 @@ type StoppableCache interface {
 }
 
 type PooledByteStreamClient interface {
-	StreamBytestreamFile(ctx context.Context, url *url.URL, writer io.Writer) error
-	FetchBytestreamZipManifest(ctx context.Context, url *url.URL) (*zipb.Manifest, error)
-	StreamSingleFileFromBytestreamZip(ctx context.Context, url *url.URL, entry *zipb.ManifestEntry, out io.Writer) error
+	StreamBytestreamFile(ctx context.Context, uri *digest.ByteStreamURI, writer io.Writer) error
+	FetchBytestreamZipManifest(ctx context.Context, uri *digest.ByteStreamURI) (*zipb.Manifest, error)
+	StreamSingleFileFromBytestreamZip(ctx context.Context, uri *digest.ByteStreamURI, entry *zipb.ManifestEntry, out io.Writer) error
+	StreamActionCacheFile(ctx context.Context, url *url.URL, writer io.Writer) error
+	StreamSingleFileFromActionCacheZip(ctx context.Context, url *url.URL, entry *zipb.ManifestEntry, out io.Writer) error
 }
 
 type DBOptions interface {

--- a/server/remote_cache/byte_stream_client/byte_stream_client.go
+++ b/server/remote_cache/byte_stream_client/byte_stream_client.go
@@ -52,27 +52,25 @@ func NewPooledByteStreamClient(env environment.Env) *pooledByteStreamClient {
 	}
 }
 
-func (p *pooledByteStreamClient) FetchBytestreamZipManifest(ctx context.Context, url *url.URL) (*zipb.Manifest, error) {
-	r, err := digest.ParseByteStreamURI(url.String())
-	if err != nil {
-		return nil, err
-	}
+// FetchBytestreamZipManifest fetches and parses the central directory of a zip
+// stored at the given ByteStream URI.
+func (p *pooledByteStreamClient) FetchBytestreamZipManifest(ctx context.Context, uri *digest.ByteStreamURI) (*zipb.Manifest, error) {
 	// Let's just read 64K and see if we can find the central directory in there.
 	// We probably don't want to be in the business of rendering 3000-file zips'
 	// contents anyway.
-	offset := r.GetDigest().GetSizeBytes() - 65536
+	offset := uri.GetDigest().GetSizeBytes() - 65536
 	if offset < 0 {
 		offset = 0
 	}
 
 	var buf bytes.Buffer
-	err = p.StreamBytestreamFileChunk(ctx, url, offset, r.GetDigest().GetSizeBytes()-offset, &buf)
+	err := p.StreamBytestreamFileChunk(ctx, uri, offset, uri.GetDigest().GetSizeBytes()-offset, &buf)
 	if err != nil {
 		return nil, err
 	}
 
 	// We dump the full contents out into a buffer, but that should be 64K or less.
-	return ParseZipManifestFooter(buf.Bytes(), offset, r.GetDigest().GetSizeBytes())
+	return ParseZipManifestFooter(buf.Bytes(), offset, uri.GetDigest().GetSizeBytes())
 }
 
 func ParseZipManifestFooter(footer []byte, offset int64, trueFileSize int64) (*zipb.Manifest, error) {
@@ -96,26 +94,35 @@ func ParseZipManifestFooter(footer []byte, offset int64, trueFileSize int64) (*z
 	return &zipb.Manifest{Entry: entries}, nil
 }
 
-// Just a little song and dance so that we can mock out streamingin tests.
-type Bytestreamer func(ctx context.Context, url *url.URL, offset int64, limit int64, writer io.Writer) error
+// Bytestreamer streams a byte range for zip parsing tests.
+type Bytestreamer func(ctx context.Context, offset int64, limit int64, writer io.Writer) error
 
-func validateLocalFileHeader(ctx context.Context, url *url.URL, entry *zipb.ManifestEntry, streamer Bytestreamer) (int, error) {
+func validateLocalFileHeader(ctx context.Context, entry *zipb.ManifestEntry, streamer Bytestreamer) (int, error) {
 	var buf bytes.Buffer
-	err := streamer(ctx, url, entry.GetHeaderOffset(), ziputil.FileHeaderLen, &buf)
+	err := streamer(ctx, entry.GetHeaderOffset(), ziputil.FileHeaderLen, &buf)
 	if err != nil {
 		return -1, err
 	}
 	return ziputil.ValidateLocalFileHeader(buf.Bytes(), entry)
 }
 
-func (p *pooledByteStreamClient) StreamSingleFileFromBytestreamZip(ctx context.Context, u *url.URL, entry *zipb.ManifestEntry, out io.Writer) error {
-	return streamSingleFileFromBytestreamZipInternal(ctx, u, entry, out, func(ctx context.Context, url *url.URL, offset int64, limit int64, writer io.Writer) error {
-		return p.StreamBytestreamFileChunk(ctx, url, offset, limit, writer)
+// StreamSingleFileFromBytestreamZip streams a zip entry from a ByteStream URI.
+func (p *pooledByteStreamClient) StreamSingleFileFromBytestreamZip(ctx context.Context, uri *digest.ByteStreamURI, entry *zipb.ManifestEntry, out io.Writer) error {
+	return streamSingleFileFromBytestreamZipInternal(ctx, entry, out, func(ctx context.Context, offset int64, limit int64, writer io.Writer) error {
+		return p.StreamBytestreamFileChunk(ctx, uri, offset, limit, writer)
 	})
 }
 
-func streamSingleFileFromBytestreamZipInternal(ctx context.Context, url *url.URL, entry *zipb.ManifestEntry, out io.Writer, streamer Bytestreamer) error {
-	dynamicHeaderBytes, err := validateLocalFileHeader(ctx, url, entry, streamer)
+// StreamSingleFileFromActionCacheZip streams a zip entry from an action-cache
+// URL.
+func (p *pooledByteStreamClient) StreamSingleFileFromActionCacheZip(ctx context.Context, u *url.URL, entry *zipb.ManifestEntry, out io.Writer) error {
+	return streamSingleFileFromBytestreamZipInternal(ctx, entry, out, func(ctx context.Context, offset int64, limit int64, writer io.Writer) error {
+		return p.streamFileChunk(ctx, u, offset, limit, writer)
+	})
+}
+
+func streamSingleFileFromBytestreamZipInternal(ctx context.Context, entry *zipb.ManifestEntry, out io.Writer, streamer Bytestreamer) error {
+	dynamicHeaderBytes, err := validateLocalFileHeader(ctx, entry, streamer)
 	if err != nil {
 		if !status.IsNotFoundError(err) {
 			log.Warningf("Error streaming zip file contents: %s", err)
@@ -127,7 +134,7 @@ func streamSingleFileFromBytestreamZipInternal(ctx context.Context, url *url.URL
 	reader, writer := io.Pipe()
 	defer reader.Close()
 	go func() {
-		err := streamer(ctx, url, entry.GetHeaderOffset()+ziputil.FileHeaderLen, entry.GetCompressedSize()+int64(dynamicHeaderBytes), writer)
+		err := streamer(ctx, entry.GetHeaderOffset()+ziputil.FileHeaderLen, entry.GetCompressedSize()+int64(dynamicHeaderBytes), writer)
 		// StreamBytestreamFileChunk shouldn't return EOF, but let's just be safe.
 		if err != nil && err != io.EOF {
 			writer.CloseWithError(err)
@@ -151,13 +158,29 @@ func streamSingleFileFromBytestreamZipInternal(ctx context.Context, url *url.URL
 	return nil
 }
 
-func (p *pooledByteStreamClient) StreamBytestreamFile(ctx context.Context, url *url.URL, writer io.Writer) error {
-	return p.StreamBytestreamFileChunk(ctx, url, 0, 0, writer)
+// StreamBytestreamFile streams a complete blob from a ByteStream URI.
+func (p *pooledByteStreamClient) StreamBytestreamFile(ctx context.Context, uri *digest.ByteStreamURI, writer io.Writer) error {
+	return p.StreamBytestreamFileChunk(ctx, uri, 0, 0, writer)
 }
 
-func (p *pooledByteStreamClient) StreamBytestreamFileChunk(ctx context.Context, url *url.URL, offset int64, limit int64, writer io.Writer) error {
+// StreamActionCacheFile streams an ActionResult from an action-cache URL.
+func (p *pooledByteStreamClient) StreamActionCacheFile(ctx context.Context, u *url.URL, writer io.Writer) error {
+	return p.streamFileChunk(ctx, u, 0, 0, writer)
+}
+
+// StreamBytestreamFileChunk streams a byte range from a ByteStream URI.
+func (p *pooledByteStreamClient) StreamBytestreamFileChunk(ctx context.Context, uri *digest.ByteStreamURI, offset int64, limit int64, writer io.Writer) error {
+	u := &url.URL{
+		Scheme: "bytestream",
+		Host:   uri.GetHost(),
+		Path:   "/" + strings.TrimPrefix(uri.DownloadString(), "/"),
+	}
+	return p.streamFileChunk(ctx, u, offset, limit, writer)
+}
+
+func (p *pooledByteStreamClient) streamFileChunk(ctx context.Context, url *url.URL, offset int64, limit int64, writer io.Writer) error {
 	if url.Scheme != "bytestream" && url.Scheme != "actioncache" {
-		return status.InvalidArgumentErrorf("Only bytestream:// uris are supported")
+		return status.InvalidArgumentError("Only bytestream:// and actioncache:// URIs are supported")
 	}
 
 	var allErrs error

--- a/server/remote_cache/byte_stream_client/byte_stream_client.go
+++ b/server/remote_cache/byte_stream_client/byte_stream_client.go
@@ -53,7 +53,7 @@ func NewPooledByteStreamClient(env environment.Env) *pooledByteStreamClient {
 }
 
 func (p *pooledByteStreamClient) FetchBytestreamZipManifest(ctx context.Context, url *url.URL) (*zipb.Manifest, error) {
-	r, err := digest.ParseDownloadResourceName(strings.TrimPrefix(url.RequestURI(), "/"))
+	r, err := digest.ParseByteStreamURI(url.String())
 	if err != nil {
 		return nil, err
 	}

--- a/server/remote_cache/byte_stream_client/byte_stream_client_test.go
+++ b/server/remote_cache/byte_stream_client/byte_stream_client_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -89,7 +88,7 @@ func TestManifest_TooManyFilesZip(t *testing.T) {
 }
 
 func createBytestreamer(b []byte) Bytestreamer {
-	return func(ctx context.Context, url *url.URL, offset int64, limit int64, writer io.Writer) error {
+	return func(ctx context.Context, offset int64, limit int64, writer io.Writer) error {
 		writer.Write(b[offset : offset+limit])
 		return nil
 	}
@@ -97,7 +96,7 @@ func createBytestreamer(b []byte) Bytestreamer {
 
 func validateZipContents(t *testing.T, ctx context.Context, entry *zipb.ManifestEntry, expectedContent string, streamer Bytestreamer) {
 	var buf bytes.Buffer
-	streamSingleFileFromBytestreamZipInternal(ctx, nil, entry, &buf, streamer)
+	streamSingleFileFromBytestreamZipInternal(ctx, entry, &buf, streamer)
 	out := make([]byte, entry.GetUncompressedSize())
 	_, err := io.ReadFull(&buf, out)
 	if err != nil {

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -12,6 +12,7 @@ import (
 	"hash"
 	"io"
 	"math/rand"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime/debug"
@@ -651,6 +652,31 @@ func ParseDownloadResourceName(resourceName string) (*CASResourceName, error) {
 		return nil, err
 	}
 	return rn.CheckCAS()
+}
+
+// ByteStreamURI contains a parsed ByteStream URI and its CAS resource name.
+type ByteStreamURI struct {
+	url.URL
+	CASResourceName
+}
+
+// ParseByteStreamURI parses a ByteStream URI and its CAS resource name.
+func ParseByteStreamURI(rawURI string) (*ByteStreamURI, error) {
+	parsedURI, err := url.Parse(rawURI)
+	if err != nil {
+		return nil, status.InvalidArgumentErrorf("invalid ByteStream URI: %s", err)
+	}
+	if parsedURI.Scheme != "bytestream" {
+		return nil, status.InvalidArgumentErrorf("invalid ByteStream URI scheme %q", parsedURI.Scheme)
+	}
+	resourceName, err := ParseDownloadResourceName(strings.TrimPrefix(parsedURI.Path, "/"))
+	if err != nil {
+		return nil, status.WrapError(err, "parse ByteStream URI")
+	}
+	return &ByteStreamURI{
+		URL:             *parsedURI,
+		CASResourceName: *resourceName,
+	}, nil
 }
 
 func ParseActionCacheResourceName(resourceName string) (*ACResourceName, error) {

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -654,10 +654,25 @@ func ParseDownloadResourceName(resourceName string) (*CASResourceName, error) {
 	return rn.CheckCAS()
 }
 
-// ByteStreamURI contains a parsed ByteStream URI and its CAS resource name.
+// ByteStreamURI contains the host and CAS resource name of a parsed ByteStream
+// URI.
 type ByteStreamURI struct {
-	url.URL
 	CASResourceName
+	host string
+}
+
+// GetHost returns the URI host, including the port if one was specified.
+func (u *ByteStreamURI) GetHost() string {
+	return u.host
+}
+
+// String returns the canonical ByteStream URI.
+func (u *ByteStreamURI) String() string {
+	return (&url.URL{
+		Scheme: "bytestream",
+		Host:   u.host,
+		Path:   "/" + strings.TrimPrefix(u.DownloadString(), "/"),
+	}).String()
 }
 
 // ParseByteStreamURI parses a ByteStream URI and its CAS resource name.
@@ -669,13 +684,19 @@ func ParseByteStreamURI(rawURI string) (*ByteStreamURI, error) {
 	if parsedURI.Scheme != "bytestream" {
 		return nil, status.InvalidArgumentErrorf("invalid ByteStream URI scheme %q", parsedURI.Scheme)
 	}
+	if parsedURI.Host == "" {
+		return nil, status.InvalidArgumentError("invalid ByteStream URI: missing host")
+	}
+	if parsedURI.User != nil || parsedURI.ForceQuery || parsedURI.RawQuery != "" || parsedURI.Fragment != "" {
+		return nil, status.InvalidArgumentError("invalid ByteStream URI: user info, query parameters, and fragments are not supported")
+	}
 	resourceName, err := ParseDownloadResourceName(strings.TrimPrefix(parsedURI.Path, "/"))
 	if err != nil {
 		return nil, status.WrapError(err, "parse ByteStream URI")
 	}
 	return &ByteStreamURI{
-		URL:             *parsedURI,
 		CASResourceName: *resourceName,
+		host:            parsedURI.Host,
 	}, nil
 }
 

--- a/server/remote_cache/digest/digest_test.go
+++ b/server/remote_cache/digest/digest_test.go
@@ -128,6 +128,62 @@ func TestParseDownloadResourceName(t *testing.T) {
 	}
 }
 
+func TestParseByteStreamURI(t *testing.T) {
+	const hash = "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d"
+
+	for _, testCase := range []struct {
+		name               string
+		uri                string
+		wantInstanceName   string
+		wantDigestFunction repb.DigestFunction_Value
+		wantError          bool
+	}{
+		{
+			name:               "SHA256",
+			uri:                "bytestream://remote.buildbuddy.io/blobs/" + hash + "/1234",
+			wantDigestFunction: repb.DigestFunction_SHA256,
+		},
+		{
+			name:               "BLAKE3WithInstanceName",
+			uri:                "bytestream://remote.buildbuddy.io/buildbuddy/test/blobs/blake3/" + hash + "/1234",
+			wantInstanceName:   "buildbuddy/test",
+			wantDigestFunction: repb.DigestFunction_BLAKE3,
+		},
+		{
+			name:      "UnsupportedScheme",
+			uri:       "https://remote.buildbuddy.io/blobs/" + hash + "/1234",
+			wantError: true,
+		},
+		{
+			name:      "InvalidURI",
+			uri:       "bytestream://remote.buildbuddy.io/blobs/%zz/1234",
+			wantError: true,
+		},
+		{
+			name:      "InvalidResourceName",
+			uri:       "bytestream://remote.buildbuddy.io/blobs/blake3/not-a-digest/1234",
+			wantError: true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Parse the full URI so both its transport location and CAS resource
+			// name are available to callers.
+			parsedURI, err := digest.ParseByteStreamURI(testCase.uri)
+			if testCase.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, "bytestream", parsedURI.Scheme)
+			assert.Equal(t, "remote.buildbuddy.io", parsedURI.Host)
+			assert.Equal(t, testCase.wantInstanceName, parsedURI.GetInstanceName())
+			assert.Equal(t, hash, parsedURI.GetDigest().GetHash())
+			assert.EqualValues(t, 1234, parsedURI.GetDigest().GetSizeBytes())
+			assert.Equal(t, testCase.wantDigestFunction, parsedURI.GetDigestFunction())
+		})
+	}
+}
+
 func FuzzParseDownloadResourceName(f *testing.F) {
 	f.Add("blobs/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49ac/1234")
 	f.Add("/compressed-blobs/zstd/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234")

--- a/server/remote_cache/digest/digest_test.go
+++ b/server/remote_cache/digest/digest_test.go
@@ -134,24 +134,52 @@ func TestParseByteStreamURI(t *testing.T) {
 	for _, testCase := range []struct {
 		name               string
 		uri                string
+		wantHost           string
 		wantInstanceName   string
 		wantDigestFunction repb.DigestFunction_Value
 		wantError          bool
 	}{
 		{
 			name:               "SHA256",
-			uri:                "bytestream://remote.buildbuddy.io/blobs/" + hash + "/1234",
+			uri:                "bytestream://remote.buildbuddy.io:1985/blobs/" + hash + "/1234",
+			wantHost:           "remote.buildbuddy.io:1985",
 			wantDigestFunction: repb.DigestFunction_SHA256,
 		},
 		{
 			name:               "BLAKE3WithInstanceName",
 			uri:                "bytestream://remote.buildbuddy.io/buildbuddy/test/blobs/blake3/" + hash + "/1234",
+			wantHost:           "remote.buildbuddy.io",
 			wantInstanceName:   "buildbuddy/test",
 			wantDigestFunction: repb.DigestFunction_BLAKE3,
 		},
 		{
 			name:      "UnsupportedScheme",
 			uri:       "https://remote.buildbuddy.io/blobs/" + hash + "/1234",
+			wantError: true,
+		},
+		{
+			name:      "ActionCacheScheme",
+			uri:       "actioncache://remote.buildbuddy.io/blobs/ac/" + hash + "/1234",
+			wantError: true,
+		},
+		{
+			name:      "MissingHost",
+			uri:       "bytestream:///blobs/" + hash + "/1234",
+			wantError: true,
+		},
+		{
+			name:      "UserInfo",
+			uri:       "bytestream://user@remote.buildbuddy.io/blobs/" + hash + "/1234",
+			wantError: true,
+		},
+		{
+			name:      "QueryParameters",
+			uri:       "bytestream://remote.buildbuddy.io/blobs/" + hash + "/1234?foo=bar",
+			wantError: true,
+		},
+		{
+			name:      "Fragment",
+			uri:       "bytestream://remote.buildbuddy.io/blobs/" + hash + "/1234#foo",
 			wantError: true,
 		},
 		{
@@ -166,16 +194,15 @@ func TestParseByteStreamURI(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			// Parse the full URI so both its transport location and CAS resource
-			// name are available to callers.
+			// Parse the full URI into its host and CAS resource name components.
 			parsedURI, err := digest.ParseByteStreamURI(testCase.uri)
 			if testCase.wantError {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, "bytestream", parsedURI.Scheme)
-			assert.Equal(t, "remote.buildbuddy.io", parsedURI.Host)
+			assert.Equal(t, testCase.wantHost, parsedURI.GetHost())
+			assert.Equal(t, testCase.uri, parsedURI.String())
 			assert.Equal(t, testCase.wantInstanceName, parsedURI.GetInstanceName())
 			assert.Equal(t, hash, parsedURI.GetDigest().GetHash())
 			assert.EqualValues(t, 1234, parsedURI.GetDigest().GetSizeBytes())

--- a/tools/replay_invocation/replay_invocation.go
+++ b/tools/replay_invocation/replay_invocation.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"path"
 	"regexp"
@@ -321,20 +320,16 @@ func main() {
 // Copies a persisted artifact from the given blobstore to the destination cache
 // target.
 func copyArtifact(ctx context.Context, dst bspb.ByteStreamClient, src interfaces.Blobstore, uri string) error {
-	parsedURL, err := url.Parse(uri)
+	parsedURI, err := digest.ParseByteStreamURI(uri)
 	if err != nil {
-		return fmt.Errorf("parse bytestream URI as URL: %w", err)
+		return fmt.Errorf("parse ByteStream URI: %w", err)
 	}
-	blobName := path.Join(*invocationID, "artifacts", "cache", parsedURL.Path)
+	blobName := path.Join(*invocationID, "artifacts", "cache", parsedURI.Path)
 	b, err := src.ReadBlob(ctx, blobName)
 	if err != nil {
 		return fmt.Errorf("read blob %q: %w", blobName, err)
 	}
-	rn, err := digest.ParseDownloadResourceName(parsedURL.Path)
-	if err != nil {
-		return fmt.Errorf("parse bytestream URI as resource name: %w", err)
-	}
-	if _, err := cachetools.UploadBlobToCAS(ctx, dst, rn.GetInstanceName(), rn.GetDigestFunction(), b); err != nil {
+	if _, err := cachetools.UploadBlobToCAS(ctx, dst, parsedURI.GetInstanceName(), parsedURI.GetDigestFunction(), b); err != nil {
 		return fmt.Errorf("upload blob to CAS: %w", err)
 	}
 	return nil

--- a/tools/replay_invocation/replay_invocation.go
+++ b/tools/replay_invocation/replay_invocation.go
@@ -324,7 +324,7 @@ func copyArtifact(ctx context.Context, dst bspb.ByteStreamClient, src interfaces
 	if err != nil {
 		return fmt.Errorf("parse ByteStream URI: %w", err)
 	}
-	blobName := path.Join(*invocationID, "artifacts", "cache", parsedURI.Path)
+	blobName := path.Join(*invocationID, "artifacts", "cache", parsedURI.DownloadString())
 	b, err := src.ReadBlob(ctx, blobName)
 	if err != nil {
 		return fmt.Errorf("read blob %q: %w", blobName, err)


### PR DESCRIPTION
- Introduce `digest.ParseByteStreamURI` for parsing bytestream URIs and use it everywhere
- This fixes `replay_invocation --copy_artifacts` not working for BLAKE3 ByteStream URIs (the bug was in `accumulator.go` - it used a regex that didn't incorporate the digest_function)
  - One implication of fixing this bug with `accumulator.go`: cache scorecards may now store file names and path prefixes for additional BLAKE3 outputs:
    - [metadata extraction code](https://github.com/buildbuddy-io/buildbuddy/blob/60a065a3d71acf1155637332e1946af9636101ad/server/build_event_protocol/accumulator/accumulator.go#L112-L125), previously not working for BLAKE3
    - [scorecard enrichment](https://github.com/buildbuddy-io/buildbuddy/blob/60a065a3d71acf1155637332e1946af9636101ad/server/remote_cache/scorecard/scorecard.go#L303-L317)
  - GCS artifact persistence was already working properly for BLAKE3, and is unchanged.
