### PR TITLE
Fix data race reading/writing command-line flags in `cache_proxy_registration.go`

### DIFF
--- a/enterprise/server/cache_proxy_registration/BUILD
+++ b/enterprise/server/cache_proxy_registration/BUILD
@@ -9,6 +9,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:cache_proxy_go_proto",
+        "//server/config",
         "//server/environment",
         "//server/hostid",
         "//server/metrics",

--- a/enterprise/server/cache_proxy_registration/cache_proxy_registration.go
+++ b/enterprise/server/cache_proxy_registration/cache_proxy_registration.go
@@ -18,8 +18,11 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/server/config"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/hostid"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
@@ -75,6 +78,11 @@ var (
 	// maxLabels labels.
 	maxLabels   = 20
 	maxLabelLen = 50
+
+	// Caching for parsed command-line flags, to avoid racing against config
+	// reparsing logic in config.go.
+	registerReloadHookOnce sync.Once
+	configuredFlagsCache   atomic.Pointer[[]string]
 )
 
 func Register(env *real_environment.RealEnv) error {
@@ -111,6 +119,12 @@ func Register(env *real_environment.RealEnv) error {
 		}
 		trimmedLabels[key] = val
 	}
+	// Register the config-reload hook and parse the current flags.
+	registerReloadHookOnce.Do(func() {
+		config.OnReload(refreshConfiguredFlags)
+	})
+	refreshConfiguredFlags()
+
 	log.Infof("Registering Cache Proxy %s on host %q", proxyID, hostname)
 	node := &cppb.CacheProxyNode{
 		Host:                 hostname,
@@ -147,6 +161,11 @@ func Register(env *real_environment.RealEnv) error {
 		run(ctx, shutdownCh, env, *appTarget, *apiKey, node)
 	}()
 	return nil
+}
+
+func refreshConfiguredFlags() {
+	flags := configuredFlags()
+	configuredFlagsCache.Store(&flags)
 }
 
 // configuredFlags returns the flags this process was configured with (via
@@ -337,11 +356,10 @@ func openStream(ctx context.Context, client cppb.CacheProxyRegistryClient, node 
 // has already terminated (io.EOF), it drains the trailer via CloseAndRecv to
 // surface the real status (PermissionDenied, etc.) instead of a bare EOF.
 func sendHeartbeat(stream cppb.CacheProxyRegistry_RegisterAndStreamHeartbeatClient, req *cppb.RegisterCacheProxyRequest) error {
-	// Flag values can change at runtime (the config file is re-read on
-	// SIGHUP), so refresh the reported configuration on every heartbeat
-	// rather than snapshotting it once at startup.
 	if node := req.GetNode(); node != nil {
-		node.ConfiguredFlags = configuredFlags()
+		if flags := configuredFlagsCache.Load(); flags != nil {
+			node.ConfiguredFlags = *flags
+		}
 	}
 	err := stream.Send(req)
 	if err == io.EOF {

--- a/enterprise/server/cache_proxy_registration/cache_proxy_registration_test.go
+++ b/enterprise/server/cache_proxy_registration/cache_proxy_registration_test.go
@@ -2,6 +2,7 @@ package cache_proxy_registration
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -304,19 +305,45 @@ func (f *fakeHeartbeatStream) Send(req *cppb.RegisterCacheProxyRequest) error {
 }
 
 // Flag values can change at runtime (the config file is re-read on SIGHUP),
-// so every heartbeat should report the current configuration, not a snapshot
-// from startup.
+// so heartbeats should report the latest configuration snapshot, which
+// config.OnReload refreshes after each completed reload.
 func TestSendHeartbeat_RefreshesConfiguredFlags(t *testing.T) {
 	stream := &fakeHeartbeatStream{}
 	node := &cppb.CacheProxyNode{Host: "h", ProxyId: "id"}
 
 	flags.Set(t, "cache_proxy.app_target", "grpcs://before.example.com")
+	refreshConfiguredFlags()
 	require.NoError(t, sendHeartbeat(stream, &cppb.RegisterCacheProxyRequest{Node: node}))
 
+	// After a config reload (e.g. on SIGHUP), config.OnReload triggers
+	// refreshConfiguredFlags and subsequent heartbeats pick up the change.
 	flags.Set(t, "cache_proxy.app_target", "grpcs://after.example.com")
+	refreshConfiguredFlags()
 	require.NoError(t, sendHeartbeat(stream, &cppb.RegisterCacheProxyRequest{Node: node}))
 
 	require.Len(t, stream.sent, 2)
 	assert.Contains(t, stream.sent[0].GetNode().GetConfiguredFlags(), "--cache_proxy.app_target=grpcs://before.example.com")
 	assert.Contains(t, stream.sent[1].GetNode().GetConfiguredFlags(), "--cache_proxy.app_target=grpcs://after.example.com")
+}
+
+func TestSendHeartbeat_FlagMutationRaciness(t *testing.T) {
+	stream := &fakeHeartbeatStream{}
+	node := &cppb.CacheProxyNode{Host: "h", ProxyId: "id"}
+	refreshConfiguredFlags()
+
+	const iterations = 1_000
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < iterations; i++ {
+			_ = sendHeartbeat(stream, &cppb.RegisterCacheProxyRequest{Node: node})
+		}
+	}()
+
+	for i := 0; i < iterations; i++ {
+		flags.Set(t, "cache_proxy.app_target", fmt.Sprintf("grpcs://app-%d.example.com", i))
+	}
+	<-done
+
+	assert.Len(t, stream.sent, iterations)
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -6,7 +6,10 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime/debug"
+	"slices"
 	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -33,6 +36,9 @@ var (
 
 	// This may be optionally set by a configured provider.
 	SecretProvider interfaces.ConfigSecretProvider
+
+	reloadHooksMu sync.Mutex
+	reloadHooks   []func()
 )
 
 func Path() string {
@@ -119,11 +125,42 @@ func Load() error {
 	return LoadFromFile(configFile)
 }
 
+// OnReload registers fn to run after the config has been successfully
+// reloaded (e.g. on SIGHUP). The order in which hooks run is not guaranteed.
+func OnReload(fn func()) {
+	reloadHooksMu.Lock()
+	defer reloadHooksMu.Unlock()
+	reloadHooks = append(reloadHooks, fn)
+}
+
 // Reload resets the flags to their default values, re-parses the flags and
 // loads the config file specified by config.Path().
 func Reload() error {
-	flagutil.ResetFlags()
-	return Load()
+	if err := flagutil.ResetFlags(); err != nil {
+		return err
+	}
+	if err := Load(); err != nil {
+		return err
+	}
+	reloadHooksMu.Lock()
+	hooks := slices.Clone(reloadHooks)
+	reloadHooksMu.Unlock()
+	for _, fn := range hooks {
+		runReloadHook(fn)
+	}
+	return nil
+}
+
+// runReloadHook runs one reload hook, recovering from any panic so that a
+// misbehaving hook can't take down the reloading goroutine (typically the
+// process-wide SIGHUP handler) or prevent later hooks from running.
+func runReloadHook(fn func()) {
+	defer func() {
+		if panicErr := recover(); panicErr != nil {
+			log.Errorf("Config reload hook panicked: %v\n%s", panicErr, debug.Stack())
+		}
+	}()
+	fn()
 }
 
 // ReloadOnSIGHUP registers a signal handler (as a goroutine) for syscall.SIGHUP

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -3,6 +3,7 @@ package config_test
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -276,4 +277,23 @@ must_be_a_number: "not a string, like this"
 		require.Contains(t, err.Error(), "retyping YAML map")
 		require.Contains(t, err.Error(), "into int")
 	}
+}
+
+func TestOnReload(t *testing.T) {
+	replaceFlagsForTesting(t)
+
+	// Point config.Path() at a config file we control.
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(""), 0644))
+	configPathFlag := flag.CommandLine.Lookup("config_file")
+	require.NotNil(t, configPathFlag)
+	previousPath := config.Path()
+	require.NoError(t, configPathFlag.Value.Set(configFile))
+	t.Cleanup(func() { configPathFlag.Value.Set(previousPath) })
+
+	calls := 0
+	config.OnReload(func() { calls++ })
+
+	require.NoError(t, config.Reload())
+	require.Equal(t, 1, calls)
 }


### PR DESCRIPTION
The `configuredFlags()` function in [cache_proxy_registration.go](https://github.com/buildbuddy-io/buildbuddy/blob/bf8fe4a1ab327cd0e81dacbcdb7e5f0e23b46220/enterprise/server/cache_proxy_registration/cache_proxy_registration.go#L152-L169), which reads the command-line arguments the proxy is running with could race against the `Reload()` function in [config.go](https://github.com/buildbuddy-io/buildbuddy/blob/bf8fe4a1ab327cd0e81dacbcdb7e5f0e23b46220/server/config/config.go#L122-L147) which reparses the command-line flags the server is running with. This change introduces a hook mechanism in `config.go` to allow callers to read flags in a way that `config.go` ensures won't race with its reparsing logic.