### PR TITLE
Remove redundant usage UnexpectedEvent alert

### DIFF
--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -338,7 +338,7 @@ func (ut *tracker) startDBFlush() {
 			select {
 			case <-ticker.C:
 				if err := ut.FlushToDB(ctx); err != nil {
-					alert.UnexpectedEvent("usage_data_flush_failed", "Error flushing usage data to DB: %s", err)
+					log.CtxErrorf(ctx, "Error flushing usage data to DB: %s", err)
 				}
 			case <-ut.stopFlush:
 				return


### PR DESCRIPTION
The `usage_data_flush_failed` alert fires after trying and failing to flush usage to the DB. However, when we fail to flush usage to the DB, we leave the unflushed usage in redis, so the flush should get retried.

We have a separate alert `usage_flush_not_keeping_up` if too much data is buffered in redis (i.e. we're flushing usage from too long ago), so it should be safe to remove this alert.