### PR TITLE
Use klauspost/compress/gzip @ bestspeed for blobstore artifacts

### DIFF
--- a/server/backends/blobstore/util/BUILD
+++ b/server/backends/blobstore/util/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//server/interfaces",
         "//server/metrics",
+        "@com_github_klauspost_compress//gzip",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_grpc//status",
     ],

--- a/server/backends/blobstore/util/util.go
+++ b/server/backends/blobstore/util/util.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"flag"
 	"io"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
+	"github.com/klauspost/compress/gzip"
 	"github.com/prometheus/client_golang/prometheus"
 
 	gstatus "google.golang.org/grpc/status"
@@ -18,8 +18,15 @@ import (
 
 var pathPrefix = flag.String("storage.path_prefix", "", "The prefix directory to store all blobs in")
 
+// NewCompressWriter returns a gzip writer tuned for speed rather than
+// compression ratio.
 func NewCompressWriter(w io.Writer) io.WriteCloser {
-	return gzip.NewWriter(w)
+	zw, err := gzip.NewWriterLevel(w, gzip.BestSpeed)
+	if err != nil {
+		// Only reachable with an invalid level constant.
+		return gzip.NewWriter(w)
+	}
+	return zw
 }
 
 func NewCompressReader(r io.Reader) (io.ReadCloser, error) {


### PR DESCRIPTION
- klauspost/compress/gzip is faster than stdlib by 2x
- bestspeed should save a bit of CPU for a marginal (10-15%) space increase (but it's on gcs so doesn't matter a ton)