### PR TITLE
Make the executor page warning banners the same width as the executor cards

### DIFF
--- a/enterprise/app/executors/executors.css
+++ b/enterprise/app/executors/executors.css
@@ -96,7 +96,6 @@
 .executors-page .self-hosted-executors-banner {
   margin-top: 32px;
   margin-bottom: 32px;
-  max-width: 600px;
 }
 
 .executors-page .executor-details {
@@ -114,5 +113,4 @@
 
 .executors-page .pool-size-warning {
   margin-top: 16px;
-  display: inline-flex;
 }


### PR DESCRIPTION
I think this looks better, but this is just my opinion. Curious if others agree.

Before:
<img width="1200" height="590" alt="Screenshot 2026-07-22 at 9 28 24 AM" src="https://github.com/user-attachments/assets/efbe25ae-c640-4446-8370-823eeeb35afa" />

After:
<img width="1200" height="590" alt="Screenshot 2026-07-22 at 9 28 02 AM" src="https://github.com/user-attachments/assets/6e87ef74-5e17-474f-8860-34293c9cc5d5" />