### PR TITLE
test_buddy: define protocol and serving storage

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -830,6 +830,14 @@ proto_library(
 )
 
 proto_library(
+    name = "test_buddy_proto",
+    srcs = ["test_buddy.proto"],
+    deps = [
+        ":context_proto",
+    ],
+)
+
+proto_library(
     name = "telemetry_proto",
     srcs = ["telemetry.proto"],
     deps = [
@@ -1785,6 +1793,16 @@ go_proto_library(
 )
 
 go_proto_library(
+    name = "test_buddy_go_proto",
+    importpath = "github.com/buildbuddy-io/buildbuddy/proto/test_buddy",
+    mode = "messages_and_services",
+    proto = ":test_buddy_proto",
+    deps = [
+        ":context_go_proto",
+    ],
+)
+
+go_proto_library(
     name = "telemetry_go_proto",
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/telemetry",
     mode = "messages_and_services",
@@ -2341,6 +2359,14 @@ ts_proto_library(
         ":kythe_filetree_ts_proto",
         ":kythe_graph_ts_proto",
         ":kythe_xref_ts_proto",
+    ],
+)
+
+ts_proto_library(
+    name = "test_buddy_ts_proto",
+    proto = ":test_buddy_proto",
+    deps = [
+        ":context_ts_proto",
     ],
 )
 

--- a/proto/target.proto
+++ b/proto/target.proto
@@ -207,6 +207,10 @@ message GetTargetRequest {
   // substring (case insensitive), and if any file names are matched then
   // restrict the file listing to just the matched files.
   string filter = 5;
+
+  // Include test-result events when listing test targets. By default these
+  // are expanded only for an exact target-label lookup.
+  bool include_test_result_events = 7;
 }
 
 message GetTargetResponse {

--- a/proto/test_buddy.proto
+++ b/proto/test_buddy.proto
@@ -1,0 +1,305 @@
+syntax = "proto3";
+
+import "proto/context.proto";
+
+package test_buddy;
+
+message TestTargetIdentity {
+  string target_label = 1;
+}
+
+message TestCaseIdentity {
+  TestTargetIdentity target = 1;
+  string case_name = 2;
+}
+
+enum TestOutcome {
+  TEST_OUTCOME_UNKNOWN = 0;
+  TEST_OUTCOME_PASS = 1;
+  TEST_OUTCOME_FAIL = 2;
+  TEST_OUTCOME_TIMEOUT = 3;
+}
+
+enum TestObservationSource {
+  TEST_OBSERVATION_SOURCE_UNKNOWN = 0;
+  TEST_OBSERVATION_SOURCE_PRESUBMIT = 1;
+  TEST_OBSERVATION_SOURCE_POSTSUBMIT = 2;
+  TEST_OBSERVATION_SOURCE_MONITOR = 3;
+}
+
+message TestObservation {
+  TestOutcome outcome = 1;
+  int64 duration_usec = 2;
+  string failure_message = 3;
+  string source_url = 4;
+  int64 event_time_usec = 5;
+  string observation_id = 6;
+  TestObservationSource source = 7;
+  string commit_sha = 8;
+  bool workspace_dirty = 9;
+}
+
+message TestCaseObservation {
+  TestCaseIdentity identity = 1;
+  TestObservation observation = 2;
+}
+
+message TestTargetObservation {
+  TestTargetIdentity identity = 1;
+  TestObservation observation = 2;
+}
+
+enum TestHealth {
+  TEST_HEALTH_UNKNOWN = 0;
+  TEST_HEALTH_INSUFFICIENT_DATA = 1;
+  TEST_HEALTH_HEALTHY = 2;
+  TEST_HEALTH_FLAKY = 3;
+  TEST_HEALTH_TIMEOUT = 4;
+  TEST_HEALTH_FAILING = 5;
+}
+
+enum TestExecutionDisposition {
+  TEST_EXECUTION_DISPOSITION_AUTOMATIC = 0;
+  TEST_EXECUTION_DISPOSITION_ENABLED = 1;
+  TEST_EXECUTION_DISPOSITION_DISABLED = 2;
+}
+
+message LinearAnalyzer {
+  int32 window_size = 1;
+  int32 failure_threshold = 2;
+  int32 target_timeout_threshold = 3;
+}
+
+message TestAnalyzerConfig {
+  oneof analyzer {
+    LinearAnalyzer linear = 1;
+  }
+}
+
+message ReportTestResultsRequest {
+  string repo_url = 1;
+  repeated TestCaseObservation case_observations = 2;
+  repeated TestTargetObservation target_observations = 3;
+}
+
+message ReportTestResultsResponse {
+  int32 accepted_count = 1;
+  int32 rejected_count = 2;
+}
+
+message GetTestsRequest {
+  context.RequestContext request_context = 1;
+  string repo_url = 2;
+  string package_prefix = 3;
+  TestTargetIdentity target = 4;
+}
+
+message TestSummary {
+  TestHealth health = 1;
+  int64 pass_count = 2;
+  int64 fail_count = 3;
+  int64 timeout_count = 4;
+  int64 mean_duration_usec = 5;
+  double pass_rate = 6;
+}
+
+message TestCaseSummary {
+  TestCaseIdentity identity = 1;
+  TestSummary summary = 2;
+  TestExecutionDisposition disposition = 3;
+  bool deleted = 4;
+}
+
+message GetTestsResponse {
+  repeated TestCaseSummary tests = 1;
+}
+
+message TestTargetSummary {
+  TestTargetIdentity identity = 1;
+  TestSummary summary = 2;
+  TestHealthSummary cases = 3;
+  TestExecutionDisposition disposition = 4;
+  bool deleted = 5;
+}
+
+enum TestTargetSort {
+  TEST_TARGET_SORT_HEALTH = 0;
+  TEST_TARGET_SORT_PASS_RATE = 1;
+  TEST_TARGET_SORT_MEAN_DURATION = 2;
+}
+
+message GetTestTargetsRequest {
+  context.RequestContext request_context = 1;
+  string repo_url = 2;
+  string package_prefix = 3;
+  int32 page_size = 4;
+  string page_token = 5;
+  repeated TestHealth health_filter = 6;
+  TestTargetSort sort = 7;
+  bool descending = 8;
+}
+
+message GetTestTargetsResponse {
+  repeated TestTargetSummary targets = 1;
+  string next_page_token = 2;
+}
+
+message TestHealthTransition {
+  TestHealth previous_health = 1;
+  TestHealth health = 2;
+  int64 event_time_usec = 3;
+  int64 analyzer_revision = 4;
+  string analysis_reason = 5;
+  int64 eligible_sample_count = 6;
+}
+
+message GetTestCaseRequest {
+  context.RequestContext request_context = 1;
+  string repo_url = 2;
+  TestCaseIdentity identity = 3;
+}
+
+message GetTestCaseResponse {
+  TestCaseSummary test = 1;
+  repeated TestObservation recent_observations = 2;
+  repeated TestHealthTransition transitions = 3;
+  int64 analyzer_revision = 4;
+  string analysis_reason = 5;
+  int64 eligible_sample_count = 6;
+}
+
+message GetTestTargetRequest {
+  context.RequestContext request_context = 1;
+  string repo_url = 2;
+  TestTargetIdentity identity = 3;
+}
+
+message GetTestTargetResponse {
+  TestTargetSummary target = 1;
+  repeated TestObservation recent_observations = 2;
+  repeated TestHealthTransition transitions = 3;
+  int64 analyzer_revision = 4;
+  string analysis_reason = 5;
+  int64 eligible_sample_count = 6;
+  repeated TestCaseObservation recent_case_failures = 7;
+}
+
+message GetTestAnalyzerConfigRequest {
+  context.RequestContext request_context = 1;
+  string repo_url = 2;
+}
+
+message GetTestAnalyzerConfigResponse {
+  TestAnalyzerConfig config = 1;
+  int64 revision = 2;
+}
+
+message SetTestAnalyzerConfigRequest {
+  context.RequestContext request_context = 1;
+  string repo_url = 2;
+  TestAnalyzerConfig config = 3;
+}
+
+message SetTestAnalyzerConfigResponse {
+  TestAnalyzerConfig config = 1;
+  int64 revision = 2;
+}
+
+message GetRepositoryHealthRequest {
+  context.RequestContext request_context = 1;
+  string repo_url = 2;
+}
+
+message TestHealthSummary {
+  int64 total_count = 1;
+  int64 healthy_count = 2;
+  int64 flaky_count = 3;
+  int64 insufficient_data_count = 4;
+  int64 unknown_count = 5;
+  int64 pass_count = 6;
+  int64 fail_count = 7;
+  int64 timeout_count = 8;
+  double pass_rate = 9;
+  int64 mean_duration_usec = 10;
+  int64 timed_out_count = 11;
+  int64 failing_count = 12;
+}
+
+message GetRepositoryHealthResponse {
+  TestHealthSummary targets = 1;
+  TestHealthSummary cases = 2;
+}
+
+message GetTestRepositoriesRequest {
+  context.RequestContext request_context = 1;
+}
+
+message TestRepository {
+  string repo_url = 1;
+  int64 last_reported_at_usec = 2;
+}
+
+message GetTestRepositoriesResponse {
+  repeated TestRepository repositories = 1;
+}
+
+message SetTestExecutionDispositionRequest {
+  context.RequestContext request_context = 1;
+  string repo_url = 2;
+  oneof subject {
+    TestTargetIdentity target = 3;
+    TestCaseIdentity test_case = 4;
+  }
+  TestExecutionDisposition disposition = 5;
+}
+
+message SetTestExecutionDispositionResponse {
+  TestExecutionDisposition disposition = 1;
+}
+
+message SetTestDeletedRequest {
+  context.RequestContext request_context = 1;
+  string repo_url = 2;
+  oneof subject {
+    TestTargetIdentity target = 3;
+    TestCaseIdentity test_case = 4;
+  }
+  bool deleted = 5;
+}
+
+message SetTestDeletedResponse {
+  bool deleted = 1;
+}
+
+message GetTestsToSkipRequest {
+  context.RequestContext request_context = 1;
+  string repo_url = 2;
+  string package_prefix = 3;
+}
+
+message GetTestsToSkipResponse {
+  repeated TestTargetSummary targets = 1;
+  repeated TestCaseSummary test_cases = 2;
+}
+
+service TestBuddyService {
+  rpc ReportTestResults(stream ReportTestResultsRequest)
+      returns (ReportTestResultsResponse);
+  rpc GetTests(GetTestsRequest) returns (stream GetTestsResponse);
+  rpc GetTestTargets(GetTestTargetsRequest) returns (GetTestTargetsResponse);
+  rpc GetTestCase(GetTestCaseRequest) returns (GetTestCaseResponse);
+  rpc GetTestTarget(GetTestTargetRequest) returns (GetTestTargetResponse);
+  rpc GetRepositoryHealth(GetRepositoryHealthRequest)
+      returns (GetRepositoryHealthResponse);
+  rpc GetTestRepositories(GetTestRepositoriesRequest)
+      returns (GetTestRepositoriesResponse);
+  rpc SetTestExecutionDisposition(SetTestExecutionDispositionRequest)
+      returns (SetTestExecutionDispositionResponse);
+  rpc SetTestDeleted(SetTestDeletedRequest) returns (SetTestDeletedResponse);
+  rpc GetTestsToSkip(GetTestsToSkipRequest)
+      returns (stream GetTestsToSkipResponse);
+  rpc GetTestAnalyzerConfig(GetTestAnalyzerConfigRequest)
+      returns (GetTestAnalyzerConfigResponse);
+  rpc SetTestAnalyzerConfig(SetTestAnalyzerConfigRequest)
+      returns (SetTestAnalyzerConfigResponse);
+}

--- a/proto/test_buddy.proto
+++ b/proto/test_buddy.proto
@@ -1,0 +1,205 @@
+syntax = "proto3";
+
+import "proto/context.proto";
+
+package test_buddy;
+
+// WARNING: EXPERIMENTAL. NO COMPATIBILITY GUARANTEES. THIS API MAY MUTATE
+// WITHOUT NOTICE.
+
+// Identity within the repository named by the request. An empty case_name
+// identifies a target. A non-empty case_name identifies a case under that
+// target. Each identity has its own health and execution disposition.
+message TestIdentity {
+  string target_label = 1;
+  string case_name = 2;
+}
+
+enum TestOutcome {
+  TEST_OUTCOME_UNKNOWN = 0;
+  TEST_OUTCOME_PASS = 1;
+  TEST_OUTCOME_FAIL = 2;
+  TEST_OUTCOME_TIMEOUT = 3;
+
+  // The build or test harness ended without producing a test verdict. Broken
+  // observations are retained for diagnosis but do not affect test health.
+  TEST_OUTCOME_BROKEN = 4;
+}
+
+// Identifies the kind of run that produced an observation. A monitor is a
+// controlled, repeated test run whose results are eligible for health analysis.
+enum TestObservationSource {
+  TEST_OBSERVATION_SOURCE_UNKNOWN = 0;
+  TEST_OBSERVATION_SOURCE_MONITOR = 1;
+}
+
+message TestObservation {
+  TestIdentity identity = 1;
+  TestOutcome outcome = 2;
+  int64 duration_usec = 3;
+
+  // Diagnostic text for this observation. Observations are ingestion records,
+  // not durable serving records, so a server may retain this field only in
+  // bounded recent state. Durable observation and transition histories belong
+  // in storage separate from primary serving state.
+  string failure_message = 4;
+
+  // Unix microseconds when this test execution completed, not when TestBuddy
+  // processed the observation.
+  int64 event_time_usec = 5;
+
+  // Stable for one execution within a group and repository. While the token is
+  // retained, an identical repeat is ignored and conflicting content is
+  // rejected. Retention is bounded and server-defined.
+  string idempotency_token = 6;
+}
+
+enum TestHealth {
+  TEST_HEALTH_UNKNOWN = 0;
+  TEST_HEALTH_INSUFFICIENT_DATA = 1;
+  TEST_HEALTH_HEALTHY = 2;
+  TEST_HEALTH_FLAKY = 3;
+  TEST_HEALTH_FAILING = 4;
+}
+
+// Controls whether a test is selected to run without changing its measured
+// health. AUTOMATIC follows health, ENABLED always runs, and DISABLED skips.
+enum TestExecutionDisposition {
+  TEST_EXECUTION_DISPOSITION_AUTOMATIC = 0;
+  TEST_EXECUTION_DISPOSITION_ENABLED = 1;
+  TEST_EXECUTION_DISPOSITION_DISABLED = 2;
+}
+
+// The analyzer retains the latest eligible observations in processing order.
+// For example, with window_size = 3:
+//
+//   processed:  PASS PASS FAIL PASS
+//   retained:        PASS FAIL PASS
+//
+// A failure_count_threshold of 1 classifies that mixed retained window as
+// flaky. A retained window containing no passes is failing.
+message TestAnalyzerConfig {
+  // Number of eligible observations retained per test.
+  int32 window_size = 1;
+  int32 failure_count_threshold = 2;
+  int32 timeout_count_threshold = 3;
+}
+
+message Test {
+  TestIdentity identity = 1;
+  TestHealth health = 2;
+  TestExecutionDisposition disposition = 3;
+  int64 pass_count = 4;
+  int64 fail_count = 5;
+  int64 timeout_count = 6;
+  int64 broken_count = 7;
+  int64 mean_duration_usec = 8;
+
+  int64 analyzer_revision = 9;
+  string analysis_reason = 10;
+  int64 eligible_sample_count = 11;
+}
+
+message ReportTestResultsRequest {
+  context.RequestContext request_context = 1;
+  string repo_url = 2;
+  TestObservationSource source = 3;
+
+  // URL of the run or invocation that produced these observations. repo_url
+  // identifies the source repository; source_url links to this execution.
+  string source_url = 4;
+  string commit_sha = 5;
+  repeated TestObservation observations = 6;
+}
+
+// Describes one invalid observation without rejecting valid observations from
+// the same report.
+message TestObservationRejection {
+  TestIdentity identity = 1;
+  string idempotency_token = 2;
+  string message = 3;
+}
+
+message ReportTestResultsResponse {
+  context.ResponseContext response_context = 1;
+  int64 accepted_count = 2;
+  int64 rejected_count = 3;
+
+  // Bounded examples of rejected observations. Counts include rejections not
+  // returned in this list.
+  repeated TestObservationRejection rejection_samples = 4;
+}
+
+message GetTestsOptions {
+  repeated TestHealth health = 1;
+  repeated TestExecutionDisposition disposition = 2;
+  bool skip_eligible_only = 3;
+
+  // An unset scope or empty package_prefix selects the repository root.
+  oneof scope {
+    string package_prefix = 4;
+
+    // A target identity selects the target and its cases. A case identity
+    // selects only that case.
+    TestIdentity identity = 5;
+  }
+}
+
+message GetTestsRequest {
+  context.RequestContext request_context = 1;
+  string repo_url = 2;
+  GetTestsOptions options = 3;
+}
+
+message GetTestsResponse {
+  context.ResponseContext response_context = 1;
+  repeated Test tests = 2;
+}
+
+message SetTestExecutionDispositionRequest {
+  context.RequestContext request_context = 1;
+  string repo_url = 2;
+  TestIdentity identity = 3;
+  TestExecutionDisposition disposition = 4;
+}
+
+message SetTestExecutionDispositionResponse {
+  context.ResponseContext response_context = 1;
+  Test test = 2;
+}
+
+message GetTestAnalyzerConfigRequest {
+  context.RequestContext request_context = 1;
+  string repo_url = 2;
+}
+
+message GetTestAnalyzerConfigResponse {
+  context.ResponseContext response_context = 1;
+  TestAnalyzerConfig config = 2;
+  int64 revision = 3;
+}
+
+message SetTestAnalyzerConfigRequest {
+  context.RequestContext request_context = 1;
+  string repo_url = 2;
+  TestAnalyzerConfig config = 3;
+  int64 expected_revision = 4;
+}
+
+message SetTestAnalyzerConfigResponse {
+  context.ResponseContext response_context = 1;
+  TestAnalyzerConfig config = 2;
+  int64 revision = 3;
+}
+
+service TestBuddyService {
+  rpc ReportTestResults(stream ReportTestResultsRequest)
+      returns (ReportTestResultsResponse);
+  rpc GetTests(GetTestsRequest) returns (stream GetTestsResponse);
+  rpc SetTestExecutionDisposition(SetTestExecutionDispositionRequest)
+      returns (SetTestExecutionDispositionResponse);
+  rpc GetTestAnalyzerConfig(GetTestAnalyzerConfigRequest)
+      returns (GetTestAnalyzerConfigResponse);
+  rpc SetTestAnalyzerConfig(SetTestAnalyzerConfigRequest)
+      returns (SetTestAnalyzerConfigResponse);
+}

--- a/proto/test_buddy.proto
+++ b/proto/test_buddy.proto
@@ -133,15 +133,13 @@ message ReportTestResultsResponse {
 message GetTestsOptions {
   repeated TestHealth health = 1;
   repeated TestExecutionDisposition disposition = 2;
-  bool skip_eligible_only = 3;
-
   // An unset scope or empty package_prefix selects the repository root.
   oneof scope {
-    string package_prefix = 4;
+    string package_prefix = 3;
 
     // A target identity selects the target and its cases. A case identity
     // selects only that case.
-    TestIdentity identity = 5;
+    TestIdentity identity = 4;
   }
 }
 


### PR DESCRIPTION
Defines the experimental TestBuddy reporting and query protocol with its relational serving model. Targets and cases share the natural key `(group_id, repository, target_label, case_name)`, where an empty case name identifies a target. The `Tests`, `TestStates`, `TestStateChanges`, and `TestAnalyzerConfigs` tables store execution disposition, current health, bounded analyzer state, health transitions, and analyzer configuration. MySQL stores the natural key as binary strings so long labels and UTF-8 case names fit within its index limit. Individual observations are reported through the streaming RPC and are not stored as durable relational rows in this PR.