### PR TITLE
Make distributed_client handle references on the read path

### DIFF
--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -86,6 +86,7 @@ go_library(
         "//enterprise/server/webhooks/github",
         "//enterprise/server/workflow/service",
         "//enterprise/server/workspace",
+        "//server/backends/blobstore/gcs",
         "//server/config",
         "//server/interfaces",
         "//server/janitor",

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -66,6 +66,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/webhooks/bitbucket"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/webhooks/github"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/workspace"
+	"github.com/buildbuddy-io/buildbuddy/server/backends/blobstore/gcs"
 	"github.com/buildbuddy-io/buildbuddy/server/config"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/janitor"
@@ -208,6 +209,9 @@ func main() {
 		log.Fatalf("%v", err)
 	}
 	if err := crypter_service.Register(realEnv); err != nil {
+		log.Fatalf("%v", err)
+	}
+	if err := gcs.Register(realEnv); err != nil {
 		log.Fatalf("%v", err)
 	}
 	if err := gcs_cache.Register(realEnv); err != nil {

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -572,14 +572,59 @@ func (c *Proxy) RemoteReader(ctx context.Context, peer string, r *rspb.ResourceN
 		return nil, err
 	}
 	rc, err := newDistributedCacheReader(stream, r.GetDigest().GetSizeBytes() == offset)
-	if err != nil || !decompress {
-		return rc, err
+	if err != nil {
+		return nil, err
+	}
+
+	// The server provided a reference. Dereference it.
+	if rc.rsp.GetReference() != nil {
+		ref := rc.rsp.GetReference().CloneVT()
+		if err := rc.Close(); err != nil {
+			c.log.Debugf("Error closing read stream after receiving a reference: %s", err)
+		}
+		dereferencer := c.env.GetDereferencer()
+		if dereferencer == nil {
+			return nil, status.FailedPreconditionErrorf("peer %q returned a reference, but no dereferencer is configured", peer)
+		}
+		// Dereferencing yields the bytes exactly as stored, so the stored
+		// compressor must be reconciled with the one the caller wants.
+		// (When the ZSTD transport rewrite was applied above, the caller
+		// wants the original IDENTITY bytes, not the rewritten encoding.)
+		wanted := r.GetCompressor()
+		if decompress {
+			wanted = repb.Compressor_IDENTITY
+		}
+		stored := ref.GetMetadata().GetFileRecord().GetCompressor()
+		if stored == wanted {
+			return dereferencer.Dereference(ctx, ref, offset, limit)
+		}
+		if stored == repb.Compressor_ZSTD && wanted == repb.Compressor_IDENTITY && offset == 0 && limit == 0 {
+			drc, err := dereferencer.Dereference(ctx, ref, 0, 0)
+			if err != nil {
+				return nil, err
+			}
+			zr, err := compression.NewZstdDecompressingReader(drc)
+			if err != nil {
+				drc.Close()
+				return nil, err
+			}
+			return zr, nil
+		}
+		// Anything else (stored IDENTITY but ZSTD wanted, or a ranged read
+		// of a compressed blob, where offsets refer to uncompressed bytes)
+		// cannot be served from the reference.
+		return nil, status.InternalErrorf("peer %q returned a reference stored with compressor %s, but %s was requested", peer, stored, wanted)
+	}
+
+	if !decompress {
+		return rc, nil
 	}
 	dr, err := compression.NewZstdDecompressingReader(rc)
 	if err != nil {
 		rc.Close()
+		return nil, err
 	}
-	return dr, err
+	return dr, nil
 }
 
 type distributedCacheReader struct {

--- a/server/backends/blobstore/gcs/BUILD
+++ b/server/backends/blobstore/gcs/BUILD
@@ -6,8 +6,10 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/backends/blobstore/gcs",
     visibility = ["//visibility:public"],
     deps = [
+        "//proto:reference_go_proto",
         "//server/backends/blobstore/util",
         "//server/interfaces",
+        "//server/real_environment",
         "//server/rpc/interceptors",
         "//server/util/flag",
         "//server/util/ioutil",

--- a/server/backends/blobstore/gcs/gcs.go
+++ b/server/backends/blobstore/gcs/gcs.go
@@ -12,6 +12,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/blobstore/util"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/rpc/interceptors"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/ioutil"
@@ -27,6 +28,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
+	refpb "github.com/buildbuddy-io/buildbuddy/proto/reference"
 	gstatus "google.golang.org/grpc/status"
 )
 
@@ -51,6 +53,18 @@ type GCSBlobStore struct {
 
 func UseGCSBlobStore() bool {
 	return *gcsBucket != ""
+}
+
+func Register(env *real_environment.RealEnv) error {
+	if !UseGCSBlobStore() {
+		return nil
+	}
+	gcsBlobStore, err := NewGCSBlobStoreFromFlags(env.GetServerContext())
+	if err != nil {
+		return err
+	}
+	env.SetDereferencer(gcsBlobStore)
+	return nil
 }
 
 func NewGCSBlobStoreFromFlags(ctx context.Context) (*GCSBlobStore, error) {
@@ -460,6 +474,14 @@ func (g *GCSBlobStore) Reader(ctx context.Context, blobName string, offset, limi
 	} else {
 		return reader, nil
 	}
+}
+
+func (g *GCSBlobStore) Dereference(ctx context.Context, ref *refpb.Reference, offset, limit int64) (io.ReadCloser, error) {
+	blobName := ref.GetMetadata().GetStorageMetadata().GetGcsMetadata().GetBlobName()
+	if blobName == "" {
+		return nil, status.InvalidArgumentError("Malformed reference")
+	}
+	return g.Reader(ctx, blobName, offset, limit)
 }
 
 func (g *GCSBlobStore) SetBucketCustomTimeTTL(ctx context.Context, ageInDays int64) error {

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -56,6 +56,7 @@ type Env interface {
 	GetBuildEventHandler() interfaces.BuildEventHandler
 	GetBuildEventProxyClients() []pepb.PublishBuildEventClient
 	GetCache() interfaces.Cache
+	GetDereferencer() interfaces.Dereferencer
 	GetUserDB() interfaces.UserDB
 	GetAuthDB() interfaces.AuthDB
 	GetInvocationStatService() interfaces.InvocationStatService

--- a/server/interfaces/BUILD
+++ b/server/interfaces/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//proto:iprules_go_proto",
         "//proto:notification_go_proto",
         "//proto:publish_build_event_go_proto",
+        "//proto:reference_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:repo_go_proto",
         "//proto:resource_go_proto",

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -43,6 +43,7 @@ import (
 	irpb "github.com/buildbuddy-io/buildbuddy/proto/iprules"
 	npb "github.com/buildbuddy-io/buildbuddy/proto/notification"
 	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
+	refpb "github.com/buildbuddy-io/buildbuddy/proto/reference"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	rppb "github.com/buildbuddy-io/buildbuddy/proto/repo"
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
@@ -1505,6 +1506,11 @@ type MetadataWriteCloser interface {
 	io.Writer
 	io.Closer
 	Metadater
+}
+
+// Dereferences references into the bytes stored in the referenced location.
+type Dereferencer interface {
+	Dereference(ctx context.Context, ref *refpb.Reference, offset, limit int64) (io.ReadCloser, error)
 }
 
 type CommittedMetadataWriteCloser interface {

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -60,6 +60,7 @@ type RealEnv struct {
 	executionService                     interfaces.ExecutionService
 	executionSearchService               interfaces.ExecutionSearchService
 	cache                                interfaces.Cache
+	dereferencer                         interfaces.Dereferencer
 	userDB                               interfaces.UserDB
 	authDB                               interfaces.AuthDB
 	buildEventHandler                    interfaces.BuildEventHandler
@@ -267,6 +268,13 @@ func (r *RealEnv) GetCache() interfaces.Cache {
 }
 func (r *RealEnv) SetCache(c interfaces.Cache) {
 	r.cache = c
+}
+
+func (r *RealEnv) GetDereferencer() interfaces.Dereferencer {
+	return r.dereferencer
+}
+func (r *RealEnv) SetDereferencer(d interfaces.Dereferencer) {
+	r.dereferencer = d
 }
 
 func (r *RealEnv) GetAuthenticator() interfaces.Authenticator {


### PR DESCRIPTION
This change introduces an `interfaces.Dereferencer` which converts a `refpb.Reference` into an `io.ReadCloser` and makes the [distributed_client](https://github.com/buildbuddy-io/buildbuddy/blob/master/enterprise/server/util/distributed_client/distributed_client.go) use that to retrieve bytes from referenced storage (today just GCS) when it receives a reference on the read path.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7911