### PR TITLE
Make `Cache.Reader()` return an `Artifact`

### DIFF
--- a/enterprise/server/api/api_server.go
+++ b/enterprise/server/api/api_server.go
@@ -633,9 +633,13 @@ func (s *APIServer) GetFileRange(ctx context.Context, req *apipb.GetFileRangeReq
 		return nil, err
 	}
 
-	reader, err := s.env.GetCache().Reader(ctx, rn.ToProto(), start, limit)
+	artifact, err := s.env.GetCache().Reader(ctx, rn.ToProto(), start, limit)
 	if err != nil {
 		return nil, err
+	}
+	reader := artifact.ReadCloser
+	if reader == nil {
+		return nil, status.InternalError("the API server does not support cache references")
 	}
 	data, readErr := io.ReadAll(reader)
 	closeErr := reader.Close()

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -1007,7 +1007,14 @@ func (c *Cache) remoteGetMulti(ctx context.Context, peer string, rns []*rspb.Res
 
 func (c *Cache) remoteReader(ctx context.Context, peer string, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
 	if !c.opts.DisableLocalLookup && peer == c.opts.ListenAddr {
-		return c.local.Reader(ctx, r, offset, limit)
+		artifact, err := c.local.Reader(ctx, r, offset, limit)
+		if err != nil {
+			return nil, err
+		}
+		if artifact.ReadCloser == nil {
+			return nil, status.InternalErrorf("cache type %T does not support references", c.local)
+		}
+		return artifact.ReadCloser, nil
 	}
 	cacheable := offset == 0 && limit == 0
 	var lookasideWriter, localWriter interfaces.CommittedWriteCloser
@@ -1034,9 +1041,11 @@ func (c *Cache) remoteReader(ctx context.Context, peer string, r *rspb.ResourceN
 	// feature is enabled. If not, configure localWriter so the blob can be
 	// written to the local cache as it is read.
 	if c.localReadthroughEnabled() && isLocalReadthroughCacheableResource(r) {
-		if rc, err := c.local.Reader(ctx, r, offset, limit); err == nil {
+		if artifact, err := c.local.Reader(ctx, r, offset, limit); err == nil && artifact.ReadCloser != nil {
 			c.log.CtxDebugf(ctx, "Reader(%q) found locally", distributed_client.ResourceIsolationString(r))
-			readCloser = rc
+			readCloser = artifact.ReadCloser
+		} else if artifact.Reference != nil {
+			return nil, status.InternalErrorf("cache type %T does not support references", c.local)
 		} else if cacheable {
 			if local, err := c.local.Writer(ctx, r); err == nil {
 				localWriter = local
@@ -1092,9 +1101,13 @@ func (c *Cache) sendFile(ctx context.Context, rn *rspb.ResourceName, dest string
 		return nil
 	}
 
-	r, err := c.local.Reader(ctx, rn, 0, 0)
+	artifact, err := c.local.Reader(ctx, rn, 0, 0)
 	if err != nil {
 		return err
+	}
+	r := artifact.ReadCloser
+	if r == nil {
+		return status.InternalErrorf("cache type %T does not support references", c.local)
 	}
 	defer r.Close()
 	rwc, err := c.distributedProxy.RemoteWriter(ctx, dest, "", rn)
@@ -1754,8 +1767,12 @@ func (c *Cache) Delete(ctx context.Context, r *rspb.ResourceName) error {
 	return nil
 }
 
-func (c *Cache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
-	return c.distributedReader(ctx, r, uncompressedOffset, limit, "Reader" /*=metricsLabel*/)
+func (c *Cache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (interfaces.CacheArtifact, error) {
+	rc, err := c.distributedReader(ctx, r, uncompressedOffset, limit, "Reader" /*=metricsLabel*/)
+	if err != nil {
+		return interfaces.CacheArtifact{}, err
+	}
+	return interfaces.CacheArtifact{ReadCloser: rc}, nil
 }
 
 func (c *Cache) Writer(ctx context.Context, r *rspb.ResourceName) (interfaces.CommittedWriteCloser, error) {

--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -103,11 +103,11 @@ func startNewDCache(t *testing.T, te environment.Env, config Options, baseCache 
 }
 
 func readAndCompareDigest(t *testing.T, ctx context.Context, c interfaces.Cache, r *rspb.ResourceName) {
-	reader, err := c.Reader(ctx, r, 0, 0)
+	artifact, err := c.Reader(ctx, r, 0, 0)
 	if err != nil {
 		assert.FailNow(t, fmt.Sprintf("cache: %+v", c), err)
 	}
-	d1 := testdigest.ReadDigestAndClose(t, reader)
+	d1 := testdigest.ReadDigestAndClose(t, artifact.ReadCloser)
 	assert.Equal(t, r.GetDigest().GetHash(), d1.GetHash())
 }
 
@@ -444,11 +444,11 @@ func TestReadMaxOffset(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reader, err := distributedCaches[1].Reader(ctx, rn, rn.GetDigest().GetSizeBytes(), 0)
+	artifact, err := distributedCaches[1].Reader(ctx, rn, rn.GetDigest().GetSizeBytes(), 0)
 	if err != nil {
 		assert.FailNow(t, fmt.Sprintf("cache: %+v", distributedCaches[1]), err)
 	}
-	d1 := testdigest.ReadDigestAndClose(t, reader)
+	d1 := testdigest.ReadDigestAndClose(t, artifact.ReadCloser)
 	assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", d1.GetHash())
 }
 
@@ -494,11 +494,11 @@ func TestReadOffsetLimit(t *testing.T) {
 
 	offset := int64(2)
 	limit := int64(3)
-	reader, err := distributedCaches[1].Reader(ctx, rn, offset, limit)
+	artifact, err := distributedCaches[1].Reader(ctx, rn, offset, limit)
 	require.NoError(t, err)
 
 	readBuf := make([]byte, rn.GetDigest().GetSizeBytes())
-	n, err := io.ReadFull(reader, readBuf)
+	n, err := io.ReadFull(artifact.ReadCloser, readBuf)
 	require.Error(t, err)
 	require.Equal(t, "unexpected EOF", err.Error())
 	require.EqualValues(t, limit, n)
@@ -2126,8 +2126,9 @@ func TestAbandonedReadDoesntWriteToLookaside(t *testing.T) {
 	}
 
 	// Read just the first 3 bytes
-	r, err := dc.Reader(ctx, rn, 0, 0)
+	artifact, err := dc.Reader(ctx, rn, 0, 0)
 	require.NoError(t, err)
+	r := artifact.ReadCloser
 	readBuf := make([]byte, 3)
 	n, err := r.Read(readBuf)
 	assert.Equal(t, 3, n)
@@ -3199,8 +3200,9 @@ func TestLookasidePartitionIsolation(t *testing.T) {
 
 	// Read from partition A multiple times to populate the lookaside cache.
 	for i := 0; i < 5; i++ {
-		reader, err := dc.Reader(ctx1, rnA, 0, 0)
+		readerArtifact, err := dc.Reader(ctx1, rnA, 0, 0)
 		require.NoError(t, err)
+		reader := readerArtifact.ReadCloser
 		gotA, err := io.ReadAll(reader)
 		require.NoError(t, err)
 		require.NoError(t, reader.Close())
@@ -3326,7 +3328,7 @@ func (t *tracedCache) Delete(ctx context.Context, r *rspb.ResourceName) error {
 	t.addOps(Delete, r)
 	return t.Cache.Delete(ctx, r)
 }
-func (t *tracedCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
+func (t *tracedCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (interfaces.CacheArtifact, error) {
 	t.addOps(Read, r)
 	return t.Cache.Reader(ctx, r, uncompressedOffset, limit)
 }
@@ -3374,7 +3376,7 @@ func (pc *partitionedCache) SetMulti(ctx context.Context, kvs map[*rspb.Resource
 func (pc *partitionedCache) Delete(ctx context.Context, r *rspb.ResourceName) error {
 	return pc.partition(ctx).Delete(ctx, r)
 }
-func (pc *partitionedCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
+func (pc *partitionedCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (interfaces.CacheArtifact, error) {
 	return pc.partition(ctx).Reader(ctx, r, uncompressedOffset, limit)
 }
 func (pc *partitionedCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfaces.CommittedWriteCloser, error) {

--- a/enterprise/server/backends/gcs_cache/gcs_cache.go
+++ b/enterprise/server/backends/gcs_cache/gcs_cache.go
@@ -429,10 +429,10 @@ func (g *GCSCache) FindMissing(ctx context.Context, resources []*rspb.ResourceNa
 	return missing, nil
 }
 
-func (g *GCSCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
+func (g *GCSCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (interfaces.CacheArtifact, error) {
 	k, err := g.key(ctx, r)
 	if err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
 	ctx, spn := tracing.StartSpan(ctx)
 	if limit == 0 {
@@ -443,13 +443,13 @@ func (g *GCSCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompresse
 	if err != nil {
 		if err == storage.ErrObjectNotExist {
 			d := r.GetDigest()
-			return nil, status.NotFoundErrorf("Digest '%s/%d' not found in cache", d.GetHash(), d.GetSizeBytes())
+			return interfaces.CacheArtifact{}, status.NotFoundErrorf("Digest '%s/%d' not found in cache", d.GetHash(), d.GetSizeBytes())
 		}
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
 	timer := cache_metrics.NewCacheTimer(cacheLabels)
 	// rely on google's internal tracing to capture read calls from the returned reader
-	return io.NopCloser(timer.NewInstrumentedReader(reader, r.GetDigest().GetSizeBytes())), nil
+	return interfaces.CacheArtifact{ReadCloser: io.NopCloser(timer.NewInstrumentedReader(reader, r.GetDigest().GetSizeBytes()))}, nil
 }
 
 func isRetryableGCSError(err error) bool {

--- a/enterprise/server/backends/memcache/memcache.go
+++ b/enterprise/server/backends/memcache/memcache.go
@@ -281,17 +281,17 @@ func (c *Cache) Delete(ctx context.Context, r *rspb.ResourceName) error {
 }
 
 // Low level interface used for seeking and stream-writing.
-func (c *Cache) Reader(ctx context.Context, rn *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
+func (c *Cache) Reader(ctx context.Context, rn *rspb.ResourceName, uncompressedOffset, limit int64) (interfaces.CacheArtifact, error) {
 	if !eligibleForMc(rn.GetDigest()) {
-		return nil, status.ResourceExhaustedErrorf("Reader: Digest %v too big for memcache", rn.GetDigest())
+		return interfaces.CacheArtifact{}, status.ResourceExhaustedErrorf("Reader: Digest %v too big for memcache", rn.GetDigest())
 	}
 	k, err := c.key(ctx, rn)
 	if err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
 	buf, err := c.mcGet(k)
 	if err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
 
 	r := bytes.NewReader(buf)
@@ -301,9 +301,9 @@ func (c *Cache) Reader(ctx context.Context, rn *rspb.ResourceName, uncompressedO
 		length = limit
 	}
 	if length > 0 {
-		return io.NopCloser(io.LimitReader(r, length)), nil
+		return interfaces.CacheArtifact{ReadCloser: io.NopCloser(io.LimitReader(r, length))}, nil
 	}
-	return io.NopCloser(r), nil
+	return interfaces.CacheArtifact{ReadCloser: io.NopCloser(r)}, nil
 }
 
 func (c *Cache) Writer(ctx context.Context, r *rspb.ResourceName) (interfaces.CommittedWriteCloser, error) {

--- a/enterprise/server/backends/metacache/metacache.go
+++ b/enterprise/server/backends/metacache/metacache.go
@@ -589,9 +589,13 @@ func (c *Cache) Get(ctx context.Context, r *rspb.ResourceName) (res []byte, resu
 	defer spn.End()
 	setSingleResourceTraceAttributes(spn, r)
 
-	rc, err := c.Reader(ctx, r, 0, 0)
+	artifact, err := c.Reader(ctx, r, 0, 0)
 	if err != nil {
 		return nil, err
+	}
+	rc := artifact.ReadCloser
+	if rc == nil {
+		return nil, status.InternalError("metacache does not support references")
 	}
 	defer rc.Close()
 
@@ -856,27 +860,27 @@ func (c *Cache) reader(ctx context.Context, md *sgpb.FileMetadata, r *rspb.Resou
 }
 
 // Low level interface used for seeking and stream-writing.
-func (c *Cache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, uncompressedLimit int64) (rc io.ReadCloser, resultErr error) {
+func (c *Cache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, uncompressedLimit int64) (interfaces.CacheArtifact, error) {
 	ctx, spn := tracing.StartSpan(ctx)
 	defer spn.End()
 	setSingleResourceTraceAttributes(spn, r)
 
 	encryption, err := c.activeEncryption(ctx)
 	if err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
 	fileRecord, err := c.makeFileRecord(c.userGroupID(ctx), encryption, r)
 	if err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
 
 	mds, err := c.lookupMetadatas(ctx, fileRecord)
 	if err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
 	if len(mds) != 1 {
 		log.CtxErrorf(ctx, "File record %v found multiple metadatas: %v", fileRecord, mds)
-		return nil, status.InternalError("only one metadata record should match query")
+		return interfaces.CacheArtifact{}, status.InternalError("only one metadata record should match query")
 	}
 	md := mds[0]
 	if md.GetFileRecord() == nil {
@@ -886,9 +890,13 @@ func (c *Cache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOf
 		// with nils into a repeated field with empty structs, we need to check
 		// if the proto is empty rather than nil. The easiest way to do this is
 		// check if a field that should always be set is nil.
-		return nil, status.NotFoundErrorf("File metadata not found for %v", r)
+		return interfaces.CacheArtifact{}, status.NotFoundErrorf("File metadata not found for %v", r)
 	}
-	return c.reader(ctx, md, r, uncompressedOffset, uncompressedLimit, encryption)
+	rc, err := c.reader(ctx, md, r, uncompressedOffset, uncompressedLimit, encryption)
+	if err != nil {
+		return interfaces.CacheArtifact{}, err
+	}
+	return interfaces.CacheArtifact{ReadCloser: rc}, nil
 }
 
 func (c *Cache) Writer(ctx context.Context, r *rspb.ResourceName) (cwc interfaces.CommittedWriteCloser, resultErr error) {

--- a/enterprise/server/backends/metacache/metacache_test.go
+++ b/enterprise/server/backends/metacache/metacache_test.go
@@ -114,9 +114,9 @@ func TestReadWrite(t *testing.T) {
 			require.NoError(t, err)
 
 			// Use Reader() to get the bytes from the cache.
-			reader, err := bc.Reader(ctx, rn, 0, 0)
+			artifact, err := bc.Reader(ctx, rn, 0, 0)
 			require.NoError(t, err, "Error getting %q reader", rn.GetDigest().GetHash())
-			d2 := testdigest.ReadDigestAndClose(t, reader)
+			d2 := testdigest.ReadDigestAndClose(t, artifact.ReadCloser)
 			require.Equal(t, rn.GetDigest().GetHash(), d2.GetHash())
 		})
 	}

--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -782,22 +782,25 @@ func (d *doubleReader) Close() error {
 	return srcErr
 }
 
-func (mc *MigrationCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
+func (mc *MigrationCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (interfaces.CacheArtifact, error) {
 	conf, err := mc.config(ctx)
 	if err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
-	srcReader, srcErr := conf.src.Reader(ctx, r, uncompressedOffset, limit)
-	if srcErr != nil || conf.dest == nil {
-		return srcReader, srcErr
+	srcArtifact, srcErr := conf.src.Reader(ctx, r, uncompressedOffset, limit)
+	srcReader := srcArtifact.ReadCloser
+	// TODO: support migrating references.
+	if srcErr != nil || conf.dest == nil || srcReader == nil {
+		return srcArtifact, srcErr
 	}
 	if !conf.doubleRead() {
 		// We still want to copy if the source was successful.
 		mc.sendNonBlockingCopy(ctx, r, true /*=onlyCopyMissing*/, conf)
-		return srcReader, srcErr
+		return srcArtifact, srcErr
 	}
 
-	destReader, dstErr := conf.dest.Reader(ctx, r, uncompressedOffset, limit)
+	destArtifact, dstErr := conf.dest.Reader(ctx, r, uncompressedOffset, limit)
+	destReader := destArtifact.ReadCloser
 	if dstErr != nil {
 		if mc.logNotFoundErrors || !status.IsNotFoundError(dstErr) {
 			log.CtxWarningf(ctx, "Migration failed to get dest reader for %v: %s", r, dstErr)
@@ -810,12 +813,15 @@ func (mc *MigrationCache) Reader(ctx context.Context, r *rspb.ResourceName, unco
 		} else {
 			mc.sendNonBlockingCopy(ctx, r, true /*=onlyCopyMissing*/, conf)
 		}
-		return srcReader, srcErr
+		return srcArtifact, srcErr
 	}
 	metrics.MigrationDoubleReadHitCount.With(prometheus.Labels{
 		metrics.CacheRequestType: "reader",
 		metrics.GroupID:          groupID(ctx),
 	}).Inc()
+	if destReader == nil {
+		return srcArtifact, srcErr
+	}
 
 	var decompressor io.WriteCloser
 	pr, pw := io.Pipe()
@@ -862,7 +868,7 @@ func (mc *MigrationCache) Reader(ctx context.Context, r *rspb.ResourceName, unco
 		}()
 	}
 
-	return dr, nil
+	return interfaces.CacheArtifact{ReadCloser: dr}, nil
 }
 
 type doubleWriter struct {
@@ -1127,11 +1133,16 @@ func (mc *MigrationCache) copy(c *copyData) {
 		c.d.Compressor = repb.Compressor_ZSTD
 	}
 
-	srcReader, err := c.conf.src.Reader(c.ctx, c.d, 0, 0)
+	srcArtifact, err := c.conf.src.Reader(c.ctx, c.d, 0, 0)
 	if err != nil {
 		if !status.IsNotFoundError(err) {
 			log.CtxWarningf(ctx, "Migration copy err: Could not create %v reader from src cache: %s", c.d, err)
 		}
+		return
+	}
+	srcReader := srcArtifact.ReadCloser
+	if srcReader == nil {
+		log.CtxWarningf(ctx, "Migration copy err: src cache returned a reference for %v", c.d)
 		return
 	}
 	defer srcReader.Close()

--- a/enterprise/server/backends/migration_cache/migration_cache_test.go
+++ b/enterprise/server/backends/migration_cache/migration_cache_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"sync"
 	"sync/atomic"
@@ -197,9 +196,9 @@ func (c *errorCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfac
 	return nil, errors.New("error cache writer err")
 }
 
-func (c *errorCache) Reader(ctx context.Context, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
+func (c *errorCache) Reader(ctx context.Context, r *rspb.ResourceName, offset, limit int64) (interfaces.CacheArtifact, error) {
 	c.calls.Add(1)
-	return nil, errors.New("error cache reader err")
+	return interfaces.CacheArtifact{}, errors.New("error cache reader err")
 }
 
 func TestACIsolation(t *testing.T) {
@@ -1362,9 +1361,9 @@ func TestReadsCopyData(t *testing.T) {
 	t.Run("Reader", func(t *testing.T) {
 		r, buf := testdigest.RandomCASResourceBuf(t, 10)
 		require.NoError(t, srcCache.Set(ctx, r, buf))
-		reader, err := mc.Reader(ctx, r, 0, 0)
+		artifact, err := mc.Reader(ctx, r, 0, 0)
 		require.NoError(t, err)
-		reader.Close()
+		artifact.ReadCloser.Close()
 		waitForCopy(t, ctx, destCache, r)
 	})
 	t.Run("Get", func(t *testing.T) {
@@ -1418,8 +1417,9 @@ func TestReadWrite(t *testing.T) {
 			err = w.Close()
 			require.NoError(t, err)
 
-			reader, err := mc.Reader(ctx, r, 0, 0)
+			artifact, err := mc.Reader(ctx, r, 0, 0)
 			require.NoError(t, err)
+			reader := artifact.ReadCloser
 
 			actualBuf := make([]byte, len(buf))
 			n, err := reader.Read(actualBuf)
@@ -1431,8 +1431,9 @@ func TestReadWrite(t *testing.T) {
 			require.NoError(t, err)
 
 			// Verify data was written to both caches
-			srcReader, err := srcCache.Reader(ctx, r, 0, 0)
+			srcArtifact, err := srcCache.Reader(ctx, r, 0, 0)
 			require.NoError(t, err)
+			srcReader := srcArtifact.ReadCloser
 
 			actualBuf, err = ioutil.ReadAll(srcReader)
 			require.NoError(t, err)
@@ -1442,8 +1443,9 @@ func TestReadWrite(t *testing.T) {
 			err = srcReader.Close()
 			require.NoError(t, err)
 
-			destReader, err := destCache.Reader(ctx, r, 0, 0)
+			destArtifact, err := destCache.Reader(ctx, r, 0, 0)
 			require.NoError(t, err)
+			destReader := destArtifact.ReadCloser
 
 			actualBuf, err = ioutil.ReadAll(destReader)
 			require.NoError(t, err)
@@ -1488,12 +1490,12 @@ func TestReaderWriter_DestFails(t *testing.T) {
 	require.NoError(t, err)
 
 	// Will fail to set a dest reader
-	reader, err := mc.Reader(ctx, r, 0, 0)
+	artifact, err := mc.Reader(ctx, r, 0, 0)
 	require.NoError(t, err)
 
 	// Should still read from src cache without error
 	actualBuf := make([]byte, len(buf))
-	n, err := reader.Read(actualBuf)
+	n, err := artifact.ReadCloser.Read(actualBuf)
 	require.NoError(t, err)
 	require.Equal(t, 100, n)
 	require.True(t, bytes.Equal(buf, actualBuf))
@@ -1555,8 +1557,9 @@ func testOnlyOneCache(t *testing.T, reverse bool) {
 	require.NoError(t, err)
 	require.Equal(t, map[*repb.Digest][]byte{r.GetDigest(): buf}, dataMulti)
 	// reader
-	reader, err := mc.Reader(ctx, r, 0, 0)
+	artifact, err := mc.Reader(ctx, r, 0, 0)
 	require.NoError(t, err)
+	reader := artifact.ReadCloser
 	readBuf := make([]byte, len(buf))
 	_, err = reader.Read(readBuf)
 	require.NoError(t, err)

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2013,9 +2013,13 @@ func (p *PebbleCache) lookupFileMetadataBytes(db pebble.IPebbleDB, key filestore
 }
 
 func (p *PebbleCache) Get(ctx context.Context, r *rspb.ResourceName) ([]byte, error) {
-	rc, err := p.Reader(ctx, r, 0, 0)
+	artifact, err := p.Reader(ctx, r, 0, 0)
 	if err != nil {
 		return nil, err
+	}
+	rc := artifact.ReadCloser
+	if rc == nil {
+		return nil, status.InternalError("pebble_cache.Get does not support references")
 	}
 	defer rc.Close()
 	bufSize := digest.SafeBufferSize(r, maxReadBufferSize)
@@ -2299,7 +2303,7 @@ func (p *PebbleCache) Delete(ctx context.Context, r *rspb.ResourceName) error {
 	return nil
 }
 
-func (p *PebbleCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
+func (p *PebbleCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (interfaces.CacheArtifact, error) {
 	ctx, spn := tracing.StartSpan(ctx)
 	defer spn.End()
 	if spn.IsRecording() {
@@ -2309,26 +2313,26 @@ func (p *PebbleCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompre
 	}
 	db, err := p.leaser.DB()
 	if err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
 	defer db.Close()
 
 	encryption, err := p.activeEncryption(ctx)
 	if err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
 	rc, err := p.reader(ctx, db, p.userGroupID(ctx), encryption, r, uncompressedOffset, limit)
 	if err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
 
 	// Grab another lease and pass the Close function to the reader
 	// so it will be closed when the reader is.
 	db, err = p.leaser.DB()
 	if err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
-	return pebble.ReadCloserWithFunc(rc, db.Close), nil
+	return interfaces.CacheArtifact{ReadCloser: pebble.ReadCloserWithFunc(rc, db.Close)}, nil
 }
 
 func (p *PebbleCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfaces.CommittedWriteCloser, error) {

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -893,9 +893,9 @@ func TestReadWrite(t *testing.T) {
 			require.NoError(t, err)
 
 			// Use Reader() to get the bytes from the cache.
-			reader, err := pc.Reader(ctx, rn, 0, 0)
+			artifact, err := pc.Reader(ctx, rn, 0, 0)
 			require.NoError(t, err, "Error getting %q reader", rn.GetDigest().GetHash())
-			d2 := testdigest.ReadDigestAndClose(t, reader)
+			d2 := testdigest.ReadDigestAndClose(t, artifact.ReadCloser)
 			require.Equal(t, rn.GetDigest().GetHash(), d2.GetHash())
 
 			contains, err := pc.Contains(ctx, rn)
@@ -995,8 +995,9 @@ func writeResource(t *testing.T, ctx context.Context, pc *pebble_cache.PebbleCac
 }
 
 func readResource(t *testing.T, ctx context.Context, pc *pebble_cache.PebbleCache, r *rspb.ResourceName, offset, limit int64) []byte {
-	reader, err := pc.Reader(ctx, r, offset, limit)
+	artifact, err := pc.Reader(ctx, r, offset, limit)
 	require.NoError(t, err)
+	reader := artifact.ReadCloser
 	defer reader.Close()
 	data, err := io.ReadAll(reader)
 	require.NoError(t, err)
@@ -3467,8 +3468,9 @@ func expectContentPresent(t *testing.T, ctx context.Context, c interfaces.Cache,
 	require.NoError(t, err, "GetMulti")
 	require.Equal(t, data, multi[rn.GetDigest()], "GetMulti")
 
-	rc, err := c.Reader(ctx, rn, 0, 0)
+	artifact, err := c.Reader(ctx, rn, 0, 0)
 	require.NoError(t, err, "Reader")
+	rc := artifact.ReadCloser
 	got, err = io.ReadAll(rc)
 	require.NoError(t, err, "Reader.ReadAll")
 	require.NoError(t, rc.Close(), "Reader.Close")
@@ -3489,9 +3491,9 @@ func expectContentNotFound(t *testing.T, ctx context.Context, c interfaces.Cache
 	require.NoError(t, err, "GetMulti")
 	require.Nil(t, multi[rn.GetDigest()], "GetMulti")
 
-	rc, err := c.Reader(ctx, rn, 0, 0)
+	artifact, err := c.Reader(ctx, rn, 0, 0)
 	require.True(t, status.IsNotFoundError(err), "Reader: %v", err)
-	require.Nil(t, rc, "Reader")
+	require.Nil(t, artifact.ReadCloser, "Reader")
 }
 
 // expectContentError asserts that the content-returning read methods all fail
@@ -3511,10 +3513,10 @@ func expectContentError(t *testing.T, ctx context.Context, c interfaces.Cache, r
 	require.ErrorContains(t, err, wantErr, "GetMulti")
 	require.False(t, status.IsNotFoundError(err), "GetMulti: %v", err)
 
-	rc, err := c.Reader(ctx, rn, 0, 0)
+	artifact, err := c.Reader(ctx, rn, 0, 0)
 	require.ErrorContains(t, err, wantErr, "Reader")
 	require.False(t, status.IsNotFoundError(err), "Reader: %v", err)
-	require.Nil(t, rc, "Reader")
+	require.Nil(t, artifact.ReadCloser, "Reader")
 }
 
 func TestPebbleGCSBlobPresent(t *testing.T) {

--- a/enterprise/server/backends/redis_cache/redis_cache.go
+++ b/enterprise/server/backends/redis_cache/redis_cache.go
@@ -329,17 +329,17 @@ func (c *Cache) Delete(ctx context.Context, r *rspb.ResourceName) error {
 }
 
 // Low level interface used for seeking and stream-writing.
-func (c *Cache) Reader(ctx context.Context, rn *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
+func (c *Cache) Reader(ctx context.Context, rn *rspb.ResourceName, uncompressedOffset, limit int64) (interfaces.CacheArtifact, error) {
 	if !c.eligibleForCache(rn.GetDigest()) {
-		return nil, status.ResourceExhaustedErrorf("Reader: Digest %v too big for redis", rn.GetDigest())
+		return interfaces.CacheArtifact{}, status.ResourceExhaustedErrorf("Reader: Digest %v too big for redis", rn.GetDigest())
 	}
 	k, err := c.key(ctx, rn)
 	if err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
 	buf, err := c.rdbGet(ctx, k)
 	if err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
 
 	r := bytes.NewReader(buf)
@@ -349,10 +349,10 @@ func (c *Cache) Reader(ctx context.Context, rn *rspb.ResourceName, uncompressedO
 		length = limit
 	}
 	if length > 0 {
-		return io.NopCloser(io.LimitReader(r, length)), nil
+		return interfaces.CacheArtifact{ReadCloser: io.NopCloser(io.LimitReader(r, length))}, nil
 	}
 	timer := cache_metrics.NewCacheTimer(cacheLabels)
-	return io.NopCloser(timer.NewInstrumentedReader(r, length)), nil
+	return interfaces.CacheArtifact{ReadCloser: io.NopCloser(timer.NewInstrumentedReader(r, length))}, nil
 }
 
 func (c *Cache) Writer(ctx context.Context, r *rspb.ResourceName) (interfaces.CommittedWriteCloser, error) {

--- a/enterprise/server/backends/s3_cache/s3_cache.go
+++ b/enterprise/server/backends/s3_cache/s3_cache.go
@@ -527,10 +527,10 @@ func (s3c *S3Cache) FindMissing(ctx context.Context, resources []*rspb.ResourceN
 	return missing, nil
 }
 
-func (s3c *S3Cache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
+func (s3c *S3Cache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (interfaces.CacheArtifact, error) {
 	k, err := s3c.key(ctx, r)
 	if err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
 	ctx, spn := tracing.StartSpan(ctx)
 	// TODO(bduffany): track this as a contains() request, or find a way to
@@ -551,12 +551,12 @@ func (s3c *S3Cache) Reader(ctx context.Context, r *rspb.ResourceName, uncompress
 	spn.End()
 	if isNotFoundErr(err) {
 		d := r.GetDigest()
-		return nil, status.NotFoundErrorf("Digest '%s/%d' not found in cache", d.GetHash(), d.GetSizeBytes())
+		return interfaces.CacheArtifact{}, status.NotFoundErrorf("Digest '%s/%d' not found in cache", d.GetHash(), d.GetSizeBytes())
 	} else if err != nil {
-		return nil, status.InternalErrorf("Error getting s3 object at key %s for cache: %v", k, err)
+		return interfaces.CacheArtifact{}, status.InternalErrorf("Error getting s3 object at key %s for cache: %v", k, err)
 	}
 	timer := cache_metrics.NewCacheTimer(cacheLabels)
-	return io.NopCloser(timer.NewInstrumentedReader(result.Body, r.GetDigest().GetSizeBytes())), err
+	return interfaces.CacheArtifact{ReadCloser: io.NopCloser(timer.NewInstrumentedReader(result.Body, r.GetDigest().GetSizeBytes()))}, nil
 }
 
 type waitForUploadWriteCloser struct {

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -2130,18 +2130,18 @@ type faultyCache struct {
 	failErr     error
 }
 
-func (c *faultyCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
-	reader, err := c.Cache.Reader(ctx, r, uncompressedOffset, limit)
+func (c *faultyCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (interfaces.CacheArtifact, error) {
+	artifact, err := c.Cache.Reader(ctx, r, uncompressedOffset, limit)
 	if err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
 	shouldFault := c.faultDigest == r.GetDigest().GetHash()
 	failAfter := c.failAfter
 	failErr := c.failErr
 	if shouldFault {
-		return &faultyReader{ReadCloser: reader, failAfter: failAfter, failErr: failErr}, nil
+		return interfaces.CacheArtifact{ReadCloser: &faultyReader{ReadCloser: artifact.ReadCloser, failAfter: failAfter, failErr: failErr}}, nil
 	}
-	return reader, nil
+	return artifact, nil
 }
 
 type faultyReader struct {

--- a/enterprise/server/composable_cache/composable_cache.go
+++ b/enterprise/server/composable_cache/composable_cache.go
@@ -193,18 +193,20 @@ func (m *MultiCloser) Close() error {
 	return nil
 }
 
-func (c *ComposableCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
-	if outerReader, err := c.outer.Reader(ctx, r, uncompressedOffset, limit); err == nil {
-		return outerReader, nil
+func (c *ComposableCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (interfaces.CacheArtifact, error) {
+	if outerArtifact, err := c.outer.Reader(ctx, r, uncompressedOffset, limit); err == nil {
+		return outerArtifact, nil
 	}
 
-	innerReader, err := c.inner.Reader(ctx, r, uncompressedOffset, limit)
+	innerArtifact, err := c.inner.Reader(ctx, r, uncompressedOffset, limit)
 	if err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
 
-	if c.mode&ModeReadThrough == 0 || uncompressedOffset != 0 {
-		return innerReader, nil
+	// TODO: support copying references.
+	innerReader := innerArtifact.ReadCloser
+	if innerReader == nil || c.mode&ModeReadThrough == 0 || uncompressedOffset != 0 {
+		return innerArtifact, nil
 	}
 
 	// Copy the digest over to the outer cache.
@@ -212,23 +214,23 @@ func (c *ComposableCache) Reader(ctx context.Context, r *rspb.ResourceName, unco
 	// Directly return the inner reader if the outer cache doesn't want the
 	// blob.
 	if err != nil {
-		return innerReader, nil
+		return innerArtifact, nil
 	}
 	defer outerWriter.Close()
 	if _, err := io.Copy(outerWriter, innerReader); err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
 	// We're done with the inner reader at this point, we'll create a new
 	// reader below.
 	innerReader.Close()
 	if err := outerWriter.Commit(); err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
-	outerReader, err := c.outer.Reader(ctx, r, uncompressedOffset, limit)
+	outerArtifact, err := c.outer.Reader(ctx, r, uncompressedOffset, limit)
 	if err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
-	return outerReader, nil
+	return outerArtifact, nil
 }
 
 type doubleWriter struct {

--- a/enterprise/server/composable_cache/composable_cache_test.go
+++ b/enterprise/server/composable_cache/composable_cache_test.go
@@ -42,8 +42,9 @@ func writeDigest(ctx context.Context, t *testing.T, c interfaces.Cache, sizeByte
 }
 
 func readAndVerifyDigest(ctx context.Context, t *testing.T, c interfaces.Cache, d *rspb.ResourceName) {
-	r, err := c.Reader(ctx, d, 0, 0)
+	artifact, err := c.Reader(ctx, d, 0, 0)
 	require.NoError(t, err)
+	r := artifact.ReadCloser
 	rd, err := digest.Compute(r, repb.DigestFunction_SHA256)
 	require.NoError(t, err)
 	err = r.Close()
@@ -87,8 +88,9 @@ func TestReadThrough(t *testing.T) {
 	{
 		rn := writeDigest(ctx, t, inner, 99)
 
-		r, err := c.Reader(ctx, rn, 0, 0)
+		artifact, err := c.Reader(ctx, rn, 0, 0)
 		require.NoError(t, err)
+		r := artifact.ReadCloser
 
 		buf := make([]byte, 50)
 		_, err = r.Read(buf)

--- a/enterprise/server/test/performance/bytestream/bytestream_server_benchmark_test.go
+++ b/enterprise/server/test/performance/bytestream/bytestream_server_benchmark_test.go
@@ -73,18 +73,19 @@ func (c *slowCache) Writer(ctx context.Context, r *rspb.ResourceName) (interface
 	}, nil
 }
 
-func (c *slowCache) Reader(ctx context.Context, rn *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
-	r, err := c.Cache.Reader(ctx, rn, uncompressedOffset, limit)
+func (c *slowCache) Reader(ctx context.Context, rn *rspb.ResourceName, uncompressedOffset, limit int64) (interfaces.CacheArtifact, error) {
+	artifact, err := c.Cache.Reader(ctx, rn, uncompressedOffset, limit)
 	if err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
+	r := artifact.ReadCloser
 	if writerTo, ok := r.(io.WriterTo); ok {
-		return &slowReaderWriterTo{
+		return interfaces.CacheArtifact{ReadCloser: &slowReaderWriterTo{
 			slowReader: slowReader{r},
 			WriterTo:   writerTo,
-		}, nil
+		}}, nil
 	}
-	return &slowReader{r}, nil
+	return interfaces.CacheArtifact{ReadCloser: &slowReader{r}}, nil
 }
 
 type slowWriter struct {

--- a/enterprise/server/test/performance/cache/cache_test.go
+++ b/enterprise/server/test/performance/cache/cache_test.go
@@ -283,10 +283,11 @@ func benchmarkRead(ctx context.Context, c interfaces.Cache, digestSizeBytes int6
 	for b.Loop() {
 		dbuf := digestBufs[i%len(digestBufs)]
 		i++
-		r, err := c.Reader(ctx, dbuf.d, 0, 0)
+		artifact, err := c.Reader(ctx, dbuf.d, 0, 0)
 		if err != nil {
 			b.Fatal(err)
 		}
+		r := artifact.ReadCloser
 		n, err := readBuf.ReadFrom(r)
 		r.Close()
 		if err != nil {
@@ -498,8 +499,9 @@ func BenchmarkParallel(b *testing.B) {
 						}
 
 						// Read the digest from the cache.
-						r, err := cache.Cache.Reader(ctx, dbuf.d, 0, 0)
+						artifact, err := cache.Cache.Reader(ctx, dbuf.d, 0, 0)
 						require.NoError(b, err)
+						r := artifact.ReadCloser
 						n, err := io.Copy(io.Discard, r)
 						require.NoError(b, err)
 						require.Equal(b, size, n)

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -321,10 +321,14 @@ func (c *Proxy) Read(req *dcpb.ReadRequest, stream dcpb.DistributedCache_ReadSer
 	}
 	up, _ := prefix.UserPrefixFromContext(ctx)
 	rn := req.GetResource()
-	reader, err := c.cache.Reader(ctx, rn, req.GetOffset(), req.GetLimit())
+	artifact, err := c.cache.Reader(ctx, rn, req.GetOffset(), req.GetLimit())
 	if err != nil {
 		c.log.Debugf("Read(%q) failed (user prefix: %s), err: %s", ResourceIsolationString(rn), up, err)
 		return err
+	}
+	reader := artifact.ReadCloser
+	if reader == nil {
+		return status.InternalErrorf("cache type %T does not support references", c.cache)
 	}
 	defer reader.Close()
 

--- a/enterprise/server/util/distributed_client/distributed_client_test.go
+++ b/enterprise/server/util/distributed_client/distributed_client_test.go
@@ -47,7 +47,7 @@ type spyCache struct {
 	getMultiCompressors map[string]repb.Compressor_Value
 }
 
-func (s *spyCache) Reader(ctx context.Context, rn *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
+func (s *spyCache) Reader(ctx context.Context, rn *rspb.ResourceName, offset, limit int64) (interfaces.CacheArtifact, error) {
 	s.mu.Lock()
 	s.readerCompressors = append(s.readerCompressors, rn.GetCompressor())
 	s.mu.Unlock()
@@ -447,11 +447,11 @@ func TestWriter(t *testing.T) {
 
 		// Read the bytes back directly from the cache and check that
 		// they match..
-		r, err := te.GetCache().Reader(ctx, rn, 0, 0)
+		artifact, err := te.GetCache().Reader(ctx, rn, 0, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
-		d2 := testdigest.ReadDigestAndClose(t, r)
+		d2 := testdigest.ReadDigestAndClose(t, artifact.ReadCloser)
 		if d.GetHash() != d2.GetHash() {
 			t.Fatalf("Digest uploaded %q != %q downloaded", d.GetHash(), d2.GetHash())
 		}

--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -458,12 +458,16 @@ func (c *DiskCache) Delete(ctx context.Context, r *rspb.ResourceName) error {
 	return p.delete(ctx, r)
 }
 
-func (c *DiskCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
+func (c *DiskCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (interfaces.CacheArtifact, error) {
 	p, err := c.getPartition(ctx, r.GetInstanceName())
 	if err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
-	return p.reader(ctx, r, uncompressedOffset, limit)
+	rc, err := p.reader(ctx, r, uncompressedOffset, limit)
+	if err != nil {
+		return interfaces.CacheArtifact{}, err
+	}
+	return interfaces.CacheArtifact{ReadCloser: rc}, nil
 }
 
 func (c *DiskCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfaces.CommittedWriteCloser, error) {

--- a/server/backends/disk_cache/disk_cache_test.go
+++ b/server/backends/disk_cache/disk_cache_test.go
@@ -262,11 +262,11 @@ func TestReadWrite(t *testing.T) {
 			t.Fatalf("Error closing writer: %s", err.Error())
 		}
 		// Use Reader() to get the bytes from the cache.
-		reader, err := dc.Reader(ctx, rn, 0, 0)
+		artifact, err := dc.Reader(ctx, rn, 0, 0)
 		if err != nil {
 			t.Fatalf("Error getting %q reader: %s", rn.GetDigest().GetHash(), err.Error())
 		}
-		d2 := testdigest.ReadDigestAndClose(t, reader)
+		d2 := testdigest.ReadDigestAndClose(t, artifact.ReadCloser)
 		if rn.GetDigest().GetHash() != d2.GetHash() {
 			t.Fatalf("Returned digest %q did not match set value: %q", d2.GetHash(), rn.GetDigest().GetHash())
 		}
@@ -300,11 +300,11 @@ func TestReadOffset(t *testing.T) {
 		t.Fatalf("Error closing writer: %s", err.Error())
 	}
 	// Use Reader() to get the bytes from the cache.
-	reader, err := dc.Reader(ctx, rn, rn.GetDigest().GetSizeBytes(), 0)
+	artifact, err := dc.Reader(ctx, rn, rn.GetDigest().GetSizeBytes(), 0)
 	if err != nil {
 		t.Fatalf("Error getting %q reader: %s", rn.GetDigest().GetHash(), err.Error())
 	}
-	d2 := testdigest.ReadDigestAndClose(t, reader)
+	d2 := testdigest.ReadDigestAndClose(t, artifact.ReadCloser)
 	if "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" != d2.GetHash() {
 		t.Fatalf("Returned digest %q did not match set value: %q", d2.GetHash(), rn.GetDigest().GetHash())
 	}
@@ -325,11 +325,11 @@ func TestReadOffsetLimit(t *testing.T) {
 
 	offset := int64(2)
 	limit := int64(3)
-	reader, err := dc.Reader(ctx, r, offset, limit)
+	artifact, err := dc.Reader(ctx, r, offset, limit)
 	require.NoError(t, err)
 
 	readBuf := make([]byte, size)
-	n, err := reader.Read(readBuf)
+	n, err := artifact.ReadCloser.Read(readBuf)
 	require.NoError(t, err)
 	require.EqualValues(t, limit, n)
 	require.Equal(t, buf[offset:offset+limit], readBuf[:limit])

--- a/server/backends/memory_cache/memory_cache.go
+++ b/server/backends/memory_cache/memory_cache.go
@@ -228,11 +228,11 @@ func (m *MemoryCache) Delete(ctx context.Context, r *rspb.ResourceName) error {
 }
 
 // Low level interface used for seeking and stream-writing.
-func (m *MemoryCache) Reader(ctx context.Context, rn *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
+func (m *MemoryCache) Reader(ctx context.Context, rn *rspb.ResourceName, uncompressedOffset, limit int64) (interfaces.CacheArtifact, error) {
 	// Locking and key prefixing are handled in Get.
 	buf, err := m.Get(ctx, rn)
 	if err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
 	r := bytes.NewReader(buf)
 	r.Seek(uncompressedOffset, 0)
@@ -241,9 +241,9 @@ func (m *MemoryCache) Reader(ctx context.Context, rn *rspb.ResourceName, uncompr
 		length = limit
 	}
 	if length > 0 {
-		return io.NopCloser(io.LimitReader(r, length)), nil
+		return interfaces.CacheArtifact{ReadCloser: io.NopCloser(io.LimitReader(r, length))}, nil
 	}
-	return io.NopCloser(r), nil
+	return interfaces.CacheArtifact{ReadCloser: io.NopCloser(r)}, nil
 }
 
 func (m *MemoryCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfaces.CommittedWriteCloser, error) {

--- a/server/backends/memory_cache/memory_cache_test.go
+++ b/server/backends/memory_cache/memory_cache_test.go
@@ -242,11 +242,11 @@ func TestReadWrite(t *testing.T) {
 			t.Fatalf("Error closing writer: %s", err.Error())
 		}
 		// Use Reader() to get the bytes from the cache.
-		reader, err := mc.Reader(ctx, rn, 0, 0)
+		artifact, err := mc.Reader(ctx, rn, 0, 0)
 		if err != nil {
 			t.Fatalf("Error getting %q reader: %s", rn.GetDigest().GetHash(), err.Error())
 		}
-		d2 := testdigest.ReadDigestAndClose(t, reader)
+		d2 := testdigest.ReadDigestAndClose(t, artifact.ReadCloser)
 		if rn.GetDigest().GetHash() != d2.GetHash() {
 			t.Fatalf("Returned digest %q did not match set value: %q", d2.GetHash(), rn.GetDigest().GetHash())
 		}
@@ -265,11 +265,11 @@ func TestReadOffsetLimit(t *testing.T) {
 
 	offset := int64(2)
 	limit := int64(3)
-	reader, err := mc.Reader(ctx, r, offset, limit)
+	artifact, err := mc.Reader(ctx, r, offset, limit)
 	require.NoError(t, err)
 
 	readBuf := make([]byte, size)
-	n, err := reader.Read(readBuf)
+	n, err := artifact.ReadCloser.Read(readBuf)
 	require.NoError(t, err)
 	require.EqualValues(t, limit, n)
 	require.Equal(t, buf[offset:offset+limit], readBuf[:limit])

--- a/server/cache/dirtools/dirtools_test.go
+++ b/server/cache/dirtools/dirtools_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -1483,7 +1482,7 @@ type controlledCache struct {
 	getMultiCalls chan struct{}
 }
 
-func (cc *controlledCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
+func (cc *controlledCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (interfaces.CacheArtifact, error) {
 	dk := digest.NewKey(r.GetDigest())
 	cc.mu.Lock()
 	delay, ok := cc.readerDelay[dk]

--- a/server/interfaces/BUILD
+++ b/server/interfaces/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//proto:iprules_go_proto",
         "//proto:notification_go_proto",
         "//proto:publish_build_event_go_proto",
+        "//proto:reference_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:repo_go_proto",
         "//proto:resource_go_proto",

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -43,6 +43,7 @@ import (
 	irpb "github.com/buildbuddy-io/buildbuddy/proto/iprules"
 	npb "github.com/buildbuddy-io/buildbuddy/proto/notification"
 	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
+	refpb "github.com/buildbuddy-io/buildbuddy/proto/reference"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	rppb "github.com/buildbuddy-io/buildbuddy/proto/repo"
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
@@ -288,6 +289,15 @@ type CacheMetadata struct {
 	LastModifyTimeUsec int64
 }
 
+// An artifact stored in the cache. Every valid Artifact will have either a
+// ReadCloser or Reference but not both. If ReadCloser is set, the artifact is
+// being streamed from the cache. If Reference is set, the artifact is being
+// provided as a reference to data stored in another location.
+type CacheArtifact struct {
+	ReadCloser io.ReadCloser
+	Reference  *refpb.Reference
+}
+
 // Similar to a blobstore, a cache allows for reading and writing data, but
 // additionally it is responsible for deleting data that is past TTL to keep to
 // a manageable size.
@@ -306,7 +316,7 @@ type Cache interface {
 	Delete(ctx context.Context, r *rspb.ResourceName) error
 
 	// Low level interface used for seeking and stream-writing.
-	Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error)
+	Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (CacheArtifact, error)
 	Writer(ctx context.Context, r *rspb.ResourceName) (CommittedWriteCloser, error)
 
 	// Returns the partition ID for the given context and remote instance name.

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -197,7 +197,8 @@ func (s *ByteStreamServer) ReadCASResource(ctx context.Context, r *digest.CASRes
 	if passthroughCompressionEnabled {
 		cacheRN.SetCompressor(r.GetCompressor())
 	}
-	reader, err := s.cache.Reader(ctx, cacheRN.ToProto(), offset, limit)
+	artifact, err := s.cache.Reader(ctx, cacheRN.ToProto(), offset, limit)
+	reader := artifact.ReadCloser
 	if err != nil {
 		if status.IsNotFoundError(err) && chunking.ShouldReadChunked(ctx, s.env.GetExperimentFlagProvider(), cacheRN.GetDigest().GetSizeBytes(), offset, limit) {
 			reader, err = s.attemptReadChunked(ctx, cacheRN, offset)
@@ -208,6 +209,9 @@ func (s *ByteStreamServer) ReadCASResource(ctx context.Context, r *digest.CASRes
 			}
 			return err
 		}
+	}
+	if reader == nil {
+		return status.InternalError("ByteStreamServer does not support cache references")
 	}
 	defer reader.Close()
 
@@ -428,9 +432,13 @@ func (r *chunkedBlobReader) spawn(index int) {
 }
 
 func (r *chunkedBlobReader) readChunk(rn *rspb.ResourceName, offset int64, buf []byte) chunkReadResult {
-	rc, err := r.cache.Reader(r.ctx, rn, offset, 0)
+	artifact, err := r.cache.Reader(r.ctx, rn, offset, 0)
 	if err != nil {
 		return chunkReadResult{data: buf, err: err}
+	}
+	rc := artifact.ReadCloser
+	if rc == nil {
+		return chunkReadResult{data: buf, err: status.InternalError("chunked reads do not support cache references")}
 	}
 	defer rc.Close()
 

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -109,7 +109,7 @@ type gatedReadCache struct {
 	maxRead    int
 }
 
-func (c *gatedReadCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
+func (c *gatedReadCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (interfaces.CacheArtifact, error) {
 	if r.GetDigest().GetSizeBytes() != c.gateSize {
 		return c.Cache.Reader(ctx, r, uncompressedOffset, limit)
 	}
@@ -124,12 +124,12 @@ func (c *gatedReadCache) Reader(ctx context.Context, r *rspb.ResourceName, uncom
 	}()
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return interfaces.CacheArtifact{}, ctx.Err()
 	case c.started <- struct{}{}:
 	}
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return interfaces.CacheArtifact{}, ctx.Err()
 	case <-c.release:
 	}
 	return c.Cache.Reader(ctx, r, uncompressedOffset, limit)
@@ -171,8 +171,12 @@ type readerFuncCache struct {
 	reader func(ctx context.Context, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error)
 }
 
-func (c *readerFuncCache) Reader(ctx context.Context, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
-	return c.reader(ctx, r, offset, limit)
+func (c *readerFuncCache) Reader(ctx context.Context, r *rspb.ResourceName, offset, limit int64) (interfaces.CacheArtifact, error) {
+	rc, err := c.reader(ctx, r, offset, limit)
+	if err != nil {
+		return interfaces.CacheArtifact{}, err
+	}
+	return interfaces.CacheArtifact{ReadCloser: rc}, nil
 }
 
 type casCompressionCache struct {
@@ -186,7 +190,7 @@ func (c *casCompressionCache) Get(ctx context.Context, r *rspb.ResourceName) ([]
 	return (&testcompression.CompressionCache{Cache: c.Cache}).Get(ctx, r)
 }
 
-func (c *casCompressionCache) Reader(ctx context.Context, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
+func (c *casCompressionCache) Reader(ctx context.Context, r *rspb.ResourceName, offset, limit int64) (interfaces.CacheArtifact, error) {
 	if r.GetCacheType() != rspb.CacheType_CAS {
 		return c.Cache.Reader(ctx, r, offset, limit)
 	}

--- a/server/remote_cache/chunking/chunking_test.go
+++ b/server/remote_cache/chunking/chunking_test.go
@@ -708,18 +708,18 @@ type slowReaderOpenAndReadCache struct {
 	readDelay time.Duration
 }
 
-func (c *slowReaderOpenAndReadCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
+func (c *slowReaderOpenAndReadCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (interfaces.CacheArtifact, error) {
 	if err := sleepWithContext(ctx, c.openDelay); err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
-	reader, err := c.Cache.Reader(ctx, r, uncompressedOffset, limit)
+	artifact, err := c.Cache.Reader(ctx, r, uncompressedOffset, limit)
 	if err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
-	return &slowReadCloser{
-		ReadCloser: reader,
+	return interfaces.CacheArtifact{ReadCloser: &slowReadCloser{
+		ReadCloser: artifact.ReadCloser,
 		readDelay:  c.readDelay,
-	}, nil
+	}}, nil
 }
 
 func (c *slowReaderOpenAndReadCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {

--- a/server/testutil/testcompression/testcompression.go
+++ b/server/testutil/testcompression/testcompression.go
@@ -32,10 +32,10 @@ func (c *CompressionCache) Get(ctx context.Context, r *rspb.ResourceName) ([]byt
 	return cachedDataWithCompression, nil
 }
 
-func (c *CompressionCache) Reader(ctx context.Context, rn *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
+func (c *CompressionCache) Reader(ctx context.Context, rn *rspb.ResourceName, offset, limit int64) (interfaces.CacheArtifact, error) {
 	buf, err := c.Get(ctx, rn)
 	if err != nil {
-		return nil, err
+		return interfaces.CacheArtifact{}, err
 	}
 	r := bytes.NewReader(buf)
 	r.Seek(offset, 0)
@@ -44,9 +44,9 @@ func (c *CompressionCache) Reader(ctx context.Context, rn *rspb.ResourceName, of
 		length = limit
 	}
 	if length > 0 {
-		return io.NopCloser(io.LimitReader(r, length)), nil
+		return interfaces.CacheArtifact{ReadCloser: io.NopCloser(io.LimitReader(r, length))}, nil
 	}
-	return io.NopCloser(r), nil
+	return interfaces.CacheArtifact{ReadCloser: io.NopCloser(r)}, nil
 }
 
 func (c *CompressionCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {


### PR DESCRIPTION
This lets `Cache.Reader()` return a `refpb.Reference` or an `io.ReadCloser`.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7911