### PR TITLE
Reduce allocations in metacache.GetMulti

### DIFF
--- a/enterprise/server/backends/metacache/metacache.go
+++ b/enterprise/server/backends/metacache/metacache.go
@@ -276,6 +276,35 @@ func (c *Cache) makeFileRecord(groupID string, encryption *sgpb.Encryption, r *r
 	}, nil
 }
 
+// lookupMetadata returns the file metadata for r, or a NotFound error if it
+// does not exist.
+func (c *Cache) lookupMetadata(ctx context.Context, r *rspb.ResourceName, encryption *sgpb.Encryption) (*sgpb.FileMetadata, error) {
+	fileRecord, err := c.makeFileRecord(c.userGroupID(ctx), encryption, r)
+	if err != nil {
+		return nil, err
+	}
+
+	mds, err := c.lookupMetadatas(ctx, fileRecord)
+	if err != nil {
+		return nil, err
+	}
+	if len(mds) != 1 {
+		log.CtxErrorf(ctx, "File record %v found multiple metadatas: %v", fileRecord, mds)
+		return nil, status.InternalError("only one metadata record should match query")
+	}
+	md := mds[0]
+	if md.GetFileRecord() == nil {
+		// MetadataService.Get doesn't have an explicit "not found" response,
+		// but it returns an empty FileMetadata if the record is not found.
+		// Because proto marshalling and unmarshalling turns a repeated field
+		// with nils into a repeated field with empty structs, we need to check
+		// if the proto is empty rather than nil. The easiest way to do this is
+		// check if a field that should always be set is nil.
+		return nil, status.NotFoundErrorf("File metadata not found for %v", r)
+	}
+	return md, nil
+}
+
 // lookupMetadatas returns metadata index-aligned to records; a not-found entry
 // carries a nil FileRecord (an empty FileMetadata after proto round-trip).
 func (c *Cache) lookupMetadatas(ctx context.Context, records ...*sgpb.FileRecord) ([]*sgpb.FileMetadata, error) {
@@ -488,22 +517,9 @@ func (c *Cache) Metadata(ctx context.Context, r *rspb.ResourceName) (cm *interfa
 	if err != nil {
 		return nil, err
 	}
-	fileRecord, err := c.makeFileRecord(c.userGroupID(ctx), encryption, r)
+	md, err := c.lookupMetadata(ctx, r, encryption)
 	if err != nil {
 		return nil, err
-	}
-	mds, err := c.lookupMetadatas(ctx, fileRecord)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(mds) != 1 {
-		log.CtxErrorf(ctx, "File record %v found multiple metadatas: %v", fileRecord, mds)
-		return nil, status.InternalError("only one metadata record should match query")
-	}
-	md := mds[0]
-	if md.GetFileRecord() == nil {
-		return nil, status.NotFoundErrorf("Metadata not found for %v", r)
 	}
 	return &interfaces.CacheMetadata{
 		StoredSizeBytes:    md.GetStoredSizeBytes(),
@@ -548,6 +564,28 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*rspb.ResourceName)
 	return missing, nil
 }
 
+// readBufSize returns the buffer size to allocate to hold the full contents
+// of r, whose stored metadata is md.
+func (c *Cache) readBufSize(r *rspb.ResourceName, md *sgpb.FileMetadata) int64 {
+	// If the requested compression matches the stored compression, the
+	// data is returned as stored, so the stored size from the file
+	// metadata is the right buffer size. Otherwise the data is compressed
+	// or decompressed while reading, so fall back to estimating.
+	var bufSize int64
+	if r.GetCompressor() == md.GetFileRecord().GetCompressor() {
+		bufSize = min(md.GetStoredSizeBytes(), maxReadBufferSize)
+	} else {
+		bufSize = int64(digest.SafeBufferSize(r, maxReadBufferSize))
+	}
+	// Blob-backed reads go through Buffer.ReadFrom, which needs MinRead
+	// spare capacity to detect EOF without growing the buffer. Inline
+	// reads copy directly via bytes.Reader.WriteTo and don't need the pad.
+	if r.GetDigest().GetSizeBytes() >= c.opts.MaxInlineFileSizeBytes {
+		bufSize += bytes.MinRead
+	}
+	return bufSize
+}
+
 func (c *Cache) Get(ctx context.Context, r *rspb.ResourceName) (res []byte, resultErr error) {
 	start := c.opts.Clock.Now()
 	defer c.recordMetrics("Get", resultErr, start)
@@ -555,13 +593,21 @@ func (c *Cache) Get(ctx context.Context, r *rspb.ResourceName) (res []byte, resu
 	defer spn.End()
 	setSingleResourceTraceAttributes(spn, r)
 
-	rc, err := c.Reader(ctx, r, 0, 0)
+	encryption, err := c.activeEncryption(ctx)
+	if err != nil {
+		return nil, err
+	}
+	md, err := c.lookupMetadata(ctx, r, encryption)
+	if err != nil {
+		return nil, err
+	}
+	rc, err := c.reader(ctx, md, r, 0, 0, encryption)
 	if err != nil {
 		return nil, err
 	}
 	defer rc.Close()
 
-	buf := bytes.NewBuffer(make([]byte, 0, digest.SafeBufferSize(r, maxReadBufferSize)))
+	buf := bytes.NewBuffer(make([]byte, 0, c.readBufSize(r, md)))
 	_, err = io.Copy(buf, rc)
 	return buf.Bytes(), err
 }
@@ -647,7 +693,7 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 					}
 					return err
 				}
-				buf := bytes.NewBuffer(make([]byte, 0, digest.SafeBufferSize(r, maxReadBufferSize)))
+				buf := bytes.NewBuffer(make([]byte, 0, c.readBufSize(r, hit.md)))
 				_, copyErr := io.Copy(buf, rc)
 				closeErr := rc.Close()
 				if copyErr != nil {
@@ -838,28 +884,9 @@ func (c *Cache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOf
 	if err != nil {
 		return nil, err
 	}
-	fileRecord, err := c.makeFileRecord(c.userGroupID(ctx), encryption, r)
+	md, err := c.lookupMetadata(ctx, r, encryption)
 	if err != nil {
 		return nil, err
-	}
-
-	mds, err := c.lookupMetadatas(ctx, fileRecord)
-	if err != nil {
-		return nil, err
-	}
-	if len(mds) != 1 {
-		log.CtxErrorf(ctx, "File record %v found multiple metadatas: %v", fileRecord, mds)
-		return nil, status.InternalError("only one metadata record should match query")
-	}
-	md := mds[0]
-	if md.GetFileRecord() == nil {
-		// MetadataService.Get doesn't have an explicit "not found" response,
-		// but it returns an empty FileMetadata if the record is not found.
-		// Because proto marshalling and unmarshalling turns a repeated field
-		// with nils into a repeated field with empty structs, we need to check
-		// if the proto is empty rather than nil. The easiest way to do this is
-		// check if a field that should always be set is nil.
-		return nil, status.NotFoundErrorf("File metadata not found for %v", r)
 	}
 	return c.reader(ctx, md, r, uncompressedOffset, uncompressedLimit, encryption)
 }

--- a/enterprise/server/backends/metacache/metacache.go
+++ b/enterprise/server/backends/metacache/metacache.go
@@ -566,7 +566,7 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*rspb.ResourceName)
 
 // readBufSize returns the buffer size to allocate to hold the full contents
 // of r, whose stored metadata is md.
-func (c *Cache) readBufSize(r *rspb.ResourceName, md *sgpb.FileMetadata) int64 {
+func (c *Cache) readBufSize(r *rspb.ResourceName, md *sgpb.FileMetadata, reader io.Reader) int64 {
 	// If the requested compression matches the stored compression, the
 	// data is returned as stored, so the stored size from the file
 	// metadata is the right buffer size. Otherwise the data is compressed
@@ -577,10 +577,10 @@ func (c *Cache) readBufSize(r *rspb.ResourceName, md *sgpb.FileMetadata) int64 {
 	} else {
 		bufSize = int64(digest.SafeBufferSize(r, maxReadBufferSize))
 	}
-	// Blob-backed reads go through Buffer.ReadFrom, which needs MinRead
-	// spare capacity to detect EOF without growing the buffer. Inline
-	// reads copy directly via bytes.Reader.WriteTo and don't need the pad.
-	if r.GetDigest().GetSizeBytes() >= c.opts.MaxInlineFileSizeBytes {
+	// WriteTo allows copying without a second read to get EOF. Without that
+	// bytes.Buffer.ReadFrom will allocate an extra bytes.MinRead unless we
+	// oversize it.
+	if _, ok := reader.(io.WriterTo); !ok {
 		bufSize += bytes.MinRead
 	}
 	return bufSize
@@ -607,7 +607,7 @@ func (c *Cache) Get(ctx context.Context, r *rspb.ResourceName) (res []byte, resu
 	}
 	defer rc.Close()
 
-	buf := bytes.NewBuffer(make([]byte, 0, c.readBufSize(r, md)))
+	buf := bytes.NewBuffer(make([]byte, 0, c.readBufSize(r, md, rc)))
 	_, err = io.Copy(buf, rc)
 	return buf.Bytes(), err
 }
@@ -693,7 +693,7 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 					}
 					return err
 				}
-				buf := bytes.NewBuffer(make([]byte, 0, c.readBufSize(r, hit.md)))
+				buf := bytes.NewBuffer(make([]byte, 0, c.readBufSize(r, hit.md, rc)))
 				_, copyErr := io.Copy(buf, rc)
 				closeErr := rc.Close()
 				if copyErr != nil {


### PR DESCRIPTION
This is like https://github.com/buildbuddy-io/buildbuddy/pull/12832, but for the metacache instead of pebble_cache.

Benchmark results:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor
                           │  /tmp/base   │            /tmp/after             │
                           │    sec/op    │   sec/op     vs base              │
GetSingle/Meta10/AC-24       43.65µ ±  2%   41.42µ ± 3%  -5.12% (p=0.001 n=7)
GetSingle/Meta10/CAS-24      42.46µ ±  1%   42.26µ ± 7%       ~ (p=0.456 n=7)
GetSingle/Meta100/AC-24      44.06µ ±  4%   43.40µ ± 6%       ~ (p=0.535 n=7)
GetSingle/Meta100/CAS-24     42.80µ ±  3%   43.25µ ± 4%       ~ (p=0.805 n=7)
GetSingle/Meta1000/AC-24     45.22µ ±  4%   43.41µ ± 3%  -4.00% (p=0.026 n=7)
GetSingle/Meta1000/CAS-24    43.39µ ±  3%   43.88µ ± 3%       ~ (p=0.128 n=7)
GetSingle/Meta10000/AC-24    1.057m ±  1%   1.054m ± 1%       ~ (p=0.097 n=7)
GetSingle/Meta10000/CAS-24   1.054m ±  1%   1.051m ± 0%       ~ (p=0.620 n=7)
GetMulti/Meta10-24           184.3µ ±  7%   185.1µ ± 8%       ~ (p=0.620 n=7)
GetMulti/Meta100-24          193.2µ ± 13%   201.4µ ± 6%       ~ (p=0.073 n=7)
GetMulti/Meta1000-24         222.2µ ± 10%   229.6µ ± 5%       ~ (p=0.383 n=7)
GetMulti/Meta10000-24        10.37m ±  1%   10.33m ± 0%  -0.40% (p=0.007 n=7)
geomean                      171.0µ         170.7µ       -0.18%

                           │   /tmp/base   │             /tmp/after             │
                           │      B/s      │     B/s       vs base              │
GetSingle/Meta10/AC-24       224.6Ki ±  4%   234.4Ki ± 4%  +4.35% (p=0.001 n=7)
GetSingle/Meta10/CAS-24      234.4Ki ±  4%   234.4Ki ± 4%       ~ (p=0.449 n=7)
GetSingle/Meta100/AC-24      2.165Mi ±  4%   2.193Mi ± 5%       ~ (p=0.557 n=7)
GetSingle/Meta100/CAS-24     2.232Mi ±  3%   2.203Mi ± 4%       ~ (p=0.836 n=7)
GetSingle/Meta1000/AC-24     21.09Mi ±  4%   21.97Mi ± 3%  +4.21% (p=0.019 n=7)
GetSingle/Meta1000/CAS-24    21.98Mi ±  3%   21.73Mi ± 3%       ~ (p=0.118 n=7)
GetSingle/Meta10000/AC-24    9.022Mi ±  1%   9.050Mi ± 1%       ~ (p=0.108 n=7)
GetSingle/Meta10000/CAS-24   9.050Mi ±  1%   9.069Mi ± 0%       ~ (p=0.508 n=7)
GetMulti/Meta10-24           5.178Mi ±  7%   5.150Mi ± 9%       ~ (p=0.596 n=7)
GetMulti/Meta100-24          49.35Mi ± 15%   47.36Mi ± 6%       ~ (p=0.073 n=7)
GetMulti/Meta1000-24         429.1Mi ± 12%   415.4Mi ± 5%       ~ (p=0.383 n=7)
GetMulti/Meta10000-24        91.97Mi ±  1%   92.34Mi ± 0%  +0.40% (p=0.007 n=7)
geomean                      8.201Mi         8.203Mi       +0.02%

                           │   /tmp/base   │             /tmp/after              │
                           │     B/op      │     B/op      vs base               │
GetSingle/Meta10/AC-24        33.50Ki ± 0%   29.26Ki ± 0%  -12.65% (p=0.001 n=7)
GetSingle/Meta10/CAS-24       28.94Ki ± 0%   28.70Ki ± 0%   -0.84% (p=0.001 n=7)
GetSingle/Meta100/AC-24       33.60Ki ± 0%   29.41Ki ± 0%  -12.49% (p=0.001 n=7)
GetSingle/Meta100/CAS-24      29.14Ki ± 0%   28.87Ki ± 0%   -0.91% (p=0.001 n=7)
GetSingle/Meta1000/AC-24      34.58Ki ± 0%   30.70Ki ± 0%  -11.24% (p=0.001 n=7)
GetSingle/Meta1000/CAS-24     31.00Ki ± 0%   30.14Ki ± 0%   -2.77% (p=0.001 n=7)
GetSingle/Meta10000/AC-24     33.72Ki ± 0%   33.49Ki ± 0%   -0.71% (p=0.001 n=7)
GetSingle/Meta10000/CAS-24    39.19Ki ± 0%   32.95Ki ± 0%  -15.92% (p=0.001 n=7)
GetMulti/Meta10-24            187.4Ki ± 0%   186.7Ki ± 0%   -0.36% (p=0.001 n=7)
GetMulti/Meta100-24           200.2Ki ± 0%   195.8Ki ± 0%   -2.18% (p=0.001 n=7)
GetMulti/Meta1000-24          322.7Ki ± 0%   260.2Ki ± 1%  -19.39% (p=0.001 n=7)
GetMulti/Meta10000-24        1205.1Ki ± 1%   597.3Ki ± 1%  -50.44% (p=0.001 n=7)
geomean                       72.07Ki        63.30Ki       -12.17%

                           │  /tmp/base  │             /tmp/after              │
                           │  allocs/op  │  allocs/op   vs base                │
GetSingle/Meta10/AC-24        403.0 ± 0%    400.0 ± 0%  -0.74% (p=0.001 n=7)
GetSingle/Meta10/CAS-24       395.0 ± 0%    392.0 ± 0%  -0.76% (p=0.001 n=7)
GetSingle/Meta100/AC-24       403.0 ± 0%    400.0 ± 0%  -0.74% (p=0.001 n=7)
GetSingle/Meta100/CAS-24      395.0 ± 0%    392.0 ± 0%  -0.76% (p=0.001 n=7)
GetSingle/Meta1000/AC-24      403.0 ± 0%    400.0 ± 0%  -0.74% (p=0.001 n=7)
GetSingle/Meta1000/CAS-24     395.0 ± 0%    392.0 ± 0%  -0.76% (p=0.001 n=7)
GetSingle/Meta10000/AC-24     407.0 ± 0%    404.0 ± 0%  -0.74% (p=0.001 n=7)
GetSingle/Meta10000/CAS-24    399.0 ± 0%    396.0 ± 0%  -0.75% (p=0.001 n=7)
GetMulti/Meta10-24           2.904k ± 0%   2.904k ± 0%       ~ (p=1.000 n=7)
GetMulti/Meta100-24          2.910k ± 0%   2.910k ± 0%       ~ (p=1.000 n=7)
GetMulti/Meta1000-24         2.914k ± 0%   2.914k ± 0%       ~ (p=1.000 n=7) ¹
GetMulti/Meta10000-24        2.925k ± 4%   2.923k ± 4%       ~ (p=0.113 n=7)
geomean                       775.3         771.4       -0.51%
```