### PR TITLE
Add `.push_only` and `.apply_only` to `gcs(...)` and `release(...)`

### DIFF
--- a/rules/gcs/index.bzl
+++ b/rules/gcs/index.bzl
@@ -47,6 +47,28 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
         **kwargs
     )
 
+    # Generate a .push_only rule for uploading without a later apply phase.
+    native.genrule(
+        name = name + ".push_only",
+        srcs = srcs,
+        outs = [name + ".push_only.out"],
+        cmd = "echo \"%s -m %s cp %s $(SRCS) gs://%s/%s\" > $@" % (gsutil, util_options, copy_options, bucket, prefix),
+        local = 1,
+        executable = 1,
+        **kwargs
+    )
+
+    # Uploading is the only deployment operation for a GCS bundle, so there
+    # is nothing left to do during the apply-only phase.
+    native.genrule(
+        name = name + ".apply_only",
+        outs = [name + ".apply_only.out"],
+        cmd = "echo \"true\" > $@",
+        local = 1,
+        executable = 1,
+        **kwargs
+    )
+
     # Generate a .diff rule for diffing.
     native.genrule(
         name = name + ".diff",

--- a/rules/gcs/index.bzl
+++ b/rules/gcs/index.bzl
@@ -36,12 +36,14 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
     if disable_caching:
         util_options += " -h 'Cache-Control:no-store'"
 
+    upload_cmd = "echo \"%s -m %s cp %s $(SRCS) gs://%s/%s\" > $@" % (gsutil, util_options, copy_options, bucket, prefix)
+
     # Generate an .apply rule for uploading.
     native.genrule(
         name = name + ".apply",
         srcs = srcs,
         outs = [name + ".apply.out"],
-        cmd = "echo \"%s -m %s cp %s $(SRCS) gs://%s/%s\" > $@" % (gsutil, util_options, copy_options, bucket, prefix),
+        cmd = upload_cmd,
         local = 1,
         executable = 1,
         **kwargs
@@ -52,7 +54,7 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
         name = name + ".push_only",
         srcs = srcs,
         outs = [name + ".push_only.out"],
-        cmd = "echo \"%s -m %s cp %s $(SRCS) gs://%s/%s\" > $@" % (gsutil, util_options, copy_options, bucket, prefix),
+        cmd = upload_cmd,
         local = 1,
         executable = 1,
         **kwargs

--- a/rules/gcs/index.bzl
+++ b/rules/gcs/index.bzl
@@ -47,7 +47,7 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
         **kwargs
     )
 
-    # Generate a .push_only rule for uploading without a later apply phase.
+    # Generate a .push_only rule for uploading to GCS.
     native.genrule(
         name = name + ".push_only",
         srcs = srcs,

--- a/rules/release/index.bzl
+++ b/rules/release/index.bzl
@@ -24,7 +24,7 @@
 def release(name, run, after, enable_actions = True, **kwargs):
     actions = [""]
     if enable_actions:
-        actions = [".apply", ".diff", ".delete"]
+        actions = [".apply", ".diff", ".delete", ".push_only", ".apply_only"]
 
     for action in actions:
         native.genrule(


### PR DESCRIPTION
This is the last change in the stack to make all release targets supply `.push_only` and `.apply_only`