### PR TITLE
Advertise the CAS batch size limit

### DIFF
--- a/server/remote_cache/capabilities_server/BUILD
+++ b/server/remote_cache/capabilities_server/BUILD
@@ -15,5 +15,6 @@ go_library(
         "//server/remote_cache/config",
         "//server/remote_cache/digest",
         "//server/util/bazel_request",
+        "//server/util/rpcutil",
     ],
 )

--- a/server/remote_cache/capabilities_server/capabilities_server.go
+++ b/server/remote_cache/capabilities_server/capabilities_server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/chunking"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_request"
+	"github.com/buildbuddy-io/buildbuddy/server/util/rpcutil"
 
 	cappb "github.com/buildbuddy-io/buildbuddy/proto/capability"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -81,7 +82,7 @@ func (s *CapabilitiesServer) GetCapabilities(ctx context.Context, req *repb.GetC
 					},
 				},
 			},
-			MaxBatchTotalSizeBytes:          0, // Default to protocol limit.
+			MaxBatchTotalSizeBytes:          rpcutil.GRPCMaxSizeBytes,
 			SymlinkAbsolutePathStrategy:     repb.SymlinkAbsolutePathStrategy_ALLOWED,
 			SupportedCompressors:            compressors,
 			SupportedBatchUpdateCompressors: compressors,


### PR DESCRIPTION
Advertise the existing CAS limit so clients can size their batches correctly:  `BatchReadBlobs` rejects batches over 4,000,000 bytes, while the capabilities response advertises no limit. Clients falling back to gRPC’s 4 MiB default can therefore send batches that BuildBuddy rejects.

https://github.com/buildbuddy-io/buildbuddy/blob/f6e4b108fbfa033da40c1f7cf7234fde6c36c8a8/server/util/rpcutil/rpcutil.go#L22