### PR TITLE
Add withKey util to simplify state management

### DIFF
--- a/app/util/BUILD
+++ b/app/util/BUILD
@@ -156,6 +156,7 @@ ts_library(
     deps = [
         "//:node_modules/@types/react",
         "//:node_modules/react",
+        "//:node_modules/tslib",
     ],
 )
 

--- a/app/util/react.tsx
+++ b/app/util/react.tsx
@@ -62,3 +62,32 @@ export function joinReactNodes(nodes: React.ReactNode[], joiner: React.ReactNode
   }
   return joined;
 }
+
+/**
+ * Wraps a component with a derived `key` prop, causing the wrapped component
+ * instance to be discarded and re-rendered if the value returned by `getKey`
+ * changes.
+ *
+ * This is useful for simplifying state management, so that the rendered
+ * component doesn't have to manually invalidate any cached values and
+ * re-initialize state.
+ *
+ * Example:
+ *
+ * ```tsx
+ * class FooInner extends React.Component<FooProps> {}
+ * // Wrapper around `FooInner` that unmounts and remounts a new `Foo`
+ * // if `props.foo.id` changes
+ * class Foo extends withKey(FooInner, (props) => props.foo.id);
+ * ```
+ */
+export function withKey<P>(
+  Component: React.ComponentType<P>,
+  getKey: (props: P) => React.Key
+): React.ComponentClass<P> {
+  return class extends React.Component<P> {
+    render() {
+      return <Component key={getKey(this.props)} {...this.props} />;
+    }
+  };
+}

--- a/enterprise/app/api_keys/BUILD
+++ b/enterprise/app/api_keys/BUILD
@@ -26,6 +26,7 @@ ts_library(
         "//app/service:rpc_service",
         "//app/util:clipboard",
         "//app/util:errors",
+        "//app/util:react",
         "//proto:api_key_ts_proto",
         "//proto:capability_ts_proto",
     ],

--- a/enterprise/app/api_keys/api_keys.tsx
+++ b/enterprise/app/api_keys/api_keys.tsx
@@ -22,6 +22,7 @@ import { copyToClipboard } from "../../../app/util/clipboard";
 import { BuildBuddyError } from "../../../app/util/errors";
 import { api_key } from "../../../proto/api_key_ts_proto";
 import { capability } from "../../../proto/capability_ts_proto";
+import { withKey } from "../../../app/util/react";
 
 export interface ApiKeysComponentProps {
   /** The authenticated user. */
@@ -788,40 +789,25 @@ interface ApiKeyFieldState {
   displayValue: string;
 }
 
-class ApiKeyField extends React.Component<ApiKeyFieldProps, ApiKeyFieldState> {
+class ApiKeyFieldInner extends React.Component<ApiKeyFieldProps, ApiKeyFieldState> {
   static INITIAL_STATE: ApiKeyFieldState = {
     isCopied: false,
     hideValue: true,
     displayValue: "••••••••••••••••••••",
   };
 
-  state = ApiKeyField.INITIAL_STATE;
+  state = ApiKeyFieldInner.INITIAL_STATE;
 
   private copyTimeout: number | undefined;
   private value: string = this.props.apiKey.value;
-  private rpc: CancelablePromise | undefined;
-
-  componentDidUpdate(prevProps: ApiKeyFieldProps) {
-    if (prevProps.apiKey.id !== this.props.apiKey.id) {
-      // Reinitialize component.
-      this.setState(ApiKeyField.INITIAL_STATE);
-      clearTimeout(this.copyTimeout);
-      this.value = this.props.apiKey.value;
-      this.rpc?.cancel();
-      this.rpc = undefined;
-    }
-  }
 
   componentWillUnmount() {
-    this.rpc?.cancel();
     clearTimeout(this.copyTimeout);
   }
 
-  private retrieveValue(): CancelablePromise<string> {
-    this.rpc?.cancel();
-    this.rpc = undefined;
+  private async retrieveValue() {
     if (this.value) {
-      return new CancelablePromise(Promise.resolve(this.value));
+      return this.value;
     }
     return rpcService.service.getApiKey({ apiKeyId: this.props.apiKey.id }).then((response) => {
       this.value = response.apiKey?.value ?? "";
@@ -831,7 +817,7 @@ class ApiKeyField extends React.Component<ApiKeyFieldProps, ApiKeyFieldState> {
 
   // onClick handler function for the copy button
   private handleCopyClick() {
-    this.rpc = this.retrieveValue()
+    this.retrieveValue()
       .then((val) => {
         copyToClipboard(val);
         this.setState({ isCopied: true }, () => {
@@ -847,11 +833,11 @@ class ApiKeyField extends React.Component<ApiKeyFieldProps, ApiKeyFieldState> {
 
   // onClick handler function for the hide/reveal button
   private toggleHideValue() {
-    this.rpc = this.retrieveValue()
+    this.retrieveValue()
       .then((val) => {
         this.setState({
           hideValue: !this.state.hideValue,
-          displayValue: this.state.hideValue ? val : ApiKeyField.INITIAL_STATE.displayValue,
+          displayValue: this.state.hideValue ? val : ApiKeyFieldInner.INITIAL_STATE.displayValue,
         });
       })
       .catch((e) => errorService.handleError(e));
@@ -873,3 +859,5 @@ class ApiKeyField extends React.Component<ApiKeyFieldProps, ApiKeyFieldState> {
     );
   }
 }
+
+class ApiKeyField extends withKey(ApiKeyFieldInner, (props) => props.apiKey.id) {}


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy/pull/12821 fixed a bunch of edge cases with `ApiKeyField` improperly invalidating its state / RPCs etc. when props change (credit to Son for finding the issue originally). Unfortunately it was a lot more verbose than I anticipated

This PR introduces a `withKey` helper that allows the component to be unmounted and a new one to be remounted if props change, which simplifies state management.

The alternative is for the caller to manually pass `key` everywhere the component is used, but this feels like an error-prone pattern.