### PR TITLE
Speed up pebble_cache.GetMulti by creating fewer goroutines

### DIFF
--- a/enterprise/server/backends/migration_cache/migration_cache_test.go
+++ b/enterprise/server/backends/migration_cache/migration_cache_test.go
@@ -1216,7 +1216,7 @@ func TestGetMultiWithCopying(t *testing.T) {
 			mc.Start() // Starts copying in background
 			defer mc.Stop()
 
-			eg, ctx := errgroup.WithContext(ctx)
+			eg := &errgroup.Group{}
 			lock := sync.RWMutex{}
 			resourceNames := make([]*rspb.ResourceName, 50)
 			expected := make(map[*repb.Digest][]byte, 50)
@@ -1262,7 +1262,7 @@ func TestSetMulti(t *testing.T) {
 	config.SetConfigDefaults()
 	mc := migration_cache.NewMigrationCache(te, config, srcCache, destCache)
 
-	eg, ctx := errgroup.WithContext(ctx)
+	eg := &errgroup.Group{}
 	lock := sync.RWMutex{}
 	dataToSet := make(map[*rspb.ResourceName][]byte, 50)
 	for i := 0; i < 50; i++ {

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2099,16 +2099,20 @@ func (p *PebbleCache) GetMulti(ctx context.Context, resources []*rspb.ResourceNa
 	if err != nil {
 		return nil, err
 	}
-	resourceChan := make(chan *rspb.ResourceName, len(resources))
-	for _, r := range resources {
-		resourceChan <- r
-	}
-	close(resourceChan)
 	eg, ctx := errgroup.WithContext(ctx)
 	maxGoroutines := 10
+	var next atomic.Int64
 	for range min(maxGoroutines, len(resources)) {
 		eg.Go(func() error {
-			for r := range resourceChan {
+			for {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				i := int(next.Add(1)) - 1
+				if i >= len(resources) {
+					return nil
+				}
+				r := resources[i]
 				rc, md, err := p.reader(ctx, db, groupID, encryption, r, 0, 0)
 				if err != nil {
 					if status.IsNotFoundError(err) || os.IsNotExist(err) {
@@ -2131,7 +2135,6 @@ func (p *PebbleCache) GetMulti(ctx context.Context, resources []*rspb.ResourceNa
 				foundMap[r.GetDigest()] = buf.Bytes()
 				mu.Unlock()
 			}
-			return nil
 		})
 	}
 	if err := eg.Wait(); err != nil {

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2099,32 +2099,38 @@ func (p *PebbleCache) GetMulti(ctx context.Context, resources []*rspb.ResourceNa
 	if err != nil {
 		return nil, err
 	}
-	eg, ctx := errgroup.WithContext(ctx)
-	eg.SetLimit(10)
+	resourceChan := make(chan *rspb.ResourceName, len(resources))
 	for _, r := range resources {
+		resourceChan <- r
+	}
+	close(resourceChan)
+	eg, ctx := errgroup.WithContext(ctx)
+	maxGoroutines := 10
+	for range min(maxGoroutines, len(resources)) {
 		eg.Go(func() error {
-			rc, md, err := p.reader(ctx, db, groupID, encryption, r, 0, 0)
-			if err != nil {
-				if status.IsNotFoundError(err) || os.IsNotExist(err) {
-					return nil
+			for r := range resourceChan {
+				rc, md, err := p.reader(ctx, db, groupID, encryption, r, 0, 0)
+				if err != nil {
+					if status.IsNotFoundError(err) || os.IsNotExist(err) {
+						continue
+					}
+					return err
 				}
-				return err
+				buf := bytes.NewBuffer(make([]byte, 0, p.readBufSize(r, md)))
+				_, copyErr := io.Copy(buf, rc)
+				closeErr := rc.Close()
+				if copyErr != nil {
+					log.CtxWarningf(ctx, "[%s] GetMulti encountered error when copying %s: %s", p.name, r.GetDigest().GetHash(), copyErr)
+					continue
+				}
+				if closeErr != nil {
+					log.CtxWarningf(ctx, "[%s] GetMulti cannot close reader when copying %s: %s", p.name, r.GetDigest().GetHash(), closeErr)
+					continue
+				}
+				mu.Lock()
+				foundMap[r.GetDigest()] = buf.Bytes()
+				mu.Unlock()
 			}
-
-			buf := bytes.NewBuffer(make([]byte, 0, p.readBufSize(r, md)))
-			_, copyErr := io.Copy(buf, rc)
-			closeErr := rc.Close()
-			if copyErr != nil {
-				log.CtxWarningf(ctx, "[%s] GetMulti encountered error when copying %s: %s", p.name, r.GetDigest().GetHash(), copyErr)
-				return nil
-			}
-			if closeErr != nil {
-				log.CtxWarningf(ctx, "[%s] GetMulti cannot close reader when copying %s: %s", p.name, r.GetDigest().GetHash(), closeErr)
-				return nil
-			}
-			mu.Lock()
-			foundMap[r.GetDigest()] = buf.Bytes()
-			mu.Unlock()
 			return nil
 		})
 	}

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2018,7 +2018,7 @@ func (p *PebbleCache) lookupFileMetadataBytes(db pebble.IPebbleDB, key filestore
 
 // readBufSize returns the buffer size to allocate to hold the full contents
 // of r, whose stored metadata is md.
-func (p *PebbleCache) readBufSize(r *rspb.ResourceName, md *sgpb.FileMetadata) int64 {
+func (p *PebbleCache) readBufSize(r *rspb.ResourceName, md *sgpb.FileMetadata, reader io.Reader) int64 {
 	// If the requested compression matches the stored compression, the data is
 	// returned as stored, so the stored size from the file metadata is the
 	// right buffer size. Otherwise the data is compressed or decompressed while
@@ -2029,10 +2029,10 @@ func (p *PebbleCache) readBufSize(r *rspb.ResourceName, md *sgpb.FileMetadata) i
 	} else {
 		bufSize = int64(digest.SafeBufferSize(r, maxReadBufferSize))
 	}
-	// Non-inline reads go through Buffer.ReadFrom, which needs MinRead spare
-	// capacity to detect EOF without growing the buffer. Inline reads copy
-	// directly via bytes.Reader.WriteTo and don't need the pad.
-	if r.GetDigest().GetSizeBytes() >= p.maxInlineFileSizeBytes {
+	// WriteTo allows copying without a second read to get EOF. Without that
+	// bytes.Buffer.ReadFrom will allocate an extra bytes.MinRead unless we
+	// oversize it.
+	if _, ok := reader.(io.WriterTo); !ok {
 		bufSize += bytes.MinRead
 	}
 	return bufSize
@@ -2066,7 +2066,7 @@ func (p *PebbleCache) GetWithMetadata(ctx context.Context, r *rspb.ResourceName)
 		return nil, nil, err
 	}
 	defer rc.Close()
-	buf := bytes.NewBuffer(make([]byte, 0, p.readBufSize(r, md)))
+	buf := bytes.NewBuffer(make([]byte, 0, p.readBufSize(r, md, rc)))
 	_, err = io.Copy(buf, rc)
 	if err != nil {
 		return nil, nil, err
@@ -2120,7 +2120,7 @@ func (p *PebbleCache) GetMulti(ctx context.Context, resources []*rspb.ResourceNa
 					}
 					return err
 				}
-				buf := bytes.NewBuffer(make([]byte, 0, p.readBufSize(r, md)))
+				buf := bytes.NewBuffer(make([]byte, 0, p.readBufSize(r, md, rc)))
 				_, copyErr := io.Copy(buf, rc)
 				closeErr := rc.Close()
 				if copyErr != nil {


### PR DESCRIPTION
Benchmark results:
```
                                  │  /tmp/base1   │              /tmp/atomic              │
                                  │    sec/op     │    sec/op     vs base                 │
GetMulti/LocalPebble10-24           130.23µ ± 12%   84.52µ ± 11%  -35.10% (p=0.001 n=7)
GetMulti/LocalPebble100-24          130.67µ ±  9%   80.17µ ± 14%  -38.65% (p=0.001 n=7)
GetMulti/LocalPebble1000-24         139.83µ ±  4%   96.43µ ±  8%  -31.04% (p=0.001 n=7)
GetMulti/LocalPebble10000-24         237.1µ ±  3%   178.9µ ±  3%  -24.58% (p=0.001 n=7)

                                  │  /tmp/base1   │               /tmp/atomic               │
                                  │      B/s      │      B/s        vs base                 │
GetMulti/LocalPebble10-24           7.324Mi ± 13%   11.282Mi ± 13%  +54.04% (p=0.001 n=7)
GetMulti/LocalPebble100-24          72.98Mi ± 10%   118.96Mi ± 12%  +62.99% (p=0.001 n=7)
GetMulti/LocalPebble1000-24         682.0Mi ±  4%    989.0Mi ±  9%  +45.01% (p=0.001 n=7)
GetMulti/LocalPebble10000-24        3.927Gi ±  3%    5.207Gi ±  3%  +32.59% (p=0.001 n=7)

                                  │  /tmp/base1  │             /tmp/atomic              │
                                  │     B/op     │     B/op      vs base                │
GetMulti/LocalPebble10-24           137.2Ki ± 0%   126.7Ki ± 0%  -7.66% (p=0.001 n=7)
GetMulti/LocalPebble100-24          145.4Ki ± 0%   135.2Ki ± 0%  -7.00% (p=0.001 n=7)
GetMulti/LocalPebble1000-24         207.9Ki ± 1%   197.0Ki ± 0%  -5.22% (p=0.001 n=7)
GetMulti/LocalPebble10000-24        568.4Ki ± 0%   558.4Ki ± 0%  -1.76% (p=0.001 n=7)

                                  │ /tmp/base1  │             /tmp/atomic             │
                                  │  allocs/op  │  allocs/op   vs base                │
GetMulti/LocalPebble10-24           2.421k ± 0%   2.241k ± 0%  -7.43% (p=0.001 n=7)
GetMulti/LocalPebble100-24          2.421k ± 0%   2.241k ± 0%  -7.43% (p=0.001 n=7)
GetMulti/LocalPebble1000-24         2.421k ± 0%   2.241k ± 0%  -7.43% (p=0.001 n=7)
GetMulti/LocalPebble10000-24        2.622k ± 0%   2.442k ± 0%  -6.86% (p=0.001 n=7)
```