### PR TITLE
test_buddy: configure analyzer defaults

### DIFF
--- a/server/test_buddy/config/BUILD
+++ b/server/test_buddy/config/BUILD
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "config",
+    srcs = ["config.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/test_buddy/config",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto:test_buddy_go_proto",
+        "//server/util/status",
+    ],
+)
+
+go_test(
+    name = "config_test",
+    srcs = ["config_test.go"],
+    deps = [
+        ":config",
+        "//proto:test_buddy_go_proto",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/server/test_buddy/config/config.go
+++ b/server/test_buddy/config/config.go
@@ -1,0 +1,42 @@
+// Package config defines TestBuddy analyzer configuration.
+package config
+
+import (
+	tbpb "github.com/buildbuddy-io/buildbuddy/proto/test_buddy"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+)
+
+const (
+	minWindowSize = 1
+	maxWindowSize = 100
+)
+
+func Default() *tbpb.TestAnalyzerConfig {
+	return &tbpb.TestAnalyzerConfig{
+		Analyzer: &tbpb.TestAnalyzerConfig_Linear{Linear: &tbpb.LinearAnalyzer{
+			WindowSize:             50,
+			FailureThreshold:       1,
+			TargetTimeoutThreshold: 5,
+		}},
+	}
+}
+
+func Validate(cfg *tbpb.TestAnalyzerConfig) error {
+	if cfg == nil {
+		return status.InvalidArgumentError("analyzer configuration is required")
+	}
+	linear := cfg.GetLinear()
+	if linear == nil {
+		return status.InvalidArgumentError("linear analyzer configuration is required")
+	}
+	if linear.GetWindowSize() < minWindowSize || linear.GetWindowSize() > maxWindowSize {
+		return status.InvalidArgumentErrorf("window_size must be between %d and %d", minWindowSize, maxWindowSize)
+	}
+	if linear.GetFailureThreshold() <= 0 || linear.GetFailureThreshold() > linear.GetWindowSize() {
+		return status.InvalidArgumentError("failure_threshold must be between 1 and window_size")
+	}
+	if linear.GetTargetTimeoutThreshold() <= 0 || linear.GetTargetTimeoutThreshold() > linear.GetWindowSize() {
+		return status.InvalidArgumentError("target_timeout_threshold must be between 1 and window_size")
+	}
+	return nil
+}

--- a/server/test_buddy/config/config.go
+++ b/server/test_buddy/config/config.go
@@ -1,0 +1,37 @@
+// Package config defines TestBuddy analyzer configuration.
+package config
+
+import (
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+
+	tbpb "github.com/buildbuddy-io/buildbuddy/proto/test_buddy"
+)
+
+const (
+	minWindowSize = 1
+	maxWindowSize = 100
+)
+
+func Default() *tbpb.TestAnalyzerConfig {
+	return &tbpb.TestAnalyzerConfig{
+		WindowSize:            50,
+		FailureCountThreshold: 1,
+		TimeoutCountThreshold: 5,
+	}
+}
+
+func Validate(cfg *tbpb.TestAnalyzerConfig) error {
+	if cfg == nil {
+		return status.InvalidArgumentError("analyzer configuration is required")
+	}
+	if cfg.GetWindowSize() < minWindowSize || cfg.GetWindowSize() > maxWindowSize {
+		return status.InvalidArgumentErrorf("window_size must be between %d and %d", minWindowSize, maxWindowSize)
+	}
+	if cfg.GetFailureCountThreshold() <= 0 || cfg.GetFailureCountThreshold() > cfg.GetWindowSize() {
+		return status.InvalidArgumentError("failure_count_threshold must be between 1 and window_size")
+	}
+	if cfg.GetTimeoutCountThreshold() <= 0 || cfg.GetTimeoutCountThreshold() > cfg.GetWindowSize() {
+		return status.InvalidArgumentError("timeout_count_threshold must be between 1 and window_size")
+	}
+	return nil
+}

--- a/server/test_buddy/config/config_test.go
+++ b/server/test_buddy/config/config_test.go
@@ -1,0 +1,34 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/test_buddy/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	tbpb "github.com/buildbuddy-io/buildbuddy/proto/test_buddy"
+)
+
+func analyzerConfig(window, failures, timeouts int32) *tbpb.TestAnalyzerConfig {
+	return &tbpb.TestAnalyzerConfig{
+		WindowSize: window, FailureCountThreshold: failures, TimeoutCountThreshold: timeouts,
+	}
+}
+
+func TestDefault(t *testing.T) {
+	cfg := config.Default()
+	require.NoError(t, config.Validate(cfg))
+	assert.Equal(t, int32(50), cfg.GetWindowSize())
+	assert.Equal(t, int32(1), cfg.GetFailureCountThreshold())
+	assert.Equal(t, int32(5), cfg.GetTimeoutCountThreshold())
+}
+
+func TestValidate(t *testing.T) {
+	assert.Error(t, config.Validate(nil))
+	assert.NoError(t, config.Validate(analyzerConfig(1, 1, 1)))
+	assert.Error(t, config.Validate(analyzerConfig(0, 1, 1)))
+	assert.Error(t, config.Validate(analyzerConfig(101, 1, 5)))
+	assert.Error(t, config.Validate(analyzerConfig(50, 51, 5)))
+	assert.Error(t, config.Validate(analyzerConfig(50, 1, 51)))
+}

--- a/server/test_buddy/config/config_test.go
+++ b/server/test_buddy/config/config_test.go
@@ -1,0 +1,34 @@
+package config_test
+
+import (
+	"testing"
+
+	tbpb "github.com/buildbuddy-io/buildbuddy/proto/test_buddy"
+	"github.com/buildbuddy-io/buildbuddy/server/test_buddy/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func analyzerConfig(window, failures, timeouts int32) *tbpb.TestAnalyzerConfig {
+	return &tbpb.TestAnalyzerConfig{Analyzer: &tbpb.TestAnalyzerConfig_Linear{Linear: &tbpb.LinearAnalyzer{
+		WindowSize: window, FailureThreshold: failures, TargetTimeoutThreshold: timeouts,
+	}}}
+}
+
+func TestDefault(t *testing.T) {
+	cfg := config.Default()
+	require.NoError(t, config.Validate(cfg))
+	assert.Equal(t, int32(50), cfg.GetLinear().GetWindowSize())
+	assert.Equal(t, int32(1), cfg.GetLinear().GetFailureThreshold())
+	assert.Equal(t, int32(5), cfg.GetLinear().GetTargetTimeoutThreshold())
+}
+
+func TestValidate(t *testing.T) {
+	assert.Error(t, config.Validate(nil))
+	assert.Error(t, config.Validate(&tbpb.TestAnalyzerConfig{}))
+	assert.NoError(t, config.Validate(analyzerConfig(1, 1, 1)))
+	assert.Error(t, config.Validate(analyzerConfig(0, 1, 1)))
+	assert.Error(t, config.Validate(analyzerConfig(101, 1, 5)))
+	assert.Error(t, config.Validate(analyzerConfig(50, 51, 5)))
+	assert.Error(t, config.Validate(analyzerConfig(50, 1, 51)))
+}


### PR DESCRIPTION
Adds the repository-scoped analyzer configuration and validates its bounded-window thresholds. The defaults keep policy separate from reporting and state storage.