### PR TITLE
Add an LRU benchmark for the common case where Add causes eviction

### DIFF
--- a/server/util/lru/lru_test.go
+++ b/server/util/lru/lru_test.go
@@ -469,7 +469,9 @@ func BenchmarkLRUAdd(b *testing.B) {
 }
 
 // BenchmarkLRUAddWithEviction measures insertion (distinct keys, eviction on
-// every insert).
+// every insert). It should be faster and allocate less than BenchmarkLRUAdd,
+// since it doesn't grow the nodes slice during the benchmark loop. It might
+// still allocate occasionaly because of the items map.
 func BenchmarkLRUAddWithEviction(b *testing.B) {
 	for _, ttl := range []time.Duration{0, time.Minute} {
 		b.Run("ttl="+ttl.String(), func(b *testing.B) {
@@ -482,8 +484,8 @@ func BenchmarkLRUAddWithEviction(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			// Add the next N keys, which will evict the first N keys.
-			for i := b.N; i < 2*b.N; i++ {
-				l.Add(keys[i], struct{}{})
+			for _, k := range keys[b.N:] {
+				l.Add(k, struct{}{})
 			}
 			runtime.KeepAlive(l)
 		})

--- a/server/util/lru/lru_test.go
+++ b/server/util/lru/lru_test.go
@@ -468,6 +468,28 @@ func BenchmarkLRUAdd(b *testing.B) {
 	}
 }
 
+// BenchmarkLRUAddWithEviction measures insertion (distinct keys, eviction on
+// every insert).
+func BenchmarkLRUAddWithEviction(b *testing.B) {
+	for _, ttl := range []time.Duration{0, time.Minute} {
+		b.Run("ttl="+ttl.String(), func(b *testing.B) {
+			keys := benchKeys(2 * b.N)
+			l := newBenchLRU(int64(b.N), ttl)
+			// Fill the cache with the first N keys.
+			for _, k := range keys[:b.N] {
+				l.Add(k, struct{}{})
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			// Add the next N keys, which will evict the first N keys.
+			for i := b.N; i < 2*b.N; i++ {
+				l.Add(keys[i], struct{}{})
+			}
+			runtime.KeepAlive(l)
+		})
+	}
+}
+
 // BenchmarkLRUGet measures hot reads (all hits) against a full cache.
 func BenchmarkLRUGet(b *testing.B) {
 	const n = 100_000


### PR DESCRIPTION
I was looking at the results of https://github.com/buildbuddy-io/buildbuddy/pull/12706 and was surprised that it made the Add benchmark slower, but this was just because the new version spent a bunch of time growing the `nodes` slice.

This benchmark fills the cache first, which is how it will operate most of the time. Results before and after https://github.com/buildbuddy-io/buildbuddy/pull/12706:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor
                               │   /tmp/old   │              /tmp/new               │
                               │    sec/op    │    sec/op     vs base               │
LRUAdd/ttl=0s-24                 253.5n ±  4%   317.8n ±  8%  +25.36% (p=0.001 n=7)
LRUAdd/ttl=1m0s-24               347.8n ± 10%   303.5n ± 10%  -12.74% (p=0.001 n=7)
LRUAddWithEviction/ttl=0s-24     350.1n ±  5%   339.3n ± 11%        ~ (p=0.535 n=7)
LRUAddWithEviction/ttl=1m0s-24   367.8n ± 11%   344.3n ± 14%   -6.39% (p=0.017 n=7)
LRUGet-24                        62.13n ±  6%   61.13n ±  2%   -1.61% (p=0.003 n=7)
LRUGCMark-24                     7.470m ±  2%   3.053m ±  4%  -59.13% (p=0.001 n=7)
geomean                          1.319µ         1.132µ        -14.19%

                               │   /tmp/old    │               /tmp/new               │
                               │     B/op      │    B/op      vs base                 │
LRUAdd/ttl=0s-24                 149.0 ±  8%     295.0 ± 20%  +97.99% (p=0.001 n=7)
LRUAdd/ttl=1m0s-24               196.0 ±  5%     294.0 ±  6%  +50.00% (p=0.001 n=7)
LRUAddWithEviction/ttl=0s-24     72.00 ±  6%     10.00 ±   ?  -86.11% (p=0.001 n=7)
LRUAddWithEviction/ttl=1m0s-24   96.00 ± 25%     14.00 ±   ?  -85.42% (p=0.001 n=7)
LRUGet-24                        0.000 ±  0%     0.000 ±  0%        ~ (p=1.000 n=7) ¹
LRUGCMark-24                     0.000 ±   ?     0.000 ±  0%        ~ (p=1.000 n=7)
geomean                                      ²                -37.40%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                               │   /tmp/old   │                /tmp/new                │
                               │  allocs/op   │ allocs/op   vs base                    │
LRUAdd/ttl=0s-24                 2.000 ± 0%     0.000 ± 0%  -100.00% (p=0.001 n=7)
LRUAdd/ttl=1m0s-24               3.000 ± 0%     0.000 ± 0%  -100.00% (p=0.001 n=7)
LRUAddWithEviction/ttl=0s-24     2.000 ± 0%     0.000 ± 0%  -100.00% (p=0.001 n=7)
LRUAddWithEviction/ttl=1m0s-24   3.000 ± 0%     0.000 ± 0%  -100.00% (p=0.001 n=7)
LRUGet-24                        0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=7) ¹
LRUGCMark-24                     0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=7) ¹
geomean                                     ²               ?                      ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean
```

Note that Add can still allocate even when the cache is full, because of the `items` map.