### PR TITLE
fix a bug in metadata Find

### DIFF
--- a/enterprise/server/backends/metacache/metacache.go
+++ b/enterprise/server/backends/metacache/metacache.go
@@ -752,7 +752,9 @@ func (c *Cache) reader(ctx context.Context, md *sgpb.FileMetadata, r *rspb.Resou
 	// so that we avoid saying something exists when it's been deleted by
 	// a GCS lifecycle rule.
 	if gcsMetadata := md.GetStorageMetadata().GetGcsMetadata(); gcsMetadata != nil {
-		if gcsutil.ObjectIsPastTTL(c.opts.Clock, gcsMetadata, c.opts.GCSTTLDays) {
+		// GCSTTLDays==0 disables the check (no TTL, nothing reaped); kept in
+		// lockstep with the metadata server's Find.
+		if c.opts.GCSTTLDays > 0 && gcsutil.ObjectIsPastTTL(c.opts.Clock, gcsMetadata, c.opts.GCSTTLDays) {
 			return nil, status.NotFoundError("backing object may have expired")
 		}
 	}

--- a/enterprise/server/raft/metadata/metadata.go
+++ b/enterprise/server/raft/metadata/metadata.go
@@ -431,6 +431,25 @@ func (rc *Server) sendAccessTimeUpdate(a atimeUpdateData) {
 	}
 }
 
+// presentConsideringGCSTTL reports a record absent if its backing GCS object is
+// past the bucket TTL, so callers don't skip re-uploading an unreadable blob.
+func (rc *Server) presentConsideringGCSTTL(present bool, gcsMetadata *sgpb.StorageMetadata_GCSMetadata) bool {
+	if !present {
+		return false
+	}
+	// No bucket TTL configured: nothing is reaped (and ObjectIsPastTTL treats a
+	// zero TTL as always-expired), so leave presence untouched.
+	if rc.gcsTTLDays <= 0 {
+		return true
+	}
+	// Inline records have no GCS object to expire.
+	if gcsMetadata == nil {
+		return true
+	}
+	// The lifecycle rule may have deleted the object while its metadata survives.
+	return !gcsutil.ObjectIsPastTTL(rc.clock, gcsMetadata, rc.gcsTTLDays)
+}
+
 // maybeUpdateGCSAtime refreshes the backing GCS object's custom time and
 // returns the new value to record, or 0 if it was not refreshed. Refreshes are
 // billed and contend on the object, and the custom time is only a TTL backstop,
@@ -696,7 +715,7 @@ func (rc *Server) Find(ctx context.Context, req *mdpb.FindRequest) (*mdpb.FindRe
 			if err != nil {
 				return nil, err
 			}
-			present := findRsp.GetPresent()
+			present := rc.presentConsideringGCSTTL(findRsp.GetPresent(), findRsp.GetGcsMetadata())
 			res.found[k.Meta.(*sgpb.FileRecord)] = present
 			if present {
 				res.atimeUpdates = append(res.atimeUpdates, atimeUpdateData{

--- a/enterprise/server/raft/metadata/metadata.go
+++ b/enterprise/server/raft/metadata/metadata.go
@@ -431,23 +431,13 @@ func (rc *Server) sendAccessTimeUpdate(a atimeUpdateData) {
 	}
 }
 
-// presentConsideringGCSTTL reports a record absent if its backing GCS object is
-// past the bucket TTL, so callers don't skip re-uploading an unreadable blob.
-func (rc *Server) presentConsideringGCSTTL(present bool, gcsMetadata *sgpb.StorageMetadata_GCSMetadata) bool {
-	if !present {
+// gcsObjectMayBeExpired reports whether the backing GCS object was likely reaped
+// by the bucket TTL. Zero gcsTTLDays disables the check; inline records have none.
+func (rc *Server) gcsObjectMayBeExpired(gcsMetadata *sgpb.StorageMetadata_GCSMetadata) bool {
+	if rc.gcsTTLDays <= 0 || gcsMetadata == nil {
 		return false
 	}
-	// No bucket TTL configured: nothing is reaped (and ObjectIsPastTTL treats a
-	// zero TTL as always-expired), so leave presence untouched.
-	if rc.gcsTTLDays <= 0 {
-		return true
-	}
-	// Inline records have no GCS object to expire.
-	if gcsMetadata == nil {
-		return true
-	}
-	// The lifecycle rule may have deleted the object while its metadata survives.
-	return !gcsutil.ObjectIsPastTTL(rc.clock, gcsMetadata, rc.gcsTTLDays)
+	return gcsutil.ObjectIsPastTTL(rc.clock, gcsMetadata, rc.gcsTTLDays)
 }
 
 // maybeUpdateGCSAtime refreshes the backing GCS object's custom time and
@@ -715,7 +705,7 @@ func (rc *Server) Find(ctx context.Context, req *mdpb.FindRequest) (*mdpb.FindRe
 			if err != nil {
 				return nil, err
 			}
-			present := rc.presentConsideringGCSTTL(findRsp.GetPresent(), findRsp.GetGcsMetadata())
+			present := findRsp.GetPresent() && !rc.gcsObjectMayBeExpired(findRsp.GetGcsMetadata())
 			res.found[k.Meta.(*sgpb.FileRecord)] = present
 			if present {
 				res.atimeUpdates = append(res.atimeUpdates, atimeUpdateData{

--- a/enterprise/server/raft/metadata/metadata_gcs_atime_test.go
+++ b/enterprise/server/raft/metadata/metadata_gcs_atime_test.go
@@ -1,5 +1,5 @@
-// Internal test, unlike metadata_test.go: calls maybeUpdateGCSAtime directly
-// rather than standing up a cluster through New().
+// Internal test, unlike metadata_test.go: calls the GCS TTL/atime helpers
+// directly rather than standing up a cluster through New().
 
 package metadata
 
@@ -152,39 +152,39 @@ func TestMaybeUpdateGCSAtime_FailedRefreshRecordsNoCustomTime(t *testing.T) {
 	require.Zero(t, customTime)
 }
 
-func TestPresentConsideringGCSTTL_RecentObjectStaysPresent(t *testing.T) {
+func TestGCSObjectMayBeExpired_RecentObject(t *testing.T) {
 	f := newGCSAtimeFixture(t, 7 /*=ttlDays*/, 0 /*=threshold*/)
 	md := f.metadataWithCustomTime(-1 * time.Hour)
 
-	require.True(t, f.server.presentConsideringGCSTTL(true, md))
+	require.False(t, f.server.gcsObjectMayBeExpired(md))
 }
 
-func TestPresentConsideringGCSTTL_PastTTLObjectReportsAbsent(t *testing.T) {
+func TestGCSObjectMayBeExpired_PastTTL(t *testing.T) {
 	f := newGCSAtimeFixture(t, 7 /*=ttlDays*/, 0 /*=threshold*/)
 	md := f.metadataWithCustomTime(-8 * 24 * time.Hour)
 
-	// Past TTL: the object was likely reaped, so report absent.
-	require.False(t, f.server.presentConsideringGCSTTL(true, md))
+	require.True(t, f.server.gcsObjectMayBeExpired(md))
 }
 
-func TestPresentConsideringGCSTTL_TTLDisabledStaysPresent(t *testing.T) {
+func TestGCSObjectMayBeExpired_WithinBufferOfTTL(t *testing.T) {
+	f := newGCSAtimeFixture(t, 7 /*=ttlDays*/, 0 /*=threshold*/)
+	// 30m short of the 7d TTL, but the 1h safety buffer pushes it over.
+	md := f.metadataWithCustomTime(-(7*24*time.Hour - 30*time.Minute))
+
+	require.True(t, f.server.gcsObjectMayBeExpired(md))
+}
+
+func TestGCSObjectMayBeExpired_TTLDisabled(t *testing.T) {
 	f := newGCSAtimeFixture(t, 0 /*=ttlDays*/, 0 /*=threshold*/)
 	md := f.metadataWithCustomTime(-8 * 24 * time.Hour)
 
-	// No bucket TTL: the guard must keep it present.
-	require.True(t, f.server.presentConsideringGCSTTL(true, md))
+	// No bucket TTL: nothing is reaped, so never treat it as expired.
+	require.False(t, f.server.gcsObjectMayBeExpired(md))
 }
 
-func TestPresentConsideringGCSTTL_InlineRecordStaysPresent(t *testing.T) {
-	f := newGCSAtimeFixture(t, 7 /*=ttlDays*/, 0 /*=threshold*/)
-
+func TestGCSObjectMayBeExpired_InlineRecord(t *testing.T) {
 	// Inline records have no GCS object, so the TTL check does not apply.
-	require.True(t, f.server.presentConsideringGCSTTL(true, nil))
-}
-
-func TestPresentConsideringGCSTTL_AbsentStaysAbsent(t *testing.T) {
 	f := newGCSAtimeFixture(t, 7 /*=ttlDays*/, 0 /*=threshold*/)
-	md := f.metadataWithCustomTime(-1 * time.Hour)
 
-	require.False(t, f.server.presentConsideringGCSTTL(false, md))
+	require.False(t, f.server.gcsObjectMayBeExpired(nil))
 }

--- a/enterprise/server/raft/metadata/metadata_gcs_atime_test.go
+++ b/enterprise/server/raft/metadata/metadata_gcs_atime_test.go
@@ -151,3 +151,40 @@ func TestMaybeUpdateGCSAtime_FailedRefreshRecordsNoCustomTime(t *testing.T) {
 	require.Error(t, err)
 	require.Zero(t, customTime)
 }
+
+func TestPresentConsideringGCSTTL_RecentObjectStaysPresent(t *testing.T) {
+	f := newGCSAtimeFixture(t, 7 /*=ttlDays*/, 0 /*=threshold*/)
+	md := f.metadataWithCustomTime(-1 * time.Hour)
+
+	require.True(t, f.server.presentConsideringGCSTTL(true, md))
+}
+
+func TestPresentConsideringGCSTTL_PastTTLObjectReportsAbsent(t *testing.T) {
+	f := newGCSAtimeFixture(t, 7 /*=ttlDays*/, 0 /*=threshold*/)
+	md := f.metadataWithCustomTime(-8 * 24 * time.Hour)
+
+	// Past TTL: the object was likely reaped, so report absent.
+	require.False(t, f.server.presentConsideringGCSTTL(true, md))
+}
+
+func TestPresentConsideringGCSTTL_TTLDisabledStaysPresent(t *testing.T) {
+	f := newGCSAtimeFixture(t, 0 /*=ttlDays*/, 0 /*=threshold*/)
+	md := f.metadataWithCustomTime(-8 * 24 * time.Hour)
+
+	// No bucket TTL: the guard must keep it present.
+	require.True(t, f.server.presentConsideringGCSTTL(true, md))
+}
+
+func TestPresentConsideringGCSTTL_InlineRecordStaysPresent(t *testing.T) {
+	f := newGCSAtimeFixture(t, 7 /*=ttlDays*/, 0 /*=threshold*/)
+
+	// Inline records have no GCS object, so the TTL check does not apply.
+	require.True(t, f.server.presentConsideringGCSTTL(true, nil))
+}
+
+func TestPresentConsideringGCSTTL_AbsentStaysAbsent(t *testing.T) {
+	f := newGCSAtimeFixture(t, 7 /*=ttlDays*/, 0 /*=threshold*/)
+	md := f.metadataWithCustomTime(-1 * time.Hour)
+
+	require.False(t, f.server.presentConsideringGCSTTL(false, md))
+}

--- a/enterprise/server/raft/metadata/metadata_test.go
+++ b/enterprise/server/raft/metadata/metadata_test.go
@@ -48,6 +48,7 @@ type testConfig struct {
 	env    *testenv.TestEnv
 	ta     *testauth.TestAuthenticator
 	config *config.ServerConfig
+	opts   []metadata.Option
 }
 
 func getTestConfigs(t testing.TB, n int) []testConfig {
@@ -172,7 +173,7 @@ func startNodes(t testing.TB, configs []testConfig) []*metadata.Server {
 		require.NoError(t, err)
 		config.config.GossipManager = gs
 		eg.Go(func() error {
-			n, err := metadata.New(config.env, config.config)
+			n, err := metadata.New(config.env, config.config, config.opts...)
 			if err != nil {
 				return err
 			}
@@ -225,6 +226,73 @@ func randomFileMetadata(t testing.TB, sizeBytes int64, groupID string) *sgpb.Fil
 		LastModifyUsec:     now,
 	}
 	return md
+}
+
+// gcsFileMetadata builds a GCS-backed record with the given custom time.
+func gcsFileMetadata(t testing.TB, groupID string, customTime time.Time) *sgpb.FileMetadata {
+	t.Helper()
+	r, _ := testdigest.RandomCASResourceBuf(t, 100)
+	rn := digest.ResourceNameFromProto(r)
+	require.NoError(t, rn.Validate())
+	return &sgpb.FileMetadata{
+		FileRecord: &sgpb.FileRecord{
+			Isolation: &sgpb.Isolation{
+				CacheType:          rn.GetCacheType(),
+				RemoteInstanceName: rn.GetInstanceName(),
+				PartitionId:        "default",
+				GroupId:            groupID,
+			},
+			Digest:         rn.GetDigest(),
+			DigestFunction: rn.GetDigestFunction(),
+		},
+		StorageMetadata: &sgpb.StorageMetadata{
+			GcsMetadata: &sgpb.StorageMetadata_GCSMetadata{
+				BlobName:           "test-blob",
+				LastCustomTimeUsec: customTime.UnixMicro(),
+			},
+		},
+		StoredSizeBytes: 100,
+		LastAccessUsec:  customTime.UnixMicro(),
+	}
+}
+
+// End-to-end: a GCS record past the bucket TTL must report absent from Find even
+// though it exists (covers replica.find + the Find TTL check wiring).
+func TestFindReportsExpiredGCSObjectAbsent(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	configs := getTestConfigs(t, 1)
+	configs[0].env.SetClock(clock)
+	configs[0].opts = []metadata.Option{metadata.WithGCSTTLDays(7)}
+	caches := startNodes(t, configs)
+	rc1 := caches[0]
+
+	ctx, err := configs[0].ta.WithAuthenticatedUser(context.Background(), "user1")
+	require.NoError(t, err)
+
+	set := func(md *sgpb.FileMetadata) {
+		_, err := rc1.Set(ctx, &mdpb.SetRequest{
+			SetOperations: []*mdpb.SetRequest_SetOperation{{FileMetadata: md}},
+		})
+		require.NoError(t, err)
+	}
+	present := func(md *sgpb.FileMetadata) bool {
+		findRsp, err := rc1.Find(ctx, &mdpb.FindRequest{
+			FileRecords: []*sgpb.FileRecord{md.GetFileRecord()},
+		})
+		require.NoError(t, err)
+		require.Len(t, findRsp.GetFindResponses(), 1)
+		return findRsp.GetFindResponses()[0].GetPresent()
+	}
+
+	// A GCS object past the 7d TTL is reported absent though its record exists.
+	expired := gcsFileMetadata(t, "group1", clock.Now().Add(-8*24*time.Hour))
+	set(expired)
+	require.False(t, present(expired), "past-TTL GCS record must report absent")
+
+	// Control: a fresh GCS record is still reported present.
+	fresh := gcsFileMetadata(t, "group1", clock.Now())
+	set(fresh)
+	require.True(t, present(fresh))
 }
 
 func TestAutoBringup(t *testing.T) {

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -1174,7 +1174,9 @@ func (sm *Replica) find(db ReplicaReader, req *rfpb.FindRequest) (*rfpb.FindResp
 	defer iter.Close()
 
 	fileMetadata, err := lookupFileMetadata(iter, req.GetKey())
-	present := (err == nil)
+	// A zero-length stored file is an anomaly the read path treats as missing,
+	// so report it absent here too.
+	present := err == nil && fileMetadata.GetStoredSizeBytes() != 0
 
 	return &rfpb.FindResponse{
 		Present:        present,

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -1306,7 +1306,8 @@ func TestFileWriteAndFind(t *testing.T) {
 				BlobName: "blob",
 			},
 		},
-		LastAccessUsec: now,
+		StoredSizeBytes: 1000,
+		LastAccessUsec:  now,
 	}
 
 	fs := filestore.New()
@@ -1345,6 +1346,63 @@ func TestFileWriteAndFind(t *testing.T) {
 	require.True(t, findRsp.GetPresent())
 	require.Equal(t, now, findRsp.GetLastAccessUsec())
 	require.Equal(t, "blob", findRsp.GetGcsMetadata().GetBlobName())
+}
+
+// A zero-length record is an anomaly the read path rejects, so Find must report
+// it absent.
+func TestFileFindZeroLengthReportsAbsent(t *testing.T) {
+	repl := testutil.NewTestingReplica(t, 1, 1)
+	require.NotNil(t, repl)
+	t.Cleanup(func() {
+		require.NoError(t, repl.Close())
+	})
+
+	stopc := make(chan struct{})
+	_, err := repl.Open(stopc)
+	require.NoError(t, err)
+	em := newEntryMaker(t)
+	writeDefaultRangeDescriptor(t, em, repl.Replica)
+
+	r, _ := testdigest.RandomCASResourceBuf(t, 1000)
+	fileRecord := &sgpb.FileRecord{
+		Isolation: &sgpb.Isolation{
+			CacheType:   rspb.CacheType_CAS,
+			PartitionId: "default",
+			GroupId:     interfaces.AuthAnonymousUser,
+		},
+		Digest:         r.GetDigest(),
+		DigestFunction: repb.DigestFunction_SHA256,
+	}
+	md := &sgpb.FileMetadata{
+		FileRecord:      fileRecord,
+		StoredSizeBytes: 0, // zero-length anomaly
+		LastAccessUsec:  time.Now().UnixMicro(),
+	}
+
+	fs := filestore.New()
+	key, err := fs.PebbleKey(fileRecord)
+	require.NoError(t, err)
+	fileMetadataKey, err := key.Bytes(filestore.Version5)
+	require.NoError(t, err)
+	val, err := proto.Marshal(md)
+	require.NoError(t, err)
+
+	entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+		Kv: &rfpb.KV{Key: fileMetadataKey, Value: val},
+	}))
+	_, err = repl.Update([]dbsm.Entry{entry})
+	require.NoError(t, err)
+
+	buf, err := rbuilder.NewBatchBuilder().Add(&rfpb.FindRequest{
+		Key: fileMetadataKey,
+	}).ToBuf()
+	require.NoError(t, err)
+	readRsp, err := repl.Lookup(buf)
+	require.NoError(t, err)
+
+	findRsp, err := rbuilder.NewBatchResponse(readRsp).FindResponse(0)
+	require.NoError(t, err)
+	require.False(t, findRsp.GetPresent(), "zero-length record must report absent")
 }
 
 func TestUsage(t *testing.T) {


### PR DESCRIPTION
In metadata server, the Find and Get response don't align when the object past
ttl.
