### PR TITLE
Improve directory deletion logic in pebble_cache.go

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -3234,7 +3234,9 @@ func deleteDirIfEmptyAndOld(dir string) error {
 		return nil
 	}
 
-	return os.Remove(dir)
+	err := os.Remove(dir)
+	log.Infof("Deleted dir: %q; err: %v", dir, err)
+	return err
 }
 
 func (e *partitionEvictor) deleteFile(rawKey []byte, key filestore.PebbleKey, groupID string, lastModifyUsec int64, storedSizeBytes int64, storageMetadata *sgpb.StorageMetadata) error {

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -3216,17 +3216,21 @@ func (e *partitionEvictor) sample(ctx context.Context, k int) ([]*approxlru.Samp
 }
 
 func deleteDirIfEmptyAndOld(dir string) error {
-	files, err := os.ReadDir(dir)
-	if err != nil {
-		return err
-	}
 	di, err := os.Stat(dir)
 	if err != nil {
 		return err
 	}
+	if time.Since(di.ModTime()) < *dirDeletionDelay {
+		// dir is too young
+		return nil
+	}
 
-	if len(files) != 0 || time.Since(di.ModTime()) < *dirDeletionDelay {
-		// dir was not empty or was too young
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	if len(files) != 0 {
+		// dir is not empty
 		return nil
 	}
 

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -3234,7 +3234,7 @@ func deleteDirIfEmptyAndOld(dir string) error {
 		return nil
 	}
 
-	err := os.Remove(dir)
+	err = os.Remove(dir)
 	log.Infof("Deleted dir: %q; err: %v", dir, err)
 	return err
 }


### PR DESCRIPTION
Don't read the directory if its mod time is recent. This `os.ReadDir` is a significant portion of memory and CPU in cache proxies.