### PR TITLE
fix metacache GetMulti bug

### DIFF
--- a/enterprise/server/backends/metacache/metacache.go
+++ b/enterprise/server/backends/metacache/metacache.go
@@ -610,10 +610,12 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 		return nil, err
 	}
 
-	// mds is index-aligned to resources; pair hits by position instead of
-	// re-deriving a key, which would have to track the server's key derivation
-	// (e.g. CAS keys are instance-agnostic).
+	// mds is index-aligned to resources (see metadata.proto GetResponse), nil
+	// FileRecord on a miss. Pairing by position mirrors the server's match: CAS
+	// by content hash (size/instance excluded, like Get), AC instance-isolated.
 	if len(mds) != len(resources) {
+		// Aligned 1:1 is the server contract; a mismatch is a server bug.
+		log.CtxErrorf(ctx, "[%s] GetMulti metadata length %d != request length %d", c.opts.Name, len(mds), len(resources))
 		return nil, status.InternalErrorf("metadata response length %d does not match request length %d", len(mds), len(resources))
 	}
 	type resourceMetadata struct {
@@ -633,16 +635,12 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 	foundMap := make(map[*repb.Digest][]byte, len(hits))
 	eg, ctx := errgroup.WithContext(ctx)
 	numChunks := c.opts.MaxReadGoroutines
-	chunkSize := (len(hits) + numChunks - 1) / numChunks
-	if chunkSize < 1 {
-		chunkSize = 1
-	}
-	for chunk := range slices.Chunk(hits, int(chunkSize)) {
+	chunkSize := max(1, (len(hits)+numChunks-1)/numChunks)
+	for chunk := range slices.Chunk(hits, chunkSize) {
 		eg.Go(func() error {
 			for _, hit := range chunk {
 				r := hit.resource
-				md := hit.md
-				rc, err := c.reader(ctx, md, r, 0, 0, encryption)
+				rc, err := c.reader(ctx, hit.md, r, 0, 0, encryption)
 				if err != nil {
 					if status.IsNotFoundError(err) || os.IsNotExist(err) {
 						continue

--- a/enterprise/server/backends/metacache/metacache.go
+++ b/enterprise/server/backends/metacache/metacache.go
@@ -276,42 +276,8 @@ func (c *Cache) makeFileRecord(groupID string, encryption *sgpb.Encryption, r *r
 	}, nil
 }
 
-// key is a comparable key for uniquely identifying a ResourceName/FileRecord.
-// Note: groupID, partitionID, and encryptionKeyID are deliberately omitted
-// because these fields are set by the server based on request context.
-type key struct {
-	cacheType          rspb.CacheType
-	remoteInstanceName string
-	hash               string
-	sizeBytes          int64
-	digestFunction     repb.DigestFunction_Value
-}
-
-// keyFromFileRecord creates a key from a FileRecord.
-func keyFromFileRecord(fr *sgpb.FileRecord) key {
-	iso := fr.GetIsolation()
-	d := fr.GetDigest()
-	return key{
-		cacheType:          iso.GetCacheType(),
-		remoteInstanceName: iso.GetRemoteInstanceName(),
-		hash:               string(d.GetHash()),
-		sizeBytes:          d.GetSizeBytes(),
-		digestFunction:     fr.GetDigestFunction(),
-	}
-}
-
-// keyFromResourceName creates a key from a ResourceName.
-func keyFromResourceName(r *rspb.ResourceName) key {
-	d := r.GetDigest()
-	return key{
-		cacheType:          r.GetCacheType(),
-		remoteInstanceName: r.GetInstanceName(),
-		hash:               string(d.GetHash()),
-		sizeBytes:          d.GetSizeBytes(),
-		digestFunction:     r.GetDigestFunction(),
-	}
-}
-
+// lookupMetadatas returns metadata index-aligned to records; a not-found entry
+// carries a nil FileRecord (an empty FileMetadata after proto round-trip).
 func (c *Cache) lookupMetadatas(ctx context.Context, records ...*sgpb.FileRecord) ([]*sgpb.FileMetadata, error) {
 	req := &mdpb.GetRequest{
 		FileRecords: records,
@@ -644,29 +610,38 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 		return nil, err
 	}
 
-	keyToMetadata := make(map[key]*sgpb.FileMetadata, len(mds))
-	for _, md := range mds {
-		if md.GetFileRecord() == nil {
+	// mds is index-aligned to resources; pair hits by position instead of
+	// re-deriving a key, which would have to track the server's key derivation
+	// (e.g. CAS keys are instance-agnostic).
+	if len(mds) != len(resources) {
+		return nil, status.InternalErrorf("metadata response length %d does not match request length %d", len(mds), len(resources))
+	}
+	type resourceMetadata struct {
+		resource *rspb.ResourceName
+		md       *sgpb.FileMetadata
+	}
+	hits := make([]resourceMetadata, 0, len(resources))
+	for i, r := range resources {
+		if mds[i].GetFileRecord() == nil {
 			// Missing metadata, skip
 			continue
 		}
-		k := keyFromFileRecord(md.GetFileRecord())
-		keyToMetadata[k] = md
+		hits = append(hits, resourceMetadata{resource: r, md: mds[i]})
 	}
 
 	var foundMu sync.Mutex
-	foundMap := make(map[*repb.Digest][]byte, len(keyToMetadata))
+	foundMap := make(map[*repb.Digest][]byte, len(hits))
 	eg, ctx := errgroup.WithContext(ctx)
 	numChunks := c.opts.MaxReadGoroutines
-	chunkSize := (len(resources) + numChunks - 1) / numChunks
-	for chunk := range slices.Chunk(resources, int(chunkSize)) {
+	chunkSize := (len(hits) + numChunks - 1) / numChunks
+	if chunkSize < 1 {
+		chunkSize = 1
+	}
+	for chunk := range slices.Chunk(hits, int(chunkSize)) {
 		eg.Go(func() error {
-			for _, r := range chunk {
-				k := keyFromResourceName(r)
-				md, ok := keyToMetadata[k]
-				if !ok {
-					continue
-				}
+			for _, hit := range chunk {
+				r := hit.resource
+				md := hit.md
 				rc, err := c.reader(ctx, md, r, 0, 0, encryption)
 				if err != nil {
 					if status.IsNotFoundError(err) || os.IsNotExist(err) {

--- a/enterprise/server/backends/metacache/metacache_test.go
+++ b/enterprise/server/backends/metacache/metacache_test.go
@@ -368,3 +368,66 @@ func TestMultiGetSet(t *testing.T) {
 		require.Equal(t, d.GetHash(), d2.GetHash(), "d=%v; d2=%v", d, d2)
 	}
 }
+
+// CAS is content-addressed, so a blob written under one remote instance name
+// must be readable under another. GetMulti pairs results to requests by
+// position (not by re-deriving an instance-sensitive key), so this holds.
+func TestGetMultiCrossInstance(t *testing.T) {
+	te := testenv.GetTestEnv(t)
+	te.SetAuthenticator(testauth.NewTestAuthenticator(t, emptyUserMap))
+	ctx := getAnonContext(t, te)
+	clock := clockwork.NewFakeClock()
+
+	options := metacache.Options{
+		Name:                        "TestGetMultiCrossInstance",
+		MaxInlineFileSizeBytes:      1000,
+		MinBytesAutoZstdCompression: 100,
+		GCSTTLDays:                  1,
+	}
+	bc := runMetacache(t, te, clock, options)
+
+	// Write a CAS blob under one remote instance name.
+	writeRN, buf := testdigest.NewRandomResourceAndBuf(t, 256, rspb.CacheType_CAS, "instance-a")
+	require.NoError(t, bc.Set(ctx, writeRN, buf))
+
+	// Read the same content back under a different remote instance name.
+	readRN := digest.NewResourceName(writeRN.GetDigest(), "instance-b", rspb.CacheType_CAS, repb.DigestFunction_SHA256).ToProto()
+	m, err := bc.GetMulti(ctx, []*rspb.ResourceName{readRN})
+	require.NoError(t, err)
+	got, ok := m[readRN.GetDigest()]
+	require.True(t, ok, "GetMulti should find a CAS blob written under a different instance name")
+	require.Equal(t, buf, got)
+}
+
+// A miss in the middle of the request must not shift results: GetMulti relies
+// on the metadata response being index-aligned to the request.
+func TestGetMultiAlignmentWithMisses(t *testing.T) {
+	te := testenv.GetTestEnv(t)
+	te.SetAuthenticator(testauth.NewTestAuthenticator(t, emptyUserMap))
+	ctx := getAnonContext(t, te)
+	clock := clockwork.NewFakeClock()
+
+	options := metacache.Options{
+		Name:                        "TestGetMultiAlignmentWithMisses",
+		MaxInlineFileSizeBytes:      1000,
+		MinBytesAutoZstdCompression: 100,
+		GCSTTLDays:                  1,
+	}
+	bc := runMetacache(t, te, clock, options)
+
+	present1, buf1 := testdigest.NewRandomResourceAndBuf(t, 100, rspb.CacheType_CAS, "")
+	present2, buf2 := testdigest.NewRandomResourceAndBuf(t, 200, rspb.CacheType_CAS, "")
+	require.NoError(t, bc.Set(ctx, present1, buf1))
+	require.NoError(t, bc.Set(ctx, present2, buf2))
+	// Never written, so it is a miss.
+	absent, _ := testdigest.NewRandomResourceAndBuf(t, 150, rspb.CacheType_CAS, "")
+
+	// Interleave a miss between two hits so a positional bug would misalign.
+	m, err := bc.GetMulti(ctx, []*rspb.ResourceName{present1, absent, present2})
+	require.NoError(t, err)
+	require.Len(t, m, 2)
+	require.Equal(t, buf1, m[present1.GetDigest()])
+	require.Equal(t, buf2, m[present2.GetDigest()])
+	_, ok := m[absent.GetDigest()]
+	require.False(t, ok, "absent resource should not be returned")
+}

--- a/enterprise/server/backends/metacache/metacache_test.go
+++ b/enterprise/server/backends/metacache/metacache_test.go
@@ -399,6 +399,58 @@ func TestGetMultiCrossInstance(t *testing.T) {
 	require.Equal(t, buf, got)
 }
 
+// AC entries stay instance-isolated: GetMulti must not leak one across
+// instance names.
+func TestGetMultiACInstanceIsolation(t *testing.T) {
+	te := testenv.GetTestEnv(t)
+	te.SetAuthenticator(testauth.NewTestAuthenticator(t, emptyUserMap))
+	ctx := getAnonContext(t, te)
+	clock := clockwork.NewFakeClock()
+
+	options := metacache.Options{
+		Name:                        "TestGetMultiACInstanceIsolation",
+		MaxInlineFileSizeBytes:      1000,
+		MinBytesAutoZstdCompression: 100,
+		GCSTTLDays:                  1,
+	}
+	bc := runMetacache(t, te, clock, options)
+
+	// Write an AC entry under one remote instance name.
+	writeRN, buf := testdigest.NewRandomResourceAndBuf(t, 256, rspb.CacheType_AC, "instance-a")
+	require.NoError(t, bc.Set(ctx, writeRN, buf))
+
+	// The same AC digest under a different instance name must be a miss.
+	readRN := digest.NewResourceName(writeRN.GetDigest(), "instance-b", rspb.CacheType_AC, repb.DigestFunction_SHA256).ToProto()
+	m, err := bc.GetMulti(ctx, []*rspb.ResourceName{readRN})
+	require.NoError(t, err)
+	_, ok := m[readRN.GetDigest()]
+	require.False(t, ok, "AC entry must not be returned under a different instance name")
+}
+
+// GetMulti with only misses returns an empty map (exercises the zero-hit
+// chunking path).
+func TestGetMultiAllMisses(t *testing.T) {
+	te := testenv.GetTestEnv(t)
+	te.SetAuthenticator(testauth.NewTestAuthenticator(t, emptyUserMap))
+	ctx := getAnonContext(t, te)
+	clock := clockwork.NewFakeClock()
+
+	options := metacache.Options{
+		Name:                        "TestGetMultiAllMisses",
+		MaxInlineFileSizeBytes:      1000,
+		MinBytesAutoZstdCompression: 100,
+		GCSTTLDays:                  1,
+	}
+	bc := runMetacache(t, te, clock, options)
+
+	// Never written, so both are misses.
+	r1, _ := testdigest.NewRandomResourceAndBuf(t, 100, rspb.CacheType_CAS, "")
+	r2, _ := testdigest.NewRandomResourceAndBuf(t, 200, rspb.CacheType_CAS, "")
+	m, err := bc.GetMulti(ctx, []*rspb.ResourceName{r1, r2})
+	require.NoError(t, err)
+	require.Empty(t, m)
+}
+
 // A miss in the middle of the request must not shift results: GetMulti relies
 // on the metadata response being index-aligned to the request.
 func TestGetMultiAlignmentWithMisses(t *testing.T) {

--- a/proto/metadata.proto
+++ b/proto/metadata.proto
@@ -9,6 +9,9 @@ message GetRequest {
 }
 
 message GetResponse {
+  // Index-aligned to GetRequest.file_records: the i-th entry is the i-th
+  // record's metadata (nil/empty on miss). Clients pair results by position, so
+  // implementations must preserve request order and length.
   repeated storage.FileMetadata file_metadatas = 1;
 }
 


### PR DESCRIPTION
Fix a GetMulti bug where when the remote_instance_name from the request and the
filerecord retrieved from the metadata mismatch, it returns not found.
