### PR TITLE
Support 'bazel remote' with a moved detached HEAD

### DIFF
--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -468,12 +468,12 @@ func getCurrentRef() (string, error) {
 
 	// Handle detached head state
 	detachedHeadOutput, _ := runGit("branch")
-	regex := regexp.MustCompile(".*detached at ([^)]+).*")
+	regex := regexp.MustCompile(".*detached (at|from) ([^)]+).*")
 	matches := regex.FindStringSubmatch(detachedHeadOutput)
-	if len(matches) != 2 {
+	if len(matches) != 3 {
 		return "", status.UnknownErrorf("unexpected branch state %s", detachedHeadOutput)
 	}
-	return strings.TrimSpace(matches[1]), nil
+	return strings.TrimSpace(matches[2]), nil
 }
 
 // branchTrackedRemotely returns whether the given branch exists remotely, as reflected in

--- a/cli/remotebazel/remotebazel_test.go
+++ b/cli/remotebazel/remotebazel_test.go
@@ -458,6 +458,8 @@ func TestGitConfig_BranchAndSha(t *testing.T) {
 		localBranchExistsRemotely bool
 		localCommitExistsRemotely bool
 		unpushedLocalCommit       bool
+		detachedHead              bool
+		detachedHeadMoved         bool
 
 		expectedBranch  string
 		expectedCommit  string
@@ -496,6 +498,21 @@ func TestGitConfig_BranchAndSha(t *testing.T) {
 			expectedCommit:      originalMasterHeadCommit,
 			expectedPatches:     []string{"local_only_commited_file.txt"},
 		},
+		{
+			name:            "Detached HEAD without additional commits",
+			detachedHead:    true,
+			expectedBranch:  "master",
+			expectedCommit:  originalMasterHeadCommit,
+			expectedPatches: []string{"local_file.txt"},
+		},
+		{
+			name:              "Detached HEAD with additional commits",
+			detachedHead:      true,
+			detachedHeadMoved: true,
+			expectedBranch:    "master",
+			expectedCommit:    originalMasterHeadCommit,
+			expectedPatches:   []string{"detached_file.txt"},
+		},
 	}
 
 	for i, tc := range testCases {
@@ -519,6 +536,15 @@ func TestGitConfig_BranchAndSha(t *testing.T) {
 		}
 		if !tc.localCommitExistsRemotely {
 			testgit.CommitFiles(t, localRepoPath, map[string]string{"local_file.txt": "exit 0"})
+		}
+
+		if tc.detachedHead {
+			testshell.Run(t, localRepoPath, "git checkout --detach")
+			if tc.detachedHeadMoved {
+				// A commit in a detached-head condition updates the `git branch` output from "detached at"
+				// to "detached from".
+				testgit.CommitFiles(t, localRepoPath, map[string]string{"detached_file.txt": "exit 0"})
+			}
 		}
 
 		config, err := Config()


### PR DESCRIPTION
Operating on a detached head, such as adding a commit, subtly shifts the output of `git branch`. This includes tests for this situation and updates the regex to handle it.

Fixes #12790.