### PR TITLE
Improve sidecar bes error logging in sync mode

### DIFF
--- a/server/build_event_protocol/build_event_server/build_event_server.go
+++ b/server/build_event_protocol/build_event_server/build_event_server.go
@@ -108,11 +108,12 @@ func (s *BuildEventProtocolServer) PublishBuildToolEventStream(stream pepb.Publi
 			for {
 				_, err := fwdStream.Recv()
 				if err == io.EOF {
+					log.CtxInfof(ctx, "Build event forwarding stream closed by upstream")
 					break
 				}
 				if err != nil {
+					log.CtxWarningf(ctx, "Build event forwarding stream failed while receiving: %s", err)
 					if !s.synchronous {
-						log.CtxWarningf(ctx, "Proxying build event stream failed: recv: %s", err)
 						return nil
 					}
 					return status.WrapError(err, "recv from proxy stream")


### PR DESCRIPTION
Currently the error group's context cancellation is what gets presented in the sidecar logs, which masks the actual error.