### PR TITLE
Broaden generated proto pattern in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,9 @@ tramp
 /bb-out
 
 # Generated protos
-**/proto/**/*.pb.go
-**/proto/**/*_ts_proto.d.ts
-**/proto/**/*_ts_proto.js
+*.pb.go
+*_ts_proto.d.ts
+*_ts_proto.js
 
 # Node dependencies
 node_modules


### PR DESCRIPTION
`pbsync` is generating some `.pb.go` files under `tools/protoc-gen-go-vtproto-view/testdata`