### PR TITLE
cgroup: fix startup race causing "permission denied" cgroup setup errors

### DIFF
--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -76,8 +76,8 @@ go_library(
         "@io_bazel_rules_go//go/platform:linux": [
             "//enterprise/server/oci/ociconv",
             "//enterprise/server/remote_execution/cgroup",
-            "//enterprise/server/remote_execution/containers/ociruntime",
             "//enterprise/server/remote_execution/vbd",
+            "//server/util/flagutil",
             "//server/util/networking",
         ],
         "//conditions:default": [],

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -76,6 +76,7 @@ go_library(
         "@io_bazel_rules_go//go/platform:linux": [
             "//enterprise/server/oci/ociconv",
             "//enterprise/server/remote_execution/cgroup",
+            "//enterprise/server/remote_execution/containers/ociruntime",
             "//enterprise/server/remote_execution/vbd",
             "//server/util/networking",
         ],

--- a/enterprise/server/cmd/executor/executor_linux.go
+++ b/enterprise/server/cmd/executor/executor_linux.go
@@ -109,14 +109,20 @@ func setupCgroups() (*Cgroups, error) {
 		return nil, fmt.Errorf("inherit subtree control: %w", err)
 	}
 
-	// Also enable controllers for task cgroups up front. Task setup enables
-	// controllers lazily as needed, but concurrent enablement from multiple
-	// tasks is racy: a task can observe a controller as enabled while another
-	// task's enablement write is still in flight, before the kernel has made
-	// the controller's interface files visible in the task's cgroup, and fail
-	// to open them.
+	// Also enable controllers for task cgroups up front. We could alternatively
+	// do this lazily during task setup, but it's more complicated because there
+	// are potential race conditions around reading/writing
+	// cgroup.subtree_control and child cgroup files concurrently. See
+	// https://github.com/buildbuddy-io/buildbuddy/pull/12812 for more context.
 	if err := cgroup.DelegateControllers(taskCgroupPath); err != nil {
 		return nil, fmt.Errorf("delegate controllers to task cgroups: %w", err)
+	}
+	// Log the controllers that task cgroups will have enabled, for debugging
+	// purposes. Task setup skips settings for controllers that aren't enabled.
+	if b, err := os.ReadFile(filepath.Join(taskCgroupPath, "cgroup.subtree_control")); err != nil {
+		log.Warningf("Failed to read task cgroup subtree control: %s", err)
+	} else {
+		log.Infof("Enabled controllers for task cgroups: %s", strings.TrimSpace(string(b)))
 	}
 
 	return &Cgroups{

--- a/enterprise/server/cmd/executor/executor_linux.go
+++ b/enterprise/server/cmd/executor/executor_linux.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/oci/ociconv"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/cgroup"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/ociruntime"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/vbd"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/cpuset"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
@@ -70,8 +72,8 @@ func setupCgroups() (*Cgroups, error) {
 	if !*childCgroupsEnabled {
 		// Task cgroups will be created directly under the cgroupfs root.
 		// Make a best-effort attempt to enable the controllers they need.
-		if err := cgroup.EnableSetupControllers(cgroup.RootPath); err != nil {
-			return nil, fmt.Errorf("enable task cgroup controllers: %w", err)
+		if err := enableTaskCgroupControllers(cgroup.RootPath); err != nil {
+			return nil, err
 		}
 		return &Cgroups{StartingCgroup: startingCgroup}, nil
 	}
@@ -119,14 +121,53 @@ func setupCgroups() (*Cgroups, error) {
 	// are potential race conditions around reading/writing
 	// cgroup.subtree_control and child cgroup files concurrently. See
 	// https://github.com/buildbuddy-io/buildbuddy/pull/12812 for more context.
-	if err := cgroup.EnableSetupControllers(taskCgroupPath); err != nil {
-		return nil, fmt.Errorf("enable task cgroup controllers: %w", err)
+	if err := enableTaskCgroupControllers(taskCgroupPath); err != nil {
+		return nil, err
 	}
 
 	return &Cgroups{
 		StartingCgroup: startingCgroup,
 		CgroupParent:   taskCgroup,
 	}, nil
+}
+
+// enableTaskCgroupControllers makes a best-effort attempt to enable each
+// cgroup controller that task cgroups may need, by writing to the
+// cgroup.subtree_control file in the parent cgroup of task cgroups.
+// Controllers that can't be enabled are skipped, and task cgroup setup
+// ignores settings for them. An error is returned only if a controller is
+// required by an executor flag but couldn't be enabled.
+func enableTaskCgroupControllers(path string) error {
+	for _, c := range []struct {
+		controller string
+		// requiredBy names the executor flag that requires this controller.
+		// It applies only when required is true.
+		requiredBy string
+		required   bool
+	}{
+		{controller: "cpu"},
+		{controller: "cpuset", requiredBy: "executor.cpu_leaser.enable", required: cpuset.LeasingEnabled()},
+		{controller: "io"},
+		{controller: "memory", requiredBy: "executor.oci.enable_cgroup_memory_limit", required: ociruntime.CgroupMemoryLimitEnabled()},
+		{controller: "pids"},
+	} {
+		if err := cgroup.WriteSubtreeControl(path, map[string]bool{c.controller: true}); err != nil {
+			if c.required {
+				return fmt.Errorf("enable cgroup controller %q (required by %s): %w", c.controller, c.requiredBy, err)
+			}
+			// Not necessarily a problem: some controllers may be unavailable
+			// in this environment. Task cgroup settings for this controller
+			// will be ignored.
+			log.Infof("Could not enable cgroup controller %q for child cgroups of %q: %s", c.controller, path, err)
+		}
+	}
+	// Log the final subtree control contents, for debugging purposes.
+	if b, err := os.ReadFile(filepath.Join(path, "cgroup.subtree_control")); err != nil {
+		log.Warningf("Could not read cgroup.subtree_control for %q: %s", path, err)
+	} else {
+		log.Infof("Enabled cgroup controllers for child cgroups of %q: %s", path, strings.TrimSpace(string(b)))
+	}
+	return nil
 }
 
 func moveTiniToExecutorCgroup(executorCgroupPath string) error {

--- a/enterprise/server/cmd/executor/executor_linux.go
+++ b/enterprise/server/cmd/executor/executor_linux.go
@@ -109,6 +109,16 @@ func setupCgroups() (*Cgroups, error) {
 		return nil, fmt.Errorf("inherit subtree control: %w", err)
 	}
 
+	// Also enable controllers for task cgroups up front. Task setup enables
+	// controllers lazily as needed, but concurrent enablement from multiple
+	// tasks is racy: a task can observe a controller as enabled while another
+	// task's enablement write is still in flight, before the kernel has made
+	// the controller's interface files visible in the task's cgroup, and fail
+	// to open them.
+	if err := cgroup.DelegateControllers(taskCgroupPath); err != nil {
+		return nil, fmt.Errorf("delegate controllers to task cgroups: %w", err)
+	}
+
 	return &Cgroups{
 		StartingCgroup: startingCgroup,
 		CgroupParent:   taskCgroup,

--- a/enterprise/server/cmd/executor/executor_linux.go
+++ b/enterprise/server/cmd/executor/executor_linux.go
@@ -68,6 +68,11 @@ func setupCgroups() (*Cgroups, error) {
 	}
 
 	if !*childCgroupsEnabled {
+		// Task cgroups will be created directly under the cgroupfs root.
+		// Make a best-effort attempt to enable the controllers they need.
+		if err := cgroup.EnableSetupControllers(cgroup.RootPath); err != nil {
+			return nil, fmt.Errorf("enable task cgroup controllers: %w", err)
+		}
 		return &Cgroups{StartingCgroup: startingCgroup}, nil
 	}
 
@@ -114,15 +119,8 @@ func setupCgroups() (*Cgroups, error) {
 	// are potential race conditions around reading/writing
 	// cgroup.subtree_control and child cgroup files concurrently. See
 	// https://github.com/buildbuddy-io/buildbuddy/pull/12812 for more context.
-	if err := cgroup.DelegateControllers(taskCgroupPath); err != nil {
-		return nil, fmt.Errorf("delegate controllers to task cgroups: %w", err)
-	}
-	// Log the controllers that task cgroups will have enabled, for debugging
-	// purposes. Task setup skips settings for controllers that aren't enabled.
-	if b, err := os.ReadFile(filepath.Join(taskCgroupPath, "cgroup.subtree_control")); err != nil {
-		log.Warningf("Failed to read task cgroup subtree control: %s", err)
-	} else {
-		log.Infof("Enabled controllers for task cgroups: %s", strings.TrimSpace(string(b)))
+	if err := cgroup.EnableSetupControllers(taskCgroupPath); err != nil {
+		return nil, fmt.Errorf("enable task cgroup controllers: %w", err)
 	}
 
 	return &Cgroups{

--- a/enterprise/server/cmd/executor/executor_linux.go
+++ b/enterprise/server/cmd/executor/executor_linux.go
@@ -13,12 +13,12 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/oci/ociconv"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/cgroup"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/ociruntime"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/vbd"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/cpuset"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/networking"
 	"github.com/prometheus/client_golang/prometheus"
@@ -138,27 +138,28 @@ func setupCgroups() (*Cgroups, error) {
 // ignores settings for them. An error is returned only if a controller is
 // required by an executor flag but couldn't be enabled.
 func enableTaskCgroupControllers(path string) error {
-	for _, c := range []struct {
-		controller string
-		// requiredBy names the executor flag that requires this controller.
-		// It applies only when required is true.
-		requiredBy string
-		required   bool
-	}{
-		{controller: "cpu"},
-		{controller: "cpuset", requiredBy: "executor.cpu_leaser.enable", required: cpuset.LeasingEnabled()},
-		{controller: "io"},
-		{controller: "memory", requiredBy: "executor.oci.enable_cgroup_memory_limit", required: ociruntime.CgroupMemoryLimitEnabled()},
-		{controller: "pids"},
-	} {
-		if err := cgroup.WriteSubtreeControl(path, map[string]bool{c.controller: true}); err != nil {
-			if c.required {
-				return fmt.Errorf("enable cgroup controller %q (required by %s): %w", c.controller, c.requiredBy, err)
+	// Executor flags that require a controller to be enabled, keyed by
+	// controller name.
+	requiredBy := map[string]string{}
+	if cpuset.LeasingEnabled() {
+		requiredBy["cpuset"] = "executor.cpu_leaser.enable"
+	}
+	memoryLimitEnabled, err := flagutil.GetDereferencedValue[bool]("executor.oci.enable_cgroup_memory_limit")
+	if err != nil {
+		log.Warningf("Could not read executor.oci.enable_cgroup_memory_limit flag value: %s", err)
+	} else if memoryLimitEnabled {
+		requiredBy["memory"] = "executor.oci.enable_cgroup_memory_limit"
+	}
+
+	for _, controller := range cgroup.SetupControllers {
+		if err := cgroup.WriteSubtreeControl(path, map[string]bool{controller: true}); err != nil {
+			if flagName, ok := requiredBy[controller]; ok {
+				return fmt.Errorf("enable cgroup controller %q (required by %s): %w", controller, flagName, err)
 			}
 			// Not necessarily a problem: some controllers may be unavailable
 			// in this environment. Task cgroup settings for this controller
 			// will be ignored.
-			log.Infof("Could not enable cgroup controller %q for child cgroups of %q: %s", c.controller, path, err)
+			log.Infof("Could not enable cgroup controller %q for child cgroups of %q: %s", controller, path, err)
 		}
 	}
 	// Log the final subtree control contents, for debugging purposes.

--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -94,12 +94,13 @@ func Setup(ctx context.Context, path string, s *scpb.CgroupSettings, blockDevice
 	for name, value := range m {
 		controller, _, _ := strings.Cut(name, ".")
 		if !enabledControllers[controller] {
-			// Attempt to enable the controller if it's not already enabled.
-			if err := EnableController(path, controller); err != nil {
-				log.CtxWarningf(ctx, "Failed to enable cgroup controller %q for cgroup %q: %s", controller, path, err)
-				continue
-			}
-			enabledControllers[controller] = true
+			// Note: we expect all needed controllers to be enabled at
+			// executor startup, so we don't try to enable the controller
+			// here. Enabling controllers lazily is racy: a concurrent Setup
+			// for a sibling cgroup can observe the controller as enabled
+			// before the kernel has made its interface files visible.
+			log.CtxWarningf(ctx, "Skipping cgroup setting %q: the %q controller is not enabled for cgroup %q", name, controller, path)
+			continue
 		}
 		settingFilePath := filepath.Join(path, name)
 		if err := writeFile(settingFilePath, value); err != nil {

--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -212,6 +212,37 @@ func DelegateControllers(path string) error {
 	return nil
 }
 
+// Cgroup controllers that Setup may write settings for.
+var setupControllers = []string{"cpu", "cpuset", "io", "memory", "pids"}
+
+// EnableSetupControllers makes a best-effort attempt to enable every
+// controller that Setup supports for child cgroups of the cgroup at the given
+// path. Controllers that cannot be enabled are logged and skipped, and Setup
+// ignores settings for them. An error is returned if the cpuset controller
+// could not be enabled while CPU leasing is enabled, since CPU leasing
+// depends on cpuset support.
+func EnableSetupControllers(path string) error {
+	for _, controller := range setupControllers {
+		if err := WriteSubtreeControl(path, map[string]bool{controller: true}); err != nil {
+			if controller == "cpuset" && cpuset.LeasingEnabled() {
+				return fmt.Errorf("enable cpuset controller (required for CPU leasing): %w", err)
+			}
+			// Not necessarily a problem: some controllers may be unavailable
+			// in this environment. Settings for this controller will be
+			// ignored.
+			log.Infof("Could not enable cgroup controller %q for child cgroups of %q: %s", controller, path, err)
+		}
+	}
+	// Log the final subtree control contents, for debugging purposes.
+	b, err := os.ReadFile(filepath.Join(path, "cgroup.subtree_control"))
+	if err != nil {
+		log.Warningf("Could not read cgroup.subtree_control for %q: %s", path, err)
+		return nil
+	}
+	log.Infof("Enabled cgroup controllers for child cgroups of %q: %s", path, strings.TrimSpace(string(b)))
+	return nil
+}
+
 func settingsMap(s *scpb.CgroupSettings, blockDevice *block_io.Device) (map[string]string, error) {
 	m := map[string]string{}
 	if s == nil {

--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -95,16 +95,11 @@ func Setup(ctx context.Context, path string, s *scpb.CgroupSettings, blockDevice
 		controller, _, _ := strings.Cut(name, ".")
 		if !enabledControllers[controller] {
 			// Note: we expect all needed controllers to be enabled at
-			// executor startup, so we don't try to enable the controller
-			// here. Enabling controllers lazily is racy: a concurrent Setup
-			// for a sibling cgroup can observe the controller as enabled
-			// before the kernel has made its interface files visible.
-			log.CtxWarningf(ctx, "Skipping cgroup setting %q: the %q controller is not enabled for cgroup %q", name, controller, path)
+			// executor startup.
 			continue
 		}
 		settingFilePath := filepath.Join(path, name)
 		if err := writeFile(settingFilePath, value); err != nil {
-			logSetupPermissionDeniedDiagnostics(ctx, path, name, value, err)
 			return fmt.Errorf("write %q to cgroup file %q: %w", value, name, err)
 		}
 	}
@@ -126,90 +121,6 @@ func writeFile(path, value string) error {
 		return werr
 	}
 	return cerr
-}
-
-func logSetupPermissionDeniedDiagnostics(ctx context.Context, path, settingName, settingValue string, writeErr error) {
-	if !errors.Is(writeErr, fs.ErrPermission) && !errors.Is(writeErr, syscall.EPERM) && !errors.Is(writeErr, syscall.EACCES) {
-		return
-	}
-	settingPath := filepath.Join(path, settingName)
-	parent := ParentPath(path)
-	grandparent := ParentPath(parent)
-	currentCgroup, currentCgroupErr := GetCurrent()
-	currentCgroupInfo := currentCgroup
-	if currentCgroupErr != nil {
-		currentCgroupInfo = fmt.Sprintf("<%s>", currentCgroupErr)
-	}
-
-	fields := []string{
-		fmt.Sprintf("setting=%q", settingName),
-		fmt.Sprintf("value=%q", settingValue),
-		fmt.Sprintf("file=%q", settingPath),
-		fmt.Sprintf("path=%q", path),
-		fmt.Sprintf("parent=%q", parent),
-		fmt.Sprintf("grandparent=%q", grandparent),
-		fmt.Sprintf("uid=%d euid=%d gid=%d egid=%d", os.Getuid(), os.Geteuid(), os.Getgid(), os.Getegid()),
-		fmt.Sprintf("self_cgroup=%q", currentCgroupInfo),
-		describePath(path),
-		describePath(parent),
-		describePath(grandparent),
-		describeFile(settingPath),
-		describeCgroupFiles(path),
-		describeCgroupFiles(parent),
-		describeCgroupFiles(grandparent),
-	}
-
-	log.CtxWarningf(ctx, "cgroup write permission diagnostics: %s", strings.Join(fields, " | "))
-}
-
-func describePath(path string) string {
-	fi, err := os.Stat(path)
-	if err != nil {
-		return fmt.Sprintf("stat(%q):<%s>", path, err)
-	}
-	stat, ok := fi.Sys().(*syscall.Stat_t)
-	if !ok {
-		return fmt.Sprintf("stat(%q):mode=%s", path, fi.Mode().String())
-	}
-	return fmt.Sprintf("stat(%q):mode=%s uid=%d gid=%d", path, fi.Mode().String(), stat.Uid, stat.Gid)
-}
-
-func describeFile(path string) string {
-	fi, err := os.Stat(path)
-	if err != nil {
-		return fmt.Sprintf("file(%q):<%s>", path, err)
-	}
-	stat, ok := fi.Sys().(*syscall.Stat_t)
-	if !ok {
-		return fmt.Sprintf("file(%q):mode=%s", path, fi.Mode().String())
-	}
-	return fmt.Sprintf("file(%q):mode=%s uid=%d gid=%d", path, fi.Mode().String(), stat.Uid, stat.Gid)
-}
-
-func describeCgroupFiles(path string) string {
-	files := []string{"cgroup.type", "cgroup.controllers", "cgroup.subtree_control", "cgroup.procs"}
-	var parts []string
-	for _, name := range files {
-		value, err := readTrimmedCgroupValue(filepath.Join(path, name))
-		if err != nil {
-			parts = append(parts, fmt.Sprintf("%s:<%s>", name, err))
-			continue
-		}
-		parts = append(parts, fmt.Sprintf("%s:%q", name, value))
-	}
-	return fmt.Sprintf("cgroup(%q){%s}", path, strings.Join(parts, ", "))
-}
-
-func readTrimmedCgroupValue(path string) (string, error) {
-	b, err := os.ReadFile(path)
-	if err != nil {
-		return "", err
-	}
-	s := strings.TrimSpace(string(b))
-	if len(s) > 200 {
-		s = s[:200] + "...(truncated)"
-	}
-	return s, nil
 }
 
 // EnabledControllers returns the controllers enabled for the cgroup at the

--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -99,7 +99,7 @@ func Setup(ctx context.Context, path string, s *scpb.CgroupSettings, blockDevice
 			continue
 		}
 		settingFilePath := filepath.Join(path, name)
-		if err := writeFile(settingFilePath, value); err != nil {
+		if err := writeFile(settingFilePath, []byte(value)); err != nil {
 			return fmt.Errorf("write %q to cgroup file %q: %w", value, name, err)
 		}
 	}
@@ -110,12 +110,12 @@ func Setup(ctx context.Context, path string, s *scpb.CgroupSettings, blockDevice
 // file without O_CREAT: cgroupfs does not support creating files, and an
 // O_CREAT open of a missing interface file (e.g. for a controller that is not
 // yet enabled) fails with a misleading EACCES instead of ENOENT.
-func writeFile(path, value string) error {
+func writeFile(path string, value []byte) error {
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0)
 	if err != nil {
 		return err
 	}
-	_, werr := f.Write([]byte(value))
+	_, werr := f.Write(value)
 	cerr := f.Close()
 	if werr != nil {
 		return werr
@@ -195,7 +195,7 @@ func WriteSubtreeControl(path string, settings map[string]bool) error {
 		}
 		strs = append(strs, statusPrefix+controller)
 	}
-	return writeFile(filepath.Join(path, "cgroup.subtree_control"), strings.Join(strs, " "))
+	return writeFile(filepath.Join(path, "cgroup.subtree_control"), []byte(strings.Join(strs, " ")))
 }
 
 // DelegateControllers reads the currently enabled controllers for the given

--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -212,37 +212,6 @@ func DelegateControllers(path string) error {
 	return nil
 }
 
-// Cgroup controllers that Setup may write settings for.
-var setupControllers = []string{"cpu", "cpuset", "io", "memory", "pids"}
-
-// EnableSetupControllers makes a best-effort attempt to enable every
-// controller that Setup supports for child cgroups of the cgroup at the given
-// path. Controllers that cannot be enabled are logged and skipped, and Setup
-// ignores settings for them. An error is returned if the cpuset controller
-// could not be enabled while CPU leasing is enabled, since CPU leasing
-// depends on cpuset support.
-func EnableSetupControllers(path string) error {
-	for _, controller := range setupControllers {
-		if err := WriteSubtreeControl(path, map[string]bool{controller: true}); err != nil {
-			if controller == "cpuset" && cpuset.LeasingEnabled() {
-				return fmt.Errorf("enable cpuset controller (required for CPU leasing): %w", err)
-			}
-			// Not necessarily a problem: some controllers may be unavailable
-			// in this environment. Settings for this controller will be
-			// ignored.
-			log.Infof("Could not enable cgroup controller %q for child cgroups of %q: %s", controller, path, err)
-		}
-	}
-	// Log the final subtree control contents, for debugging purposes.
-	b, err := os.ReadFile(filepath.Join(path, "cgroup.subtree_control"))
-	if err != nil {
-		log.Warningf("Could not read cgroup.subtree_control for %q: %s", path, err)
-		return nil
-	}
-	log.Infof("Enabled cgroup controllers for child cgroups of %q: %s", path, strings.TrimSpace(string(b)))
-	return nil
-}
-
 func settingsMap(s *scpb.CgroupSettings, blockDevice *block_io.Device) (map[string]string, error) {
 	m := map[string]string{}
 	if s == nil {

--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -102,12 +102,29 @@ func Setup(ctx context.Context, path string, s *scpb.CgroupSettings, blockDevice
 			enabledControllers[controller] = true
 		}
 		settingFilePath := filepath.Join(path, name)
-		if err := os.WriteFile(settingFilePath, []byte(value), 0); err != nil {
+		if err := writeFile(settingFilePath, value); err != nil {
 			logSetupPermissionDeniedDiagnostics(ctx, path, name, value, err)
 			return fmt.Errorf("write %q to cgroup file %q: %w", value, name, err)
 		}
 	}
 	return nil
+}
+
+// writeFile writes a cgroup interface file. Unlike os.WriteFile, it opens the
+// file without O_CREAT: cgroupfs does not support creating files, and an
+// O_CREAT open of a missing interface file (e.g. for a controller that is not
+// yet enabled) fails with a misleading EACCES instead of ENOENT.
+func writeFile(path, value string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0)
+	if err != nil {
+		return err
+	}
+	_, werr := f.Write([]byte(value))
+	cerr := f.Close()
+	if werr != nil {
+		return werr
+	}
+	return cerr
 }
 
 func logSetupPermissionDeniedDiagnostics(ctx context.Context, path, settingName, settingValue string, writeErr error) {
@@ -266,8 +283,7 @@ func WriteSubtreeControl(path string, settings map[string]bool) error {
 		}
 		strs = append(strs, statusPrefix+controller)
 	}
-	b := []byte(strings.Join(strs, " "))
-	return os.WriteFile(filepath.Join(path, "cgroup.subtree_control"), b, 0)
+	return writeFile(filepath.Join(path, "cgroup.subtree_control"), strings.Join(strs, " "))
 }
 
 // DelegateControllers reads the currently enabled controllers for the given

--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -195,7 +195,8 @@ func WriteSubtreeControl(path string, settings map[string]bool) error {
 		}
 		strs = append(strs, statusPrefix+controller)
 	}
-	return writeFile(filepath.Join(path, "cgroup.subtree_control"), []byte(strings.Join(strs, " ")))
+	b := []byte(strings.Join(strs, " "))
+	return writeFile(filepath.Join(path, "cgroup.subtree_control"), b)
 }
 
 // DelegateControllers reads the currently enabled controllers for the given

--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -76,6 +76,10 @@ func GetCurrent() (string, error) {
 	return path, nil
 }
 
+// SetupControllers lists the cgroup controllers that Setup may write settings
+// for.
+var SetupControllers = []string{"cpu", "cpuset", "io", "memory", "pids"}
+
 // Setup configures the cgroup at the given path with the given settings.
 // Any settings for cgroup controllers that aren't enabled are ignored.
 // IO limits are applied to the given block device, if specified.
@@ -106,21 +110,25 @@ func Setup(ctx context.Context, path string, s *scpb.CgroupSettings, blockDevice
 	return nil
 }
 
-// writeFile writes a cgroup interface file. Unlike os.WriteFile, it opens the
-// file without O_CREAT: cgroupfs does not support creating files, and an
-// O_CREAT open of a missing interface file (e.g. for a controller that is not
-// yet enabled) fails with a misleading EACCES instead of ENOENT.
+// writeFile writes a cgroup interface file.
+//
+// Unlike os.WriteFile, it opens the file without O_CREAT: cgroupfs does not
+// support creating files, and an O_CREAT open of a missing interface file (e.g.
+// for a controller that is not yet enabled) fails with a misleading EACCES
+// instead of ENOENT.
 func writeFile(path string, value []byte) error {
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0)
 	if err != nil {
 		return err
 	}
-	_, werr := f.Write(value)
-	cerr := f.Close()
-	if werr != nil {
-		return werr
+	n, err := f.Write(value)
+	if err == nil && n < len(value) {
+		err = io.ErrShortWrite
 	}
-	return cerr
+	if closeErr := f.Close(); closeErr != nil && err == nil {
+		err = closeErr
+	}
+	return err
 }
 
 // EnabledControllers returns the controllers enabled for the cgroup at the

--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -99,6 +99,7 @@ go_test(
     },
     deps = [
         ":ociruntime",
+        "//enterprise/server/remote_execution/cgroup",
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/filecache",
         "//enterprise/server/remote_execution/persistentworker",

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -97,12 +97,6 @@ var (
 	errSIGSEGV = status.UnavailableErrorf("command was terminated by SIGSEGV, likely due to a memory issue")
 )
 
-// CgroupMemoryLimitEnabled returns whether task cgroup memory limits are
-// enabled via the executor.oci.enable_cgroup_memory_limit flag.
-func CgroupMemoryLimitEnabled() bool {
-	return *enableCgroupMemoryLimit
-}
-
 const (
 	ociVersion = "1.1.0-rc.3" // matches podman
 

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -97,6 +97,12 @@ var (
 	errSIGSEGV = status.UnavailableErrorf("command was terminated by SIGSEGV, likely due to a memory issue")
 )
 
+// CgroupMemoryLimitEnabled returns whether task cgroup memory limits are
+// enabled via the executor.oci.enable_cgroup_memory_limit flag.
+func CgroupMemoryLimitEnabled() bool {
+	return *enableCgroupMemoryLimit
+}
+
 const (
 	ociVersion = "1.1.0-rc.3" // matches podman
 

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/bazelbuild/rules_go/go/runfiles"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/cgroup"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/ociruntime"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache"
@@ -69,6 +70,18 @@ func init() {
 		log.Fatalf("Failed to locate crun in runfiles: %s", err)
 	}
 	*ociruntime.Runtime = runtimePath
+}
+
+func TestMain(m *testing.M) {
+	// Mirror executor startup, which enables the cgroup controllers that task
+	// cgroups need in the parent cgroup of task cgroups. Tests create task
+	// cgroups directly under the cgroupfs root.
+	for _, controller := range []string{"cpu", "cpuset", "io", "memory", "pids"} {
+		if err := cgroup.WriteSubtreeControl(cgroup.RootPath, map[string]bool{controller: true}); err != nil {
+			log.Printf("Could not enable cgroup controller %q for child cgroups of %q: %s", controller, cgroup.RootPath, err)
+		}
+	}
+	os.Exit(m.Run())
 }
 
 func setupNetworking(t *testing.T) {

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -76,7 +76,7 @@ func TestMain(m *testing.M) {
 	// Mirror executor startup, which enables the cgroup controllers that task
 	// cgroups need in the parent cgroup of task cgroups. Tests create task
 	// cgroups directly under the cgroupfs root.
-	for _, controller := range []string{"cpu", "cpuset", "io", "memory", "pids"} {
+	for _, controller := range cgroup.SetupControllers {
 		if err := cgroup.WriteSubtreeControl(cgroup.RootPath, map[string]bool{controller: true}); err != nil {
 			log.Printf("Could not enable cgroup controller %q for child cgroups of %q: %s", controller, cgroup.RootPath, err)
 		}

--- a/enterprise/server/util/cpuset/cpuset.go
+++ b/enterprise/server/util/cpuset/cpuset.go
@@ -34,6 +34,12 @@ const (
 // Compile-time check that cpuLeaser implements the interface.
 var _ interfaces.CPULeaser = (*CPULeaser)(nil)
 
+// LeasingEnabled returns whether CPU leasing is enabled via the
+// executor.cpu_leaser.enable flag.
+func LeasingEnabled() bool {
+	return *cpuLeaserEnable
+}
+
 type CPULeaser struct {
 	mu        sync.Mutex
 	cpus      []CPUInfo


### PR DESCRIPTION
Our current `cgroup.Setup` looks like this (pseudo-code)

```go
enabledControllers := EnabledControllers(cgroup)
for settingName, settingValue := range cgroupSettings {
  controllerName := parseControllerName(settingName)
  if !enabledControllers[controllerName] {
    EnableController(cgroup, controllerName)
  }
  writeFile(cgroup, settingName, settingValue)
}
```

This code has a race condition which is triggered when concurrently executing a bunch of tasks during executor startup:
- `EnabledControllers` returns the current contents of the parent's `cgroup.subtree_control` file.
- If another goroutine is concurrently writing to this file (when it calls `EnableController` the first time a task is executed), then `cgroup.subtree_control` can report that a controller is enabled, before the kernel has finished setting up child cgroup file nodes (`cpu.weight`, `cpuset.cpus`, etc.)
  - This kernel behavior is a bit unfortunate :thinking: In our case, it would be ideal if reading from `cgroup.subtree_control` didn't report that a controller is enabled unless it has finished being set up.
  - Either way, it means the code above can report that a controller is enabled before the child cgroup actually has its cgroup file nodes provisioned.

The fix is as follows:
- Enable all supported cgroup controllers once, on executor startup. This ensures that cgroup controllers are done being provisioned before we ever call `cgroup.Setup`
  - All controller setup is best-effort (i.e. doesn't prevent startup) _unless_ an executor flag requires the controller to be enabled:
    - `executor.cpu_leaser.enable` requires the `cpuset` controller.
    - `executor.oci.enable_cgroup_memory_limit` requires the `memory` controller.
- Cleanup:
  - In the per-task cgroup setup (`cgroup.Setup`), don't try to call EnableController at all since we now assume they were enabled on startup.
  - Remove the diagnostics around the EPERM error
- Minor improvement: don't write cgroup files with `O_CREAT` - this causes a confusing EPERM error which makes sense because creating cgroup files in this way is not something that is allowed - the only way to create these cgroup files is either via `mkdir` (creating a new cgroup) or by writing to `cgroup.subtree_control` (updating a cgroup). Dropping this `O_CREAT` option results in a more intuitive `ENOENT` (file doesn't exist) error.