### PR TITLE
meta cache: put group id explicitly in the key

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -338,7 +338,7 @@
   "moduleExtensions": {
     "@@aspect_rules_esbuild+//esbuild:extensions.bzl%esbuild": {
       "general": {
-        "bzlTransitiveDigest": "jIGtJJuW6DU7TGB/O9mQAtVxcTrZTx0MboqrrKOI/c8=",
+        "bzlTransitiveDigest": "/hNv7adnANcB/VaqOWXEslVX2fl2TiFcx3vr8v9u1kE=",
         "usagesDigest": "6We6zwGoawD9YXqMI0KPaxEKJTnamXBsuOekhFS2D40=",
         "recordedInputs": [
           "REPO_MAPPING:aspect_rules_esbuild+,aspect_rules_js aspect_rules_js+",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -338,7 +338,7 @@
   "moduleExtensions": {
     "@@aspect_rules_esbuild+//esbuild:extensions.bzl%esbuild": {
       "general": {
-        "bzlTransitiveDigest": "/hNv7adnANcB/VaqOWXEslVX2fl2TiFcx3vr8v9u1kE=",
+        "bzlTransitiveDigest": "jIGtJJuW6DU7TGB/O9mQAtVxcTrZTx0MboqrrKOI/c8=",
         "usagesDigest": "6We6zwGoawD9YXqMI0KPaxEKJTnamXBsuOekhFS2D40=",
         "recordedInputs": [
           "REPO_MAPPING:aspect_rules_esbuild+,aspect_rules_js aspect_rules_js+",

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -367,6 +367,13 @@ func (m *v5ToV6Migrator) FromVersion() filestore.PebbleKeyVersion {
 }
 func (m *v5ToV6Migrator) ToVersion() filestore.PebbleKeyVersion { return filestore.Version6 }
 
+type v6ToV7Migrator struct{}
+
+func (m *v6ToV7Migrator) FromVersion() filestore.PebbleKeyVersion {
+	return filestore.Version6
+}
+func (m *v6ToV7Migrator) ToVersion() filestore.PebbleKeyVersion { return filestore.Version7 }
+
 // Register creates a new PebbleCache from the configured flags and sets it in
 // the provided env.
 func Register(env *real_environment.RealEnv) error {
@@ -796,6 +803,14 @@ func NewPebbleCache(env environment.Env, opts *Options) (*PebbleCache, error) {
 		if pc.activeDatabaseVersion() >= filestore.Version6 {
 			// Migrate keys from 5->6.
 			pc.migrators = append(pc.migrators, &v5ToV6Migrator{})
+		}
+		if pc.activeDatabaseVersion() >= filestore.Version7 {
+			// Migrate keys from 6->7. v7 is a raft-only, group-prefixed layout;
+			// pebble_cache never sets its active version to v7, so this migrator
+			// is only exercised by tests. The generic migrator rebuilds the key
+			// from the value's FileRecord, so the discarded groupID/digest is
+			// recovered.
+			pc.migrators = append(pc.migrators, &v6ToV7Migrator{})
 		}
 	}
 

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -270,6 +270,10 @@ type PebbleCache struct {
 	maxDBVersion     filestore.PebbleKeyVersion
 	migrators        []keyMigrator
 
+	// migrating is true while the background data migration runs; it gates a
+	// retry in the read path (see lookupFileMetadataAndVersion).
+	migrating atomic.Bool
+
 	env    environment.Env
 	db     pebble.IPebbleDB
 	leaser pebble.Leaser
@@ -1236,6 +1240,11 @@ func (p *PebbleCache) migrateData(quitChan chan struct{}) error {
 		return nil
 	}
 
+	// Signal the read path that keys may be moving between versions, so that it
+	// retries a total miss (see lookupFileMetadataAndVersion).
+	p.migrating.Store(true)
+	defer p.migrating.Store(false)
+
 	limiter := rate.NewLimiter(rate.Limit(*migrationQPSLimit), 1)
 	db, err := p.leaser.DB()
 	if err != nil {
@@ -1808,6 +1817,21 @@ func (p *PebbleCache) makeFileRecord(groupID string, encryption *sgpb.Encryption
 }
 
 func (p *PebbleCache) lookupFileMetadataAndVersion(ctx context.Context, db pebble.IPebbleDB, key filestore.PebbleKey, fileMetadata *sgpb.FileMetadata) (filestore.PebbleKeyVersion, error) {
+	// The migrator writes the new-version key before deleting the old one and
+	// never deletes the new one, so a key is always present at some version.
+	// Our non-atomic descending probe can still straddle a key's (one-time)
+	// migration and miss both versions. Sampling migrating before and after the
+	// probe brackets the migration window: if it was ever set, re-probe once
+	// (the migration has settled by now). A still-missing key doesn't exist.
+	migrating := p.migrating.Load()
+	version, err := p.probeFileMetadataVersions(db, key, fileMetadata)
+	if status.IsNotFoundError(err) && (migrating || p.migrating.Load()) {
+		version, err = p.probeFileMetadataVersions(db, key, fileMetadata)
+	}
+	return version, err
+}
+
+func (p *PebbleCache) probeFileMetadataVersions(db pebble.IPebbleDB, key filestore.PebbleKey, fileMetadata *sgpb.FileMetadata) (filestore.PebbleKeyVersion, error) {
 	var lastErr error
 	for minVersion, version := p.minAndMaxDatabaseVersions(); version >= minVersion; version-- {
 		keyBytes, err := key.Bytes(version)
@@ -1993,6 +2017,18 @@ func (p *PebbleCache) findMissing(ctx context.Context, db pebble.IPebbleDB, grou
 // unmarshalling it. The returned buffer is only valid until the returned
 // closer is closed; on success the caller must close it.
 func (p *PebbleCache) lookupFileMetadataBytes(db pebble.IPebbleDB, key filestore.PebbleKey) ([]byte, io.Closer, error) {
+	// See lookupFileMetadataAndVersion: a concurrent migration can make a
+	// non-atomic multi-version probe miss a key that is in fact always present.
+	// Re-probe once if a migration overlapped this probe.
+	migrating := p.migrating.Load()
+	buf, closer, err := p.probeFileMetadataBytes(db, key)
+	if status.IsNotFoundError(err) && (migrating || p.migrating.Load()) {
+		buf, closer, err = p.probeFileMetadataBytes(db, key)
+	}
+	return buf, closer, err
+}
+
+func (p *PebbleCache) probeFileMetadataBytes(db pebble.IPebbleDB, key filestore.PebbleKey) ([]byte, io.Closer, error) {
 	var lastErr error
 	for minVersion, version := p.minAndMaxDatabaseVersions(); version >= minVersion; version-- {
 		keyBytes, err := key.Bytes(version)

--- a/enterprise/server/filestore/filestore.go
+++ b/enterprise/server/filestore/filestore.go
@@ -116,6 +116,12 @@ const (
 	// their remote isntance name, groupID, and digest.
 	Version6
 
+	// Version7 is like Version4 but always prepends the (fixed-width) groupID,
+	// for CAS as well as AC, so a group's keys are contiguous in the keyspace.
+	// The real digest is preserved, so the groupID is recoverable. Not part of
+	// the v0..v6 migration chain (v5/v6 discard the groupID).
+	Version7
+
 	// MaxKeyVersion is always 1 more than the highest defined version, which
 	// allows for tests to iterate across all versions from UndefinedKeyVersion
 	// to MaxKeyVersion and check cross compatibility.
@@ -316,6 +322,21 @@ func (pmk *PebbleKey) Bytes(version PebbleKeyVersion) ([]byte, error) {
 		}
 		filePath := filepath.Join(hashStr, strconv.Itoa(int(pmk.digestFunction)), pmk.isolation, pmk.encryptionKeyID)
 		return []byte(PartitionDirectoryPrefix + pmk.partID + "/" + filePath + "/v6"), nil
+	case Version7:
+		// Group-local layout. A groupID is required for both AC and CAS so that
+		// every key sits under its group's contiguous prefix.
+		if pmk.groupID == "" {
+			return nil, status.FailedPreconditionErrorf("cannot make v7 key: %w", ErrMissingKeyInfo)
+		}
+		rih := pmk.remoteInstanceHash
+		if pmk.isolation == "ac" && rih == "" {
+			rih = "0"
+		}
+		filePath := filepath.Join(pmk.hash, strconv.Itoa(int(pmk.digestFunction)), pmk.isolation, rih, pmk.encryptionKeyID)
+		filePath = filepath.Join(remapANONToFixedGroupID(FixedWidthGroupID(pmk.groupID)), filePath)
+		partDir := PartitionDirectoryPrefix + pmk.partID
+		filePath = filepath.Join(partDir, filePath, "v7")
+		return []byte(filePath), nil
 	default:
 		return nil, status.FailedPreconditionErrorf("Unknown key version: %v", version)
 	}
@@ -512,6 +533,51 @@ func (pmk *PebbleKey) parseVersion6(parts [][]byte) error {
 	return nil
 }
 
+func (pmk *PebbleKey) parseVersion7(parts [][]byte) error {
+	digestFunctionString := ""
+
+	switch len(parts) {
+	// CAS artifact
+	// PTfoo/GR00000000000000000123/abcd..../1/cas/v7
+	case 6:
+		pmk.partID, pmk.groupID, pmk.hash, digestFunctionString, pmk.isolation = string(parts[0]), string(parts[1]), string(parts[2]), string(parts[3]), string(parts[4])
+	case 7:
+		// Either an encrypted CAS artifact or an unencrypted AC artifact; both
+		// have 7 segments, so disambiguate on the isolation segment (parts[4]).
+		if string(parts[4]) == "cas" {
+			// encrypted CAS: PTfoo/GR.../abcd..../1/cas/EK123/v7
+			pmk.partID, pmk.groupID, pmk.hash, digestFunctionString, pmk.isolation, pmk.encryptionKeyID = string(parts[0]), string(parts[1]), string(parts[2]), string(parts[3]), string(parts[4]), string(parts[5])
+		} else {
+			// AC: PTfoo/GR.../abcd..../1/ac/123/v7
+			pmk.partID, pmk.groupID, pmk.hash, digestFunctionString, pmk.isolation, pmk.remoteInstanceHash = string(parts[0]), string(parts[1]), string(parts[2]), string(parts[3]), string(parts[4]), string(parts[5])
+			if pmk.remoteInstanceHash == "0" {
+				pmk.remoteInstanceHash = ""
+			}
+		}
+	// encrypted AC artifact
+	// PTfoo/GR.../abcd..../1/ac/123/EK123/v7
+	case 8:
+		pmk.partID, pmk.groupID, pmk.hash, digestFunctionString, pmk.isolation, pmk.remoteInstanceHash, pmk.encryptionKeyID = string(parts[0]), string(parts[1]), string(parts[2]), string(parts[3]), string(parts[4]), string(parts[5]), string(parts[6])
+		if pmk.remoteInstanceHash == "0" {
+			pmk.remoteInstanceHash = ""
+		}
+	default:
+		return parseError(parts)
+	}
+
+	// Parse hash type string back into a digestFunction enum.
+	intDigestFunction, err := strconv.Atoi(digestFunctionString)
+	if err != nil || intDigestFunction == 0 {
+		// It is an error for a v7 key to have a 0 digestFunction value.
+		return parseError(parts)
+	}
+	pmk.digestFunction = repb.DigestFunction_Value(intDigestFunction)
+
+	pmk.partID = strings.TrimPrefix(pmk.partID, PartitionDirectoryPrefix)
+	pmk.groupID = remapFixedToANONGroupID(trimFixedWidthGroupID(pmk.groupID))
+	return nil
+}
+
 func (pmk *PebbleKey) FromBytes(in []byte) (PebbleKeyVersion, error) {
 	version := UndefinedKeyVersion
 	slash := []byte{filepath.Separator}
@@ -555,6 +621,8 @@ func (pmk *PebbleKey) FromBytes(in []byte) (PebbleKeyVersion, error) {
 		return Version5, pmk.parseVersion5(parts)
 	case Version6:
 		return Version6, pmk.parseVersion6(parts)
+	case Version7:
+		return Version7, pmk.parseVersion7(parts)
 	default:
 		return -1, status.InvalidArgumentErrorf("Unable to parse %q to pebble key", in)
 	}

--- a/enterprise/server/filestore/filestore_test.go
+++ b/enterprise/server/filestore/filestore_test.go
@@ -3,6 +3,7 @@ package filestore_test
 import (
 	"bytes"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/filestore"
@@ -26,7 +27,8 @@ func TestKeyVersionDefinitions(t *testing.T) {
 	assert.Equal(t, 4, int(filestore.Version4))
 	assert.Equal(t, 5, int(filestore.Version5))
 	assert.Equal(t, 6, int(filestore.Version6))
-	assert.Equal(t, 7, int(filestore.MaxKeyVersion))
+	assert.Equal(t, 7, int(filestore.Version7))
+	assert.Equal(t, 8, int(filestore.MaxKeyVersion))
 }
 
 func toFileRecord(r *rspb.ResourceName) *sgpb.FileRecord {
@@ -69,12 +71,22 @@ func TestKeyVersionCrossCompatibility(t *testing.T) {
 	// CAS entries cannot be converted to v6 from an earlier version because
 	// group ID info is lost.
 	//
+	// v7 keeps the real digest + literal groupID, so it's reachable only from a
+	// source that still carries both: CAS keys never stored a groupID, and
+	// v5/v6 replaced the real digest with a lossy synthetic hash. Those sources
+	// are listed below and yield ErrMissingKeyInfo when migrated to v7.
+	acLostDigestForV7 := map[filestore.PebbleKeyVersion]bool{
+		filestore.Version5: true,
+		filestore.Version6: true,
+	}
 	testCases := []testCase{}
 	for i := filestore.UndefinedKeyVersion; i < filestore.MaxKeyVersion; i++ {
 		for _, cacheType := range []rspb.CacheType{rspb.CacheType_AC, rspb.CacheType_CAS} {
 			maxCASMigratableVersion := filestore.Version5
 			if i >= filestore.Version6 {
-				maxCASMigratableVersion = filestore.MaxKeyVersion - 1
+				// v6+ CAS/synthetic keys carry their own encoded form, so they
+				// round-trip only to their own version.
+				maxCASMigratableVersion = i
 			}
 			for j := i; j < filestore.MaxKeyVersion; j++ {
 				tc := testCase{
@@ -84,6 +96,9 @@ func TestKeyVersionCrossCompatibility(t *testing.T) {
 					wantErr:     nil,
 				}
 				if j > maxCASMigratableVersion && cacheType == rspb.CacheType_CAS {
+					tc.wantErr = filestore.ErrMissingKeyInfo
+				}
+				if j == filestore.Version7 && cacheType == rspb.CacheType_AC && acLostDigestForV7[i] {
 					tc.wantErr = filestore.ErrMissingKeyInfo
 				}
 				testCases = append(testCases, tc)
@@ -163,6 +178,14 @@ func TestKnownVersions(t *testing.T) {
 			"PTFOO/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/9/ac/v6",
 			"PTFOO/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/9/ac/EK123/v6",
 		},
+		filestore.Version7: {
+			// CAS keys carry the groupID too, so they are group-prefixed like AC.
+			"PTFOO/GR00000000000000007890/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/9/cas/v7",
+			"PTFOO/GR00000000000000007890/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/9/cas/EK123/v7",
+			"PTFOO/GR00000000000000007890/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/9/ac/2364854541/v7",
+			"PTFOO/GR00000000000000007890/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/9/ac/2364854541/EK123/v7",
+			"PTFOO/GR00000000000000007890/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/9/ac/0/v7",
+		},
 	}
 
 	for version := filestore.UndefinedKeyVersion; version < filestore.MaxKeyVersion; version++ {
@@ -187,6 +210,10 @@ func TestMigration(t *testing.T) {
 	type result struct {
 		key     string
 		wantErr error
+		// unmigratableFrom lists the source versions that can't produce this
+		// target's key because they discarded information it needs; migrating
+		// from one of them yields ErrMissingKeyInfo instead of `key`.
+		unmigratableFrom []filestore.PebbleKeyVersion
 	}
 	cases := []map[filestore.PebbleKeyVersion]result{
 		{
@@ -197,6 +224,8 @@ func TestMigration(t *testing.T) {
 			filestore.Version4:            {key: "PTFOO/baec85817b2bf76db939f38e33f1acccdfeb5683885d014717918bbc0c1996d2/1/cas/v4"},
 			filestore.Version5:            {key: "PTFOO/baec85817b2bf76db939f38e33f1acccdfeb5683885d014717918bbc0c1996d2/1/cas/v5"},
 			filestore.Version6:            {wantErr: filestore.ErrMissingKeyInfo},
+			// CAS keys never stored a groupID, which v7 requires.
+			filestore.Version7: {wantErr: filestore.ErrMissingKeyInfo},
 		},
 		{
 			filestore.UndefinedKeyVersion: {key: "PTFOO/GR7890/ac/2364854541/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309"},
@@ -206,6 +235,7 @@ func TestMigration(t *testing.T) {
 			filestore.Version4:            {key: "PTFOO/GR00000000000000007890/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/1/ac/2364854541/v4"},
 			filestore.Version5:            {key: "PTFOO/8d35507f8943fa0242206a2077054c0ead9c71ba9f5d01c6b7f3578c6d4ba464/1/ac/v5"},
 			filestore.Version6:            {key: "PTFOO/8d35507f8943fa0242206a2077054c0ead9c71ba9f5d01c6b7f3578c6d4ba464/1/ac/v6"},
+			filestore.Version7:            {key: "PTFOO/GR00000000000000007890/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/1/ac/2364854541/v7", unmigratableFrom: []filestore.PebbleKeyVersion{filestore.Version5, filestore.Version6}},
 		},
 		{
 			filestore.UndefinedKeyVersion: {key: "PTdefault/GR7890/ac/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f"},
@@ -215,6 +245,7 @@ func TestMigration(t *testing.T) {
 			filestore.Version4:            {key: "PTdefault/GR00000000000000007890/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f/1/ac/0/v4"},
 			filestore.Version5:            {key: "PTdefault/1e664dcc33e701dc7d59472f93f110159ca128b5e52e4e849d6eefeb4bda7f72/1/ac/v5"},
 			filestore.Version6:            {key: "PTdefault/1e664dcc33e701dc7d59472f93f110159ca128b5e52e4e849d6eefeb4bda7f72/1/ac/v6"},
+			filestore.Version7:            {key: "PTdefault/GR00000000000000007890/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f/1/ac/0/v7", unmigratableFrom: []filestore.PebbleKeyVersion{filestore.Version5, filestore.Version6}},
 		},
 		{
 			filestore.UndefinedKeyVersion: {key: "PTdefault/ANON/ac/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f"},
@@ -224,6 +255,7 @@ func TestMigration(t *testing.T) {
 			filestore.Version4:            {key: "PTdefault/GR74042147050500190371/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f/1/ac/0/v4"},
 			filestore.Version5:            {key: "PTdefault/4929cde6f4c93cd5ab0ffde947e7e5da09bdb0677057c2ae7ea75b083c67feaa/1/ac/v5"},
 			filestore.Version6:            {key: "PTdefault/4929cde6f4c93cd5ab0ffde947e7e5da09bdb0677057c2ae7ea75b083c67feaa/1/ac/v6"},
+			filestore.Version7:            {key: "PTdefault/GR74042147050500190371/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f/1/ac/0/v7", unmigratableFrom: []filestore.PebbleKeyVersion{filestore.Version5, filestore.Version6}},
 		},
 	}
 
@@ -245,6 +277,12 @@ func TestMigration(t *testing.T) {
 					expected, ok := tc[version]
 					if !ok {
 						t.Fatalf("Please add test exemplars for pebble key version: %d", version)
+					}
+					// A target may be unreachable from certain sources (see
+					// result.unmigratableFrom); from those, expect the lossy error
+					// rather than the key.
+					if slices.Contains(expected.unmigratableFrom, startingVersion) {
+						expected = result{wantErr: filestore.ErrMissingKeyInfo}
 					}
 					versionedKey, err := parsedKey.Bytes(version)
 					if expected.wantErr == nil {
@@ -426,5 +464,82 @@ func TestVersion5(t *testing.T) {
 		// CAS w/ encryption
 		fr.Encryption = &sgpb.Encryption{KeyId: "EK456"}
 		assert.Equal(t, "PTfoo/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/1/cas/EK456/v5", formatKey(t, fr, filestore.Version5))
+	}
+}
+
+func TestVersion7(t *testing.T) {
+	partitionID := "foo"
+	groupID := "GR123"
+	fixedGroupID := "GR00000000000000000123"
+	d := &repb.Digest{Hash: "647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309", SizeBytes: 123}
+
+	// AC: group-prefixed, real digest preserved.
+	{
+		// AC w/o instance name (rih defaults to "0").
+		fr := &sgpb.FileRecord{
+			Isolation: &sgpb.Isolation{
+				CacheType:          rspb.CacheType_AC,
+				RemoteInstanceName: "",
+				PartitionId:        partitionID,
+				GroupId:            groupID,
+			},
+			Digest:         d,
+			DigestFunction: repb.DigestFunction_SHA256,
+		}
+		assert.Equal(t, "PTfoo/"+fixedGroupID+"/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/1/ac/0/v7", formatKey(t, fr, filestore.Version7))
+
+		// AC w/ instance name.
+		fr.Isolation.RemoteInstanceName = "remote_instance_name"
+		assert.Equal(t, "PTfoo/"+fixedGroupID+"/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/1/ac/2364854541/v7", formatKey(t, fr, filestore.Version7))
+
+		// AC w/ instance name & encryption.
+		fr.Encryption = &sgpb.Encryption{KeyId: "EK456"}
+		assert.Equal(t, "PTfoo/"+fixedGroupID+"/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/1/ac/2364854541/EK456/v7", formatKey(t, fr, filestore.Version7))
+	}
+
+	// CAS: unlike v5/v6, the groupID is a literal, recoverable prefix.
+	{
+		fr := &sgpb.FileRecord{
+			Isolation: &sgpb.Isolation{
+				CacheType:   rspb.CacheType_CAS,
+				PartitionId: partitionID,
+				GroupId:     groupID,
+			},
+			Digest:         d,
+			DigestFunction: repb.DigestFunction_SHA256,
+		}
+		casKey := "PTfoo/" + fixedGroupID + "/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/1/cas/v7"
+		assert.Equal(t, casKey, formatKey(t, fr, filestore.Version7))
+
+		// CAS w/ encryption
+		fr.Encryption = &sgpb.Encryption{KeyId: "EK456"}
+		assert.Equal(t, "PTfoo/"+fixedGroupID+"/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/1/cas/EK456/v7", formatKey(t, fr, filestore.Version7))
+
+		// The groupID must be recoverable from a parsed CAS key (the property
+		// v5/v6 gave up and that group-weighted sampling depends on).
+		var parsed filestore.PebbleKey
+		version, err := parsed.FromBytes([]byte(casKey))
+		require.NoError(t, err)
+		assert.Equal(t, filestore.Version7, version)
+		reSerialized, err := parsed.Bytes(filestore.Version7)
+		require.NoError(t, err)
+		assert.Equal(t, casKey, string(reSerialized))
+	}
+
+	// A v7 key cannot be created without a groupID (true for CAS as well as AC).
+	{
+		fr := &sgpb.FileRecord{
+			Isolation: &sgpb.Isolation{
+				CacheType:   rspb.CacheType_CAS,
+				PartitionId: partitionID,
+			},
+			Digest:         d,
+			DigestFunction: repb.DigestFunction_SHA256,
+		}
+		fs := filestore.New()
+		key, err := fs.PebbleKey(fr)
+		require.NoError(t, err)
+		_, err = key.Bytes(filestore.Version7)
+		assert.ErrorIs(t, err, filestore.ErrMissingKeyInfo)
 	}
 }

--- a/enterprise/server/raft/metadata/metadata.go
+++ b/enterprise/server/raft/metadata/metadata.go
@@ -367,7 +367,7 @@ func (rc *Server) fileMetadataKey(fr *sgpb.FileRecord) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return pebbleKey.Bytes(filestore.Version6)
+	return pebbleKey.Bytes(filestore.Version7)
 }
 
 func (rc *Server) fileRecordsToKeyMetas(fileRecords []*sgpb.FileRecord) ([]*sender.KeyMeta, error) {

--- a/enterprise/server/raft/metadata/metadata_test.go
+++ b/enterprise/server/raft/metadata/metadata_test.go
@@ -480,13 +480,11 @@ func TestLRU(t *testing.T) {
 	// and (2) stale-atime samples making recently-Find()'d records appear
 	// old enough to evict.
 	flags.Set(t, "cache.raft.min_eviction_age", 18*time.Minute)
-	// Read a small batch forward per range visit instead of a huge one, so the
-	// sampler rotates ranges and reaches the last few eligible records quickly.
+	// Small batch so the sampler rotates ranges and reaches the last eligible
+	// records quickly.
 	flags.Set(t, "cache.raft.samples_per_range", 10)
-	// The sampler reuses one iterator and refreshes it on this period; the
-	// sampler goroutine starts before this test writes its records, so keep the
-	// refresh short (wall time) so the iterator picks up the writes and current
-	// atimes promptly instead of sampling an empty/stale snapshot.
+	// Short refresh (wall time) so the reused iterator promptly picks up writes,
+	// atime updates, and deletions instead of re-sampling a stale snapshot.
 	flags.Set(t, "cache.raft.sampler_iter_refresh_period", time.Millisecond)
 	// Disable the sampler's idle sleep. In production the sampler sleeps when
 	// it can't find an eligible entry (e.g. a random key landing past the end

--- a/enterprise/server/raft/metadata/metadata_test.go
+++ b/enterprise/server/raft/metadata/metadata_test.go
@@ -41,7 +41,7 @@ import (
 )
 
 var (
-	userMap = testauth.TestUsers("user1", "group1", "user2", "group2")
+	userMap = testauth.TestUsers("user1", "GR1", "user2", "GR2")
 )
 
 type testConfig struct {
@@ -244,7 +244,7 @@ func TestGetAndSet(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := 0; i < 10; i++ {
-		md := randomFileMetadata(t, 100, "group1")
+		md := randomFileMetadata(t, 100, "GR1")
 
 		// Should be able to Set a record.
 		_, err := rc1.Set(ctxUser1, &mdpb.SetRequest{
@@ -272,7 +272,7 @@ func TestGetAndSet(t *testing.T) {
 		// User 2 should not be able to fetch User 1's record even when setting to
 		// its own group id.
 		fr2 := md.GetFileRecord().CloneVT()
-		fr2.GetIsolation().GroupId = "group2"
+		fr2.GetIsolation().GroupId = "GR2"
 		getRsp, err = rc1.Get(ctxUser2, &mdpb.GetRequest{
 			FileRecords: []*sgpb.FileRecord{fr2},
 		})
@@ -480,13 +480,14 @@ func TestLRU(t *testing.T) {
 	// and (2) stale-atime samples making recently-Find()'d records appear
 	// old enough to evict.
 	flags.Set(t, "cache.raft.min_eviction_age", 18*time.Minute)
-	// Read a small batch forward per random seek instead of refreshing the
-	// iterator on every single read. The records this test evicts (18-24) are
-	// never Find()'d, so their atimes are set once and never change -- a short
-	// batch keeps them fresh while avoiding the per-record db.NewIter churn
-	// that, under the race detector, starves the evictor and makes the sampler
-	// take far too long to randomly land on the last few eligible records.
-	flags.Set(t, "cache.raft.samples_per_batch", 10)
+	// Read a small batch forward per range visit instead of a huge one, so the
+	// sampler rotates ranges and reaches the last few eligible records quickly.
+	flags.Set(t, "cache.raft.samples_per_range", 10)
+	// The sampler reuses one iterator and refreshes it on this period; the
+	// sampler goroutine starts before this test writes its records, so keep the
+	// refresh short (wall time) so the iterator picks up the writes and current
+	// atimes promptly instead of sampling an empty/stale snapshot.
+	flags.Set(t, "cache.raft.sampler_iter_refresh_period", time.Millisecond)
 	// Disable the sampler's idle sleep. In production the sampler sleeps when
 	// it can't find an eligible entry (e.g. a random key landing past the end
 	// of a small partition) to avoid wasting CPU. That sleep uses the fake

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"maps"
 	"math"
+	"math/rand"
 	"net"
 	"os"
 	"path/filepath"
@@ -403,7 +404,7 @@ func New(env environment.Env, cfg *raftConfig.ServerConfig, opts ...Option) (*St
 	txnCoordinator := txn.NewCoordinator(s, apiClient, clock)
 	s.txnCoordinator = txnCoordinator
 
-	usages, err := usagetracker.New(s.sender, s.leaser, cfg.GossipManager, s.NodeDescriptor(), cfg.Partitions, clock, cfg.FileStorer)
+	usages, err := usagetracker.New(s, s.sender, s.leaser, cfg.GossipManager, s.NodeDescriptor(), cfg.Partitions, clock, cfg.FileStorer)
 
 	if *enableDriver {
 		s.driverQueue = driver.NewQueue(s, s.sender, cfg.GossipManager, nhLog, apiClient, clock, env.GetExperimentFlagProvider())
@@ -1682,6 +1683,65 @@ func (s *Store) getLeasedReplicas(ctx context.Context) []*replica.Replica {
 		res = append(res, r)
 	}
 	return res
+}
+
+// RandomOpenRangeDescriptor returns a uniformly random range this store hosts
+// (as leader or follower) whose data lives in the given partition, or nil if
+// this store hosts no ranges for that partition. Used by the eviction sampler,
+// which samples node-wide: scoping to hosted (not just leased) ranges keeps
+// each range sampled by all its replicas (as today) and avoids tying the
+// sampling rate to the lease distribution.
+func (s *Store) RandomOpenRangeDescriptor(partitionID string) *rfpb.RangeDescriptor {
+	s.rangeMu.RLock()
+	defer s.rangeMu.RUnlock()
+	// Reservoir sample (Algorithm R, reservoir size 1): pick the n-th eligible
+	// range with probability 1/n, which leaves every range equally likely (1/N)
+	// in a single pass, without materializing a filtered slice.
+	var chosen *rfpb.RangeDescriptor
+	n := 0
+	for _, rd := range s.openRanges {
+		if !rangeInPartition(rd, partitionID) {
+			continue
+		}
+		n++
+		if rand.Intn(n) == 0 {
+			chosen = rd
+		}
+	}
+	return chosen
+}
+
+// rangeInPartition reports whether rd holds evictable cache data in the given
+// partition: not the meta range (which holds range descriptors, not cache data,
+// and must never be evicted), and matching the partition. It prefers the
+// descriptor's partition_id and falls back to parsing the start key for
+// descriptors that predate the field (see the alert in validatedRange).
+func rangeInPartition(rd *rfpb.RangeDescriptor, partitionID string) bool {
+	if rd.GetRangeId() == constants.MetaRangeID {
+		return false
+	}
+	partID := rd.GetPartitionId()
+	if partID == "" {
+		partID = keys.PartitionIDFromRangeStart(rd.GetStart())
+	}
+	return partID == partitionID
+}
+
+// HostedRangeIDs returns the set of range IDs this store hosts (as leader or
+// follower) whose data lives in the given partition, excluding the meta range.
+// Used by the eviction sampler to prune resume cursors for ranges it no longer
+// hosts.
+func (s *Store) HostedRangeIDs(partitionID string) map[uint64]struct{} {
+	s.rangeMu.RLock()
+	defer s.rangeMu.RUnlock()
+	ids := make(map[uint64]struct{}, len(s.openRanges))
+	for _, rd := range s.openRanges {
+		if !rangeInPartition(rd, partitionID) {
+			continue
+		}
+		ids[rd.GetRangeId()] = struct{}{}
+	}
+	return ids
 }
 
 func (s *Store) StartShard(ctx context.Context, req *rfpb.StartShardRequest) (*rfpb.StartShardResponse, error) {

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -1686,17 +1686,14 @@ func (s *Store) getLeasedReplicas(ctx context.Context) []*replica.Replica {
 }
 
 // RandomOpenRangeDescriptor returns a uniformly random range this store hosts
-// (as leader or follower) whose data lives in the given partition, or nil if
-// this store hosts no ranges for that partition. Used by the eviction sampler,
-// which samples node-wide: scoping to hosted (not just leased) ranges keeps
-// each range sampled by all its replicas (as today) and avoids tying the
-// sampling rate to the lease distribution.
+// (leader or follower) whose data lives in the given partition, or nil if none.
+// Used by the eviction sampler; scoping to hosted (not leased) ranges keeps the
+// sampling rate independent of lease distribution.
 func (s *Store) RandomOpenRangeDescriptor(partitionID string) *rfpb.RangeDescriptor {
 	s.rangeMu.RLock()
 	defer s.rangeMu.RUnlock()
-	// Reservoir sample (Algorithm R, reservoir size 1): pick the n-th eligible
-	// range with probability 1/n, which leaves every range equally likely (1/N)
-	// in a single pass, without materializing a filtered slice.
+	// Reservoir sample (Algorithm R, size 1): pick the n-th eligible range with
+	// probability 1/n, leaving every range equally likely in a single pass.
 	var chosen *rfpb.RangeDescriptor
 	n := 0
 	for _, rd := range s.openRanges {
@@ -1711,11 +1708,9 @@ func (s *Store) RandomOpenRangeDescriptor(partitionID string) *rfpb.RangeDescrip
 	return chosen
 }
 
-// rangeInPartition reports whether rd holds evictable cache data in the given
-// partition: not the meta range (which holds range descriptors, not cache data,
-// and must never be evicted), and matching the partition. It prefers the
-// descriptor's partition_id and falls back to parsing the start key for
-// descriptors that predate the field (see the alert in validatedRange).
+// rangeInPartition reports whether rd holds evictable data in the partition:
+// not the meta range, and partition-matching. Prefers partition_id, falling
+// back to the start key for descriptors that predate the field.
 func rangeInPartition(rd *rfpb.RangeDescriptor, partitionID string) bool {
 	if rd.GetRangeId() == constants.MetaRangeID {
 		return false
@@ -1727,10 +1722,8 @@ func rangeInPartition(rd *rfpb.RangeDescriptor, partitionID string) bool {
 	return partID == partitionID
 }
 
-// HostedRangeIDs returns the set of range IDs this store hosts (as leader or
-// follower) whose data lives in the given partition, excluding the meta range.
-// Used by the eviction sampler to prune resume cursors for ranges it no longer
-// hosts.
+// HostedRangeIDs returns the range IDs this store hosts in the given partition
+// (excluding the meta range), used by the sampler to prune stale resume cursors.
 func (s *Store) HostedRangeIDs(partitionID string) map[uint64]struct{} {
 	s.rangeMu.RLock()
 	defer s.rangeMu.RUnlock()

--- a/enterprise/server/raft/usagetracker/BUILD
+++ b/enterprise/server/raft/usagetracker/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -31,5 +31,26 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_x_sync//errgroup",
         "@org_golang_x_sync//semaphore",
+    ],
+)
+
+go_test(
+    name = "usagetracker_test",
+    srcs = ["usagetracker_test.go"],
+    embed = [":usagetracker"],
+    deps = [
+        "//enterprise/server/filestore",
+        "//enterprise/server/util/pebble",
+        "//proto:raft_go_proto",
+        "//proto:resource_go_proto",
+        "//proto:storage_go_proto",
+        "//server/testutil/testdigest",
+        "//server/testutil/testfs",
+        "//server/util/approxlru",
+        "//server/util/disk",
+        "@com_github_cockroachdb_pebble//:pebble",
+        "@com_github_jonboulle_clockwork//:clockwork",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/raft/usagetracker/usagetracker.go
+++ b/enterprise/server/raft/usagetracker/usagetracker.go
@@ -1,6 +1,7 @@
 package usagetracker
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"flag"
@@ -43,14 +44,14 @@ var (
 	partitionUsageDeltaGossipThreshold = flag.Int("cache.raft.partition_usage_delta_bytes_threshold", 100e6, "Gossip partition usage information if it has changed by more than this amount since the last gossip.")
 	localSizeUpdatePeriod              = flag.Duration("cache.raft.local_size_update_period", 10*time.Second, "How often we update local size updates.")
 	samplesPerEviction                 = flag.Int("cache.raft.samples_per_eviction", 20, "How many records to sample on each eviction")
-	samplesPerBatch                    = flag.Int("cache.raft.samples_per_batch", 10000, "How many keys we read forward every time we get a random key.")
+	samplesPerRange                    = flag.Int("cache.raft.samples_per_range", 10000, "How many keys the eviction sampler reads forward on each range visit.")
 	samplePoolSize                     = flag.Int("cache.raft.sample_pool_size", 500, "How many deletion candidates to maintain between evictions")
 	sampleBufferSize                   = flag.Int("cache.raft.sample_buffer_size", 100, "Buffer up to this many samples for eviction sampling")
 	deletesPerEviction                 = flag.Int("cache.raft.deletes_per_eviction", 5, "Maximum number keys to delete in one eviction attempt before resampling.")
 	evictionRateLimit                  = flag.Int("cache.raft.eviction_rate_limit", 300, "Maximum number of entries to evict per second (per partition).")
 	deleteBufferSize                   = flag.Int("cache.raft.delete_buffer_size", 20, "Buffer up to this many samples for eviction eviction")
 	minEvictionAge                     = flag.Duration("cache.raft.min_eviction_age", 6*time.Hour, "Don't evict anything unless it's been idle for at least this long")
-	samplerIterRefreshPeriod           = flag.Duration("cache.raft.sampler_iter_refresh_peroid", 5*time.Minute, "How often we refresh iterator in sampler")
+	samplerIterRefreshPeriod           = flag.Duration("cache.raft.sampler_iter_refresh_period", 5*time.Minute, "How often the eviction sampler recreates its (reused) pebble iterator so it observes newly written keys and freshened atimes.")
 	samplerSleepDuration               = flag.Duration("cache.raft.sampler_sleep_duration", 1*time.Second, "How long the eviction sampler sleeps when it cannot find eligible entries to evict. Set to 0 to disable sleeping (intended for tests).")
 	evictionBatchSize                  = flag.Int("cache.raft.eviction_batch_size", 100, "Buffer this many writes before delete")
 	numDeleteWorkers                   = flag.Int("cache.raft.num_delete_worker", 4, "Number of deletes in parallel")
@@ -76,7 +77,31 @@ const (
 	samplerSleepThreshold = float64(0.2)
 	evictFlushPeriod      = 10 * time.Second
 	metricsRefreshPeriod  = 30 * time.Second
+
+	// maxEmptyRangeStreak is how many consecutive empty range selections the
+	// range-scoped sampler tolerates before backing off. A few empty ranges
+	// among populated ones are skipped cheaply; a node hosting only empty
+	// ranges (while the cluster-wide sleep guard doesn't fire) backs off after
+	// this many, rather than busy-spinning a core.
+	maxEmptyRangeStreak = 10
+
+	// cursorReconcileInterval is how many sampler batches elapse between passes
+	// that drop resume cursors for ranges this node no longer hosts. Range IDs
+	// are never reused, so without this the cursor map would grow for every
+	// range removed (merge/split/rebalance) over the life of the process.
+	cursorReconcileInterval = 1000
 )
+
+// IStore is the subset of the raft store the tracker needs, defined in the
+// consumer to avoid a tracker->store import cycle.
+type IStore interface {
+	// RandomOpenRangeDescriptor returns a uniformly random range this store
+	// hosts (leader or follower) in the given partition, or nil if none.
+	RandomOpenRangeDescriptor(partitionID string) *rfpb.RangeDescriptor
+	// HostedRangeIDs returns the set of range IDs this store hosts in the given
+	// partition (excluding the meta range). Used to prune stale resume cursors.
+	HostedRangeIDs(partitionID string) map[uint64]struct{}
+}
 
 type Tracker struct {
 	gossipManager interfaces.GossipService
@@ -129,6 +154,7 @@ type metricSet struct {
 type partitionUsage struct {
 	part disk.Partition
 
+	store    IStore
 	dbGetter pebble.Leaser
 	sender   *sender.Sender
 	clock    clockwork.Clock
@@ -154,15 +180,22 @@ type partitionUsage struct {
 
 	sizeBytes int64
 
-	samplesPerBatch          int
+	samplesPerRange          int
 	samplerIterRefreshPeriod time.Duration
 	samplerSleepDuration     time.Duration
-	minEvictionAge           time.Duration
-	localSizeUpdatePeriod    time.Duration
-	evictionBatchSize        int
-	numDeleteWorkers         int
-	numGCSDeleteWorkers      int
-	fileStorer               filestore.Store
+
+	// cursors tracks, per range, the next key to resume sampling from. Each
+	// range is swept in a circle: a random entry key when the cursor is empty
+	// (a fresh start or a restart), then forward, wrapping at the range end back
+	// to the range start. Pruned periodically against the store's hosted ranges
+	// (see reconcileCursors) since range IDs are never reused.
+	cursors               map[uint64][]byte
+	minEvictionAge        time.Duration
+	localSizeUpdatePeriod time.Duration
+	evictionBatchSize     int
+	numDeleteWorkers      int
+	numGCSDeleteWorkers   int
+	fileStorer            filestore.Store
 
 	metrics metricSet
 }
@@ -421,17 +454,6 @@ func (pu *partitionUsage) startSampleGenerator(ctx context.Context) {
 	close(pu.samples)
 }
 
-var digestRunes = []rune("abcdef1234567890")
-
-func (pu *partitionUsage) randomKey(n int) []byte {
-	var randKey strings.Builder
-	randKey.WriteString(pu.partitionKeyPrefix() + "/")
-	for i := 0; i < n; i++ {
-		randKey.WriteString(string(digestRunes[rand.Intn(len(digestRunes))]))
-	}
-	return []byte(randKey.String())
-}
-
 // samplerSleep pauses the sampler for the configured sleep duration to avoid
 // busy-looping when there is nothing useful to sample. It returns false if the
 // context was cancelled.
@@ -454,90 +476,218 @@ func (pu *partitionUsage) generateSamplesForEviction(ctx context.Context) error 
 		return err
 	}
 	defer db.Close()
-	start, end := keys.Range([]byte(pu.partitionKeyPrefix() + "/"))
-	iterCreatedAt := time.Now()
-	iter, err := db.NewIter(&pebble.IterOptions{LowerBound: start, UpperBound: end})
+
+	return pu.generateSamplesRangeScoped(ctx, db)
+}
+
+// generateSamplesRangeScoped samples eviction candidates by picking a hosted
+// range uniformly and sweeping its keys with a per-range resume cursor so every
+// key is sampled over successive visits. Each range is swept in a circle: it
+// enters at a random key (built from the range bounds by randomKeyInRange) when
+// the cursor is empty, then reads forward, wrapping at the range end back to
+// the range start. The cursor lives only in memory, so "empty" means a fresh
+// start or a restart — entering randomly there keeps the head from being
+// over-sampled across restarts, while the wrap-to-start keeps coverage complete
+// within a run. (A plain random-key seek can't stand alone here: a range spans
+// the whole hash band it was provisioned for, but v7 keys cluster under a
+// shared group prefix, so on a loose range randomKeyInRange lands ~at the head
+// and the sweep supplies the coverage.) Sampling is node-wide (all hosted
+// ranges, leader or follower).
+func (pu *partitionUsage) generateSamplesRangeScoped(ctx context.Context, db pebble.IPebbleDB) error {
+	// One partition-wide iterator, reused across range visits (SeekGE repositions
+	// it) and recreated only on the refresh period below — far less NewIter churn
+	// than recreating per visit, which matters most at a small samplesPerRange.
+	partStart, partEnd := keys.Range([]byte(pu.partitionKeyPrefix() + "/"))
+	iter, err := db.NewIter(&pebble.IterOptions{LowerBound: partStart, UpperBound: partEnd})
 	if err != nil {
 		return err
 	}
-	// We update the iter variable later on, so we need to wrap the Close call
-	// in a func to operate on the correct iterator instance.
 	defer func() {
-		iter.Close()
+		if iter != nil {
+			iter.Close()
+		}
 	}()
+	iterCreatedAt := time.Now()
 
-	leftInBatch := pu.samplesPerBatch
 	fileMetadata := sgpb.FileMetadataFromVTPool()
 	defer fileMetadata.ReturnToVTPool()
 
 	timer := pu.clock.NewTimer(0)
 	defer timer.Stop()
 
-	// Files are kept in random order (because they are keyed by digest), so
-	// instead of doing a new seek for every random sample we will seek once
-	// and just read forward, yielding digests until we've found enough.
+	emptyStreak := 0
+	reconcile := 0
+
 	for {
 		if ctx.Err() != nil {
 			return nil
 		}
 
-		// When we started to populate a cache, we cannot find any eligible
-		// entries to evict. We will sleep for some time to prevent from
-		// constantly generating samples in vain.
-		globalSize := pu.GlobalSizeBytes()
-		shouldSleep := globalSize <= int64(samplerSleepThreshold*float64(pu.part.MaxSizeBytes))
-		if shouldSleep {
-			if !pu.samplerSleep(ctx) {
-				return nil
-			}
+		// Periodically drop cursors for ranges this node no longer hosts, so the
+		// map can't grow without bound as ranges are removed.
+		if reconcile++; reconcile >= cursorReconcileInterval {
+			reconcile = 0
+			pu.reconcileCursors()
 		}
 
-		// Refresh the iterator once a while
-		if leftInBatch <= 0 || time.Since(iterCreatedAt) > pu.samplerIterRefreshPeriod {
-			leftInBatch = pu.samplesPerBatch
-			iterCreatedAt = time.Now()
-			// This iterator won't be positioned (Valid() will return false),
-			// so we will position it below.
-			newIter, err := db.NewIter(&pebble.IterOptions{LowerBound: start, UpperBound: end})
+		// Refresh the reused iterator once it ages past the refresh period so it
+		// observes writes and atime updates made since it was created. Wall time
+		// (not pu.clock) so it fires even under a frozen test clock.
+		if time.Since(iterCreatedAt) > pu.samplerIterRefreshPeriod {
+			newIter, err := db.NewIter(&pebble.IterOptions{LowerBound: partStart, UpperBound: partEnd})
 			if err != nil {
 				return err
 			}
 			iter.Close()
 			iter = newIter
+			iterCreatedAt = time.Now()
 		}
-		leftInBatch--
-		if !iter.Valid() {
-			// This happens when we create a new iterator or exhaust the
-			// existing one.
-			randomKey := pu.randomKey(64)
-			if valid := iter.SeekGE(randomKey); !valid {
-				// This is a probabilistic sleep. A partition with no rows on
-				// this node will always sleep. A partition with many rows is
-				// very unlikely to sleep. This ensures that we don't waste CPU
-				// cycles trying to find samples for a partition with no (or
-				// few) rows.
+
+		// Sleep while the partition is mostly empty to avoid busy-looping.
+		globalSize := pu.GlobalSizeBytes()
+		if globalSize <= int64(samplerSleepThreshold*float64(pu.part.MaxSizeBytes)) {
+			if !pu.samplerSleep(ctx) {
+				return nil
+			}
+		}
+
+		// Pick a random hosted range in this partition. The store owns
+		// selection, so it always reflects the current range set (splits and
+		// merges included) without the tracker caching a stale list.
+		rd := pu.store.RandomOpenRangeDescriptor(pu.part.ID)
+		if rd == nil {
+			// No ranges hosted for this partition yet; sleep and re-check.
+			if !pu.samplerSleep(ctx) {
+				return nil
+			}
+			continue
+		}
+		start, end := rd.GetStart(), rd.GetEnd()
+
+		// Resume sweeping from where the last visit left off. When the cursor is
+		// empty (a fresh start or a restart) enter at a random key so the head
+		// isn't over-sampled; otherwise resume from the saved position.
+		resume := pu.cursors[rd.GetRangeId()]
+		if len(resume) == 0 || bytes.Compare(resume, start) < 0 || bytes.Compare(resume, end) >= 0 {
+			resume = randomKeyInRange(start, end)
+		}
+		valid := iter.SeekGE(resume)
+		// The iterator spans the whole partition, so a seek can land past this
+		// range's end: a random-entry overshoot, or a resume cursor pointing past
+		// keys deleted since the last visit. Neither means the range is empty —
+		// wrap to the range start before giving up on it.
+		if (!valid || bytes.Compare(iter.Key(), end) >= 0) && bytes.Compare(resume, start) > 0 {
+			valid = iter.SeekGE(start)
+		}
+
+		// Read forward up to samplesPerRange keys, stopping at the range end (the
+		// iterator is bounded to the whole partition, not this range).
+		read := 0
+		for ; read < pu.samplesPerRange && valid && bytes.Compare(iter.Key(), end) < 0; read++ {
+			if ctx.Err() != nil {
+				return nil
+			}
+			var key filestore.PebbleKey
+			if _, err := key.FromBytes(iter.Key()); err != nil {
+				log.Warningf("cannot generate sample for eviction, skipping: failed to read key: %s", err)
+				valid = iter.Next()
+				continue
+			}
+			fileMetadata.ResetVT()
+			if err := fileMetadata.UnmarshalVT(iter.Value()); err != nil {
+				log.Warningf("cannot generate sample for eviction, skipping: failed to read proto: %s", err)
+				valid = iter.Next()
+				continue
+			}
+			pu.maybeAddToSampleChan(ctx, iter, fileMetadata, timer)
+			valid = iter.Next()
+		}
+
+		// Remember where to resume next visit. On reaching the range end, wrap to
+		// the range start (head) rather than deleting the cursor: within a run we
+		// keep sweeping head-anchored (which covers everything uniformly); only a
+		// restart, which clears the in-memory map, re-enters at a random key.
+		if valid && bytes.Compare(iter.Key(), end) < 0 {
+			pu.cursors[rd.GetRangeId()] = append([]byte(nil), iter.Key()...)
+		} else {
+			pu.cursors[rd.GetRangeId()] = append([]byte(nil), start...)
+		}
+
+		if read == 0 {
+			// Genuinely empty range (the retry from the range start above also
+			// found nothing). Skip cheaply, and only back off after a run of
+			// empty selections so isolated empty ranges don't stall eviction.
+			emptyStreak++
+			if emptyStreak >= maxEmptyRangeStreak {
 				if !pu.samplerSleep(ctx) {
 					return nil
 				}
-				leftInBatch = 0 // Force creating a new iterator
-				continue
+				emptyStreak = 0
 			}
-		}
-		var key filestore.PebbleKey
-		if _, err := key.FromBytes(iter.Key()); err != nil {
-			log.Warningf("cannot generate sample for eviction, skipping: failed to read key: %s", err)
 			continue
 		}
-		fileMetadata.ResetVT() // UnmarshalVT doesn't reset, unlike proto.Unmarshal.
-		err = fileMetadata.UnmarshalVT(iter.Value())
-		if err != nil {
-			log.Warningf("cannot generate sample for eviction, skipping: failed to read proto: %s", err)
-			continue
-		}
-
-		pu.maybeAddToSampleChan(ctx, iter, fileMetadata, timer)
-		iter.Next()
+		emptyStreak = 0
 	}
+}
+
+// reconcileCursors drops resume cursors for ranges this node no longer hosts.
+// Range IDs are never reused, so without this the cursor map would grow for
+// every range removed (merge, split, or rebalance) over the process lifetime.
+func (pu *partitionUsage) reconcileCursors() {
+	if len(pu.cursors) == 0 {
+		return
+	}
+	hosted := pu.store.HostedRangeIDs(pu.part.ID)
+	for id := range pu.cursors {
+		if _, ok := hosted[id]; !ok {
+			delete(pu.cursors, id)
+		}
+	}
+}
+
+// randomKeyInRange returns a key that sorts within (roughly) [start, end),
+// built from the range bounds so it lands where keys actually are — unlike a
+// random position in the raw byte range, which on a group-clustered v7 keyspace
+// falls in the empty gap and SeekGE snaps to the head.
+//
+// The common prefix of start and end is held fixed and randomization begins at
+// the first byte that differs. For a single-group range (bounds share the
+// PT/GR<group>/ prefix) that first differing byte is in the digest, which is
+// dense and uniform, so the result lands on a real key. For a multi-group range
+// it's in the group field; group IDs are uniform, so a random value there plus
+// SeekGE lands on a ~uniform real group. A draw that overshoots the range's
+// last key is the caller's problem (it falls back to the range start).
+//
+// It degrades to ~start when the bounds aren't group-structured (e.g. the
+// hex-band bringup ranges): the common prefix is just PT<part>/ and the random
+// byte sorts before the GR cluster. That's the loose-range case where the
+// caller's cursor sweep still guarantees coverage.
+func randomKeyInRange(start, end []byte) []byte {
+	n := 0
+	for n < len(start) && n < len(end) && start[n] == end[n] {
+		n++
+	}
+	if n >= len(end) {
+		// end is a prefix of start (or they're equal): nothing to randomize.
+		return append([]byte(nil), start...)
+	}
+	lo := byte(0x00)
+	if n < len(start) {
+		lo = start[n]
+	}
+	hi := end[n]
+	if lo > hi {
+		return append([]byte(nil), start...)
+	}
+	key := make([]byte, 0, n+9)
+	key = append(key, start[:n]...)
+	key = append(key, lo+byte(rand.Intn(int(hi-lo)+1)))
+	// A few random tail bytes so we don't always land on a prefix boundary.
+	var tail [8]byte
+	for i := range tail {
+		tail[i] = byte(rand.Intn(256))
+	}
+	return append(key, tail[:]...)
 }
 
 func (pu *partitionUsage) maybeAddToSampleChan(ctx context.Context, iter pebble.Iterator, fileMetadata *sgpb.FileMetadata, timer clockwork.Timer) {
@@ -623,7 +773,7 @@ func (pu *partitionUsage) updateMetrics() {
 	pu.metrics.evictionGCSChanSize.Set(float64(len(pu.gcsDeletes)))
 }
 
-func New(sender *sender.Sender, dbGetter pebble.Leaser, gossipManager interfaces.GossipService, node *rfpb.NodeDescriptor, partitions []disk.Partition, clock clockwork.Clock, fileStorer filestore.Store) (*Tracker, error) {
+func New(store IStore, sender *sender.Sender, dbGetter pebble.Leaser, gossipManager interfaces.GossipService, node *rfpb.NodeDescriptor, partitions []disk.Partition, clock clockwork.Clock, fileStorer filestore.Store) (*Tracker, error) {
 	ut := &Tracker{
 		gossipManager: gossipManager,
 		node:          node,
@@ -654,14 +804,16 @@ func New(sender *sender.Sender, dbGetter pebble.Leaser, gossipManager interfaces
 		}
 		u := &partitionUsage{
 			part:                     p,
+			store:                    store,
 			sender:                   sender,
 			clock:                    clock,
 			nodes:                    make(map[string]*nodePartitionUsage),
+			cursors:                  make(map[uint64][]byte),
 			dbGetter:                 dbGetter,
 			samples:                  make(chan *approxlru.Sample[*evictionKey], *sampleBufferSize),
 			deletes:                  make(chan *approxlru.Sample[*evictionKey], *deleteBufferSize),
 			gcsDeletes:               make(chan *sgpb.StorageMetadata_GCSMetadata, *gcsDeleteBufferSize),
-			samplesPerBatch:          *samplesPerBatch,
+			samplesPerRange:          *samplesPerRange,
 			samplerIterRefreshPeriod: *samplerIterRefreshPeriod,
 			samplerSleepDuration:     *samplerSleepDuration,
 			minEvictionAge:           *minEvictionAge,

--- a/enterprise/server/raft/usagetracker/usagetracker.go
+++ b/enterprise/server/raft/usagetracker/usagetracker.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"math"
+	"math/big"
 	"math/rand"
 	"sort"
 	"strings"
@@ -51,7 +52,7 @@ var (
 	evictionRateLimit                  = flag.Int("cache.raft.eviction_rate_limit", 300, "Maximum number of entries to evict per second (per partition).")
 	deleteBufferSize                   = flag.Int("cache.raft.delete_buffer_size", 20, "Buffer up to this many samples for eviction eviction")
 	minEvictionAge                     = flag.Duration("cache.raft.min_eviction_age", 6*time.Hour, "Don't evict anything unless it's been idle for at least this long")
-	samplerIterRefreshPeriod           = flag.Duration("cache.raft.sampler_iter_refresh_period", 5*time.Minute, "How often the eviction sampler recreates its (reused) pebble iterator so it observes newly written keys and freshened atimes.")
+	samplerIterRefreshPeriod           = flag.Duration("cache.raft.sampler_iter_refresh_period", 5*time.Minute, "How often the eviction sampler recreates its reused pebble iterator.")
 	samplerSleepDuration               = flag.Duration("cache.raft.sampler_sleep_duration", 1*time.Second, "How long the eviction sampler sleeps when it cannot find eligible entries to evict. Set to 0 to disable sleeping (intended for tests).")
 	evictionBatchSize                  = flag.Int("cache.raft.eviction_batch_size", 100, "Buffer this many writes before delete")
 	numDeleteWorkers                   = flag.Int("cache.raft.num_delete_worker", 4, "Number of deletes in parallel")
@@ -79,16 +80,13 @@ const (
 	metricsRefreshPeriod  = 30 * time.Second
 
 	// maxEmptyRangeStreak is how many consecutive empty range selections the
-	// range-scoped sampler tolerates before backing off. A few empty ranges
-	// among populated ones are skipped cheaply; a node hosting only empty
-	// ranges (while the cluster-wide sleep guard doesn't fire) backs off after
-	// this many, rather than busy-spinning a core.
+	// sampler tolerates before backing off, so a node hosting only empty ranges
+	// doesn't busy-spin.
 	maxEmptyRangeStreak = 10
 
-	// cursorReconcileInterval is how many sampler batches elapse between passes
-	// that drop resume cursors for ranges this node no longer hosts. Range IDs
-	// are never reused, so without this the cursor map would grow for every
-	// range removed (merge/split/rebalance) over the life of the process.
+	// cursorReconcileInterval is how many sampler visits between passes that drop
+	// cursors for ranges this node no longer hosts (range IDs are never reused,
+	// so the map would otherwise grow unbounded).
 	cursorReconcileInterval = 1000
 )
 
@@ -184,11 +182,9 @@ type partitionUsage struct {
 	samplerIterRefreshPeriod time.Duration
 	samplerSleepDuration     time.Duration
 
-	// cursors tracks, per range, the next key to resume sampling from. Each
-	// range is swept in a circle: a random entry key when the cursor is empty
-	// (a fresh start or a restart), then forward, wrapping at the range end back
-	// to the range start. Pruned periodically against the store's hosted ranges
-	// (see reconcileCursors) since range IDs are never reused.
+	// cursors holds, per range, the next key to resume sampling from. Pruned
+	// against the store's hosted ranges (see reconcileCursors) since range IDs
+	// are never reused.
 	cursors               map[uint64][]byte
 	minEvictionAge        time.Duration
 	localSizeUpdatePeriod time.Duration
@@ -481,22 +477,14 @@ func (pu *partitionUsage) generateSamplesForEviction(ctx context.Context) error 
 }
 
 // generateSamplesRangeScoped samples eviction candidates by picking a hosted
-// range uniformly and sweeping its keys with a per-range resume cursor so every
-// key is sampled over successive visits. Each range is swept in a circle: it
-// enters at a random key (built from the range bounds by randomKeyInRange) when
-// the cursor is empty, then reads forward, wrapping at the range end back to
-// the range start. The cursor lives only in memory, so "empty" means a fresh
-// start or a restart — entering randomly there keeps the head from being
-// over-sampled across restarts, while the wrap-to-start keeps coverage complete
-// within a run. (A plain random-key seek can't stand alone here: a range spans
-// the whole hash band it was provisioned for, but v7 keys cluster under a
-// shared group prefix, so on a loose range randomKeyInRange lands ~at the head
-// and the sweep supplies the coverage.) Sampling is node-wide (all hosted
-// ranges, leader or follower).
+// range uniformly (node-wide, any replica) and sweeping it in a circle: enter
+// at a random key when the cursor is empty (a fresh start/restart, since it's
+// in-memory), read forward, wrap at the range end back to start. Random entry
+// avoids over-sampling the head across restarts; the wrap keeps coverage
+// complete within a run.
 func (pu *partitionUsage) generateSamplesRangeScoped(ctx context.Context, db pebble.IPebbleDB) error {
-	// One partition-wide iterator, reused across range visits (SeekGE repositions
-	// it) and recreated only on the refresh period below — far less NewIter churn
-	// than recreating per visit, which matters most at a small samplesPerRange.
+	// One partition-wide iterator, reused across visits (SeekGE repositions it)
+	// and recreated only on the refresh period below, to avoid per-visit NewIter.
 	partStart, partEnd := keys.Range([]byte(pu.partitionKeyPrefix() + "/"))
 	iter, err := db.NewIter(&pebble.IterOptions{LowerBound: partStart, UpperBound: partEnd})
 	if err != nil {
@@ -530,9 +518,11 @@ func (pu *partitionUsage) generateSamplesRangeScoped(ctx context.Context, db peb
 			pu.reconcileCursors()
 		}
 
-		// Refresh the reused iterator once it ages past the refresh period so it
-		// observes writes and atime updates made since it was created. Wall time
-		// (not pu.clock) so it fires even under a frozen test clock.
+		// Refresh the snapshot periodically so it sees writes, atime updates, and
+		// deletions. Wall time (not pu.clock) on purpose: it must keep refreshing
+		// during eviction to stop re-sampling already-deleted keys, but eviction
+		// tests run under a frozen fake clock (TestingWaitForGC never advances
+		// it). Cost: the cadence isn't fake-clock-controllable.
 		if time.Since(iterCreatedAt) > pu.samplerIterRefreshPeriod {
 			newIter, err := db.NewIter(&pebble.IterOptions{LowerBound: partStart, UpperBound: partEnd})
 			if err != nil {
@@ -551,9 +541,8 @@ func (pu *partitionUsage) generateSamplesRangeScoped(ctx context.Context, db peb
 			}
 		}
 
-		// Pick a random hosted range in this partition. The store owns
-		// selection, so it always reflects the current range set (splits and
-		// merges included) without the tracker caching a stale list.
+		// Pick a random hosted range; the store owns selection, so it always
+		// reflects the current range set without the tracker caching a stale list.
 		rd := pu.store.RandomOpenRangeDescriptor(pu.part.ID)
 		if rd == nil {
 			// No ranges hosted for this partition yet; sleep and re-check.
@@ -564,24 +553,22 @@ func (pu *partitionUsage) generateSamplesRangeScoped(ctx context.Context, db peb
 		}
 		start, end := rd.GetStart(), rd.GetEnd()
 
-		// Resume sweeping from where the last visit left off. When the cursor is
-		// empty (a fresh start or a restart) enter at a random key so the head
-		// isn't over-sampled; otherwise resume from the saved position.
+		// Resume from the saved cursor, or enter at a random key on a fresh/empty
+		// cursor (avoids over-sampling the head).
 		resume := pu.cursors[rd.GetRangeId()]
 		if len(resume) == 0 || bytes.Compare(resume, start) < 0 || bytes.Compare(resume, end) >= 0 {
 			resume = randomKeyInRange(start, end)
 		}
 		valid := iter.SeekGE(resume)
-		// The iterator spans the whole partition, so a seek can land past this
-		// range's end: a random-entry overshoot, or a resume cursor pointing past
-		// keys deleted since the last visit. Neither means the range is empty —
-		// wrap to the range start before giving up on it.
-		if (!valid || bytes.Compare(iter.Key(), end) >= 0) && bytes.Compare(resume, start) > 0 {
+		// The iterator is partition-wide, so a seek can land outside [start, end)
+		// (random overshoot, stale cursor, or a randomKeyInRange draw below start);
+		// re-seek to start so the sweep stays range-local.
+		if !valid || bytes.Compare(iter.Key(), start) < 0 || bytes.Compare(iter.Key(), end) >= 0 {
 			valid = iter.SeekGE(start)
 		}
 
-		// Read forward up to samplesPerRange keys, stopping at the range end (the
-		// iterator is bounded to the whole partition, not this range).
+		// Read forward up to samplesPerRange keys, bounded on end (the seek above
+		// starts >= start and Next() only advances, so all keys stay in [start,end)).
 		read := 0
 		for ; read < pu.samplesPerRange && valid && bytes.Compare(iter.Key(), end) < 0; read++ {
 			if ctx.Err() != nil {
@@ -603,10 +590,9 @@ func (pu *partitionUsage) generateSamplesRangeScoped(ctx context.Context, db peb
 			valid = iter.Next()
 		}
 
-		// Remember where to resume next visit. On reaching the range end, wrap to
-		// the range start (head) rather than deleting the cursor: within a run we
-		// keep sweeping head-anchored (which covers everything uniformly); only a
-		// restart, which clears the in-memory map, re-enters at a random key.
+		// Save the resume point; at the range end wrap to start (head) rather than
+		// deleting, so we keep sweeping head-anchored within a run (a restart
+		// clears the map and re-enters randomly).
 		if valid && bytes.Compare(iter.Key(), end) < 0 {
 			pu.cursors[rd.GetRangeId()] = append([]byte(nil), iter.Key()...)
 		} else {
@@ -614,9 +600,8 @@ func (pu *partitionUsage) generateSamplesRangeScoped(ctx context.Context, db peb
 		}
 
 		if read == 0 {
-			// Genuinely empty range (the retry from the range start above also
-			// found nothing). Skip cheaply, and only back off after a run of
-			// empty selections so isolated empty ranges don't stall eviction.
+			// Empty range: back off only after a streak so isolated empties don't
+			// stall eviction.
 			emptyStreak++
 			if emptyStreak >= maxEmptyRangeStreak {
 				if !pu.samplerSleep(ctx) {
@@ -630,9 +615,8 @@ func (pu *partitionUsage) generateSamplesRangeScoped(ctx context.Context, db peb
 	}
 }
 
-// reconcileCursors drops resume cursors for ranges this node no longer hosts.
-// Range IDs are never reused, so without this the cursor map would grow for
-// every range removed (merge, split, or rebalance) over the process lifetime.
+// reconcileCursors drops cursors for ranges this node no longer hosts, bounding
+// the map (range IDs are never reused).
 func (pu *partitionUsage) reconcileCursors() {
 	if len(pu.cursors) == 0 {
 		return
@@ -645,49 +629,54 @@ func (pu *partitionUsage) reconcileCursors() {
 	}
 }
 
-// randomKeyInRange returns a key that sorts within (roughly) [start, end),
-// built from the range bounds so it lands where keys actually are — unlike a
-// random position in the raw byte range, which on a group-clustered v7 keyspace
-// falls in the empty gap and SeekGE snaps to the head.
+// randomKeyInRange returns a key ~uniform in [start, end) for the sweep's entry
+// point. It holds the common prefix fixed and interpolates the differing suffix
+// as a base-256 integer (full suffix width, so the result never falls outside
+// [start, end)); SeekGE then snaps to the next real key.
 //
-// The common prefix of start and end is held fixed and randomization begins at
-// the first byte that differs. For a single-group range (bounds share the
-// PT/GR<group>/ prefix) that first differing byte is in the digest, which is
-// dense and uniform, so the result lands on a real key. For a multi-group range
-// it's in the group field; group IDs are uniform, so a random value there plus
-// SeekGE lands on a ~uniform real group. A draw that overshoots the range's
-// last key is the caller's problem (it falls back to the range start).
-//
-// It degrades to ~start when the bounds aren't group-structured (e.g. the
-// hex-band bringup ranges): the common prefix is just PT<part>/ and the random
-// byte sorts before the GR cluster. That's the loose-range case where the
-// caller's cursor sweep still guarantees coverage.
+// Caution: this is uniform over byte space, not the real alphabets (decimal
+// group IDs, hex digests), so a draw in an alphabet gap (e.g. hex '9'..'a')
+// snaps forward and over-weights the next char. Fine here because it only picks
+// the entry point — the sweep still visits every key. A cursor-less sampler
+// would need field-aware interpolation.
 func randomKeyInRange(start, end []byte) []byte {
-	n := 0
-	for n < len(start) && n < len(end) && start[n] == end[n] {
-		n++
+	p := 0
+	for p < len(start) && p < len(end) && start[p] == end[p] {
+		p++
 	}
-	if n >= len(end) {
-		// end is a prefix of start (or they're equal): nothing to randomize.
+	// Full suffix width so padRight only zero-pads (never truncates), keeping the
+	// result >= start.
+	w := len(start) - p
+	if n := len(end) - p; n > w {
+		w = n
+	}
+	if w <= 0 {
 		return append([]byte(nil), start...)
 	}
-	lo := byte(0x00)
-	if n < len(start) {
-		lo = start[n]
-	}
-	hi := end[n]
-	if lo > hi {
+	lo := new(big.Int).SetBytes(padRight(start[p:], w))
+	hi := new(big.Int).SetBytes(padRight(end[p:], w))
+	delta := new(big.Int).Sub(hi, lo)
+	if delta.Sign() <= 0 {
 		return append([]byte(nil), start...)
 	}
-	key := make([]byte, 0, n+9)
-	key = append(key, start[:n]...)
-	key = append(key, lo+byte(rand.Intn(int(hi-lo)+1)))
-	// A few random tail bytes so we don't always land on a prefix boundary.
-	var tail [8]byte
-	for i := range tail {
-		tail[i] = byte(rand.Intn(256))
+	// Uniform in [lo, hi): draw w+8 bytes and reduce mod delta (bias negligible).
+	rb := make([]byte, w+8)
+	for i := range rb {
+		rb[i] = byte(rand.Intn(256))
 	}
-	return append(key, tail[:]...)
+	r := new(big.Int).Mod(new(big.Int).SetBytes(rb), delta)
+	r.Add(r, lo)
+	return append(append([]byte(nil), start[:p]...), r.FillBytes(make([]byte, w))...)
+}
+
+// padRight widens b to w bytes with trailing zeros (b is never longer than w).
+func padRight(b []byte, w int) []byte {
+	if len(b) >= w {
+		return b[:w]
+	}
+	out := make([]byte, w)
+	copy(out, b)
+	return out
 }
 
 func (pu *partitionUsage) maybeAddToSampleChan(ctx context.Context, iter pebble.Iterator, fileMetadata *sgpb.FileMetadata, timer clockwork.Timer) {

--- a/enterprise/server/raft/usagetracker/usagetracker_test.go
+++ b/enterprise/server/raft/usagetracker/usagetracker_test.go
@@ -37,7 +37,8 @@ func TestRandomKeyInRange(t *testing.T) {
 		lo, hi := byte(0xff), byte(0x00)
 		for i := 0; i < draws; i++ {
 			k := randomKeyInRange(start, end)
-			require.True(t, bytes.HasPrefix(k, gp), "key %q not under the group prefix", k)
+			require.True(t, bytes.Compare(k, start) >= 0 && bytes.Compare(k, end) < 0,
+				"key %q out of [%q, %q)", k, start, end)
 			// The byte just after the group prefix is the randomized digest nibble.
 			b := k[len(gp)]
 			if b < lo {
@@ -50,6 +51,23 @@ func TestRandomKeyInRange(t *testing.T) {
 		// Over 2000 draws it should cover most of ['2','8'], not a single value.
 		assert.Less(t, lo, byte('4'), "low end of digest range never sampled")
 		assert.Greater(t, hi, byte('6'), "high end of digest range never sampled")
+	})
+
+	// Narrow range (bounds differ only in the last byte, digest sub-slot 0..4):
+	// every draw must stay strictly in [start, end) and spread across the slots,
+	// not collapse to the head the way clamping out-of-range draws would.
+	t.Run("narrow_range_stays_in_bounds", func(t *testing.T) {
+		gp := []byte("PTFOO/" + filestore.FixedWidthGroupID("GR1") + "/")
+		start := append(append([]byte(nil), gp...), []byte("abcd000000000000000000000000000000000000000000000000000000000000")...)
+		end := append(append([]byte(nil), gp...), []byte("abcd000000000000000000000000000000000000000000000000000000000005")...)
+		seen := map[string]bool{}
+		for i := 0; i < draws; i++ {
+			k := randomKeyInRange(start, end)
+			require.True(t, bytes.Compare(k, start) >= 0 && bytes.Compare(k, end) < 0,
+				"key %q out of [%q, %q)", k, start, end)
+			seen[string(k)] = true
+		}
+		assert.Greater(t, len(seen), 1, "narrow range collapsed to a single key (head bias)")
 	})
 
 	// Multi-group range: bounds differ in the group field. Keys stay within the

--- a/enterprise/server/raft/usagetracker/usagetracker_test.go
+++ b/enterprise/server/raft/usagetracker/usagetracker_test.go
@@ -1,0 +1,215 @@
+package usagetracker
+
+import (
+	"bytes"
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/filestore"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/pebble"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/buildbuddy-io/buildbuddy/server/util/approxlru"
+	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pebblev1 "github.com/cockroachdb/pebble"
+
+	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
+	sgpb "github.com/buildbuddy-io/buildbuddy/proto/storage"
+)
+
+func TestRandomKeyInRange(t *testing.T) {
+	const draws = 2000
+
+	// Single-group range: bounds share PT/GR<group>/ and differ in the digest.
+	// randomKeyInRange should spread across the digest span (not stick to the
+	// head), because the first differing byte is dense/uniform hex.
+	t.Run("single_group_spreads_over_digests", func(t *testing.T) {
+		gp := []byte("PTFOO/" + filestore.FixedWidthGroupID("GR1") + "/")
+		start := append(append([]byte(nil), gp...), []byte("20000000")...)
+		end := append(append([]byte(nil), gp...), []byte("80000000")...)
+		lo, hi := byte(0xff), byte(0x00)
+		for i := 0; i < draws; i++ {
+			k := randomKeyInRange(start, end)
+			require.True(t, bytes.HasPrefix(k, gp), "key %q not under the group prefix", k)
+			// The byte just after the group prefix is the randomized digest nibble.
+			b := k[len(gp)]
+			if b < lo {
+				lo = b
+			}
+			if b > hi {
+				hi = b
+			}
+		}
+		// Over 2000 draws it should cover most of ['2','8'], not a single value.
+		assert.Less(t, lo, byte('4'), "low end of digest range never sampled")
+		assert.Greater(t, hi, byte('6'), "high end of digest range never sampled")
+	})
+
+	// Multi-group range: bounds differ in the group field. Keys stay within the
+	// group span and vary.
+	t.Run("multi_group_stays_in_group_span", func(t *testing.T) {
+		// Full group field is "PTFOO/" + 22-char GR id = 28 bytes.
+		groupFieldLen := len("PTFOO/") + len(filestore.FixedWidthGroupID("GR1"))
+		start := []byte("PTFOO/" + filestore.FixedWidthGroupID("GR1") + "/00000000")
+		end := []byte("PTFOO/" + filestore.FixedWidthGroupID("GR9") + "/ffffffff")
+		seen := map[string]bool{}
+		for i := 0; i < draws; i++ {
+			k := randomKeyInRange(start, end)
+			require.True(t, bytes.HasPrefix(k, []byte("PTFOO/GR")), "key %q lost the group prefix", k)
+			require.GreaterOrEqual(t, len(k), groupFieldLen)
+			seen[string(k[:groupFieldLen])] = true
+		}
+		assert.Greater(t, len(seen), 1, "group field never varied")
+	})
+
+	// Degenerate bounds must not panic and fall back to ~start.
+	t.Run("degenerate_bounds", func(t *testing.T) {
+		assert.NotPanics(t, func() { randomKeyInRange([]byte("PTx/"), []byte("PTx/")) })
+		assert.NotPanics(t, func() { randomKeyInRange([]byte("PTx/abc"), []byte("PTx/")) })
+		// end is a prefix of start → return start unchanged.
+		assert.Equal(t, "PTx/abc", string(randomKeyInRange([]byte("PTx/abc"), []byte("PTx/ab"))))
+	})
+}
+
+// writeKeys writes n CAS v7 keys under the given group and flushes. Range-scoped
+// sampling is layout-independent, but the sampled keys must still parse as
+// PebbleKeys, so we write real keys with random digests.
+func writeKeys(t *testing.T, dir, groupID string, n int) pebble.IPebbleDB {
+	db, err := pebble.Open(dir, "test", &pebblev1.Options{})
+	require.NoError(t, err)
+
+	fs := filestore.New()
+	md := &sgpb.FileMetadata{
+		LastAccessUsec:  1_000_000, // far in the past; passes minEvictionAge=0
+		StorageMetadata: &sgpb.StorageMetadata{},
+	}
+	val, err := md.MarshalVT()
+	require.NoError(t, err)
+
+	for i := 0; i < n; i++ {
+		rn, _ := testdigest.RandomCASResourceBuf(t, 1)
+		fr := &sgpb.FileRecord{
+			Isolation: &sgpb.Isolation{
+				CacheType:   rspb.CacheType_CAS,
+				PartitionId: "FOO",
+				GroupId:     groupID,
+			},
+			Digest:         rn.GetDigest(),
+			DigestFunction: rn.GetDigestFunction(),
+		}
+		pk, err := fs.PebbleKey(fr)
+		require.NoError(t, err)
+		keyBytes, err := pk.Bytes(filestore.Version7)
+		require.NoError(t, err)
+		require.NoError(t, db.Set(keyBytes, val, &pebblev1.WriteOptions{}))
+	}
+	require.NoError(t, db.Flush())
+	return db
+}
+
+type fakeStore struct{ rds []*rfpb.RangeDescriptor }
+
+// All test ranges are in partition FOO, so the partition filter is a no-op here.
+func (f *fakeStore) RandomOpenRangeDescriptor(partitionID string) *rfpb.RangeDescriptor {
+	if len(f.rds) == 0 {
+		return nil
+	}
+	return f.rds[rand.Intn(len(f.rds))]
+}
+
+func (f *fakeStore) HostedRangeIDs(partitionID string) map[uint64]struct{} {
+	ids := make(map[uint64]struct{}, len(f.rds))
+	for _, rd := range f.rds {
+		ids[rd.GetRangeId()] = struct{}{}
+	}
+	return ids
+}
+
+func newRangeTestPU(t *testing.T, db pebble.IPebbleDB, store IStore, samplesPerRange int) *partitionUsage {
+	leaser := pebble.NewDBLeaser(db)
+	t.Cleanup(func() {
+		leaser.Close()
+		db.Close()
+	})
+	return &partitionUsage{
+		part:     disk.Partition{ID: "FOO", MaxSizeBytes: 1 << 20},
+		store:    store,
+		dbGetter: leaser,
+		clock:    clockwork.NewRealClock(),
+		// GlobalSizeBytes (1<<40) stays above the sleep threshold
+		// (0.2 * MaxSizeBytes) so the sampler never sleeps and blocks the test.
+		nodes:   map[string]*nodePartitionUsage{"n1": {sizeBytes: 1 << 40}},
+		cursors: make(map[uint64][]byte),
+		samples: make(chan *approxlru.Sample[*evictionKey], 128),
+
+		samplesPerRange:          samplesPerRange,
+		samplerIterRefreshPeriod: time.Hour, // keys are written before sampling; no refresh needed
+		samplerSleepDuration:     time.Hour,
+		minEvictionAge:           0,
+	}
+}
+
+func rangeOf(ranges []*rfpb.RangeDescriptor, key []byte) uint64 {
+	for _, rd := range ranges {
+		if bytes.Compare(key, rd.GetStart()) >= 0 && bytes.Compare(key, rd.GetEnd()) < 0 {
+			return rd.GetRangeId()
+		}
+	}
+	return 0
+}
+
+// End-to-end: uniform range selection should give each range an ~equal share of
+// samples, regardless of how many keys each range holds. (In production ranges
+// are size-balanced by the splitter, so equal-per-range ~= uniform per key.)
+func TestRangeScopedSamplingIsUniformOverRanges(t *testing.T) {
+	dir := testfs.MakeTempDir(t)
+	// One group, keys spread across the hash space; three ranges partition it.
+	// Deliberately unequal key counts per range (first-hash-char buckets are
+	// 0-5, 6-a, b-f) to show the share depends on range selection, not size.
+	db := writeKeys(t, dir, "GR1", 6000)
+	gp := "PTFOO/" + filestore.FixedWidthGroupID("GR1") + "/"
+	ranges := []*rfpb.RangeDescriptor{
+		{RangeId: 1, Start: []byte(gp + "0"), End: []byte(gp + "6")},
+		{RangeId: 2, Start: []byte(gp + "6"), End: []byte(gp + "b")},
+		{RangeId: 3, Start: []byte(gp + "b"), End: []byte(gp + "g")},
+	}
+	// samplesPerRange small (< every range's key count) so each visit yields a
+	// fixed number of samples and the per-range share reflects range selection.
+	pu := newRangeTestPU(t, db, &fakeStore{rds: ranges}, 2)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		pu.generateSamplesForEviction(ctx)
+		close(done)
+	}()
+
+	const want = 30000
+	counts := map[uint64]int{}
+	for i := 0; i < want; i++ {
+		select {
+		case s := <-pu.samples:
+			rid := rangeOf(ranges, s.Key.bytes)
+			require.NotZerof(t, rid, "sampled key %q fell outside all ranges", s.Key.bytes)
+			counts[rid]++
+		case <-time.After(30 * time.Second):
+			cancel()
+			<-done
+			t.Fatalf("timed out after %d/%d samples", i, want)
+		}
+	}
+	cancel()
+	<-done
+
+	for _, rd := range ranges {
+		got := float64(counts[rd.GetRangeId()]) / float64(want)
+		assert.InDeltaf(t, 1.0/3.0, got, 0.04, "range %d share (got=%.3f)", rd.GetRangeId(), got)
+	}
+}


### PR DESCRIPTION
This PR added a v7 key. Instead of putting group id as part of the synthetic
hash, use it explictly in the key. 

As a result, we have to change the evictor logic since the current logic relies
on the assumption that the keys are randomly distributed. In this PR, we are
going to select a random range, we will choose a random key to start (when
server restarted) and then traverse through it. when it reaches the end, it will
then go to the start. 

In order to make sure the keys are uniformly distributed, we can't set a large
samples_per_batch like the default 10_000. As a result, we might ended up with
more SeekGE calls. 

Followup:
  we need to change the bringup code to how we pre-slice the range if we put
  group ID first. 
