### PR TITLE
Make distributed_client handle references on the read path

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -314,6 +314,7 @@ type PebbleCache struct {
 	minGCSFileSizeBytes     int64
 	gcsTTLDays              int64
 	gcsAtimeUpdateThreshold time.Duration
+	gcsBlobstore            *gcs.GCSBlobStore
 
 	metrics struct {
 		compressedBlobSizeWrite   prometheus.Counter
@@ -653,6 +654,7 @@ func NewPebbleCache(env environment.Env, opts *Options) (*PebbleCache, error) {
 		clock = clockwork.NewRealClock()
 	}
 
+	var gcsBlobstore *gcs.GCSBlobStore
 	fileStorer := opts.FileStorer
 	if fileStorer == nil {
 		filestoreOpts := make([]filestore.Option, 0)
@@ -661,7 +663,8 @@ func NewPebbleCache(env environment.Env, opts *Options) (*PebbleCache, error) {
 			// will already compress blobs before storing them, so we don't
 			// want the gcs lib to attempt to compress them too.
 			ctx := env.GetServerContext()
-			gcsBlobstore, err := gcs.NewGCSBlobStore(ctx, opts.GCSBucket, "", opts.GCSCredentials, opts.GCSProjectID, false /*=enableCompression*/)
+			var err error
+			gcsBlobstore, err = gcs.NewGCSBlobStore(ctx, opts.GCSBucket, "", opts.GCSCredentials, opts.GCSProjectID, false /*=enableCompression*/)
 			if err != nil {
 				return nil, err
 			}
@@ -725,6 +728,7 @@ func NewPebbleCache(env environment.Env, opts *Options) (*PebbleCache, error) {
 		minGCSFileSizeBytes:         *opts.MinGCSFileSizeBytes,
 		gcsTTLDays:                  *opts.GCSTTLDays,
 		gcsAtimeUpdateThreshold:     *opts.GCSAtimeUpdateThreshold,
+		gcsBlobstore:                gcsBlobstore,
 		fileStorer:                  fileStorer,
 	}
 	zstdLabels := prometheus.Labels{metrics.CacheNameLabel: pc.name, metrics.CompressionType: "zstd"}
@@ -2150,6 +2154,19 @@ func (p *PebbleCache) GetReference(ctx context.Context, r *rspb.ResourceName) (*
 	p.sendAtimeUpdate(ctx, key, md.GetLastAccessUsec())
 
 	return &refpb.Reference{Metadata: md}, nil
+}
+
+func (p *PebbleCache) Dereferencer() interfaces.Dereferencer {
+	if p.gcsBlobstore == nil {
+		return nil
+	}
+	return func(ctx context.Context, ref *refpb.Reference, offset, limit int64) (io.ReadCloser, error) {
+		blobName := ref.GetMetadata().GetStorageMetadata().GetGcsMetadata().GetBlobName()
+		if blobName == "" {
+			return nil, status.InvalidArgumentError("Malformed reference (empty blob name)")
+		}
+		return p.gcsBlobstore.Reader(ctx, blobName, offset, limit)
+	}
 }
 
 func (p *PebbleCache) Set(ctx context.Context, r *rspb.ResourceName, data []byte) error {

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -572,14 +572,63 @@ func (c *Proxy) RemoteReader(ctx context.Context, peer string, r *rspb.ResourceN
 		return nil, err
 	}
 	rc, err := newDistributedCacheReader(stream, r.GetDigest().GetSizeBytes() == offset)
-	if err != nil || !decompress {
-		return rc, err
+	if err != nil {
+		return nil, err
+	}
+
+	// The server provided a reference. Dereference it.
+	if rc.rsp.GetReference() != nil {
+		ref := rc.rsp.GetReference().CloneVT()
+		if err := rc.Close(); err != nil {
+			c.log.Debugf("Error closing read stream after receiving a reference: %s", err)
+		}
+		resolver, ok := c.cache.(interfaces.ReferenceCache)
+		if !ok {
+			return nil, status.FailedPreconditionErrorf("peer %q returned a reference, but the local cache (%T) cannot dereference", peer, c.cache)
+		}
+		dereference, err := resolver.GetDereferencer()
+		if err != nil {
+			return nil, err
+		}
+		// Dereferencing yields the bytes exactly as stored, so the stored
+		// compressor must be reconciled with the one the caller wants.
+		// (When the ZSTD transport rewrite was applied above, the caller
+		// wants the original IDENTITY bytes, not the rewritten encoding.)
+		wanted := r.GetCompressor()
+		if decompress {
+			wanted = repb.Compressor_IDENTITY
+		}
+		stored := ref.GetMetadata().GetFileRecord().GetCompressor()
+		if stored == wanted {
+			return dereference(ctx, ref, offset, limit)
+		}
+		if stored == repb.Compressor_ZSTD && wanted == repb.Compressor_IDENTITY && offset == 0 && limit == 0 {
+			drc, err := dereference(ctx, ref, 0, 0)
+			if err != nil {
+				return nil, err
+			}
+			zr, err := compression.NewZstdDecompressingReader(drc)
+			if err != nil {
+				drc.Close()
+				return nil, err
+			}
+			return zr, nil
+		}
+		// Anything else (stored IDENTITY but ZSTD wanted, or a ranged read
+		// of a compressed blob, where offsets refer to uncompressed bytes)
+		// cannot be served from the reference.
+		return nil, status.InternalErrorf("peer %q returned a reference stored with compressor %s, but %s was requested", peer, stored, wanted)
+	}
+
+	if !decompress {
+		return rc, nil
 	}
 	dr, err := compression.NewZstdDecompressingReader(rc)
 	if err != nil {
 		rc.Close()
+		return nil, err
 	}
-	return dr, err
+	return dr, nil
 }
 
 type distributedCacheReader struct {

--- a/server/backends/blobstore/gcs/BUILD
+++ b/server/backends/blobstore/gcs/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/backends/blobstore/gcs",
     visibility = ["//visibility:public"],
     deps = [
+        "//proto:reference_go_proto",
         "//server/backends/blobstore/util",
         "//server/interfaces",
         "//server/rpc/interceptors",

--- a/server/backends/blobstore/gcs/gcs.go
+++ b/server/backends/blobstore/gcs/gcs.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
+	refpb "github.com/buildbuddy-io/buildbuddy/proto/reference"
 	gstatus "google.golang.org/grpc/status"
 )
 
@@ -460,6 +461,14 @@ func (g *GCSBlobStore) Reader(ctx context.Context, blobName string, offset, limi
 	} else {
 		return reader, nil
 	}
+}
+
+func (g *GCSBlobStore) Dereference(ctx context.Context, ref *refpb.Reference, offset, limit int64) (io.ReadCloser, error) {
+	blobName := ref.GetMetadata().GetStorageMetadata().GetGcsMetadata().GetBlobName()
+	if blobName == "" {
+		return nil, status.InvalidArgumentError("malformed reference (empty blob name)")
+	}
+	return g.Reader(ctx, blobName, offset, limit)
 }
 
 func (g *GCSBlobStore) SetBucketCustomTimeTTL(ctx context.Context, ageInDays int64) error {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -326,10 +326,13 @@ type StoppableCache interface {
 	Stop() error
 }
 
+type Dereferencer func(ctx context.Context, ref *refpb.Reference, offset, limit int64) (io.ReadCloser, error)
+
 // A Cache implementation that supports reading and writing refpb.References.
 type ReferenceCache interface {
 	Cache
 	GetReference(ctx context.Context, r *rspb.ResourceName) (*refpb.Reference, error)
+	GetDereferencer() (Dereferencer, error)
 }
 
 type PooledByteStreamClient interface {


### PR DESCRIPTION
This change introduces an `interfaces.Dereferencer` which converts a `refpb.Reference` into an `io.ReadCloser` and makes the [distributed_client](https://github.com/buildbuddy-io/buildbuddy/blob/master/enterprise/server/util/distributed_client/distributed_client.go) use that to retrieve bytes from referenced storage (today just GCS) when it receives a reference on the read path. The `interfaces.Dereferencer` is retrieved from the `interfaces.ReferenceCache` to avoid having to configure the backing cache's connection to GCS (or whatever backend its using) in the distributed cache layer.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7911