### PR TITLE
Fix flaky CAS proxy test atime update wait

### DIFF
--- a/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy_test.go
+++ b/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy_test.go
@@ -215,9 +215,14 @@ func TestBatchUpdateBlobsCompressorMetricsLabelsAreBounded(t *testing.T) {
 
 func expectAtimeUpdate(t *testing.T, clock *clockwork.FakeClock, requestCount *atomic.Int32) {
 	requestCount.Store(0)
-	clock.Advance(atimeUpdatePeriod + time.Second)
 	wait := time.Millisecond
-	for i := 0; i < 7; i++ {
+	for i := 0; i < 10; i++ {
+		// The read that enqueued this atime update is processed asynchronously
+		// by the batcher goroutine, so the pending batch may not be ready when
+		// the sender's flush fires. Advance the clock on every iteration (rather
+		// than only once up front) so that a later tick still flushes the update
+		// once the batcher has caught up.
+		clock.Advance(atimeUpdatePeriod + time.Second)
 		time.Sleep(wait)
 		wait = wait * 2
 		if requestCount.Load() == 1 {

--- a/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy_test.go
+++ b/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy_test.go
@@ -225,7 +225,12 @@ func expectAtimeUpdate(t *testing.T, clock *clockwork.FakeClock, requestCount *a
 		clock.Advance(atimeUpdatePeriod + time.Second)
 		time.Sleep(wait)
 		wait = wait * 2
-		if requestCount.Load() == 1 {
+		// A single read can enqueue multiple digests (e.g. read(foo, baz)
+		// updates the atime of both). If the batcher splits them across
+		// pending batches, they may flush on separate ticks, so more than one
+		// update RPC can be observed here. Accept >= 1 rather than == 1 so we
+		// don't spuriously fail when a second flush has already landed.
+		if requestCount.Load() >= 1 {
 			requestCount.Store(0)
 			return
 		}


### PR DESCRIPTION
## Problem

`//enterprise/server/content_addressable_storage_server_proxy:content_addressable_storage_server_proxy_test` is flaky. Under `bazel test --config=race --runs_per_test=100` it fails intermittently with:

```
content_addressable_storage_server_proxy_test.go:228: Timed out waiting for remote atime update
--- FAIL: TestReadUpdateBlobs
```

## Root cause

The `expectAtimeUpdate` test helper advanced the fake clock **once** up front and then polled with an exponential backoff, expecting a remote atime update RPC.

However, a proxy `read()` enqueues the atime update onto a channel that the `batchOperator`'s `batcher()` goroutine drains **asynchronously** into a pending batch. Advancing the clock fires exactly **one** `sender()` flush. If the batcher goroutine hadn't yet moved the enqueued digest into a pending batch when that single flush fired (easy to miss under `--config=race` with 100 parallel runs), the flush sent nothing. Since the retry loop only slept without re-advancing the clock, no subsequent flush ever occurred and the helper timed out.

## Fix

Advance the clock on **every** retry iteration (matching the pattern already used by the neighboring `expectNoAtimeUpdate` helper). Once the batcher catches up, a later tick flushes the pending update. The helper still returns immediately on the first observed request, so timing on the happy path is unchanged.

Two follow-on details:

- The retry loop count was bumped 7 → 10. This raises the worst-case *failure-path* wall time from ~127ms to ~1.02s (only paid when the helper is about to `t.Fatal` anyway); the happy path is unaffected since it returns on the first observed request.
- Because every iteration now fires a tick, more than one flush can occur inside the helper. A single read can enqueue multiple digests (e.g. `read(foo, baz)` updates the atime of both), and if the batcher splits them across pending batches they flush on separate ticks, so `requestCount` can reach 2. The assertion is therefore `>= 1` rather than `== 1`, so it doesn't spuriously fail when a second flush has already landed.

## Verification

`bazel test --config=race --runs_per_test=100 //enterprise/server/content_addressable_storage_server_proxy:content_addressable_storage_server_proxy_test` now passes 100/100 runs (reproduced a failure before the fix).