### PR TITLE
Add a summary/details view to the executors page

### DIFF
--- a/enterprise/app/executors/BUILD
+++ b/enterprise/app/executors/BUILD
@@ -16,6 +16,7 @@ ts_library(
         "//app/auth:auth_service",
         "//app/components/banner",
         "//app/components/breadcrumbs",
+        "//app/components/button",
         "//app/components/button:link_button",
         "//app/components/link",
         "//app/components/select",

--- a/enterprise/app/executors/executor_card.tsx
+++ b/enterprise/app/executors/executor_card.tsx
@@ -11,6 +11,7 @@ interface Props {
   node: scheduler.ExecutionNode;
   isDefault: boolean;
   lastCheckInTime?: google_timestamp.protobuf.Timestamp | null;
+  details?: boolean;
 }
 
 export default class ExecutorCardComponent extends React.Component<Props> {
@@ -70,71 +71,6 @@ export default class ExecutorCardComponent extends React.Component<Props> {
                 <div>{this.props.node.osDisplayName}</div>
               </div>
             )}
-            {this.props.node.assignableCustomResources && this.props.node.assignableCustomResources.length > 0 && (
-              <div className="executor-section">
-                <div className="executor-section-title">Assignable Resources:</div>
-                <div className="executor-custom-resource">
-                  {this.props.node.assignableCustomResources.map((r) => {
-                    return (
-                      <div className="executor-custom-resource-wrapper">
-                        <div className="executor-custom-resource-key">{r.name}: </div>
-                        <div>{r.value}</div>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            )}
-            {this.props.node.xcodeVersions && this.props.node.xcodeVersions.length > 0 && (
-              <div className="executor-section">
-                {this.props.node.xcodeVersions.length == 1 && (
-                  <div className="executor-section-title">Xcode Version:</div>
-                )}
-                {this.props.node.xcodeVersions.length > 1 && (
-                  <div className="executor-section-title">Xcode Versions:</div>
-                )}
-                <div>{this.props.node.xcodeVersions.join(", ")}</div>
-              </div>
-            )}
-            {this.props.node.xcodeSimulatorRuntimes && this.props.node.xcodeSimulatorRuntimes.length > 0 && (
-              <div className="executor-section">
-                <div className="executor-section-title">Xcode Simulator Runtimes:</div>
-                <div>{this.props.node.xcodeSimulatorRuntimes.join(", ")}</div>
-              </div>
-            )}
-            {this.props.node.supportedIsolationTypes && this.props.node.supportedIsolationTypes.length > 0 && (
-              <div className="executor-section">
-                <div className="executor-section-title">Isolation Types:</div>
-                <div>{this.props.node.supportedIsolationTypes.join(", ")}</div>
-              </div>
-            )}
-            <div className="executor-section">
-              <div className="executor-section-title">Warmup Images:</div>
-              <div className="executor-warmup-images">
-                {(this.props.node.warmupImages || []).map((image, index) => (
-                  <div className="executor-warmup-image" key={`${image.isolation}-${image.image}-${index}`}>
-                    <span className="executor-warmup-image-isolation">{image.isolation || "default"}:</span>
-                    <span>{image.image}</span>
-                  </div>
-                ))}
-                {(this.props.node.warmupImages || []).length == 0 && "none"}
-              </div>
-            </div>
-            <div className="executor-section">
-              <div className="executor-section-title">Default:</div>
-              <div>{this.props.isDefault ? "True" : "False"}</div>
-            </div>
-            {this.props.node.configuredFlags.length > 0 && (
-              <div className="executor-section">
-                <div className="executor-section-title">Configuration:</div>
-                <div className="executor-configured-flags">
-                  {this.props.node.configuredFlags.map((f) => (
-                    <div key={f}>{f}</div>
-                  ))}
-                </div>
-              </div>
-            )}
-
             {this.props.lastCheckInTime && (
               <>
                 <div className="executor-section">
@@ -147,8 +83,82 @@ export default class ExecutorCardComponent extends React.Component<Props> {
                 </div>
               </>
             )}
+            {this.props.details &&
+              this.props.node.assignableCustomResources &&
+              this.props.node.assignableCustomResources.length > 0 && (
+                <div className="executor-section">
+                  <div className="executor-section-title">Assignable Resources:</div>
+                  <div className="executor-custom-resource">
+                    {this.props.node.assignableCustomResources.map((r) => {
+                      return (
+                        <div className="executor-custom-resource-wrapper">
+                          <div className="executor-custom-resource-key">{r.name}: </div>
+                          <div>{r.value}</div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+            {this.props.details && this.props.node.xcodeVersions && this.props.node.xcodeVersions.length > 0 && (
+              <div className="executor-section">
+                {this.props.node.xcodeVersions.length == 1 && (
+                  <div className="executor-section-title">Xcode Version:</div>
+                )}
+                {this.props.node.xcodeVersions.length > 1 && (
+                  <div className="executor-section-title">Xcode Versions:</div>
+                )}
+                <div>{this.props.node.xcodeVersions.join(", ")}</div>
+              </div>
+            )}
+            {this.props.details &&
+              this.props.node.xcodeSimulatorRuntimes &&
+              this.props.node.xcodeSimulatorRuntimes.length > 0 && (
+                <div className="executor-section">
+                  <div className="executor-section-title">Xcode Simulator Runtimes:</div>
+                  <div>{this.props.node.xcodeSimulatorRuntimes.join(", ")}</div>
+                </div>
+              )}
+            {this.props.details &&
+              this.props.node.supportedIsolationTypes &&
+              this.props.node.supportedIsolationTypes.length > 0 && (
+                <div className="executor-section">
+                  <div className="executor-section-title">Isolation Types:</div>
+                  <div>{this.props.node.supportedIsolationTypes.join(", ")}</div>
+                </div>
+              )}
+            {this.props.details && (
+              <div className="executor-section">
+                <div className="executor-section-title">Warmup Images:</div>
+                <div className="executor-warmup-images">
+                  {(this.props.node.warmupImages || []).map((image, index) => (
+                    <div className="executor-warmup-image" key={`${image.isolation}-${image.image}-${index}`}>
+                      <span className="executor-warmup-image-isolation">{image.isolation || "default"}:</span>
+                      <span>{image.image}</span>
+                    </div>
+                  ))}
+                  {(this.props.node.warmupImages || []).length == 0 && "none"}
+                </div>
+              </div>
+            )}
+            {this.props.details && (
+              <div className="executor-section">
+                <div className="executor-section-title">Default:</div>
+                <div>{this.props.isDefault ? "True" : "False"}</div>
+              </div>
+            )}
+            {this.props.details && this.props.node.configuredFlags.length > 0 && (
+              <div className="executor-section">
+                <div className="executor-section-title">Configuration:</div>
+                <div className="executor-configured-flags">
+                  {this.props.node.configuredFlags.map((f) => (
+                    <div key={f}>{f}</div>
+                  ))}
+                </div>
+              </div>
+            )}
 
-            {this.props.node.labels && Object.keys(this.props.node.labels).length > 0 && (
+            {this.props.details && this.props.node.labels && Object.keys(this.props.node.labels).length > 0 && (
               <div className="executor-section">
                 <div className="executor-section-title">Labels:</div>
                 <div>

--- a/enterprise/app/executors/executors.css
+++ b/enterprise/app/executors/executors.css
@@ -5,6 +5,19 @@
   font-weight: 700;
 }
 
+/* Push the summary/details toggle to the right edge of the tabs row. */
+.executors-page .view-mode-toggle {
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+}
+
+/* The tabs are taller than the pool heading they sit next to, so don't let
+ * their vertical margins stretch that row. */
+.executors-page .executor-pool-header .view-mode-toggle .tab {
+  margin-top: 0;
+}
+
 .executors-page .executor-section {
   display: flex;
 }
@@ -97,6 +110,22 @@
   margin-top: 32px;
   margin-bottom: 32px;
   max-width: 600px;
+}
+
+.executors-page .executor-cards {
+  margin-top: 16px;
+}
+
+/* Pool heading + "view executions" link. */
+.executors-page .executor-pool-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.executors-page .executor-pool-header h2 {
+  margin: 0;
 }
 
 .executors-page .executor-details {

--- a/enterprise/app/executors/executors.tsx
+++ b/enterprise/app/executors/executors.tsx
@@ -1,4 +1,4 @@
-import { BarChart2, Cpu, Globe, Hash, Laptop, LucideIcon } from "lucide-react";
+import { BarChart2, Cpu, Globe, Hash, Laptop, ListChevronsDownUp, ListChevronsUpDown, LucideIcon } from "lucide-react";
 import React from "react";
 import { Subscription } from "rxjs";
 import { User } from "../../../app/auth/auth_service";
@@ -18,6 +18,7 @@ import { scheduler } from "../../../proto/scheduler_ts_proto";
 import { stat_filter } from "../../../proto/stat_filter_ts_proto";
 import { encodeEffectivePoolUrlParam, encodeMetricUrlParam } from "../trends/common";
 import ExecutorCardComponent from "./executor_card";
+import { OutlinedButton } from "../../../app/components/button/button";
 
 enum FetchType {
   Executors,
@@ -388,23 +389,22 @@ export default class ExecutorsComponent extends React.Component<Props, State> {
     router.navigateTo(`/executors/${tabId}`);
   }
 
-  onClickViewMode(viewMode: ViewMode) {
-    this.setState({ viewMode });
+  toggleViewMode() {
+    this.setState({ viewMode: this.state.viewMode === "summary" ? "details" : "summary" });
   }
 
   renderViewModeToggle() {
     return (
       <div className="view-mode-toggle">
-        <div
-          className={`tab ${this.state.viewMode === "summary" ? "selected" : ""}`}
-          onClick={this.onClickViewMode.bind(this, "summary")}>
-          Summary
-        </div>
-        <div
-          className={`tab ${this.state.viewMode === "details" ? "selected" : ""}`}
-          onClick={this.onClickViewMode.bind(this, "details")}>
-          Details
-        </div>
+        {this.state.viewMode === "summary" ? (
+          <OutlinedButton className="icon-button" title="Show details" onClick={() => this.toggleViewMode()}>
+            <ListChevronsUpDown />
+          </OutlinedButton>
+        ) : (
+          <OutlinedButton className="icon-button" title="Hide details" onClick={() => this.toggleViewMode()}>
+            <ListChevronsDownUp />
+          </OutlinedButton>
+        )}
       </div>
     );
   }

--- a/enterprise/app/executors/executors.tsx
+++ b/enterprise/app/executors/executors.tsx
@@ -143,6 +143,10 @@ class ExecutorSetup extends React.Component<ExecutorSetupProps> {
 
 interface ExecutorsListProps {
   regions: { name: string; response: scheduler.GetExecutionNodesResponse }[];
+  details: boolean;
+  // Rendered at the right edge of the first pool's heading row. Used when the
+  // page has no tab row to hang the summary/details toggle off of.
+  toggle?: React.ReactNode;
 }
 
 class ExecutorsList extends React.Component<ExecutorsListProps> {
@@ -168,7 +172,7 @@ class ExecutorsList extends React.Component<ExecutorsListProps> {
         <div className="executor-cards">
           {keys
             .map((key) => executorsByPool.get(key))
-            .map((executors) => {
+            .map((executors, index) => {
               if (!executors || executors.length == 0) {
                 return null;
               }
@@ -182,14 +186,14 @@ class ExecutorsList extends React.Component<ExecutorsListProps> {
               );
               return (
                 <>
-                  <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+                  <div className="executor-pool-header">
                     <h2>{poolName}</h2>
                     <Link
                       className="executor-history-button history-button"
-                      style={{ marginTop: "32px" }}
                       href={`/trends/?d=${encodeURIComponent(poolUrlParam)}&ddMetric=${metricUrlParam}#drilldown`}>
                       <BarChart2 /> View executions
                     </Link>
+                    {index === 0 && this.props.toggle}
                   </div>
                   <div className="executor-details">
                     {executors[0].region && (
@@ -221,6 +225,7 @@ class ExecutorsList extends React.Component<ExecutorsListProps> {
                           node={node.executor.node}
                           isDefault={node.executor.isDefault}
                           lastCheckInTime={node.executor.lastCheckInTime}
+                          details={this.props.details}
                         />
                       )
                   )}
@@ -252,6 +257,8 @@ interface Props {
   path: string;
 }
 
+type ViewMode = "summary" | "details";
+
 interface State {
   userOwnedExecutorsSupported: boolean;
   regions: { name: string; response: scheduler.GetExecutionNodesResponse }[];
@@ -259,6 +266,7 @@ interface State {
   loading: FetchType[];
   schedulerUri: string;
   error: BuildBuddyError | null;
+  viewMode: ViewMode;
 }
 
 export default class ExecutorsComponent extends React.Component<Props, State> {
@@ -269,6 +277,7 @@ export default class ExecutorsComponent extends React.Component<Props, State> {
     loading: [],
     schedulerUri: "",
     error: null,
+    viewMode: "summary",
   };
 
   subscription?: Subscription;
@@ -379,6 +388,27 @@ export default class ExecutorsComponent extends React.Component<Props, State> {
     router.navigateTo(`/executors/${tabId}`);
   }
 
+  onClickViewMode(viewMode: ViewMode) {
+    this.setState({ viewMode });
+  }
+
+  renderViewModeToggle() {
+    return (
+      <div className="view-mode-toggle">
+        <div
+          className={`tab ${this.state.viewMode === "summary" ? "selected" : ""}`}
+          onClick={this.onClickViewMode.bind(this, "summary")}>
+          Summary
+        </div>
+        <div
+          className={`tab ${this.state.viewMode === "details" ? "selected" : ""}`}
+          onClick={this.onClickViewMode.bind(this, "details")}>
+          Details
+        </div>
+      </div>
+    );
+  }
+
   // "bring your own runners" is enabled for the installation (i.e. BuildBuddy Cloud deployment).
   renderWithGroupOwnedExecutorsEnabled() {
     const allNodes = this.state.regions.flatMap((r) => r.response.executor);
@@ -398,6 +428,7 @@ export default class ExecutorsComponent extends React.Component<Props, State> {
             onClick={this.onClickTab.bind(this, "setup")}>
             Setup
           </div>
+          {activeTab === "status" && allNodes.length > 0 && this.renderViewModeToggle()}
         </div>
         {activeTab === "status" && (
           <>
@@ -414,7 +445,7 @@ export default class ExecutorsComponent extends React.Component<Props, State> {
                 </div>
               </Banner>
             )}
-            <ExecutorsList regions={this.state.regions} />
+            <ExecutorsList regions={this.state.regions} details={this.state.viewMode === "details"} />
             {!allNodes.length && this.props.user.selectedGroup.useGroupOwnedExecutors && (
               <div className="empty-state">
                 <h1>No self-hosted executors are connected.</h1>
@@ -459,7 +490,15 @@ export default class ExecutorsComponent extends React.Component<Props, State> {
         </div>
       );
     } else {
-      return <ExecutorsList regions={this.state.regions} />;
+      // There's no tab row here to hang the toggle off of, so it rides along
+      // with the first pool's heading instead.
+      return (
+        <ExecutorsList
+          regions={this.state.regions}
+          details={this.state.viewMode === "details"}
+          toggle={this.renderViewModeToggle()}
+        />
+      );
     }
   }
 


### PR DESCRIPTION
Had to do some TypeScript/CSS stuff to get the toggle to render in the same place on the proxies and executors page.

<img width="1281" height="734" alt="Screenshot 2026-07-30 at 2 07 43 PM" src="https://github.com/user-attachments/assets/ba07eed1-bc63-46f1-a500-cfc001f2dfe8" />