### PR TITLE
Always flush executions and record usage on PublishOperation EOF

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -555,24 +555,19 @@ func (s *ExecutionServer) updateExecution(ctx context.Context, executionID strin
 	return dbErr
 }
 
-// flushExecutionToOLAP flushes execution data to Clickhouse. Returns the
-// merged StoredExecution if and only if the execution was successfully flushed.
-// Because operation updates can be retried, this function may be called twice
-// for the same execution. The Redis invocation-link cleanup at the end of the
-// first successful call ensures the second call short-circuits and returns a
-// nil StoredExecution.
-func (s *ExecutionServer) flushExecutionToOLAP(ctx context.Context, executionID string) (*repb.StoredExecution, error) {
-	if !olapdbconfig.WriteExecutionsToOLAPDBEnabled() {
-		return nil, nil
-	}
-
+// flushExecutionToOLAP flushes the given merged execution to Clickhouse and
+// cleans up the execution's in-progress state in the collector.
+func (s *ExecutionServer) flushExecutionToOLAP(ctx context.Context, executionProto *repb.StoredExecution) error {
 	// Always clean up executionInvocationLinks, invocationExecutionLinks, and
 	// execution updates from the collector. The execution cannot be retried
 	// after this point, so nothing will clean up this data if we don't do it
 	// here. This means that even if we fail to AppendExecution or
 	// FlushExecutionStats, we will still remove all links and in-progress
-	// executions.
+	// executions. Deleting the in-progress execution is also what guarantees
+	// that the execution is flushed and usage is recorded at most once: later
+	// calls get NotFound from GetInProgressExecution and skip both.
 	var links []*sipb.StoredInvocationLink
+	executionID := executionProto.GetExecutionId()
 	defer func() {
 		err := s.executionCollector.DeleteExecutionInvocationLinks(ctx, executionID)
 		if err != nil {
@@ -589,14 +584,14 @@ func (s *ExecutionServer) flushExecutionToOLAP(ctx context.Context, executionID 
 		}
 	}()
 
-	executionProto, err := s.executionCollector.GetInProgressExecution(ctx, executionID)
-	if err != nil {
-		return nil, status.InternalErrorf("failed to get execution %q from redis: %s", executionID, err)
-	}
-
+	var err error
 	links, err = s.executionCollector.GetExecutionInvocationLinks(ctx, executionID)
 	if err != nil {
-		return nil, status.InternalErrorf("failed to get invocations for execution %q: %s", executionID, err)
+		return status.InternalErrorf("failed to get invocations for execution %q: %s", executionID, err)
+	}
+
+	if !olapdbconfig.WriteExecutionsToOLAPDBEnabled() {
+		return nil
 	}
 	for _, link := range links {
 		executionProto := executionProto.CloneVT()
@@ -628,19 +623,29 @@ func (s *ExecutionServer) flushExecutionToOLAP(ctx context.Context, executionID 
 			}
 		}
 	}
-	return executionProto, nil
+	return nil
 }
 
+// flushAndRecordUsage reads the merged in-progress execution from the
+// collector, flushes it to Clickhouse and records usage from it. Usage
+// recording only requires the merged execution from Redis, so it happens even
+// if OLAP writes are disabled or fail.
 func (s *ExecutionServer) flushAndRecordUsage(ctx context.Context, taskID string) {
-	execution, err := s.flushExecutionToOLAP(ctx, taskID)
+	execution, err := s.executionCollector.GetInProgressExecution(ctx, taskID)
 	if err != nil {
+		// NotFound means there is nothing to flush: either no operation was
+		// ever received on this stream, or the execution was already flushed.
+		if !status.IsNotFoundError(err) {
+			log.CtxErrorf(ctx, "failed to get execution %q from redis: %s", taskID, err)
+		}
+		return
+	}
+	if err := s.flushExecutionToOLAP(ctx, execution); err != nil {
 		log.CtxErrorf(ctx, "failed to flush execution %q to clickhouse: %s", taskID, err)
 	}
-	if execution != nil {
-		// TODO(vanja) should this be done when the executor got a cache hit?
-		if err := s.updateUsageFromStoredExecution(ctx, execution); err != nil {
-			log.CtxWarningf(ctx, "Failed to update usage for execution %q: %s", taskID, err)
-		}
+	// TODO(vanja) should this be done when the executor got a cache hit?
+	if err := s.updateUsage(ctx, execution); err != nil {
+		log.CtxWarningf(ctx, "Failed to update usage for execution %q: %s", taskID, err)
 	}
 }
 
@@ -954,9 +959,16 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 		executionTask.Experiments = append(executionTask.Experiments, "executor.download_inputs_chunked")
 	}
 
-	if efp != nil && efp.Boolean(ctx, "remote_execution.publish_post_completion_stats", false) {
-		executionTask.Experiments = append(executionTask.Experiments, "remote_execution.publish_post_completion_stats")
-	}
+	// Always tell the executor to publish post-completion stats, so that
+	// older versions of executors that are checking for this experiment flag
+	// will still publish the stats. This allows
+	//  - old self-hosted executors to continue publishing post-completion stats
+	//  - on-prem executors to be upgraded to a version which conditionally
+	// 		publish post-completion stats without having to upgrade their
+	// 		on-prem apps first.
+	// TODO(vanja): remove this once all self-hosted and on-prem executors are
+	// upgraded to a version which always publishes post-completion stats.
+	executionTask.Experiments = append(executionTask.Experiments, "remote_execution.publish_post_completion_stats")
 
 	// Add in secrets for any action explicitly requesting secrets, and all workflows.
 	secretService := s.env.GetSecretService()
@@ -1372,7 +1384,9 @@ func (s *ExecutionServer) recordFailedExecution(ctx context.Context, taskID stri
 	if err := s.updateExecution(ctx, taskID, repb.ExecutionStage_COMPLETED, executeRsp, auxMetadata, properties, action, cmd); err != nil {
 		return err
 	}
-	if _, err := s.flushExecutionToOLAP(ctx, taskID); err != nil {
+	if execution, err := s.executionCollector.GetInProgressExecution(ctx, taskID); err != nil {
+		log.CtxWarningf(ctx, "MarkExecutionFailed: failed to get execution %q from redis: %s", taskID, err)
+	} else if err := s.flushExecutionToOLAP(ctx, execution); err != nil {
 		log.CtxWarningf(ctx, "MarkExecutionFailed: failed to flush execution to clickhouse: %s", err)
 	}
 	return nil
@@ -1462,21 +1476,10 @@ func (s *ExecutionServer) PublishOperation(stream repb.Execution_PublishOperatio
 	})
 	defer deletePendingExecutionOnce()
 
-	flushExecutionsOnEOF := false
-	if *writeExecutionProgressStateToRedis {
-		// It only makes sense to flush on EOF if we're appending updates in
-		// Redis.
-		if fp := s.env.GetExperimentFlagProvider(); fp != nil {
-			flushExecutionsOnEOF = fp.Boolean(ctx, "remote_execution.flush_executions_after_cleanup", false)
-		}
-	}
-
 	for {
 		op, err := stream.Recv()
 		if err == io.EOF {
-			if flushExecutionsOnEOF {
-				s.flushAndRecordUsage(ctx, taskID)
-			}
+			s.flushAndRecordUsage(ctx, taskID)
 			return stream.SendAndClose(&repb.PublishOperationResponse{})
 		}
 		if err != nil {
@@ -1492,10 +1495,8 @@ func (s *ExecutionServer) PublishOperation(stream repb.Execution_PublishOperatio
 			if err != nil {
 				log.CtxWarningf(ctx, "Failed to parse PostCompletionStats: %s", err)
 			} else if ok {
-				if flushExecutionsOnEOF {
-					if err := s.updateExecutionPostCompletion(ctx, taskID, stats); err != nil {
-						log.CtxErrorf(ctx, "PublishOperation: error updating PostCompletionStats: %s", err)
-					}
+				if err := s.updateExecutionPostCompletion(ctx, taskID, stats); err != nil {
+					log.CtxErrorf(ctx, "PublishOperation: error updating PostCompletionStats: %s", err)
 				}
 				// Always skip the rest when we get PostCompletionStats. This
 				// means that a previous COMPLETED message already should have
@@ -1575,8 +1576,8 @@ func (s *ExecutionServer) PublishOperation(stream repb.Execution_PublishOperatio
 			if err := s.cacheActionResult(ctx, actionRN, trimmedResponse, action); err != nil {
 				return status.UnavailableErrorf("Error uploading action result: %s", err.Error())
 			}
-			if err := s.markTaskComplete(ctx, actionRN, response, auxMeta, action, cmd, properties, flushExecutionsOnEOF); err != nil {
-				// Errors updating the router or recording usage are non-fatal.
+			if err := s.markTaskComplete(ctx, actionRN, response, action, cmd, properties); err != nil {
+				// Errors updating the router are non-fatal.
 				log.CtxErrorf(ctx, "Could not update post-completion metadata: %s", err)
 			}
 
@@ -1599,11 +1600,6 @@ func (s *ExecutionServer) PublishOperation(stream repb.Execution_PublishOperatio
 				if err := s.updateExecution(ctx, taskID, stage, response, auxMeta, properties, action, cmd); err != nil {
 					log.CtxErrorf(ctx, "PublishOperation: error updating execution: %s", err)
 					return status.WrapErrorf(err, "failed to update execution %q", taskID)
-				}
-				if !flushExecutionsOnEOF {
-					if _, err := s.flushExecutionToOLAP(ctx, taskID); err != nil {
-						log.CtxErrorf(ctx, "failed to flush execution %q to clickhouse: %s", taskID, err)
-					}
 				}
 				return nil
 			}()
@@ -1673,12 +1669,14 @@ func (s *ExecutionServer) cacheActionResult(ctx context.Context, actionResourceN
 
 // markTaskComplete contains logic to be run when the task is complete but
 // before letting the client know that the task has completed.
-//
-// When flushExecutionsOnEOF is false (the legacy path, experiment off),
-// usage is recorded here from the live ExecuteResponse + platform.Properties.
-// When true, usage is recorded later by flushAndRecordUsage from the merged
-// StoredExecution in Redis.
-func (s *ExecutionServer) markTaskComplete(ctx context.Context, actionResourceName *digest.ACResourceName, executeResponse *repb.ExecuteResponse, auxMeta *espb.ExecutionAuxiliaryMetadata, action *repb.Action, cmd *repb.Command, properties *platform.Properties, flushExecutionsOnEOF bool) error {
+func (s *ExecutionServer) markTaskComplete(
+	ctx context.Context,
+	actionResourceName *digest.ACResourceName,
+	executeResponse *repb.ExecuteResponse,
+	action *repb.Action,
+	cmd *repb.Command,
+	properties *platform.Properties) error {
+
 	execErr := gstatus.ErrorProto(executeResponse.GetStatus())
 	router := s.env.GetTaskRouter()
 	if router != nil && !executeResponse.GetCachedResult() {
@@ -1711,103 +1709,15 @@ func (s *ExecutionServer) markTaskComplete(ctx context.Context, actionResourceNa
 		}
 	}
 
-	if !flushExecutionsOnEOF {
-		if err := s.updateUsage(ctx, executeResponse, auxMeta, properties); err != nil {
-			// TODO(vanja) should this be done when the executor got a cache hit?
-			log.CtxWarningf(ctx, "Failed to update usage for ExecuteResponse %+v: %s", executeResponse, err)
-		}
-	}
-
 	return nil
 }
 
-func (s *ExecutionServer) updateUsage(ctx context.Context, executeResponse *repb.ExecuteResponse, auxMeta *espb.ExecutionAuxiliaryMetadata, plat *platform.Properties) error {
+func (s *ExecutionServer) updateUsage(ctx context.Context, execution *repb.StoredExecution) error {
 	ut := s.env.GetUsageTracker()
 	if ut == nil {
 		return nil
 	}
-	dur, err := executionDuration(executeResponse.GetResult().GetExecutionMetadata())
-	if err != nil {
-		// If the task encountered an error, it's somewhat expected that the
-		// execution duration will be unset, so don't return an error. For
-		// example, we may have failed to pull the image, so execution could not
-		// even begin. Note that an error doesn't necessarily imply a missing
-		// exec duration though; we may get a DeadlineExceeded error if the task
-		// times out, but still get an exec duration.
-		if execErr := gstatus.ErrorProto(executeResponse.GetStatus()); execErr != nil {
-			return nil
-		}
-		return err
-	}
-
-	pool, err := s.env.GetSchedulerService().GetPoolInfo(ctx, plat.OS, plat.Arch, plat.Pool, plat.OriginalPool, plat.WorkflowID, plat.PoolType)
-	if err != nil {
-		return status.InternalErrorf("failed to determine executor pool: %s", err)
-	}
-
-	counts := &tables.UsageCounts{}
-	setExecutionDuration(counts, dur, pool.IsSelfHosted, plat.OS)
-	usg := executeResponse.GetResult().GetExecutionMetadata().GetUsageStats()
-	if !pool.IsSelfHosted && usg.GetCpuNanos() > 0 {
-		counts.CPUNanos = usg.GetCpuNanos()
-
-		// If quota is exceeded, the next execution will be blocked.
-		if qm := s.env.GetQuotaManager(); qm != nil {
-			namespace := quota.GetSKUKey(sku.RemoteExecutionExecuteWorkerCPUNanos)
-			if err := qm.Allow(ctx, namespace, counts.CPUNanos); err != nil {
-				log.CtxWarningf(ctx, "CPU time quota exhausted after execution: %s", err)
-			}
-		}
-	}
-	labels, olapLabels, err := usageutil.LabelsForUsageRecording(ctx, usageutil.ServerName())
-	if err != nil {
-		return status.WrapError(err, "compute usage labels")
-	}
-	var lastErr error
-	if err := ut.Increment(ctx, labels, counts); err != nil {
-		log.CtxWarningf(ctx, "Failed to increment usage: %s", err)
-		lastErr = err
-	}
-
-	// Project the live ExecuteResponse + aux metadata onto a StoredExecution
-	// so we can reuse incrementOLAPExecutionUsage's accounting logic. Only
-	// the fields that function reads are populated; snapshot stats arrive
-	// via a second COMPLETED that this code path doesn't merge. The
-	// Estimated* fields come from md.EstimatedTaskSize — same source the
-	// stored path uses (via fillExecutionFromActionMetadata, line 107-108).
-	md := executeResponse.GetResult().GetExecutionMetadata()
-	estimatedTaskSize := md.GetEstimatedTaskSize()
-	execution := &repb.StoredExecution{
-		Os:                     plat.OS,
-		Arch:                   plat.Arch,
-		SelfHosted:             pool.IsSelfHosted,
-		EffectiveIsolationType: auxMeta.GetIsolationType(),
-		CpuNanos:               counts.CPUNanos,
-		PeakMemoryBytes:        usg.GetPeakMemoryBytes(),
-		RequestedComputeUnits:  plat.EstimatedComputeUnits,
-		RequestedMilliCpu:      plat.EstimatedMilliCPU,
-		RequestedMemoryBytes:   plat.EstimatedMemoryBytes,
-		RequestedFreeDiskBytes: plat.EstimatedFreeDiskBytes,
-		EstimatedMilliCpu:      estimatedTaskSize.GetEstimatedMilliCpu(),
-		EstimatedMemoryBytes:   estimatedTaskSize.GetEstimatedMemoryBytes(),
-		EstimatedFreeDiskBytes: estimatedTaskSize.GetEstimatedFreeDiskBytes(),
-	}
-	if err := incrementOLAPExecutionUsage(ctx, ut, olapLabels, execution, dur); err != nil {
-		log.CtxWarningf(ctx, "Failed to increment OLAP usage: %s", err)
-		lastErr = err
-	}
-
-	return lastErr
-}
-
-// updateUsageFromStoredExecution records usage counters from a merged
-// StoredExecution read out of Redis by flushExecutionToOLAP.
-func (s *ExecutionServer) updateUsageFromStoredExecution(ctx context.Context, execution *repb.StoredExecution) error {
-	ut := s.env.GetUsageTracker()
-	if ut == nil {
-		return nil
-	}
-	dur, err := executionDurationFromStored(execution)
+	dur, err := executionDuration(execution)
 	if err != nil {
 		// If the task encountered an error, it's somewhat expected that the
 		// execution duration will be unset, so don't return an error. For
@@ -1966,22 +1876,6 @@ func redactExecutionAuxiliaryMetadata(ctx context.Context, auxAny *anypb.Any) {
 	}
 }
 
-func executionDuration(md *repb.ExecutedActionMetadata) (time.Duration, error) {
-	if err := md.GetWorkerStartTimestamp().CheckValid(); err != nil {
-		return 0, err
-	}
-	if err := md.GetWorkerCompletedTimestamp().CheckValid(); err != nil {
-		return 0, err
-	}
-	start := md.GetWorkerStartTimestamp().AsTime()
-	end := md.GetWorkerCompletedTimestamp().AsTime()
-	dur := end.Sub(start)
-	if dur <= 0 {
-		return 0, status.InternalErrorf("Execution duration is <= 0")
-	}
-	return dur, nil
-}
-
 func setExecutionDuration(counts *tables.UsageCounts, duration time.Duration, isSelfHosted bool, os string) {
 	if duration < 0 {
 		return
@@ -2001,7 +1895,7 @@ func setExecutionDuration(counts *tables.UsageCounts, duration time.Duration, is
 	}
 }
 
-func executionDurationFromStored(execution *repb.StoredExecution) (time.Duration, error) {
+func executionDuration(execution *repb.StoredExecution) (time.Duration, error) {
 	startUsec := execution.GetWorkerStartTimestampUsec()
 	endUsec := execution.GetWorkerCompletedTimestampUsec()
 	if startUsec == 0 || endUsec == 0 {

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -776,6 +776,16 @@ func TestExecuteAndPublishOperation(t *testing.T) {
 			},
 		},
 		{
+			// The on-prem default configuration: execution progress state is
+			// not written to Redis, so the collector only ever sees the single
+			// COMPLETED update. The EOF flush and usage recording must work
+			// from that merged row alone.
+			name:                   "PublishMoreMetadata_NoProgressStateInRedis",
+			expectedExecutionUsage: tables.UsageCounts{LinuxExecutionDurationUsec: durationUsec},
+			publishMoreMetadata:    true,
+			noRedisProgressState:   true,
+		},
+		{
 			// Restarting Redis wipes the per-execution invocation links
 			// before the COMPLETED operation arrives, exercising the same
 			// "empty invocation links" path that normal-flow executions
@@ -808,17 +818,9 @@ func TestExecuteAndPublishOperation(t *testing.T) {
 			invalidTestSize:        "extra-large",
 		},
 	} {
-		for _, flushAfterCleanup := range []bool{false, true} {
-			test := test
-			test.flushAfterCleanup = flushAfterCleanup
-			name := test.name
-			if flushAfterCleanup {
-				name += "/FlushAfterCleanup"
-			}
-			t.Run(name, func(t *testing.T) {
-				testExecuteAndPublishOperation(t, test)
-			})
-		}
+		t.Run(test.name, func(t *testing.T) {
+			testExecuteAndPublishOperation(t, test)
+		})
 	}
 }
 
@@ -835,7 +837,7 @@ type publishTest struct {
 	redisRestart             bool
 	useDefaultPool           bool
 	recycleRunner            bool
-	flushAfterCleanup        bool
+	noRedisProgressState     bool
 	invalidTestSize          string
 	// flexibleCompute routes the execution into the flexible-compute branch
 	// of incrementOLAPExecutionUsage.
@@ -845,14 +847,11 @@ type publishTest struct {
 func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 	ctx := context.Background()
 	flags.Set(t, "app.enable_write_executions_to_olap_db", true)
-	flags.Set(t, "remote_execution.write_execution_progress_state_to_redis", true)
+	flags.Set(t, "remote_execution.write_execution_progress_state_to_redis", !test.noRedisProgressState)
 	for k, v := range test.flagOverrides {
 		flags.Set(t, k, v)
 	}
 	env, conn, r := setupEnv(t)
-	if test.flushAfterCleanup {
-		configureExperiments(t, env, map[string]bool{"remote_execution.flush_executions_after_cleanup": true})
-	}
 	client := repb.NewExecutionClient(conn)
 	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
 	env.SetAuthenticator(ta)
@@ -1231,6 +1230,11 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 		expectedExecution.RequestedPool = "test-pool"
 		expectedExecution.EffectivePool = "test-pool"
 	}
+	if test.noRedisProgressState {
+		// The output path is only captured by the dispatch-time write to
+		// Redis, which is disabled in this configuration.
+		expectedExecution.OutputPath = ""
+	}
 	if test.publishMoreMetadata {
 		expectedExecution.ExecutionPriority = 999
 		expectedExecution.SkipCacheLookup = true
@@ -1271,20 +1275,14 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 // server should flush the OLAP row and record usage exactly once across the
 // retry chain.
 //
-// Only run with the flush_executions_after_cleanup experiment enabled: that's
-// where the exactly-once guarantee comes from. The recv loop only calls
-// flushAndRecordUsage on io.EOF, and the retryingClient only opens a new
-// stream after a non-EOF error — so at most one stream in the chain ever
-// triggers the flush. Under the legacy COMPLETED-flush path the flush runs
-// inline with the COMPLETED handler regardless of how the stream ends, so
-// retries are inherently subject to over-counting; that's pre-existing
-// behavior and not what this test pins down.
+// The recv loop only calls flushAndRecordUsage on io.EOF, and the
+// retryingClient only opens a new stream after a non-EOF error — so at most one
+// stream in the chain ever triggers the flush.
 func TestPublishOperation_RetriedStream(t *testing.T) {
 	ctx := context.Background()
 	flags.Set(t, "app.enable_write_executions_to_olap_db", true)
 	flags.Set(t, "remote_execution.write_execution_progress_state_to_redis", true)
 	env, conn, _ := setupEnv(t)
-	configureExperiments(t, env, map[string]bool{"remote_execution.flush_executions_after_cleanup": true})
 	client := repb.NewExecutionClient(conn)
 	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
 	env.SetAuthenticator(ta)
@@ -1424,25 +1422,10 @@ func TestPublishOperation_RetriedStream(t *testing.T) {
 // convenient mechanism; the contract applies regardless of how the links
 // list ends up empty.
 func TestPublishOperation_FlushWithEmptyLinks(t *testing.T) {
-	for _, flushOnEOF := range []bool{false, true} {
-		name := "FlushOnComplete"
-		if flushOnEOF {
-			name = "FlushAfterCleanup"
-		}
-		t.Run(name, func(t *testing.T) {
-			testPublishOperationFlushWithEmptyLinks(t, flushOnEOF)
-		})
-	}
-}
-
-func testPublishOperationFlushWithEmptyLinks(t *testing.T, flushOnEOF bool) {
 	ctx := context.Background()
 	flags.Set(t, "app.enable_write_executions_to_olap_db", true)
 	flags.Set(t, "remote_execution.write_execution_progress_state_to_redis", true)
 	env, conn, r := setupEnv(t)
-	if flushOnEOF {
-		configureExperiments(t, env, map[string]bool{"remote_execution.flush_executions_after_cleanup": true})
-	}
 	client := repb.NewExecutionClient(conn)
 	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
 	env.SetAuthenticator(ta)
@@ -1546,13 +1529,127 @@ func testPublishOperationFlushWithEmptyLinks(t *testing.T, flushOnEOF bool) {
 	assert.Equal(t, durationUsec, foundExecutorUsage.Counts.LinuxExecutionDurationUsec)
 }
 
+// TestPublishOperation_UsageRecordedWhenOLAPDisabled verifies that usage
+// recording does not depend on app.enable_write_executions_to_olap_db: the
+// EOF flush must record usage from the merged StoredExecution in Redis and
+// clean up the in-progress state even when OLAP writes are disabled. The
+// cleanup is what guarantees usage is recorded at most once, so it must not
+// be skipped along with the OLAP write.
+//
+// Runs with the on-prem default of no execution progress state in Redis,
+// since deployments without ClickHouse are typically on-prem apps.
+func TestPublishOperation_UsageRecordedWhenOLAPDisabled(t *testing.T) {
+	ctx := context.Background()
+	flags.Set(t, "app.enable_write_executions_to_olap_db", false)
+	env, conn, _ := setupEnv(t)
+	client := repb.NewExecutionClient(conn)
+	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
+	env.SetAuthenticator(ta)
+	ctx, err := ta.WithAuthenticatedUser(ctx, "user1")
+	require.NoError(t, err)
+
+	const instanceName = "test-instance"
+	const invocationID = "93383cc1-5d6c-4ad1-a321-8ee87c2f6816"
+	const digestFunction = repb.DigestFunction_SHA256
+
+	clientCtx, err := bazel_request.WithRequestMetadata(ctx, &repb.RequestMetadata{
+		ToolInvocationId: invocationID,
+		TargetId:         "//some:test",
+		ActionMnemonic:   "TestRunner",
+	})
+	require.NoError(t, err)
+	arn := uploadAction(clientCtx, t, env, instanceName, digestFunction, &repb.Action{
+		Timeout: &durationpb.Duration{Seconds: 10},
+		Platform: &repb.Platform{Properties: []*repb.Platform_Property{
+			{Name: "pool", Value: "test-pool"},
+		}},
+	})
+	executionClient, err := client.Execute(clientCtx, &repb.ExecuteRequest{
+		InstanceName:   arn.GetInstanceName(),
+		ActionDigest:   arn.GetDigest(),
+		DigestFunction: arn.GetDigestFunction(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, executionClient.CloseSend())
+	initialOp, err := executionClient.Recv()
+	require.NoError(t, err)
+	taskID := initialOp.GetName()
+
+	executorCtx := metadata.AppendToOutgoingContext(clientCtx, usageutil.ClientHeaderName, "executor")
+	executorCtx = metadata.AppendToOutgoingContext(executorCtx, "x-buildbuddy-executor-region", "test-region")
+	stream, err := client.PublishOperation(executorCtx)
+	require.NoError(t, err)
+
+	workerStartTime := time.Unix(100, 0)
+	workerEndTime := workerStartTime.Add(5 * time.Second)
+	durationUsec := workerEndTime.Sub(workerStartTime).Microseconds()
+	aux := &espb.ExecutionAuxiliaryMetadata{
+		SchedulingMetadata: &scpb.SchedulingMetadata{
+			ExecutorGroupId: sharedPoolGroupID,
+			Pool:            "test-pool",
+		},
+	}
+	auxAny, err := anypb.New(aux)
+	require.NoError(t, err)
+	completedOp, err := operation.Assemble(
+		taskID,
+		operation.Metadata(repb.ExecutionStage_COMPLETED, arn.GetDigest()),
+		&repb.ExecuteResponse{
+			Result: &repb.ActionResult{
+				ExecutionMetadata: &repb.ExecutedActionMetadata{
+					WorkerStartTimestamp:     tspb.New(workerStartTime),
+					WorkerCompletedTimestamp: tspb.New(workerEndTime),
+					AuxiliaryMetadata:        []*anypb.Any{auxAny},
+				},
+			},
+			Status: gstatus.Convert(nil).Proto(),
+		},
+	)
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(completedOp))
+	_, err = stream.CloseAndRecv()
+	require.NoError(t, err)
+
+	// Usage must be recorded even though OLAP writes are disabled.
+	ut := env.GetUsageTracker().(*testusage.Tracker)
+	var foundExecutorUsage *testusage.Total
+	for _, u := range ut.Totals() {
+		if u.Labels.Client == "executor" {
+			foundExecutorUsage = &u
+			break
+		}
+	}
+	require.NotNil(t, foundExecutorUsage, "expected executor usage to be recorded with OLAP writes disabled")
+	assert.Equal(t, durationUsec, foundExecutorUsage.Counts.LinuxExecutionDurationUsec)
+	var foundOLAPExecutorUsage *testusage.OLAPTotal
+	for _, u := range ut.OLAPTotals() {
+		if _, ok := u.Counts[sku.RemoteExecutionExecuteWorkerDurationNanos]; ok {
+			foundOLAPExecutorUsage = &u
+		}
+	}
+	require.NotNil(t, foundOLAPExecutorUsage, "expected usage SKU counters to be recorded with OLAP writes disabled")
+
+	// No rows may be buffered for the OLAP flush.
+	collectedExecutions, err := env.GetExecutionCollector().GetExecutions(ctx, invocationID, 0, -1)
+	require.NoError(t, err)
+	assert.Empty(t, collectedExecutions, "no OLAP rows should be buffered when OLAP writes are disabled")
+
+	// The in-progress state must still be cleaned up: the deleted in-progress
+	// execution is what makes a duplicate flush a NotFound no-op.
+	_, err = env.GetExecutionCollector().GetInProgressExecution(ctx, taskID)
+	assert.True(t, status.IsNotFoundError(err), "expected in-progress execution to be cleaned up, got: %v", err)
+	links, err := env.GetExecutionCollector().GetExecutionInvocationLinks(ctx, taskID)
+	require.NoError(t, err)
+	assert.Empty(t, links, "expected invocation links to be cleaned up")
+}
+
 // TestPublishOperation_PeriodicFlushDoesNotClobberCompletedRow exercises the
 // race where the periodic flush goroutine fires more than 5 seconds after
 // PublishOperation's main loop has already written the authoritative
-// COMPLETED row. With the bug, the goroutine wakes up, sees `lastWrite`
+// COMPLETED update. With the bug, the goroutine wakes up, sees `lastWrite`
 // is stale, and pushes a partial update (auxMeta/properties/action/cmd
-// all nil) back into Redis — resurrecting an in-progress entry that
-// flushExecutionToOLAP had already cleaned up.
+// all nil) into Redis on top of the authoritative COMPLETED update — which
+// would then be merged into the row flushed to OLAP when the stream closes.
 func TestPublishOperation_PeriodicFlushDoesNotClobberCompletedRow(t *testing.T) {
 	ctx := context.Background()
 	flags.Set(t, "app.enable_write_executions_to_olap_db", true)
@@ -1625,33 +1722,51 @@ func TestPublishOperation_PeriodicFlushDoesNotClobberCompletedRow(t *testing.T) 
 	require.NoError(t, err)
 	require.NoError(t, stream.Send(completedOp))
 
-	// Wait for the main loop's COMPLETED write + flushExecutionToOLAP to
-	// land. The flush appends the merged execution to the per-invocation
-	// list and deletes the in-progress updates list.
+	// Wait for the main loop's COMPLETED write to land in Redis. The OLAP
+	// flush doesn't happen until the stream is closed, so until then the
+	// in-progress entry holds the authoritative COMPLETED row.
+	var completedRow *repb.StoredExecution
 	require.Eventually(t, func() bool {
-		execs, err := env.GetExecutionCollector().GetExecutions(ctx, invocationID, 0, -1)
-		return err == nil && len(execs) == 1
-	}, 5*time.Second, 10*time.Millisecond, "main loop's COMPLETED write never landed in the per-invocation list")
+		ex, err := env.GetExecutionCollector().GetInProgressExecution(ctx, taskID)
+		if err != nil || ex.GetStage() != int64(repb.ExecutionStage_COMPLETED) {
+			return false
+		}
+		completedRow = ex
+		return true
+	}, 5*time.Second, 10*time.Millisecond, "main loop's COMPLETED write never landed in the in-progress entry")
 
-	// Sanity check: in-progress data was cleaned up by flushExecutionToOLAP.
-	require.Eventually(t, func() bool {
-		_, err := env.GetExecutionCollector().GetInProgressExecution(ctx, taskID)
-		return status.IsNotFoundError(err)
-	}, 5*time.Second, 10*time.Millisecond, "expected in-progress data to be cleaned up after flush")
-
-	// Advance past the 5s flush threshold to let the periodic goroutine wake up
+	// Advance past the 5s flush threshold to let the periodic goroutine wake
+	// up while the stream is still open.
 	fakeClock.Advance(6 * time.Second)
 
-	// Give the periodic goroutine real wall-clock time to fire. With the
-	// fix in place it skips the write; with the bug it resurrects the
-	// in-progress entry.
+	// Give the periodic goroutine real wall-clock time to fire. With the fix
+	// in place it sees the COMPLETED stage and skips the write; with the bug
+	// it appends a partial update on top of the authoritative COMPLETED row.
+	require.Never(t, func() bool {
+		ex, err := env.GetExecutionCollector().GetInProgressExecution(ctx, taskID)
+		return err != nil || !proto.Equal(ex, completedRow)
+	}, 500*time.Millisecond, 25*time.Millisecond, "periodic flush wrote on top of the authoritative COMPLETED update")
+
+	// Close the stream; the EOF handler flushes the merged execution to the
+	// per-invocation list and deletes the in-progress entry.
+	_, err = stream.CloseAndRecv()
+	require.NoError(t, err)
+
+	execs, err := env.GetExecutionCollector().GetExecutions(ctx, invocationID, 0, -1)
+	require.NoError(t, err)
+	require.Len(t, execs, 1, "expected exactly one flushed execution row")
+	assert.Equal(t, int64(repb.ExecutionStage_COMPLETED), execs[0].GetStage())
+	assert.Equal(t, "exec-host-1", execs[0].GetExecutorHostname())
+
+	_, err = env.GetExecutionCollector().GetInProgressExecution(ctx, taskID)
+	require.True(t, status.IsNotFoundError(err), "expected in-progress data to be cleaned up after flush")
+
+	// The in-progress entry must stay deleted: a straggler periodic write
+	// after the flush would resurrect it.
 	require.Never(t, func() bool {
 		_, err := env.GetExecutionCollector().GetInProgressExecution(ctx, taskID)
 		return err == nil
-	}, 500*time.Millisecond, 25*time.Millisecond, "periodic flush resurrected the in-progress entry after the authoritative COMPLETED write")
-
-	// Close the stream cleanly so PublishOperation returns.
-	_, _ = stream.CloseAndRecv()
+	}, 500*time.Millisecond, 25*time.Millisecond, "periodic flush resurrected the in-progress entry after the flush")
 }
 
 // TestPublishOperation_SecondCompletedCarriesSnapshotStats verifies that a
@@ -1659,37 +1774,17 @@ func TestPublishOperation_PeriodicFlushDoesNotClobberCompletedRow(t *testing.T) 
 // carrying a PostCompletionStats entry in auxiliary_metadata, is handled
 // correctly under both experiment values.
 //
-// Under flush_executions_after_cleanup=true (the path this PR exists to
-// enable), the snapshot fields get merged into the recorded
-// StoredExecution. The first COMPLETED's other fields survive the merge
+// The snapshot fields get merged into the recorded StoredExecution on the
+// second COMPLETED event. The first COMPLETED's other fields survive the merge
 // (proto.Merge semantics).
 //
-// Under flush_executions_after_cleanup=false (legacy path), the OLAP flush
-// already ran on the first COMPLETED, so the second COMPLETED is dropped
-// server-side and the snapshot fields don't appear in the recorded row.
-//
-// In both modes the action result must not be re-cached and usage must be
-// recorded exactly once.
+// The action result must not be re-cached and usage must be recorded exactly
+// once.
 func TestPublishOperation_SecondCompletedCarriesSnapshotStats(t *testing.T) {
-	for _, flushAfterCleanup := range []bool{false, true} {
-		name := "FlushOnComplete"
-		if flushAfterCleanup {
-			name = "FlushAfterCleanup"
-		}
-		t.Run(name, func(t *testing.T) {
-			testPublishOperationSecondCompletedCarriesSnapshotStats(t, flushAfterCleanup)
-		})
-	}
-}
-
-func testPublishOperationSecondCompletedCarriesSnapshotStats(t *testing.T, flushAfterCleanup bool) {
 	ctx := context.Background()
 	flags.Set(t, "app.enable_write_executions_to_olap_db", true)
 	flags.Set(t, "remote_execution.write_execution_progress_state_to_redis", true)
 	env, conn, _ := setupEnv(t)
-	if flushAfterCleanup {
-		configureExperiments(t, env, map[string]bool{"remote_execution.flush_executions_after_cleanup": true})
-	}
 	client := repb.NewExecutionClient(conn)
 	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
 	env.SetAuthenticator(ta)
@@ -1805,23 +1900,12 @@ func testPublishOperationSecondCompletedCarriesSnapshotStats(t *testing.T, flush
 	assert.Equal(t, "//some:test", got.GetTargetLabel())
 	assert.Equal(t, workerStartTime.UnixMicro(), got.GetWorkerStartTimestampUsec())
 	assert.Equal(t, workerEndTime.UnixMicro(), got.GetWorkerCompletedTimestampUsec())
-	if flushAfterCleanup {
-		// Second-COMPLETED snapshot stats were merged in.
-		assert.True(t, got.GetSnapshotSavedLocally(), "snapshot_saved_locally")
-		assert.True(t, got.GetSnapshotSavedRemotely(), "snapshot_saved_remotely")
-		assert.True(t, got.GetSnapshotIsDiff(), "snapshot_is_diff")
-		assert.Equal(t, int64(12345), got.GetSnapshotSavedBytes())
-		assert.Equal(t, int64(67890), got.GetPauseDurationUsec())
-	} else {
-		// Legacy path: the OLAP flush already ran on the first COMPLETED, so
-		// the second COMPLETED is dropped server-side and its snapshot
-		// fields don't make it to the recorded row.
-		assert.False(t, got.GetSnapshotSavedLocally(), "snapshot_saved_locally should be unset on legacy path")
-		assert.False(t, got.GetSnapshotSavedRemotely(), "snapshot_saved_remotely should be unset on legacy path")
-		assert.False(t, got.GetSnapshotIsDiff(), "snapshot_is_diff should be unset on legacy path")
-		assert.Zero(t, got.GetSnapshotSavedBytes(), "snapshot_saved_bytes should be unset on legacy path")
-		assert.Zero(t, got.GetPauseDurationUsec(), "pause_duration_usec should be unset on legacy path")
-	}
+	// Second-COMPLETED snapshot stats were merged in.
+	assert.True(t, got.GetSnapshotSavedLocally(), "snapshot_saved_locally")
+	assert.True(t, got.GetSnapshotSavedRemotely(), "snapshot_saved_remotely")
+	assert.True(t, got.GetSnapshotIsDiff(), "snapshot_is_diff")
+	assert.Equal(t, int64(12345), got.GetSnapshotSavedBytes())
+	assert.Equal(t, int64(67890), got.GetPauseDurationUsec())
 
 	// Action cache should hold the result from the first COMPLETED only.
 	// The sparse second COMPLETED must not have triggered another cache write.
@@ -1846,22 +1930,15 @@ func testPublishOperationSecondCompletedCarriesSnapshotStats(t *testing.T, flush
 
 	// OLAP snapshot bytes are only recorded when the snapshot fields actually
 	// reach the StoredExecution that updateUsageFromStoredExecution reads.
-	// That only happens on the flushAfterCleanup path; on the legacy path
-	// the second COMPLETED is dropped before the OLAP flush runs.
 	var foundRemoteSnapshotBytes, foundLocalSnapshotBytes int64
 	for _, u := range ut.OLAPTotals() {
 		foundRemoteSnapshotBytes += u.Counts[sku.RemoteExecutionExecuteRemoteSnapshotSavedBytes]
 		foundLocalSnapshotBytes += u.Counts[sku.RemoteExecutionExecuteLocalSnapshotSavedBytes]
 	}
-	if flushAfterCleanup {
-		// Both snapshot_saved_locally and snapshot_saved_remotely were sent,
-		// but the remote branch takes precedence in incrementOLAPExecutionUsage.
-		assert.Equal(t, int64(12345), foundRemoteSnapshotBytes, "expected remote snapshot bytes SKU to be recorded")
-		assert.Zero(t, foundLocalSnapshotBytes, "local snapshot bytes SKU should not be recorded when remote takes precedence")
-	} else {
-		assert.Zero(t, foundRemoteSnapshotBytes, "no snapshot SKUs should be recorded on the legacy path")
-		assert.Zero(t, foundLocalSnapshotBytes, "no snapshot SKUs should be recorded on the legacy path")
-	}
+	// Both snapshot_saved_locally and snapshot_saved_remotely were sent,
+	// but the remote branch takes precedence in incrementOLAPExecutionUsage.
+	assert.Equal(t, int64(12345), foundRemoteSnapshotBytes, "expected remote snapshot bytes SKU to be recorded")
+	assert.Zero(t, foundLocalSnapshotBytes, "local snapshot bytes SKU should not be recorded when remote takes precedence")
 }
 
 // TestPublishOperation_RetryStreamWithOnlyPostCompletionStats simulates the
@@ -1872,25 +1949,10 @@ func testPublishOperationSecondCompletedCarriesSnapshotStats(t *testing.T, flush
 // COMPLETED — otherwise it would clobber the cached action result with a
 // sparse one, double-count usage, and emit a duplicate StoredExecution row.
 func TestPublishOperation_RetryStreamWithOnlyPostCompletionStats(t *testing.T) {
-	for _, flushAfterCleanup := range []bool{false, true} {
-		name := "FlushOnComplete"
-		if flushAfterCleanup {
-			name = "FlushAfterCleanup"
-		}
-		t.Run(name, func(t *testing.T) {
-			testPublishOperationRetryStreamWithOnlyPostCompletionStats(t, flushAfterCleanup)
-		})
-	}
-}
-
-func testPublishOperationRetryStreamWithOnlyPostCompletionStats(t *testing.T, flushAfterCleanup bool) {
 	ctx := context.Background()
 	flags.Set(t, "app.enable_write_executions_to_olap_db", true)
 	flags.Set(t, "remote_execution.write_execution_progress_state_to_redis", true)
 	env, conn, _ := setupEnv(t)
-	if flushAfterCleanup {
-		configureExperiments(t, env, map[string]bool{"remote_execution.flush_executions_after_cleanup": true})
-	}
 	client := repb.NewExecutionClient(conn)
 	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
 	env.SetAuthenticator(ta)

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -320,6 +320,8 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		// do this if the peer is ready to handle this partial COMPLETED update,
 		// which is indicated by the presence of
 		// "remote_execution.publish_post_completion_stats" in experiments.
+		// TODO(vanja) remove this once every app (including on-prem) is ready
+		// for the second COMPLETED Operation.
 		if slices.Contains(task.GetExperiments(), "remote_execution.publish_post_completion_stats") {
 			if stats := r.PostCompletionStats(); stats != nil && firstCompletedPublished {
 				statsAny, err := anypb.New(stats)


### PR DESCRIPTION
Previously, flushing executions to ClickHouse and recording usage at the end of the PublishOperation stream (instead of inline when the COMPLETED operation arrives) was gated on the `remote_execution.flush_executions_after_cleanup` experiment plus the `remote_execution.write_execution_progress_state_to_redis` flag. This PR makes flush-on-EOF the only path:

- **Flush on EOF unconditionally.** The EOF flush only needs the COMPLETED update and the forward invocation links from Redis, both of which are written regardless of the progress-state flag. The legacy inline flush on COMPLETED is removed along with the experiment gating.
- **Always record PostCompletionStats.** A second COMPLETED operation carrying post-completion stats is now merged into the stored execution in all configurations, so on-prem apps get snapshot/pause stats too.
- **Always tell executors to publish post-completion stats.** Executors check for the `remote_execution.publish_post_completion_stats` experiment string in the task; sending it unconditionally keeps old self-hosted executors publishing, and lets on-prem executors upgrade to the conditionally-publishing version before their apps upgrade. (TODO to remove once everything always publishes.)
- **Decouple usage recording from OLAP writes.** `flushAndRecordUsage` now reads the merged execution from Redis itself and records usage even when `app.enable_write_executions_to_olap_db` is disabled; previously usage recording silently depended on the OLAP gate. Cleanup of the in-progress state and invocation links also now runs regardless of the OLAP flag — deleting the in-progress execution is what guarantees the flush and usage recording happen at most once (later flushes get NotFound and no-op).
- `flushExecutionToOLAP` now takes the merged `StoredExecution` (deriving the ID from the proto) and only handles the OLAP write + cleanup. `markTaskComplete` no longer records usage inline, and the legacy live-`ExecuteResponse` usage path is deleted.

Tests:
- Rewrote `TestPublishOperation_PeriodicFlushDoesNotClobberCompletedRow` for the flush-on-EOF flow and removed the per-experiment test variants.
- Added `TestExecuteAndPublishOperation/PublishMoreMetadata_NoProgressStateInRedis` covering the on-prem default configuration (no progress state in Redis: the merged row is just the COMPLETED update).
- Added `TestPublishOperation_UsageRecordedWhenOLAPDisabled` pinning usage recording and state cleanup with OLAP writes disabled (verified it fails if the old OLAP gating is reintroduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)