### PR TITLE
Support sending references on read server-side in the distributed cache

### DIFF
--- a/enterprise/server/util/distributed_client/BUILD
+++ b/enterprise/server/util/distributed_client/BUILD
@@ -9,6 +9,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:distributed_cache_go_proto",
+        "//proto:reference_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//server/environment",
@@ -43,6 +44,7 @@ go_test(
     srcs = ["distributed_client_test.go"],
     deps = [
         ":distributed_client",
+        "//enterprise/server/experiments",
         "//proto:distributed_cache_go_proto",
         "//proto:reference_go_proto",
         "//proto:remote_execution_go_proto",
@@ -62,8 +64,11 @@ go_test(
         "//server/util/testing/flags",
         "@com_github_docker_go_units//:go-units",
         "@com_github_google_go_cmp//cmp",
+        "@com_github_open_feature_go_sdk//openfeature",
+        "@com_github_open_feature_go_sdk//openfeature/memprovider",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//credentials/insecure",
         "@org_golang_google_protobuf//testing/protocmp",
     ],
 )

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -37,6 +37,7 @@ import (
 	"google.golang.org/grpc/reflection"
 
 	dcpb "github.com/buildbuddy-io/buildbuddy/proto/distributed_cache"
+	refpb "github.com/buildbuddy-io/buildbuddy/proto/reference"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
@@ -316,6 +317,24 @@ func (c *Proxy) GetMulti(ctx context.Context, req *dcpb.GetMultiRequest) (*dcpb.
 	return rsp, nil
 }
 
+// referenceReadMode returns whether Read should send the client a reference
+// to the blob's location in shared storage, and whether it should stream the
+// blob's bytes, based on the reference-read experiments. Sending both lets
+// the client verify the reference against the authoritative byte stream.
+func (c *Proxy) referenceReadMode(ctx context.Context) (sendReference bool, sendBytes bool) {
+	fp := c.env.GetExperimentFlagProvider()
+	if fp == nil {
+		return false, true
+	}
+	if fp.Boolean(ctx, "distributed_cache.verify_gcs_references", false) {
+		return true, true
+	}
+	if fp.Boolean(ctx, "distributed_cache.read_gcs_references", false) {
+		return true, false
+	}
+	return false, true
+}
+
 func (c *Proxy) Read(req *dcpb.ReadRequest, stream dcpb.DistributedCache_ReadServer) error {
 	ctx, err := c.readWriteContext(stream.Context())
 	if err != nil {
@@ -323,12 +342,44 @@ func (c *Proxy) Read(req *dcpb.ReadRequest, stream dcpb.DistributedCache_ReadSer
 	}
 	up, _ := prefix.UserPrefixFromContext(ctx)
 	rn := req.GetResource()
+
+	sendReference, sendBytes := c.referenceReadMode(ctx)
+	var ref *refpb.Reference
+	if refCache, ok := c.cache.(interfaces.ReferenceCache); ok {
+		if sendReference {
+			if r, err := refCache.GetReference(ctx, rn); err == nil {
+				ref = r
+			}
+		}
+		// If no reference was minted, just stream the bytes.
+		if ref == nil {
+			sendBytes = true
+		}
+	}
+
+	if ref != nil && !sendBytes {
+		if err := stream.Send(&dcpb.ReadResponse{Reference: ref}); err != nil {
+			return err
+		}
+		c.log.Debugf("Read(%q) succeeded by reference (user prefix: %s)", ResourceIsolationString(rn), up)
+		return nil
+	}
+
 	reader, err := c.cache.Reader(ctx, rn, req.GetOffset(), req.GetLimit())
 	if err != nil {
 		c.log.Debugf("Read(%q) failed (user prefix: %s), err: %s", ResourceIsolationString(rn), up, err)
 		return err
 	}
 	defer reader.Close()
+
+	// In verification mode, only send the reference once the byte reader has
+	// been opened successfully, so a missing blob surfaces to the client the
+	// same way it does today.
+	if ref != nil {
+		if err := stream.Send(&dcpb.ReadResponse{Reference: ref}); err != nil {
+			return err
+		}
+	}
 
 	bufSize := int64(digest.SafeBufferSize(rn, *config.ReadBufSizeBytes))
 	copyBuf := c.bufPool.Get(bufSize)

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -66,6 +66,7 @@ type Proxy struct {
 	env                   environment.Env
 	cache                 interfaces.Cache
 	log                   log.Logger
+	readRefLogger         log.Logger
 	bufPool               *bytebufferpool.VariableSizePool
 	mu                    *sync.Mutex
 	server                *grpc.Server
@@ -78,13 +79,15 @@ type Proxy struct {
 }
 
 func New(env environment.Env, c interfaces.Cache, listenAddr string) *Proxy {
+	logger := log.NamedSubLogger(fmt.Sprintf("Proxy(%s)", listenAddr))
 	proxy := &Proxy{
-		env:        env,
-		cache:      c,
-		log:        log.NamedSubLogger(fmt.Sprintf("Proxy(%s)", listenAddr)),
-		bufPool:    bytebufferpool.VariableSize(max(*config.ReadBufSizeBytes, writeBufSizeBytes)),
-		listenAddr: listenAddr,
-		mu:         &sync.Mutex{},
+		env:           env,
+		cache:         c,
+		log:           logger,
+		readRefLogger: logger.EveryN(100),
+		bufPool:       bytebufferpool.VariableSize(max(*config.ReadBufSizeBytes, writeBufSizeBytes)),
+		listenAddr:    listenAddr,
+		mu:            &sync.Mutex{},
 		// server goes here
 		clients: make(map[string]*grpc_client.ClientConnPool),
 	}
@@ -361,7 +364,7 @@ func (c *Proxy) Read(req *dcpb.ReadRequest, stream dcpb.DistributedCache_ReadSer
 		if err := stream.Send(&dcpb.ReadResponse{Reference: ref}); err != nil {
 			return err
 		}
-		c.log.Debugf("Read(%q) succeeded by reference (user prefix: %s)", ResourceIsolationString(rn), up)
+		c.readRefLogger.Debugf("Read(%q) succeeded by reference (user prefix: %s)", ResourceIsolationString(rn), up)
 		return nil
 	}
 

--- a/enterprise/server/util/distributed_client/distributed_client_test.go
+++ b/enterprise/server/util/distributed_client/distributed_client_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/experiments"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/distributed_client"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
@@ -29,8 +30,11 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/docker/go-units"
 	"github.com/google/go-cmp/cmp"
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	dcpb "github.com/buildbuddy-io/buildbuddy/proto/distributed_cache"
@@ -1565,5 +1569,141 @@ func TestRemoteReadReference(t *testing.T) {
 		_, err := c.RemoteReader(ctx, peer, rn, 0, 0)
 		require.Error(t, err)
 		require.True(t, status.IsNotFoundError(err), "expected NotFoundError, got %s", err)
+	})
+}
+
+// serverReferenceCache implements interfaces.ReferenceCache, returning canned
+// references for configured digests.
+type serverReferenceCache struct {
+	interfaces.Cache
+	refs map[string]*refpb.Reference
+}
+
+func (c *serverReferenceCache) GetReference(ctx context.Context, r *rspb.ResourceName) (*refpb.Reference, error) {
+	if ref, ok := c.refs[r.GetDigest().GetHash()]; ok {
+		return ref, nil
+	}
+	return nil, status.NotFoundError("no reference available")
+}
+
+// Dereference is unused by the read server, but the server only offers
+// references if its cache implements the full interfaces.ReferenceCache.
+func (c *serverReferenceCache) Dereference(ctx context.Context, ref *refpb.Reference, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
+	return nil, status.UnimplementedError("not implemented")
+}
+
+func setReferenceReadExperiments(t *testing.T, te *testenv.TestEnv, readReferences bool, verifyReferences bool) {
+	provider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		"distributed_cache.read_gcs_references": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "on",
+			Variants:       map[string]any{"on": readReferences},
+		},
+		"distributed_cache.verify_gcs_references": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "on",
+			Variants:       map[string]any{"on": verifyReferences},
+		},
+	})
+	require.NoError(t, openfeature.SetProviderAndWait(provider))
+	fp, err := experiments.NewFlagProvider("")
+	require.NoError(t, err)
+	te.SetExperimentFlagProvider(fp)
+	// Restore the no-experiment-provider state when the (sub)test finishes,
+	// so tests do not depend on their ordering. Note that openfeature's
+	// provider is process-global state, so tests that use this helper must
+	// not run in parallel.
+	t.Cleanup(func() {
+		te.SetExperimentFlagProvider(nil)
+		require.NoError(t, openfeature.SetProviderAndWait(openfeature.NoopProvider{}))
+	})
+}
+
+// readRawResponses reads rn from peer with a raw gRPC client, returning any
+// received reference and the concatenated data bytes.
+func readRawResponses(t *testing.T, peer string, rn *rspb.ResourceName) (*refpb.Reference, []byte) {
+	t.Helper()
+	conn, err := grpc.NewClient(peer, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	client := dcpb.NewDistributedCacheClient(conn)
+	stream, err := client.Read(context.Background(), &dcpb.ReadRequest{Resource: rn})
+	require.NoError(t, err)
+	var ref *refpb.Reference
+	var data []byte
+	for {
+		rsp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		if rsp.GetReference() != nil {
+			require.Nil(t, ref, "server sent more than one reference")
+			require.Empty(t, data, "server sent a reference after data")
+			ref = rsp.GetReference()
+		}
+		data = append(data, rsp.GetData()...)
+	}
+	return ref, data
+}
+
+func TestReadReferenceExperiments(t *testing.T) {
+	te := getTestEnv(t, emptyUserMap)
+	ctx, err := prefix.AttachUserPrefixToContext(context.Background(), te.GetAuthenticator())
+	require.NoError(t, err)
+
+	rn, buf := testdigest.RandomCASResourceBuf(t, 100)
+	noRefRN, noRefBuf := testdigest.RandomCASResourceBuf(t, 100)
+	expectedRef := &refpb.Reference{
+		Metadata: &sgpb.FileMetadata{
+			FileRecord: &sgpb.FileRecord{Digest: rn.GetDigest()},
+			StorageMetadata: &sgpb.StorageMetadata{
+				GcsMetadata: &sgpb.StorageMetadata_GCSMetadata{BlobName: "blobs/test-blob"},
+			},
+		},
+	}
+	cache := &serverReferenceCache{
+		Cache: te.GetCache(),
+		refs:  map[string]*refpb.Reference{rn.GetDigest().GetHash(): expectedRef},
+	}
+	peer := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	c := distributed_client.New(te, cache, peer)
+	require.NoError(t, c.StartListening())
+	waitUntilServerIsAlive(peer)
+	require.NoError(t, te.GetCache().Set(ctx, rn, buf))
+	require.NoError(t, te.GetCache().Set(ctx, noRefRN, noRefBuf))
+
+	t.Run("no experiment provider", func(t *testing.T) {
+		ref, data := readRawResponses(t, peer, rn)
+		require.Nil(t, ref)
+		require.Equal(t, buf, data)
+	})
+
+	t.Run("experiments off", func(t *testing.T) {
+		setReferenceReadExperiments(t, te, false, false)
+		ref, data := readRawResponses(t, peer, rn)
+		require.Nil(t, ref)
+		require.Equal(t, buf, data)
+	})
+
+	t.Run("verify flag sends reference and bytes", func(t *testing.T) {
+		setReferenceReadExperiments(t, te, false, true)
+		ref, data := readRawResponses(t, peer, rn)
+		require.Empty(t, cmp.Diff(expectedRef, ref, protocmp.Transform()))
+		require.Equal(t, buf, data)
+	})
+
+	t.Run("read flag sends reference only", func(t *testing.T) {
+		setReferenceReadExperiments(t, te, true, false)
+		ref, data := readRawResponses(t, peer, rn)
+		require.Empty(t, cmp.Diff(expectedRef, ref, protocmp.Transform()))
+		require.Empty(t, data)
+	})
+
+	t.Run("read flag falls back to bytes when no reference can be minted", func(t *testing.T) {
+		setReferenceReadExperiments(t, te, true, false)
+		ref, data := readRawResponses(t, peer, noRefRN)
+		require.Nil(t, ref)
+		require.Equal(t, noRefBuf, data)
 	})
 }


### PR DESCRIPTION
This change implements the server-side of the distributed cache protocol that reads via GCS reference. This is done using two experiments: `distributed_cache.verify_gcs_references` which makes the distributed cache server return both a reference and the underlying bytes for a given artifact so that the caller can perform read verification, and `distributed_cache.read_gcs_references` which makes the distributed cache server just return a reference when possible.

The client has no experiment logic, it just acts based on what it receives. If it receives both a reference and bytes, it performs a verification, it if just receives a reference it dereferences it, and if it just receives bytes, it returns them to the client as it does today.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7911