### PR TITLE
test_buddy: classify observations with a linear window

### DIFF
--- a/server/test_buddy/analyzer/BUILD
+++ b/server/test_buddy/analyzer/BUILD
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "analyzer",
+    srcs = ["analyzer.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/test_buddy/analyzer",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto:test_buddy_go_proto",
+        "//server/test_buddy/config",
+    ],
+)
+
+go_test(
+    name = "analyzer_test",
+    srcs = ["analyzer_test.go"],
+    deps = [
+        ":analyzer",
+        "//proto:test_buddy_go_proto",
+        "//server/test_buddy/config",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/server/test_buddy/analyzer/analyzer.go
+++ b/server/test_buddy/analyzer/analyzer.go
@@ -1,0 +1,123 @@
+// Package analyzer classifies a test from recently processed observations.
+package analyzer
+
+import (
+	"github.com/buildbuddy-io/buildbuddy/server/test_buddy/config"
+
+	tbpb "github.com/buildbuddy-io/buildbuddy/proto/test_buddy"
+)
+
+type Sample struct {
+	Outcome tbpb.TestOutcome
+	Source  tbpb.TestObservationSource
+}
+
+type Reason string
+
+const (
+	ReasonNoEligibleSamples Reason = "no_eligible_samples"
+	ReasonAllNonPasses      Reason = "all_non_passes"
+	ReasonFailuresInWindow  Reason = "failures_in_window"
+	ReasonTimeoutsInWindow  Reason = "timeouts_in_window"
+	ReasonAllPasses         Reason = "all_passes"
+	ReasonConsecutivePasses Reason = "consecutive_passes"
+	ReasonUncertain         Reason = "uncertain"
+)
+
+type Evidence struct {
+	EligibleSamples   int
+	Passes            int
+	Failures          int
+	Timeouts          int
+	Ineligible        int
+	ConsecutivePasses int
+}
+
+type Result struct {
+	Health   tbpb.TestHealth
+	Reason   Reason
+	Evidence Evidence
+}
+
+func Linear(samples []Sample, cfg *tbpb.TestAnalyzerConfig) (Result, error) {
+	if err := config.Validate(cfg); err != nil {
+		return Result{}, err
+	}
+	eligible := make([]Sample, 0, len(samples))
+	ineligible := 0
+	for _, sample := range samples {
+		if Eligible(sample) {
+			eligible = append(eligible, sample)
+		} else {
+			ineligible++
+		}
+	}
+	if extra := len(eligible) - int(cfg.GetWindowSize()); extra > 0 {
+		eligible = eligible[extra:]
+	}
+	evidence := summarize(eligible)
+	evidence.Ineligible = ineligible
+	result := Result{Evidence: evidence}
+	switch {
+	case len(eligible) == 0:
+		result.Health = tbpb.TestHealth_TEST_HEALTH_INSUFFICIENT_DATA
+		result.Reason = ReasonNoEligibleSamples
+	case evidence.Failures+evidence.Timeouts == len(eligible):
+		result.Health = tbpb.TestHealth_TEST_HEALTH_FAILING
+		result.Reason = ReasonAllNonPasses
+	case evidence.Failures >= int(cfg.GetFailureCountThreshold()):
+		result.Health = tbpb.TestHealth_TEST_HEALTH_FLAKY
+		result.Reason = ReasonFailuresInWindow
+	case evidence.Timeouts >= int(cfg.GetTimeoutCountThreshold()):
+		result.Health = tbpb.TestHealth_TEST_HEALTH_FLAKY
+		result.Reason = ReasonTimeoutsInWindow
+	case evidence.Failures+evidence.Timeouts == 0:
+		result.Health = tbpb.TestHealth_TEST_HEALTH_HEALTHY
+		result.Reason = ReasonAllPasses
+	case evidence.ConsecutivePasses >= min(3, int(cfg.GetWindowSize())):
+		result.Health = tbpb.TestHealth_TEST_HEALTH_HEALTHY
+		result.Reason = ReasonConsecutivePasses
+	default:
+		result.Health = tbpb.TestHealth_TEST_HEALTH_INSUFFICIENT_DATA
+		result.Reason = ReasonUncertain
+	}
+	return result, nil
+}
+
+func Eligible(sample Sample) bool {
+	if sample.Source != tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR {
+		return false
+	}
+	switch sample.Outcome {
+	case tbpb.TestOutcome_TEST_OUTCOME_PASS,
+		tbpb.TestOutcome_TEST_OUTCOME_FAIL,
+		tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT:
+		return true
+	default:
+		return false
+	}
+}
+
+func summarize(samples []Sample) Evidence {
+	evidence := Evidence{EligibleSamples: len(samples)}
+	if len(samples) == 0 {
+		return evidence
+	}
+	for _, sample := range samples {
+		switch sample.Outcome {
+		case tbpb.TestOutcome_TEST_OUTCOME_PASS:
+			evidence.Passes++
+		case tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT:
+			evidence.Timeouts++
+		case tbpb.TestOutcome_TEST_OUTCOME_FAIL:
+			evidence.Failures++
+		case tbpb.TestOutcome_TEST_OUTCOME_UNKNOWN,
+			tbpb.TestOutcome_TEST_OUTCOME_BROKEN:
+			continue
+		}
+	}
+	for i := len(samples) - 1; i >= 0 && samples[i].Outcome == tbpb.TestOutcome_TEST_OUTCOME_PASS; i-- {
+		evidence.ConsecutivePasses++
+	}
+	return evidence
+}

--- a/server/test_buddy/analyzer/analyzer.go
+++ b/server/test_buddy/analyzer/analyzer.go
@@ -1,0 +1,138 @@
+// Package analyzer classifies a test from recently processed observations.
+package analyzer
+
+import (
+	tbpb "github.com/buildbuddy-io/buildbuddy/proto/test_buddy"
+	"github.com/buildbuddy-io/buildbuddy/server/test_buddy/config"
+)
+
+type Sample struct {
+	Outcome tbpb.TestOutcome
+	Source  tbpb.TestObservationSource
+}
+
+type Reason string
+
+const (
+	ReasonNoEligibleSamples Reason = "no_eligible_samples"
+	ReasonAllFailures       Reason = "all_failures"
+	ReasonFailuresInWindow  Reason = "failures_in_window"
+	ReasonTimeoutsInWindow  Reason = "timeouts_in_window"
+	ReasonAllPasses         Reason = "all_passes"
+	ReasonConsecutivePasses Reason = "consecutive_passes"
+	ReasonUncertain         Reason = "uncertain"
+)
+
+type Evidence struct {
+	EligibleSamples     int
+	Passes              int
+	Failures            int
+	Timeouts            int
+	Ineligible          int
+	ConsecutivePasses   int
+	ConsecutiveFailures int
+}
+
+type Result struct {
+	Health   tbpb.TestHealth
+	Reason   Reason
+	Evidence Evidence
+}
+
+func Linear(samples []Sample, cfg *tbpb.TestAnalyzerConfig) (Result, error) {
+	return linear(samples, cfg, false)
+}
+
+func LinearTarget(samples []Sample, cfg *tbpb.TestAnalyzerConfig) (Result, error) {
+	return linear(samples, cfg, true)
+}
+
+func linear(samples []Sample, cfg *tbpb.TestAnalyzerConfig, target bool) (Result, error) {
+	if err := config.Validate(cfg); err != nil {
+		return Result{}, err
+	}
+	linear := cfg.GetLinear()
+	eligible := make([]Sample, 0, len(samples))
+	ineligible := 0
+	for _, sample := range samples {
+		if Eligible(sample) {
+			eligible = append(eligible, sample)
+		} else {
+			ineligible++
+		}
+	}
+	if extra := len(eligible) - int(linear.GetWindowSize()); extra > 0 {
+		eligible = eligible[extra:]
+	}
+	evidence := summarize(eligible)
+	evidence.Ineligible = ineligible
+	result := Result{Evidence: evidence}
+	switch {
+	case len(eligible) == 0:
+		result.Health = tbpb.TestHealth_TEST_HEALTH_INSUFFICIENT_DATA
+		result.Reason = ReasonNoEligibleSamples
+	case evidence.Failures-evidence.Timeouts >= int(linear.GetFailureThreshold()) &&
+		evidence.Failures-evidence.Timeouts == len(eligible):
+		result.Health = tbpb.TestHealth_TEST_HEALTH_FAILING
+		result.Reason = ReasonAllFailures
+	case !target && evidence.Failures >= int(linear.GetFailureThreshold()):
+		result.Health = tbpb.TestHealth_TEST_HEALTH_FLAKY
+		result.Reason = ReasonFailuresInWindow
+	case target && evidence.Failures-evidence.Timeouts >= int(linear.GetFailureThreshold()):
+		result.Health = tbpb.TestHealth_TEST_HEALTH_FLAKY
+		result.Reason = ReasonFailuresInWindow
+	case target && evidence.Timeouts >= int(linear.GetTargetTimeoutThreshold()):
+		result.Health = tbpb.TestHealth_TEST_HEALTH_TIMEOUT
+		result.Reason = ReasonTimeoutsInWindow
+	case evidence.Failures == 0:
+		result.Health = tbpb.TestHealth_TEST_HEALTH_HEALTHY
+		result.Reason = ReasonAllPasses
+	case evidence.ConsecutivePasses >= min(3, int(linear.GetWindowSize())):
+		result.Health = tbpb.TestHealth_TEST_HEALTH_HEALTHY
+		result.Reason = ReasonConsecutivePasses
+	default:
+		result.Health = tbpb.TestHealth_TEST_HEALTH_INSUFFICIENT_DATA
+		result.Reason = ReasonUncertain
+	}
+	return result, nil
+}
+
+func Eligible(sample Sample) bool {
+	if sample.Source != tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR &&
+		sample.Source != tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_POSTSUBMIT {
+		return false
+	}
+	switch sample.Outcome {
+	case tbpb.TestOutcome_TEST_OUTCOME_PASS,
+		tbpb.TestOutcome_TEST_OUTCOME_FAIL,
+		tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT:
+		return true
+	default:
+		return false
+	}
+}
+
+func summarize(samples []Sample) Evidence {
+	evidence := Evidence{EligibleSamples: len(samples)}
+	if len(samples) == 0 {
+		return evidence
+	}
+	for _, sample := range samples {
+		switch sample.Outcome {
+		case tbpb.TestOutcome_TEST_OUTCOME_PASS:
+			evidence.Passes++
+		case tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT:
+			evidence.Timeouts++
+			evidence.Failures++
+		default:
+			evidence.Failures++
+		}
+	}
+	for i := len(samples) - 1; i >= 0 && samples[i].Outcome == tbpb.TestOutcome_TEST_OUTCOME_PASS; i-- {
+		evidence.ConsecutivePasses++
+	}
+	for i := len(samples) - 1; i >= 0 && samples[i].Outcome != tbpb.TestOutcome_TEST_OUTCOME_PASS; i-- {
+		evidence.ConsecutiveFailures++
+	}
+	return evidence
+}

--- a/server/test_buddy/analyzer/analyzer_test.go
+++ b/server/test_buddy/analyzer/analyzer_test.go
@@ -1,0 +1,125 @@
+package analyzer_test
+
+import (
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/test_buddy/analyzer"
+	"github.com/buildbuddy-io/buildbuddy/server/test_buddy/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	tbpb "github.com/buildbuddy-io/buildbuddy/proto/test_buddy"
+)
+
+func samples(outcomes ...tbpb.TestOutcome) []analyzer.Sample {
+	out := make([]analyzer.Sample, 0, len(outcomes))
+	for _, outcome := range outcomes {
+		out = append(out, analyzer.Sample{
+			Outcome: outcome,
+			Source:  tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR,
+		})
+	}
+	return out
+}
+
+func TestLinearUsesProcessingOrder(t *testing.T) {
+	cfg := &tbpb.TestAnalyzerConfig{
+		WindowSize: 2, FailureCountThreshold: 1, TimeoutCountThreshold: 1,
+	}
+	result, err := analyzer.Linear(samples(
+		tbpb.TestOutcome_TEST_OUTCOME_FAIL,
+		tbpb.TestOutcome_TEST_OUTCOME_PASS,
+		tbpb.TestOutcome_TEST_OUTCOME_PASS,
+	), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, tbpb.TestHealth_TEST_HEALTH_HEALTHY, result.Health)
+	assert.Equal(t, 2, result.Evidence.Passes)
+}
+
+func TestLinearDistinguishesFailingFromFlaky(t *testing.T) {
+	failing, err := analyzer.Linear(samples(
+		tbpb.TestOutcome_TEST_OUTCOME_FAIL,
+		tbpb.TestOutcome_TEST_OUTCOME_FAIL,
+	), config.Default())
+	require.NoError(t, err)
+	assert.Equal(t, tbpb.TestHealth_TEST_HEALTH_FAILING, failing.Health)
+	assert.Equal(t, analyzer.ReasonAllNonPasses, failing.Reason)
+
+	flaky, err := analyzer.Linear(samples(
+		tbpb.TestOutcome_TEST_OUTCOME_FAIL,
+		tbpb.TestOutcome_TEST_OUTCOME_PASS,
+	), config.Default())
+	require.NoError(t, err)
+	assert.Equal(t, tbpb.TestHealth_TEST_HEALTH_FLAKY, flaky.Health)
+}
+
+func TestLinearClassifiesHealthyAndInsufficient(t *testing.T) {
+	healthy, err := analyzer.Linear(samples(tbpb.TestOutcome_TEST_OUTCOME_PASS), config.Default())
+	require.NoError(t, err)
+	assert.Equal(t, tbpb.TestHealth_TEST_HEALTH_HEALTHY, healthy.Health)
+	assert.Equal(t, analyzer.ReasonAllPasses, healthy.Reason)
+
+	insufficient, err := analyzer.Linear(nil, config.Default())
+	require.NoError(t, err)
+	assert.Equal(t, tbpb.TestHealth_TEST_HEALTH_INSUFFICIENT_DATA, insufficient.Health)
+}
+
+func TestLinearRecoversBelowThreshold(t *testing.T) {
+	cfg := &tbpb.TestAnalyzerConfig{
+		WindowSize: 50, FailureCountThreshold: 2, TimeoutCountThreshold: 5,
+	}
+	result, err := analyzer.Linear(samples(
+		tbpb.TestOutcome_TEST_OUTCOME_FAIL,
+		tbpb.TestOutcome_TEST_OUTCOME_PASS,
+		tbpb.TestOutcome_TEST_OUTCOME_PASS,
+		tbpb.TestOutcome_TEST_OUTCOME_PASS,
+	), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, tbpb.TestHealth_TEST_HEALTH_HEALTHY, result.Health)
+	assert.Equal(t, analyzer.ReasonConsecutivePasses, result.Reason)
+}
+
+func TestLinearUsesSeparateTimeoutThreshold(t *testing.T) {
+	fourTimeouts := samples(
+		tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT,
+		tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT,
+		tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT,
+		tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT,
+		tbpb.TestOutcome_TEST_OUTCOME_PASS,
+	)
+	result, err := analyzer.Linear(fourTimeouts, config.Default())
+	require.NoError(t, err)
+	assert.Equal(t, tbpb.TestHealth_TEST_HEALTH_INSUFFICIENT_DATA, result.Health)
+
+	result, err = analyzer.Linear(append(fourTimeouts, analyzer.Sample{
+		Outcome: tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT,
+		Source:  tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR,
+	}), config.Default())
+	require.NoError(t, err)
+	assert.Equal(t, tbpb.TestHealth_TEST_HEALTH_FLAKY, result.Health)
+	assert.Equal(t, analyzer.ReasonTimeoutsInWindow, result.Reason)
+}
+
+func TestLinearClassifiesAllTimeoutsAsFailing(t *testing.T) {
+	result, err := analyzer.Linear(samples(
+		tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT,
+		tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT,
+	), config.Default())
+	require.NoError(t, err)
+	assert.Equal(t, tbpb.TestHealth_TEST_HEALTH_FAILING, result.Health)
+	assert.Equal(t, analyzer.ReasonAllNonPasses, result.Reason)
+}
+
+func TestLinearIgnoresIneligibleSamples(t *testing.T) {
+	window := []analyzer.Sample{
+		{Outcome: tbpb.TestOutcome_TEST_OUTCOME_UNKNOWN, Source: tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR},
+		{Outcome: tbpb.TestOutcome_TEST_OUTCOME_BROKEN, Source: tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR},
+		{Outcome: tbpb.TestOutcome_TEST_OUTCOME_FAIL, Source: tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_UNKNOWN},
+		{Outcome: tbpb.TestOutcome_TEST_OUTCOME_PASS, Source: tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR},
+	}
+	result, err := analyzer.Linear(window, config.Default())
+	require.NoError(t, err)
+	assert.Equal(t, tbpb.TestHealth_TEST_HEALTH_HEALTHY, result.Health)
+	assert.Equal(t, 1, result.Evidence.EligibleSamples)
+	assert.Equal(t, 3, result.Evidence.Ineligible)
+}

--- a/server/test_buddy/analyzer/analyzer_test.go
+++ b/server/test_buddy/analyzer/analyzer_test.go
@@ -1,0 +1,142 @@
+package analyzer_test
+
+import (
+	"testing"
+
+	tbpb "github.com/buildbuddy-io/buildbuddy/proto/test_buddy"
+	"github.com/buildbuddy-io/buildbuddy/server/test_buddy/analyzer"
+	"github.com/buildbuddy-io/buildbuddy/server/test_buddy/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func samples(outcomes ...tbpb.TestOutcome) []analyzer.Sample {
+	out := make([]analyzer.Sample, 0, len(outcomes))
+	for _, outcome := range outcomes {
+		out = append(out, analyzer.Sample{
+			Outcome: outcome,
+			Source:  tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR,
+		})
+	}
+	return out
+}
+
+func TestLinearUsesProcessingOrder(t *testing.T) {
+	result, err := analyzer.Linear(samples(
+		tbpb.TestOutcome_TEST_OUTCOME_FAIL,
+		tbpb.TestOutcome_TEST_OUTCOME_PASS,
+		tbpb.TestOutcome_TEST_OUTCOME_FAIL,
+	), config.Default())
+	require.NoError(t, err)
+	assert.Equal(t, tbpb.TestHealth_TEST_HEALTH_FLAKY, result.Health)
+	assert.Equal(t, 2, result.Evidence.Failures)
+}
+
+func TestLinearDistinguishesFailingFromFlaky(t *testing.T) {
+	failing, err := analyzer.Linear(samples(
+		tbpb.TestOutcome_TEST_OUTCOME_FAIL,
+		tbpb.TestOutcome_TEST_OUTCOME_FAIL,
+	), config.Default())
+	require.NoError(t, err)
+	assert.Equal(t, tbpb.TestHealth_TEST_HEALTH_FAILING, failing.Health)
+	assert.Equal(t, analyzer.ReasonAllFailures, failing.Reason)
+
+	flaky, err := analyzer.Linear(samples(
+		tbpb.TestOutcome_TEST_OUTCOME_FAIL,
+		tbpb.TestOutcome_TEST_OUTCOME_PASS,
+	), config.Default())
+	require.NoError(t, err)
+	assert.Equal(t, tbpb.TestHealth_TEST_HEALTH_FLAKY, flaky.Health)
+}
+
+func TestLinearClassifiesHealthyAndInsufficient(t *testing.T) {
+	healthy, err := analyzer.Linear(samples(tbpb.TestOutcome_TEST_OUTCOME_PASS), config.Default())
+	require.NoError(t, err)
+	assert.Equal(t, tbpb.TestHealth_TEST_HEALTH_HEALTHY, healthy.Health)
+	assert.Equal(t, analyzer.ReasonAllPasses, healthy.Reason)
+
+	insufficient, err := analyzer.Linear(nil, config.Default())
+	require.NoError(t, err)
+	assert.Equal(t, tbpb.TestHealth_TEST_HEALTH_INSUFFICIENT_DATA, insufficient.Health)
+}
+
+func TestLinearRecoversBelowThresholdMixedEvidence(t *testing.T) {
+	cfg := &tbpb.TestAnalyzerConfig{Analyzer: &tbpb.TestAnalyzerConfig_Linear{Linear: &tbpb.LinearAnalyzer{
+		WindowSize: 50, FailureThreshold: 2, TargetTimeoutThreshold: 5,
+	}}}
+	result, err := analyzer.Linear(samples(
+		tbpb.TestOutcome_TEST_OUTCOME_FAIL,
+		tbpb.TestOutcome_TEST_OUTCOME_PASS,
+		tbpb.TestOutcome_TEST_OUTCOME_PASS,
+		tbpb.TestOutcome_TEST_OUTCOME_PASS,
+	), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, tbpb.TestHealth_TEST_HEALTH_HEALTHY, result.Health)
+	assert.Equal(t, analyzer.ReasonConsecutivePasses, result.Reason)
+}
+
+func TestTimeoutCountsAsFailure(t *testing.T) {
+	result, err := analyzer.Linear(samples(
+		tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT,
+		tbpb.TestOutcome_TEST_OUTCOME_PASS,
+		tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT,
+	), config.Default())
+	require.NoError(t, err)
+	assert.Equal(t, tbpb.TestHealth_TEST_HEALTH_FLAKY, result.Health)
+	assert.Equal(t, 2, result.Evidence.Timeouts)
+}
+
+func TestTargetRequiresFiveTimeouts(t *testing.T) {
+	four, err := analyzer.LinearTarget(samples(
+		tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT,
+		tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT,
+		tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT,
+		tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT,
+	), config.Default())
+	require.NoError(t, err)
+	assert.Equal(t, tbpb.TestHealth_TEST_HEALTH_INSUFFICIENT_DATA, four.Health)
+
+	five, err := analyzer.LinearTarget(samples(
+		tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT,
+		tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT,
+		tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT,
+		tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT,
+		tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT,
+	), config.Default())
+	require.NoError(t, err)
+	assert.Equal(t, tbpb.TestHealth_TEST_HEALTH_TIMEOUT, five.Health)
+}
+
+func TestTargetFailureUsesFailureThreshold(t *testing.T) {
+	result, err := analyzer.LinearTarget(samples(
+		tbpb.TestOutcome_TEST_OUTCOME_FAIL,
+	), config.Default())
+	require.NoError(t, err)
+	assert.Equal(t, tbpb.TestHealth_TEST_HEALTH_FAILING, result.Health)
+}
+
+func TestUnknownOutcomesAreIgnored(t *testing.T) {
+	window := samples(
+		tbpb.TestOutcome_TEST_OUTCOME_PASS,
+		tbpb.TestOutcome_TEST_OUTCOME_PASS,
+		tbpb.TestOutcome_TEST_OUTCOME_PASS,
+	)
+	window[0].Outcome = tbpb.TestOutcome_TEST_OUTCOME_UNKNOWN
+	result, err := analyzer.Linear(window, config.Default())
+	require.NoError(t, err)
+	assert.Equal(t, tbpb.TestHealth_TEST_HEALTH_HEALTHY, result.Health)
+	assert.Equal(t, 1, result.Evidence.Ineligible)
+}
+
+func TestPresubmitSamplesAreIgnored(t *testing.T) {
+	window := []analyzer.Sample{
+		{Outcome: tbpb.TestOutcome_TEST_OUTCOME_FAIL, Source: tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_PRESUBMIT},
+		{Outcome: tbpb.TestOutcome_TEST_OUTCOME_PASS, Source: tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_POSTSUBMIT},
+		{Outcome: tbpb.TestOutcome_TEST_OUTCOME_PASS, Source: tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR},
+	}
+	result, err := analyzer.Linear(window, config.Default())
+	require.NoError(t, err)
+	assert.Equal(t, tbpb.TestHealth_TEST_HEALTH_HEALTHY, result.Health)
+	assert.Equal(t, 2, result.Evidence.EligibleSamples)
+	assert.Equal(t, 1, result.Evidence.Ineligible)
+}


### PR DESCRIPTION
Adds the deterministic linear-window analyzer used to classify case and target health from processing-order evidence. Timeout handling remains explicit and independently configurable for targets.