### PR TITLE
Ask BuildBuddy: Fix this build

### DIFF
--- a/server/util/flag/flag.go
+++ b/server/util/flag/flag.go
@@ -40,7 +40,7 @@ func Parse() {
 }
 
 func String(name string, value string, usage string, tags ...flagtags.Taggable) *string {
-	return auxtoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
+	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }
 
 func Bool(name string, value bool, usage string, tags ...flagtags.Taggable) *bool {


### PR DESCRIPTION
Fixed a compile-time typo in [`server/util/flag/flag.go`](./server/util/flag/flag.go): `String()` was calling `auxtoflags.New(...)`, but the imported package is `autoflags`. That undefined identifier was the build failure.

Confirmed:
- BuildBuddy log showed `server/util/flag/flag.go:43:9: undefined: auxtoflags`.
- The file now uses `autoflags.New(...)` at that call site.

Verification:
- I tried a local `bazel build //server/util/flag:flag`, but Bazel in this environment crashes during startup because `--digest_function=BLAKE3` is not accepted by the local Bazel binary here, so I couldn’t complete a fresh local build check in this container.

If you want, I can keep going and look for the next failing target once this invocation is re-run.

Generated by [Ask BuildBuddy](http://localhost:8080/invocation/bad33e92-7e14-4948-82d1-54cfb4fde1de).