### PR TITLE
[RB] Specify which runfiles should be executable

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1316,9 +1316,9 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 							Arguments:          runScriptInfo.args,
 							RunfilesRoot:       runScriptInfo.runfilesRoot,
 							Runfiles:           runScriptInfo.runfiles,
+							RunfileEntries:     runScriptInfo.runfileEntries,
 							RunfileDirectories: runScriptInfo.runfileDirs,
 							ExecutablePath:     runScriptInfo.executablePath,
-							ExecutableRunfiles: runScriptInfo.executableRunfiles,
 						}},
 					}
 					ar.reporter.Publish(e)
@@ -1434,16 +1434,21 @@ func deserializeAction(actionString string) (*config.Action, error) {
 }
 
 type runInfo struct {
-	args               []string
-	runfiles           []*bespb.File
-	runfileDirs        []*bespb.Tree
-	runfilesRoot       string
-	executablePath     string
-	executableRunfiles []string
+	args           []string
+	runfiles       []*bespb.File
+	runfileEntries []*bespb.Runfile
+	runfileDirs    []*bespb.Tree
+	runfilesRoot   string
+	executablePath string
 }
 
-func collectRunfiles(runfilesDir string) (map[digest.Key]string, map[string]string, error) {
-	fileDigestMap := make(map[digest.Key]string)
+type runfile struct {
+	path         string
+	isExecutable bool
+}
+
+func collectRunfiles(runfilesDir string) (map[digest.Key]*runfile, map[string]string, error) {
+	fileDigestMap := make(map[digest.Key]*runfile)
 	dirsToUpload := make(map[string]string)
 	err := filepath.WalkDir(runfilesDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -1452,6 +1457,8 @@ func collectRunfiles(runfilesDir string) (map[digest.Key]string, map[string]stri
 		if d.IsDir() {
 			return nil
 		}
+		// Get file metadata for symlinks.
+		var info fs.FileInfo
 		if d.Type()&fs.ModeSymlink != 0 {
 			t, err := os.Readlink(path)
 			if err != nil {
@@ -1461,20 +1468,30 @@ func collectRunfiles(runfilesDir string) (map[digest.Key]string, map[string]stri
 			if !filepath.IsAbs(targetPath) {
 				targetPath = filepath.Join(filepath.Dir(path), targetPath)
 			}
-			fi, err := os.Stat(targetPath)
+			info, err = os.Stat(targetPath)
 			if err != nil {
 				return err
 			}
-			if fi.IsDir() {
+			if info.IsDir() {
 				dirsToUpload[path] = targetPath
 				return nil
+			}
+		}
+		// Get file metadata for regular files.
+		if info == nil {
+			info, err = d.Info()
+			if err != nil {
+				return err
 			}
 		}
 		rn, err := cachetools.ComputeFileDigest(path, *remoteInstanceName, repb.DigestFunction_SHA256)
 		if err != nil {
 			return err
 		}
-		fileDigestMap[digest.NewKey(rn.GetDigest())] = path
+		fileDigestMap[digest.NewKey(rn.GetDigest())] = &runfile{
+			path:         path,
+			isExecutable: info.Mode()&0111 != 0,
+		}
 		return nil
 	})
 	if err != nil && !os.IsNotExist(err) {
@@ -1483,7 +1500,7 @@ func collectRunfiles(runfilesDir string) (map[digest.Key]string, map[string]stri
 	return fileDigestMap, dirsToUpload, err
 }
 
-func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*bespb.File, []*bespb.Tree, []string, error) {
+func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*bespb.File, []*bespb.Tree, []*bespb.Runfile, error) {
 	healthChecker := healthcheck.NewHealthChecker("ci-runner")
 	env := real_environment.NewRealEnv(healthChecker)
 
@@ -1507,29 +1524,27 @@ func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*
 
 	var digests []*repb.Digest
 	var runfiles []*bespb.File
-	var executableRunfiles []string
-	for d, runfilePath := range fileDigestMap {
+	var runfileEntries []*bespb.Runfile
+	for d, runfileInfo := range fileDigestMap {
 		digests = append(digests, d.ToDigest())
-		relPath, err := filepath.Rel(workspaceRoot, runfilePath)
+		relPath, err := filepath.Rel(workspaceRoot, runfileInfo.path)
 		if err != nil {
 			return nil, nil, nil, err
-		}
-		info, err := os.Stat(runfilePath)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		if info.Mode()&0111 != 0 {
-			executableRunfiles = append(executableRunfiles, relPath)
 		}
 		downloadString := digest.NewCASResourceName(d.ToDigest(), *remoteInstanceName, repb.DigestFunction_SHA256).DownloadString()
 		if !strings.HasPrefix(downloadString, "/") {
 			downloadString = "/" + downloadString
 		}
-		runfiles = append(runfiles, &bespb.File{
+		runfile := &bespb.File{
 			Name: relPath,
 			File: &bespb.File_Uri{
 				Uri: fmt.Sprintf("%s%s", bytestreamURIPrefix, downloadString),
 			},
+		}
+		runfiles = append(runfiles, runfile)
+		runfileEntries = append(runfileEntries, &bespb.Runfile{
+			File:         runfile,
+			IsExecutable: runfileInfo.isExecutable,
 		})
 	}
 	rsp, err := env.GetContentAddressableStorageClient().FindMissingBlobs(ctx, &repb.FindMissingBlobsRequest{
@@ -1546,12 +1561,12 @@ func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*
 	u := cachetools.NewBatchCASUploader(ctx, env, *remoteInstanceName, repb.DigestFunction_SHA256, nil /*=chunkingParams*/)
 
 	for _, d := range missingDigests {
-		runfilePath, ok := fileDigestMap[digest.NewKey(d)]
+		runfileInfo, ok := fileDigestMap[digest.NewKey(d)]
 		if !ok {
 			// not supposed to happen...
 			return nil, nil, nil, status.InternalErrorf("missing digest not in our digest map")
 		}
-		f, err := os.Open(runfilePath)
+		f, err := os.Open(runfileInfo.path)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -1595,7 +1610,7 @@ func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*
 		return nil, nil, nil, err
 	}
 
-	return runfiles, runfileDirs, executableRunfiles, nil
+	return runfiles, runfileDirs, runfileEntries, nil
 }
 
 // processRunScript processes the contents of a bazel run script (produced via bazel run --script_path) and extracts
@@ -1653,18 +1668,19 @@ func processRunScript(ctx context.Context, runScript string) (*runInfo, error) {
 	}
 
 	runfilesDir := bin + ".runfiles"
-	runfiles, runfileDirs, executableRunfiles, err := uploadRunfiles(ctx, wsRoot, runfilesDir)
+	runfiles, runfileDirs, runfileEntries, err := uploadRunfiles(ctx, wsRoot, runfilesDir)
 	if err != nil {
 		return nil, err
 	}
 
 	return &runInfo{
-		args:               args,
-		runfiles:           runfiles,
-		runfileDirs:        runfileDirs,
-		runfilesRoot:       runfilesRoot,
-		executablePath:     executablePath,
-		executableRunfiles: executableRunfiles,
+		args: args,
+		// TODO(Maggie): Delete deprecated field
+		runfiles:       runfiles,
+		runfileEntries: runfileEntries,
+		runfileDirs:    runfileDirs,
+		runfilesRoot:   runfilesRoot,
+		executablePath: executablePath,
 	}, nil
 }
 

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1318,6 +1318,7 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 							Runfiles:           runScriptInfo.runfiles,
 							RunfileDirectories: runScriptInfo.runfileDirs,
 							ExecutablePath:     runScriptInfo.executablePath,
+							ExecutableRunfiles: runScriptInfo.executableRunfiles,
 						}},
 					}
 					ar.reporter.Publish(e)
@@ -1433,11 +1434,12 @@ func deserializeAction(actionString string) (*config.Action, error) {
 }
 
 type runInfo struct {
-	args           []string
-	runfiles       []*bespb.File
-	runfileDirs    []*bespb.Tree
-	runfilesRoot   string
-	executablePath string
+	args               []string
+	runfiles           []*bespb.File
+	runfileDirs        []*bespb.Tree
+	runfilesRoot       string
+	executablePath     string
+	executableRunfiles []string
 }
 
 func collectRunfiles(runfilesDir string) (map[digest.Key]string, map[string]string, error) {
@@ -1481,17 +1483,17 @@ func collectRunfiles(runfilesDir string) (map[digest.Key]string, map[string]stri
 	return fileDigestMap, dirsToUpload, err
 }
 
-func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*bespb.File, []*bespb.Tree, error) {
+func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*bespb.File, []*bespb.Tree, []string, error) {
 	healthChecker := healthcheck.NewHealthChecker("ci-runner")
 	env := real_environment.NewRealEnv(healthChecker)
 
 	fileDigestMap, dirs, err := collectRunfiles(runfilesDir)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	conn, err := grpc_client.DialSimple(*cacheBackend)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	env.SetByteStreamClient(bspb.NewByteStreamClient(conn))
 	env.SetContentAddressableStorageClient(repb.NewContentAddressableStorageClient(conn))
@@ -1499,17 +1501,25 @@ func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*
 
 	backendURL, err := url.Parse(*cacheBackend)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	bytestreamURIPrefix := "bytestream://" + backendURL.Host
 
 	var digests []*repb.Digest
 	var runfiles []*bespb.File
+	var executableRunfiles []string
 	for d, runfilePath := range fileDigestMap {
 		digests = append(digests, d.ToDigest())
 		relPath, err := filepath.Rel(workspaceRoot, runfilePath)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
+		}
+		info, err := os.Stat(runfilePath)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if info.Mode()&0111 != 0 {
+			executableRunfiles = append(executableRunfiles, relPath)
 		}
 		downloadString := digest.NewCASResourceName(d.ToDigest(), *remoteInstanceName, repb.DigestFunction_SHA256).DownloadString()
 		if !strings.HasPrefix(downloadString, "/") {
@@ -1528,7 +1538,7 @@ func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*
 		Purpose:      repb.FindMissingBlobsRequest_CI_RUNNER_UPLOAD,
 	})
 	if err != nil {
-		return nil, nil, status.UnknownErrorf("could not check digest existence: %s", err)
+		return nil, nil, nil, status.UnknownErrorf("could not check digest existence: %s", err)
 	}
 	missingDigests := rsp.GetMissingBlobDigests()
 
@@ -1539,14 +1549,14 @@ func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*
 		runfilePath, ok := fileDigestMap[digest.NewKey(d)]
 		if !ok {
 			// not supposed to happen...
-			return nil, nil, status.InternalErrorf("missing digest not in our digest map")
+			return nil, nil, nil, status.InternalErrorf("missing digest not in our digest map")
 		}
 		f, err := os.Open(runfilePath)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		if err := u.Upload(d, f); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 	}
 
@@ -1582,10 +1592,10 @@ func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*
 	}
 
 	if err := eg.Wait(); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return runfiles, runfileDirs, nil
+	return runfiles, runfileDirs, executableRunfiles, nil
 }
 
 // processRunScript processes the contents of a bazel run script (produced via bazel run --script_path) and extracts
@@ -1643,17 +1653,18 @@ func processRunScript(ctx context.Context, runScript string) (*runInfo, error) {
 	}
 
 	runfilesDir := bin + ".runfiles"
-	runfiles, runfileDirs, err := uploadRunfiles(ctx, wsRoot, runfilesDir)
+	runfiles, runfileDirs, executableRunfiles, err := uploadRunfiles(ctx, wsRoot, runfilesDir)
 	if err != nil {
 		return nil, err
 	}
 
 	return &runInfo{
-		args:           args,
-		runfiles:       runfiles,
-		runfileDirs:    runfileDirs,
-		runfilesRoot:   runfilesRoot,
-		executablePath: executablePath,
+		args:               args,
+		runfiles:           runfiles,
+		runfileDirs:        runfileDirs,
+		runfilesRoot:       runfilesRoot,
+		executablePath:     executablePath,
+		executableRunfiles: executableRunfiles,
 	}, nil
 }
 

--- a/enterprise/server/cmd/ci_runner/main_test.go
+++ b/enterprise/server/cmd/ci_runner/main_test.go
@@ -38,6 +38,27 @@ func TestCollectRunfiles_RelativeDirectorySymlink(t *testing.T) {
 	assert.Equal(t, map[string]string{linkPath: targetDir}, dirs)
 }
 
+func TestCollectRunfiles_ExecutableMetadata(t *testing.T) {
+	runfilesDir := t.TempDir()
+	executablePath := filepath.Join(runfilesDir, "executable")
+	require.NoError(t, os.WriteFile(executablePath, []byte("executable"), 0644))
+	require.NoError(t, os.Chmod(executablePath, 0755))
+	nonExecutablePath := filepath.Join(runfilesDir, "non-executable")
+	require.NoError(t, os.WriteFile(nonExecutablePath, []byte("non-executable"), 0644))
+
+	files, _, err := collectRunfiles(runfilesDir)
+	require.NoError(t, err)
+
+	executableByPath := make(map[string]bool, len(files))
+	for _, runfile := range files {
+		executableByPath[runfile.path] = runfile.isExecutable
+	}
+	assert.Equal(t, map[string]bool{
+		executablePath:    true,
+		nonExecutablePath: false,
+	}, executableByPath)
+}
+
 type stallingReadCloser struct {
 	ctx context.Context
 	io.ReadCloser

--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -1668,6 +1668,8 @@ message RunTargetAnalyzed {
   repeated Tree runfileDirectories = 4;
   // Workspace-relative path to the executable selected by `bazel run`.
   string executable_path = 5;
+  // Workspace-relative paths of runfiles that should be executable.
+  repeated string executable_runfiles = 6;
 }
 
 // Event reporting stats about the git fetches performed by a remote runner

--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -1655,6 +1655,12 @@ message Tree {
   string uri = 2;
 }
 
+// A runtime file dependency and its metadata.
+message Runfile {
+  File file = 1;
+  bool is_executable = 2;
+}
+
 // Event describing the runtime properties of a runnable target.
 message RunTargetAnalyzed {
   // Default arguments configured for the target, typically in the BUILD file.
@@ -1663,13 +1669,13 @@ message RunTargetAnalyzed {
   // Path to the root of the runfiles directory.
   string runfiles_root = 2;
   // Any runtime file dependencies for the runnable target.
-  repeated File runfiles = 3;
+  repeated Runfile runfile_entries = 6;
   // Any runtime directory dependencies for the runnable target.
   repeated Tree runfileDirectories = 4;
   // Workspace-relative path to the executable selected by `bazel run`.
   string executable_path = 5;
-  // Workspace-relative paths of runfiles that should be executable.
-  repeated string executable_runfiles = 6;
+
+  repeated File runfiles = 3 [deprecated = true];
 }
 
 // Event reporting stats about the git fetches performed by a remote runner


### PR DESCRIPTION
With Remote Bazel, we support building remotely and running an executable locally. The ci_runner emits the RunTargetAnalyzed event with data about the generated run script. We need to specify which runfiles should be executable so that when they're downloaded, they can be handled correctly and executed

[[Bug report]](https://buildbuddy-corp.slack.com/archives/C0BG9TB4B8E/p1784839050177429)