### PR TITLE
test_buddy: define natural test addresses

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -229,6 +229,7 @@ gazelle_python_manifest(
 # gazelle:resolve go github.com/bazelbuild/bazel-gazelle/rule @bazel_gazelle//rule
 # gazelle:resolve go github.com/bazelbuild/rules_go/go/runfiles @io_bazel_rules_go//go/runfiles
 # gazelle:resolve go github.com/bazelbuild/rules_go/go/tools/bazel @io_bazel_rules_go//go/tools/bazel
+# gazelle:resolve go github.com/bazel-contrib/bazel-gazelle/v2/label @bazel_gazelle//v2/label
 gazelle(
     name = "gazelle",
     gazelle = ":bb_gazelle_binary",

--- a/go.mod
+++ b/go.mod
@@ -255,7 +255,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
 	github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df // indirect
-	github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-2 // indirect
+	github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-2
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -653,6 +653,134 @@ func (ts *TargetStatus) TableName() string {
 	return "TargetStatuses"
 }
 
+// TestBuddy stores every target and case as a test. An empty CaseName means
+// the row is for a target. A non-empty CaseName means the row is for a case.
+// Each row has its own health, analyzer state, and execution disposition.
+// The UI may group cases under a target, but storage does not aggregate them.
+//
+// The primary key is group, repository, target label, and case name. It
+// supports one-row test lookups and range scans for a target and its cases.
+// PackagePath supports directory cone queries.
+//
+// MySQL uses binary comparison for test identity. Repository URLs and target
+// labels use ascii_bin. Case names use UTF-8 bytes in a binary column. This
+// preserves case-sensitive identity and keeps the key within MySQL's limit.
+
+// TestRepositoryCatalog records a repository that has reported tests.
+type TestRepositoryCatalog struct {
+	Model
+	GroupID    string `gorm:"primaryKey;size:64;not null"`
+	Repository string `gorm:"primaryKey;size:512;not null"`
+}
+
+func (*TestRepositoryCatalog) TableName() string { return "TestRepositoryCatalogs" }
+
+// Test stores identity and execution disposition.
+type Test struct {
+	Model
+	GroupID       string `gorm:"primaryKey;size:64;not null;index:test_cone_idx,priority:1"`
+	Repository    string `gorm:"primaryKey;size:512;not null;index:test_cone_idx,priority:2"`
+	TargetLabel   string `gorm:"primaryKey;size:1539;not null"`
+	CaseName      []byte `gorm:"primaryKey;size:512;not null"`
+	PackagePath   string `gorm:"size:1024;not null;index:test_cone_idx,priority:3"`
+	Disposition   int32  `gorm:"not null;default:0"`
+	DeletedAtUsec int64  `gorm:"not null;default:0"`
+}
+
+func (*Test) TableName() string { return "Tests" }
+
+// TestPackageCoverage records the latest coverage fraction for a Bazel package.
+type TestPackageCoverage struct {
+	Model
+	GroupID          string  `gorm:"primaryKey;size:64;not null"`
+	Repository       string  `gorm:"primaryKey;size:512;not null"`
+	PackagePath      string  `gorm:"primaryKey;size:1024;not null"`
+	CoverageFraction float64 `gorm:"not null"`
+}
+
+func (*TestPackageCoverage) TableName() string { return "TestPackageCoverages" }
+
+// TestAnalyzerConfig is the analyzer configuration for one repository in a
+// group.
+type TestAnalyzerConfig struct {
+	Model
+	GroupID    string `gorm:"primaryKey;size:64;not null"`
+	Repository string `gorm:"primaryKey;size:512;not null"`
+	Revision   int64  `gorm:"not null"`
+	// Config contains a serialized test_buddy.TestAnalyzerConfig.
+	Config []byte `gorm:"size:max;not null"`
+}
+
+func (*TestAnalyzerConfig) TableName() string { return "TestAnalyzerConfigs" }
+
+// TestState stores the current health and analyzer window for one test.
+type TestState struct {
+	Model
+	GroupID     string `gorm:"primaryKey;size:64;not null"`
+	Repository  string `gorm:"primaryKey;size:512;not null"`
+	TargetLabel string `gorm:"primaryKey;size:1539;not null"`
+	CaseName    []byte `gorm:"primaryKey;size:512;not null"`
+
+	Health              string `gorm:"size:32;not null"`
+	RecentObservations  []byte `gorm:"size:max;not null"`
+	PassCount           int64
+	FailCount           int64
+	TimeoutCount        int64
+	BrokenCount         int64
+	TotalDurationUsec   int64
+	StateVersion        int64  `gorm:"not null"`
+	AnalyzerRevision    int64  `gorm:"not null"`
+	AnalysisReason      string `gorm:"size:64;not null"`
+	EligibleSampleCount int64  `gorm:"not null"`
+}
+
+func (*TestState) TableName() string { return "TestStates" }
+
+// TestStateChange records one health transition for one test.
+type TestStateChange struct {
+	Model
+	GroupID      string `gorm:"primaryKey;size:64;not null"`
+	Repository   string `gorm:"primaryKey;size:512;not null"`
+	TargetLabel  string `gorm:"primaryKey;size:1539;not null"`
+	CaseName     []byte `gorm:"primaryKey;size:512;not null"`
+	StateVersion int64  `gorm:"primaryKey;autoIncrement:false;not null"`
+
+	PreviousHealth      string `gorm:"size:32;not null"`
+	Health              string `gorm:"size:32;not null"`
+	PassCount           int64
+	FailCount           int64
+	TimeoutCount        int64
+	BrokenCount         int64
+	TransitionTimeUsec  int64  `gorm:"not null"`
+	AnalyzerRevision    int64  `gorm:"not null"`
+	AnalysisReason      string `gorm:"size:64;not null"`
+	EligibleSampleCount int64  `gorm:"not null"`
+}
+
+func (*TestStateChange) TableName() string { return "TestStateChanges" }
+
+const testBuddyTableOptions = "ENGINE=InnoDB DEFAULT CHARSET=ascii COLLATE=ascii_bin"
+
+func testBuddyTables() []Table {
+	return []Table{
+		&TestRepositoryCatalog{}, &Test{},
+		&TestPackageCoverage{}, &TestAnalyzerConfig{},
+		&TestState{}, &TestStateChange{},
+	}
+}
+
+func createTestBuddyTables(db *gorm.DB) error {
+	for _, table := range testBuddyTables() {
+		if db.Migrator().HasTable(table) {
+			continue
+		}
+		if err := db.Set("gorm:table_options", " "+testBuddyTableOptions).Migrator().CreateTable(table); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // GitHubAppInstallation represents a BuildBuddy GitHub App installation linked
 // to an organization.
 //
@@ -1047,6 +1175,16 @@ func PreAutoMigrate(db *gorm.DB) ([]PostAutoMigrateLogic, error) {
 	postMigrate := make([]PostAutoMigrateLogic, 0)
 
 	m := db.Migrator()
+
+	// GORM creates indexes in the CREATE TABLE statement, so changing the
+	// charset after AutoMigrate is too late: MySQL has already rejected the
+	// composite keys as too wide. Pre-creating these tables also establishes
+	// binary comparison before any addresses are written.
+	if db.Dialector.Name() == mysqlDialect {
+		if err := createTestBuddyTables(db); err != nil {
+			return nil, err
+		}
+	}
 
 	// Initialize UserGroups.membership_status to 1 if the column doesn't exist.
 	if m.HasTable("UserGroups") && !m.HasColumn(&UserGroup{}, "membership_status") {
@@ -1538,6 +1676,12 @@ func RegisterTables() {
 	registerTable("SK", &Secret{})
 	registerTable("SR", &ScheduledRun{})
 	registerTable("TA", &Target{})
+	registerTable("TC", &Test{})
+	registerTable("TD", &TestPackageCoverage{})
+	registerTable("TF", &TestRepositoryCatalog{})
+	registerTable("TG", &TestState{})
+	registerTable("TI", &TestAnalyzerConfig{})
+	registerTable("TJ", &TestStateChange{})
 	registerTable("TL", &TelemetryLog{})
 	registerTable("TO", &Token{})
 	registerTable("TS", &TargetStatus{})

--- a/server/test_buddy/identity/BUILD
+++ b/server/test_buddy/identity/BUILD
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "identity",
+    srcs = ["identity.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/test_buddy/identity",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto:test_buddy_go_proto",
+        "//server/util/git",
+        "//server/util/status",
+        "@bazel_gazelle//v2/label",
+    ],
+)
+
+go_test(
+    name = "identity_test",
+    srcs = ["identity_test.go"],
+    deps = [
+        ":identity",
+        "//proto:test_buddy_go_proto",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/server/test_buddy/identity/BUILD
+++ b/server/test_buddy/identity/BUILD
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "identity",
+    srcs = ["identity.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/test_buddy/identity",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto:test_buddy_go_proto",
+        "//server/util/git",
+        "//server/util/status",
+        "@bazel_gazelle//label",
+    ],
+)
+
+go_test(
+    name = "identity_test",
+    srcs = ["identity_test.go"],
+    deps = [
+        ":identity",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/server/test_buddy/identity/identity.go
+++ b/server/test_buddy/identity/identity.go
@@ -1,0 +1,292 @@
+// Package identity validates TestBuddy target and case addresses.
+package identity
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	gazellelabel "github.com/bazelbuild/bazel-gazelle/label"
+	tbpb "github.com/buildbuddy-io/buildbuddy/proto/test_buddy"
+	gitutil "github.com/buildbuddy-io/buildbuddy/server/util/git"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+)
+
+const (
+	MaxRepositoryURLBytes = 512
+	MaxPackagePathBytes   = 1024
+	MaxTargetNameBytes    = 512
+	MaxTargetLabelBytes   = MaxPackagePathBytes + MaxTargetNameBytes + len("//:")
+	MaxCaseNameBytes      = 512
+	MaxCaseNameKeyBytes   = 1 + (MaxCaseNameBytes*8+5)/6
+)
+
+const encodedCaseNamePrefix = "~"
+
+type PackageAddress struct {
+	Repository  string
+	PackagePath string
+}
+
+func (a PackageAddress) Validate() error {
+	repository, err := NormalizeRepositoryURL(a.Repository)
+	if err != nil {
+		return err
+	}
+	if repository != a.Repository {
+		return status.InvalidArgumentError("repository URL is not canonical")
+	}
+	packagePath, _, err := parseTargetLabel("//" + a.PackagePath + ":__test_buddy_package__")
+	if err != nil {
+		return err
+	}
+	if packagePath != a.PackagePath {
+		return status.InvalidArgumentError("package path is not canonical")
+	}
+	return nil
+}
+
+type TargetAddress struct {
+	Repository  string
+	PackagePath string
+	TargetName  string
+}
+
+func (a TargetAddress) Package() PackageAddress {
+	return PackageAddress{Repository: a.Repository, PackagePath: a.PackagePath}
+}
+
+func (a TargetAddress) Validate() error {
+	if err := a.Package().Validate(); err != nil {
+		return err
+	}
+	packagePath, targetName, err := parseTargetLabel(a.Label())
+	if err != nil {
+		return err
+	}
+	if packagePath != a.PackagePath || targetName != a.TargetName {
+		return status.InvalidArgumentError("target address is not canonical")
+	}
+	return nil
+}
+
+func (a TargetAddress) Label() string {
+	return "//" + a.PackagePath + ":" + a.TargetName
+}
+
+func (a TargetAddress) String() string {
+	return fmt.Sprintf("%s:%s:%s", strconv.Quote(a.Repository),
+		strconv.Quote(a.PackagePath), strconv.Quote(a.TargetName))
+}
+
+func (a TargetAddress) IsZero() bool { return a == TargetAddress{} }
+
+type CaseAddress struct {
+	TargetAddress
+	CaseName string
+}
+
+func (a CaseAddress) Target() TargetAddress { return a.TargetAddress }
+
+func (a CaseAddress) Validate() error {
+	if err := a.Target().Validate(); err != nil {
+		return err
+	}
+	return ValidateCaseName(a.CaseName)
+}
+
+func (a CaseAddress) String() string {
+	return fmt.Sprintf("%s:%s", a.TargetAddress.String(), strconv.Quote(a.CaseName))
+}
+
+func (a CaseAddress) IsZero() bool { return a == CaseAddress{} }
+
+func CanonicalizeCase(repositoryURL, targetLabel, caseName string) (CaseAddress, error) {
+	target, err := CanonicalizeTarget(repositoryURL, targetLabel)
+	if err != nil {
+		return CaseAddress{}, err
+	}
+	if err := ValidateCaseName(caseName); err != nil {
+		return CaseAddress{}, err
+	}
+	return CaseAddress{TargetAddress: target, CaseName: caseName}, nil
+}
+
+func CanonicalizeTarget(repositoryURL, targetLabel string) (TargetAddress, error) {
+	repository, err := NormalizeRepositoryURL(repositoryURL)
+	if err != nil {
+		return TargetAddress{}, err
+	}
+	packagePath, targetName, err := parseTargetLabel(targetLabel)
+	if err != nil {
+		return TargetAddress{}, err
+	}
+	return TargetAddress{
+		Repository: repository, PackagePath: packagePath, TargetName: targetName,
+	}, nil
+}
+
+func CanonicalizeTargetLabel(targetLabel string) (string, error) {
+	packagePath, targetName, err := parseTargetLabel(targetLabel)
+	if err != nil {
+		return "", err
+	}
+	return TargetAddress{PackagePath: packagePath, TargetName: targetName}.Label(), nil
+}
+
+func CanonicalizePackagePath(packagePath string) (string, error) {
+	canonical, _, err := parseTargetLabel("//" + packagePath + ":__test_buddy_package__")
+	return canonical, err
+}
+
+func parseTargetLabel(raw string) (string, string, error) {
+	if raw == "" {
+		return "", "", status.InvalidArgumentError("target label is required")
+	}
+	if err := validatePrintableASCII("target label", raw, MaxTargetLabelBytes); err != nil {
+		return "", "", err
+	}
+	parsed, err := gazellelabel.Parse(raw)
+	if err != nil {
+		return "", "", status.InvalidArgumentErrorf("invalid target label %q: %s", raw, err)
+	}
+	if parsed.Relative {
+		return "", "", status.InvalidArgumentErrorf("target label %q must be absolute", raw)
+	}
+	if parsed.Repo != "" && parsed.Repo != "@" {
+		return "", "", status.InvalidArgumentErrorf(
+			"external repository target label %q is not supported", raw)
+	}
+	if len(parsed.Pkg) > MaxPackagePathBytes {
+		return "", "", status.InvalidArgumentErrorf(
+			"package path exceeds %d bytes", MaxPackagePathBytes)
+	}
+	if len(parsed.Name) > MaxTargetNameBytes {
+		return "", "", status.InvalidArgumentErrorf(
+			"target name exceeds %d bytes", MaxTargetNameBytes)
+	}
+	return parsed.Pkg, parsed.Name, nil
+}
+
+func (a CaseAddress) Proto() *tbpb.TestCaseIdentity { return CaseProto(a) }
+
+func (a TargetAddress) Proto() *tbpb.TestTargetIdentity { return TargetProto(a) }
+
+func CaseProto(address CaseAddress) *tbpb.TestCaseIdentity {
+	return &tbpb.TestCaseIdentity{
+		Target: TargetProto(address.Target()), CaseName: address.CaseName,
+	}
+}
+
+func TargetProto(address TargetAddress) *tbpb.TestTargetIdentity {
+	return &tbpb.TestTargetIdentity{TargetLabel: address.Label()}
+}
+
+func CaseAddressFromProto(repository string, in *tbpb.TestCaseIdentity) (CaseAddress, error) {
+	return CanonicalizeCase(repository, in.GetTarget().GetTargetLabel(), in.GetCaseName())
+}
+
+func NormalizeRepositoryURL(raw string) (string, error) {
+	normalized, err := gitutil.NormalizeRepoURL(raw)
+	if err != nil {
+		return "", status.InvalidArgumentErrorf("normalize repository URL: %s", err)
+	}
+	value := normalized.String()
+	if value == "" {
+		return "", status.InvalidArgumentError("repository URL is required")
+	}
+	if err := validatePrintableASCII("repository URL", value, MaxRepositoryURLBytes); err != nil {
+		return "", err
+	}
+	return value, nil
+}
+
+func ValidateCaseName(caseName string) error {
+	if caseName == "" {
+		return status.InvalidArgumentError("case name is required")
+	}
+	if err := ValidateBoundedString("case name", caseName, MaxCaseNameBytes); err != nil {
+		return err
+	}
+	for _, r := range caseName {
+		if unicode.IsControl(r) {
+			return status.InvalidArgumentErrorf("case name contains control character %U", r)
+		}
+	}
+	return nil
+}
+
+func CaseNameKey(caseName string) (string, error) {
+	if err := ValidateCaseName(caseName); err != nil {
+		return "", err
+	}
+	if !strings.HasPrefix(caseName, encodedCaseNamePrefix) && isPrintableASCII(caseName) {
+		return caseName, nil
+	}
+	return encodedCaseNamePrefix + base64.RawURLEncoding.EncodeToString([]byte(caseName)), nil
+}
+
+func CaseNameFromKey(key string) (string, error) {
+	if !strings.HasPrefix(key, encodedCaseNamePrefix) {
+		if err := ValidateCaseName(key); err != nil {
+			return "", err
+		}
+		if !isPrintableASCII(key) {
+			return "", status.InternalError("unencoded case-name key is not printable ASCII")
+		}
+		return key, nil
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(key, encodedCaseNamePrefix))
+	if err != nil {
+		return "", status.InternalErrorf("decode case-name key: %s", err)
+	}
+	caseName := string(decoded)
+	canonical, err := CaseNameKey(caseName)
+	if err != nil {
+		return "", status.InternalErrorf("invalid decoded case-name key: %s", err)
+	}
+	if canonical != key {
+		return "", status.InternalError("case-name key is not canonical")
+	}
+	return caseName, nil
+}
+
+func validatePrintableASCII(name, value string, maxBytes int) error {
+	if err := ValidateBoundedString(name, value, maxBytes); err != nil {
+		return err
+	}
+	if !isPrintableASCII(value) {
+		for i := 0; i < len(value); i++ {
+			if c := value[i]; c < 0x20 || c > 0x7e {
+				return status.InvalidArgumentErrorf(
+					"%s must be printable ASCII; byte %d is %#02x", name, i, c)
+			}
+		}
+	}
+	return nil
+}
+
+func isPrintableASCII(value string) bool {
+	for i := 0; i < len(value); i++ {
+		if c := value[i]; c < 0x20 || c > 0x7e {
+			return false
+		}
+	}
+	return true
+}
+
+func ValidateBoundedString(name, value string, maxBytes int) error {
+	if len(value) > maxBytes {
+		return status.InvalidArgumentErrorf("%s exceeds %d bytes", name, maxBytes)
+	}
+	if !utf8.ValidString(value) {
+		return status.InvalidArgumentErrorf("%s is not valid UTF-8", name)
+	}
+	if strings.ContainsRune(value, '\x00') {
+		return status.InvalidArgumentErrorf("%s contains NUL", name)
+	}
+	return nil
+}

--- a/server/test_buddy/identity/identity.go
+++ b/server/test_buddy/identity/identity.go
@@ -1,0 +1,196 @@
+// Package identity validates TestBuddy test addresses.
+package identity
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/bazel-contrib/bazel-gazelle/v2/label"
+	"github.com/buildbuddy-io/buildbuddy/server/util/git"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+
+	tbpb "github.com/buildbuddy-io/buildbuddy/proto/test_buddy"
+)
+
+const (
+	maxRepositoryURLBytes = 512
+	maxPackagePathBytes   = 1024
+	maxTargetNameBytes    = 512
+	maxTargetLabelBytes   = maxPackagePathBytes + maxTargetNameBytes + len("//:")
+	maxCaseNameBytes      = 512
+)
+
+type Address struct {
+	Repository  string
+	PackagePath string
+	TargetName  string
+	CaseName    string
+}
+
+func Canonicalize(repositoryURL string, test *tbpb.TestIdentity) (Address, error) {
+	repository, err := NormalizeRepositoryURL(repositoryURL)
+	if err != nil {
+		return Address{}, err
+	}
+	packagePath, targetName, err := parseTargetLabel(test.GetTargetLabel())
+	if err != nil {
+		return Address{}, err
+	}
+	if err := ValidateCaseName(test.GetCaseName()); err != nil {
+		return Address{}, err
+	}
+	return Address{
+		Repository:  repository,
+		PackagePath: packagePath,
+		TargetName:  targetName,
+		CaseName:    test.GetCaseName(),
+	}, nil
+}
+
+func (a Address) Validate() error {
+	canonical, err := Canonicalize(a.Repository, a.Proto())
+	if err != nil {
+		return err
+	}
+	if canonical != a {
+		return status.InvalidArgumentError("test address is not canonical")
+	}
+	return nil
+}
+
+func (a Address) TargetLabel() string {
+	return "//" + a.PackagePath + ":" + a.TargetName
+}
+
+func (a Address) Proto() *tbpb.TestIdentity {
+	return &tbpb.TestIdentity{TargetLabel: a.TargetLabel(), CaseName: a.CaseName}
+}
+
+func (a Address) String() string {
+	address := fmt.Sprintf("%s:%s:%s", strconv.Quote(a.Repository),
+		strconv.Quote(a.PackagePath), strconv.Quote(a.TargetName))
+	if a.CaseName != "" {
+		address += ":" + strconv.Quote(a.CaseName)
+	}
+	return address
+}
+
+func NormalizeRepositoryURL(raw string) (string, error) {
+	normalized, err := git.NormalizeRepoURL(raw)
+	if err != nil {
+		return "", status.InvalidArgumentErrorf("normalize repository URL: %s", err)
+	}
+	for {
+		value := normalized.String()
+		next, err := git.NormalizeRepoURL(value)
+		if err != nil {
+			return "", status.InvalidArgumentErrorf("normalize repository URL: %s", err)
+		}
+		if next.String() == value {
+			break
+		}
+		normalized = next
+	}
+	value := normalized.String()
+	if err := validatePrintableASCII("repository URL", value, maxRepositoryURLBytes); err != nil {
+		return "", err
+	}
+	if normalized.Host == "" || strings.Trim(normalized.Path, "/") == "" {
+		return "", status.InvalidArgumentError("repository URL must have a host and path")
+	}
+	if normalized.Scheme != "https" && !(normalized.Scheme == "http" && normalized.Hostname() == "localhost") {
+		return "", status.InvalidArgumentErrorf("repository URL has unsupported scheme %q", normalized.Scheme)
+	}
+	if normalized.RawQuery != "" || normalized.Fragment != "" {
+		return "", status.InvalidArgumentError("repository URL must not contain a query or fragment")
+	}
+	return value, nil
+}
+
+func CanonicalizeTargetLabel(raw string) (string, error) {
+	packagePath, targetName, err := parseTargetLabel(raw)
+	if err != nil {
+		return "", err
+	}
+	return "//" + packagePath + ":" + targetName, nil
+}
+
+func parseTargetLabel(raw string) (string, string, error) {
+	if raw == "" {
+		return "", "", status.InvalidArgumentError("target label is required")
+	}
+	if err := validatePrintableASCII("target label", raw, maxTargetLabelBytes); err != nil {
+		return "", "", err
+	}
+	parsed, err := label.Parse(raw)
+	if err != nil {
+		return "", "", status.InvalidArgumentErrorf("invalid target label %q: %s", raw, err)
+	}
+	if parsed.Relative {
+		return "", "", status.InvalidArgumentErrorf("target label %q must be absolute", raw)
+	}
+	if parsed.Repo != "" && parsed.Repo != "@" {
+		return "", "", status.InvalidArgumentErrorf(
+			"external repository target label %q is not supported", raw)
+	}
+	if parsed.Name == "all" || parsed.Name == "all-targets" || parsed.Name == "*" || parsed.Name == "..." {
+		return "", "", status.InvalidArgumentErrorf("target label %q is a target pattern", raw)
+	}
+	if slices.Contains(strings.Split(parsed.Pkg, "/"), "...") {
+		return "", "", status.InvalidArgumentErrorf("target label %q is a target pattern", raw)
+	}
+	if len(parsed.Pkg) > maxPackagePathBytes {
+		return "", "", status.InvalidArgumentErrorf(
+			"package path exceeds %d bytes", maxPackagePathBytes)
+	}
+	if len(parsed.Name) > maxTargetNameBytes {
+		return "", "", status.InvalidArgumentErrorf(
+			"target name exceeds %d bytes", maxTargetNameBytes)
+	}
+	return parsed.Pkg, parsed.Name, nil
+}
+
+func ValidateCaseName(caseName string) error {
+	if caseName == "" {
+		return nil
+	}
+	if err := validateBoundedString("case name", caseName, maxCaseNameBytes); err != nil {
+		return err
+	}
+	for _, r := range caseName {
+		if unicode.IsControl(r) {
+			return status.InvalidArgumentErrorf("case name contains control character %U", r)
+		}
+	}
+	return nil
+}
+
+func validatePrintableASCII(name, value string, maxBytes int) error {
+	if err := validateBoundedString(name, value, maxBytes); err != nil {
+		return err
+	}
+	for i := 0; i < len(value); i++ {
+		if c := value[i]; c < 0x20 || c > 0x7e {
+			return status.InvalidArgumentErrorf(
+				"%s must be printable ASCII; byte %d is %#02x", name, i, c)
+		}
+	}
+	return nil
+}
+
+func validateBoundedString(name, value string, maxBytes int) error {
+	if len(value) > maxBytes {
+		return status.InvalidArgumentErrorf("%s exceeds %d bytes", name, maxBytes)
+	}
+	if !utf8.ValidString(value) {
+		return status.InvalidArgumentErrorf("%s is not valid UTF-8", name)
+	}
+	if strings.ContainsRune(value, '\x00') {
+		return status.InvalidArgumentErrorf("%s contains NUL", name)
+	}
+	return nil
+}

--- a/server/test_buddy/identity/identity_test.go
+++ b/server/test_buddy/identity/identity_test.go
@@ -1,0 +1,124 @@
+package identity_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/test_buddy/identity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	tbpb "github.com/buildbuddy-io/buildbuddy/proto/test_buddy"
+)
+
+func TestCanonicalize(t *testing.T) {
+	got, err := identity.Canonicalize(
+		"git@github.com:buildbuddy-io/buildbuddy.git",
+		&tbpb.TestIdentity{
+			TargetLabel: "//enterprise/server/remote_execution/containers/firecracker:firecracker_test",
+			CaseName:    "TestFirecrackerRunSimple/this test has spaces",
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, identity.Address{
+		Repository:  "https://github.com/buildbuddy-io/buildbuddy",
+		PackagePath: "enterprise/server/remote_execution/containers/firecracker",
+		TargetName:  "firecracker_test",
+		CaseName:    "TestFirecrackerRunSimple/this test has spaces",
+	}, got)
+	require.NoError(t, got.Validate())
+
+	roundTrip, err := identity.Canonicalize(got.Repository, got.Proto())
+	require.NoError(t, err)
+	assert.Equal(t, got, roundTrip)
+}
+
+func TestCanonicalizeTarget(t *testing.T) {
+	for input, want := range map[string]string{
+		"//pkg":         "//pkg:pkg",
+		"//pkg:target":  "//pkg:target",
+		"@//pkg:target": "//pkg:target",
+	} {
+		t.Run(input, func(t *testing.T) {
+			got, err := identity.Canonicalize(
+				"https://github.com/acme/repo",
+				&tbpb.TestIdentity{TargetLabel: input},
+			)
+			require.NoError(t, err)
+			assert.Equal(t, want, got.TargetLabel())
+			assert.Empty(t, got.CaseName)
+		})
+	}
+}
+
+func TestCanonicalizePreservesUnicodeCaseName(t *testing.T) {
+	caseName := "TestTruncateStringSlice/[ツ]/🙂"
+	got, err := identity.Canonicalize(
+		"https://github.com/acme/repo",
+		&tbpb.TestIdentity{TargetLabel: "//pkg:test", CaseName: caseName},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, caseName, got.CaseName)
+}
+
+func TestCanonicalizeRepositoryURLIsStable(t *testing.T) {
+	got, err := identity.Canonicalize(
+		"https://github.com/acme/repo.git.git",
+		&tbpb.TestIdentity{TargetLabel: "//pkg:test"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "https://github.com/acme/repo", got.Repository)
+	require.NoError(t, got.Validate())
+}
+
+func TestAddressValidation(t *testing.T) {
+	assert.Error(t, (identity.Address{
+		Repository: "git@github.com:acme/repo.git", PackagePath: "pkg", TargetName: "test",
+	}).Validate())
+	assert.Error(t, (identity.Address{
+		Repository: "https://github.com/acme/repo", PackagePath: "pkg",
+	}).Validate())
+}
+
+func TestInvalidAddressesAreRejected(t *testing.T) {
+	for _, input := range []struct {
+		repository string
+		target     string
+		caseName   string
+	}{
+		{repository: "", target: "//pkg:test"},
+		{repository: "https://", target: "//pkg:test"},
+		{repository: "/", target: "//pkg:test"},
+		{repository: "buildbuddy", target: "//pkg:test"},
+		{repository: "https://github.com/acme/repo?ref=main", target: "//pkg:test"},
+		{repository: "https://github.com/acme/repo", target: "pkg:test"},
+		{repository: "https://github.com/acme/repo", target: "@@repo+1.0//pkg:test"},
+		{repository: "https://github.com/acme/repo", target: "//..."},
+		{repository: "https://github.com/acme/repo", target: "//foo/..."},
+		{repository: "https://github.com/acme/repo", target: "//pkg:all"},
+		{repository: "https://github.com/acme/repo", target: "//pkg:*"},
+		{repository: "https://github.com/acme/repo", target: "//pkg:test", caseName: "Test\nNewline"},
+		{repository: "https://github.com/acme/repo", target: "//pkg:test", caseName: "Test\tTab"},
+	} {
+		_, err := identity.Canonicalize(input.repository, &tbpb.TestIdentity{
+			TargetLabel: input.target,
+			CaseName:    input.caseName,
+		})
+		assert.Error(t, err, input)
+	}
+
+	_, err := identity.Canonicalize(
+		"https://github.com/acme/repo",
+		&tbpb.TestIdentity{TargetLabel: "//pkg:test", CaseName: strings.Repeat("x", 513)},
+	)
+	assert.Error(t, err)
+}
+
+func TestAddressRenderingIsReadableAndUnambiguous(t *testing.T) {
+	address := identity.Address{
+		Repository: "https://github.com/acme/repo", PackagePath: "pkg", TargetName: "test",
+		CaseName: `subtest "quoted"`,
+	}
+	assert.Equal(t, `"https://github.com/acme/repo":"pkg":"test":"subtest \"quoted\""`, address.String())
+	assert.False(t, strings.Contains(address.String(), "\n"))
+}

--- a/server/test_buddy/identity/identity_test.go
+++ b/server/test_buddy/identity/identity_test.go
@@ -1,0 +1,142 @@
+package identity_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/test_buddy/identity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalizeCase(t *testing.T) {
+	got, err := identity.CanonicalizeCase(
+		"git@github.com:buildbuddy-io/buildbuddy.git",
+		"//enterprise/server/remote_execution/containers/firecracker:firecracker_test",
+		"TestFirecrackerRunSimple/this test has spaces",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, identity.CaseAddress{
+		TargetAddress: identity.TargetAddress{
+			Repository:  "https://github.com/buildbuddy-io/buildbuddy",
+			PackagePath: "enterprise/server/remote_execution/containers/firecracker",
+			TargetName:  "firecracker_test",
+		},
+		CaseName: "TestFirecrackerRunSimple/this test has spaces",
+	}, got)
+	assert.Equal(t, identity.PackageAddress{
+		Repository:  "https://github.com/buildbuddy-io/buildbuddy",
+		PackagePath: "enterprise/server/remote_execution/containers/firecracker",
+	}, got.Target().Package())
+
+	proto := got.Proto()
+	roundTrip, err := identity.CaseAddressFromProto(got.Repository, proto)
+	require.NoError(t, err)
+	assert.Equal(t, got, roundTrip)
+	assert.Equal(t, got.Target().Label(), proto.GetTarget().GetTargetLabel())
+	assert.Equal(t, got.CaseName, proto.GetCaseName())
+}
+
+func TestCaseNameStorageKey(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		wantEncoded bool
+	}{
+		{name: "TestCaseName"},
+		{name: "TestTruncateStringSlice/[ツ]/1", wantEncoded: true},
+		{name: "~literal-prefix", wantEncoded: true},
+		{name: strings.Repeat("🙂", identity.MaxCaseNameBytes/4), wantEncoded: true},
+	} {
+		key, err := identity.CaseNameKey(test.name)
+		require.NoError(t, err)
+		if test.wantEncoded {
+			assert.NotEqual(t, test.name, key)
+			assert.True(t, strings.HasPrefix(key, "~"))
+		} else {
+			assert.Equal(t, test.name, key)
+		}
+		assert.LessOrEqual(t, len(key), identity.MaxCaseNameKeyBytes)
+		got, err := identity.CaseNameFromKey(key)
+		require.NoError(t, err)
+		assert.Equal(t, test.name, got)
+	}
+
+	unicodeKey, err := identity.CaseNameKey("TestTruncateStringSlice/[ツ]/1")
+	require.NoError(t, err)
+	literalPrefixKey, err := identity.CaseNameKey(unicodeKey)
+	require.NoError(t, err)
+	assert.NotEqual(t, unicodeKey, literalPrefixKey)
+
+	_, err = identity.CaseNameFromKey("~not!base64")
+	assert.Error(t, err)
+}
+
+func TestCanonicalizeTargetLabel(t *testing.T) {
+	for input, want := range map[string]string{
+		"//pkg":         "//pkg:pkg",
+		"//pkg:target":  "//pkg:target",
+		"@//pkg:target": "//pkg:target",
+	} {
+		t.Run(input, func(t *testing.T) {
+			got, err := identity.CanonicalizeTargetLabel(input)
+			require.NoError(t, err)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestAddressValidation(t *testing.T) {
+	packageAddress := identity.PackageAddress{
+		Repository: "https://github.com/acme/repo", PackagePath: "pkg/subpkg",
+	}
+	targetAddress := identity.TargetAddress{
+		Repository: packageAddress.Repository, PackagePath: packageAddress.PackagePath, TargetName: "unit_test",
+	}
+	caseAddress := identity.CaseAddress{TargetAddress: targetAddress, CaseName: "TestCase"}
+	require.NoError(t, packageAddress.Validate())
+	require.NoError(t, targetAddress.Validate())
+	require.NoError(t, caseAddress.Validate())
+
+	assert.Error(t, (identity.PackageAddress{
+		Repository: "git@github.com:acme/repo.git", PackagePath: "pkg/subpkg",
+	}).Validate())
+	assert.Error(t, (identity.TargetAddress{
+		Repository: packageAddress.Repository, PackagePath: packageAddress.PackagePath,
+	}).Validate())
+	assert.Error(t, (identity.CaseAddress{TargetAddress: targetAddress}).Validate())
+}
+
+func TestInvalidAddressesAreRejected(t *testing.T) {
+	for _, input := range []struct {
+		repository string
+		target     string
+		caseName   string
+	}{
+		{repository: "", target: "//pkg:test", caseName: "Test"},
+		{repository: "https://github.com/acme/repo", target: "pkg:test", caseName: "Test"},
+		{repository: "https://github.com/acme/repo", target: "@@repo+1.0//pkg:test", caseName: "Test"},
+		{repository: "https://github.com/acme/repo", target: "//pkg:test", caseName: ""},
+		{repository: "https://github.com/acme/repo", target: "//pkg:test", caseName: "Test\nNewline"},
+		{repository: "https://github.com/acme/repo", target: "//pkg:test", caseName: "Test\tTab"},
+	} {
+		_, err := identity.CanonicalizeCase(input.repository, input.target, input.caseName)
+		assert.Error(t, err, input)
+	}
+
+	_, err := identity.CanonicalizeCase(
+		"https://github.com/acme/repo", "//pkg:test",
+		strings.Repeat("x", identity.MaxCaseNameBytes+1),
+	)
+	assert.Error(t, err)
+}
+
+func TestAddressRenderingIsReadableAndUnambiguous(t *testing.T) {
+	address := identity.CaseAddress{
+		TargetAddress: identity.TargetAddress{
+			Repository: "https://github.com/acme/repo", PackagePath: "pkg", TargetName: "test",
+		},
+		CaseName: `subtest "quoted"`,
+	}
+	assert.Equal(t, `"https://github.com/acme/repo":"pkg":"test":"subtest \"quoted\""`, address.String())
+	assert.False(t, strings.Contains(address.String(), "\n"))
+}


### PR DESCRIPTION
Defines readable natural addresses for repositories, targets, and exact test cases without surrogate test identifiers. Later storage and query layers use these canonical addresses directly.