### PR TITLE
test_buddy: normalize reported observations

### DIFF
--- a/server/test_buddy/normalize/BUILD
+++ b/server/test_buddy/normalize/BUILD
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "normalize",
+    srcs = ["normalize.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/test_buddy/normalize",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto:test_buddy_go_proto",
+        "//server/test_buddy/identity",
+        "//server/util/status",
+        "@org_golang_google_protobuf//proto",
+    ],
+)
+
+go_test(
+    name = "normalize_test",
+    srcs = ["normalize_test.go"],
+    deps = [
+        ":normalize",
+        "//proto:test_buddy_go_proto",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/server/test_buddy/normalize/BUILD
+++ b/server/test_buddy/normalize/BUILD
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "normalize",
+    srcs = ["normalize.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/test_buddy/normalize",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto:test_buddy_go_proto",
+        "//server/test_buddy/identity",
+        "//server/util/status",
+        "@org_golang_google_protobuf//proto",
+    ],
+)
+
+go_test(
+    name = "normalize_test",
+    srcs = ["normalize_test.go"],
+    deps = [
+        ":normalize",
+        "//proto:test_buddy_go_proto",
+        "//server/test_buddy/identity",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/server/test_buddy/normalize/normalize.go
+++ b/server/test_buddy/normalize/normalize.go
@@ -1,0 +1,239 @@
+// Package normalize validates reported test observations.
+package normalize
+
+import (
+	"net/url"
+
+	tbpb "github.com/buildbuddy-io/buildbuddy/proto/test_buddy"
+	"github.com/buildbuddy-io/buildbuddy/server/test_buddy/identity"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	MaxFailureMessageBytes = 512
+	MaxSourceURLBytes      = 2048
+	MaxObservationIDBytes  = 128
+	MaxCommitSHABytes      = 128
+	MaxRetainedRejections  = 100
+)
+
+type RejectionReason string
+
+const (
+	RejectionInvalidIdentity RejectionReason = "invalid_identity"
+	RejectionInvalidContent  RejectionReason = "invalid_content"
+)
+
+type RecordKind string
+
+const (
+	RecordKindCase   RecordKind = "case"
+	RecordKindTarget RecordKind = "target"
+)
+
+type CaseRecord struct {
+	TargetLabel     string
+	CaseName        string
+	Outcome         tbpb.TestOutcome
+	DurationUsec    int64
+	FailureMessage  string
+	EventTimeUsec   int64
+	OccurrenceIndex int
+}
+
+type CaseObservation struct {
+	Observation *tbpb.TestCaseObservation
+	Address     identity.CaseAddress
+}
+
+type TargetObservation struct {
+	Observation *tbpb.TestTargetObservation
+	Address     identity.TargetAddress
+}
+
+type Rejection struct {
+	Kind        RecordKind
+	RecordIndex int
+	Reason      RejectionReason
+	Message     string
+}
+
+type Report struct {
+	RepositoryURL      string
+	CaseObservations   []*CaseObservation
+	TargetObservations []*TargetObservation
+	Rejections         []Rejection
+	Rejected           Counts
+}
+
+type Counts struct {
+	Cases   int
+	Targets int
+}
+
+func (c Counts) Total() int { return c.Cases + c.Targets }
+
+func (c *Counts) add(kind RecordKind) {
+	if kind == RecordKindTarget {
+		c.Targets++
+	} else {
+		c.Cases++
+	}
+}
+
+type Session struct {
+	repository string
+	targets    map[string]identity.TargetAddress
+}
+
+func NewSession(repositoryURL string) (*Session, error) {
+	repository, err := identity.NormalizeRepositoryURL(repositoryURL)
+	if err != nil {
+		return nil, err
+	}
+	return &Session{repository: repository, targets: make(map[string]identity.TargetAddress)}, nil
+}
+
+func Normalize(repositoryURL string, cases []*tbpb.TestCaseObservation, targets []*tbpb.TestTargetObservation) (*Report, error) {
+	session, err := NewSession(repositoryURL)
+	if err != nil {
+		return nil, err
+	}
+	return session.Normalize(cases, targets), nil
+}
+
+func (s *Session) Normalize(cases []*tbpb.TestCaseObservation, targets []*tbpb.TestTargetObservation) *Report {
+	report := &Report{RepositoryURL: s.repository}
+	for i, record := range cases {
+		observation, err := s.normalizeCase(record)
+		if err != nil {
+			report.reject(RecordKindCase, i, RejectionInvalidContent, err)
+			continue
+		}
+		report.CaseObservations = append(report.CaseObservations, observation)
+	}
+	for i, record := range targets {
+		observation, err := s.normalizeTarget(record)
+		if err != nil {
+			report.reject(RecordKindTarget, i, RejectionInvalidContent, err)
+			continue
+		}
+		report.TargetObservations = append(report.TargetObservations, observation)
+	}
+	return report
+}
+
+func (s *Session) normalizeCase(record *tbpb.TestCaseObservation) (*CaseObservation, error) {
+	if record.GetIdentity().GetTarget() == nil {
+		return nil, status.InvalidArgumentError("case identity is required")
+	}
+	target, err := s.target(record.GetIdentity().GetTarget().GetTargetLabel())
+	if err != nil {
+		return nil, err
+	}
+	if err := identity.ValidateCaseName(record.GetIdentity().GetCaseName()); err != nil {
+		return nil, err
+	}
+	address := identity.CaseAddress{
+		TargetAddress: target, CaseName: record.GetIdentity().GetCaseName(),
+	}
+	observation, err := normalizeObservation(record.GetObservation())
+	if err != nil {
+		return nil, err
+	}
+	return &CaseObservation{
+		Address:     address,
+		Observation: &tbpb.TestCaseObservation{Identity: address.Proto(), Observation: observation},
+	}, nil
+}
+
+func (s *Session) normalizeTarget(record *tbpb.TestTargetObservation) (*TargetObservation, error) {
+	if record.GetIdentity() == nil {
+		return nil, status.InvalidArgumentError("target identity is required")
+	}
+	target, err := s.target(record.GetIdentity().GetTargetLabel())
+	if err != nil {
+		return nil, err
+	}
+	observation, err := normalizeObservation(record.GetObservation())
+	if err != nil {
+		return nil, err
+	}
+	return &TargetObservation{
+		Address:     target,
+		Observation: &tbpb.TestTargetObservation{Identity: target.Proto(), Observation: observation},
+	}, nil
+}
+
+func (s *Session) target(label string) (identity.TargetAddress, error) {
+	if target, ok := s.targets[label]; ok {
+		return target, nil
+	}
+	target, err := identity.CanonicalizeTarget(s.repository, label)
+	if err != nil {
+		return identity.TargetAddress{}, err
+	}
+	s.targets[label] = target
+	return target, nil
+}
+
+func validateObservation(observation *tbpb.TestObservation) error {
+	if observation == nil {
+		return status.InvalidArgumentError("observation is required")
+	}
+	if _, ok := tbpb.TestOutcome_name[int32(observation.GetOutcome())]; !ok {
+		return status.InvalidArgumentErrorf("unrecognized outcome %d", observation.GetOutcome())
+	}
+	if observation.GetSource() == tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_UNKNOWN {
+		return status.InvalidArgumentError("source is required")
+	}
+	if _, ok := tbpb.TestObservationSource_name[int32(observation.GetSource())]; !ok {
+		return status.InvalidArgumentErrorf("unrecognized source %d", observation.GetSource())
+	}
+	if observation.GetCommitSha() == "" {
+		return status.InvalidArgumentError("commit_sha is required")
+	}
+	if err := identity.ValidateBoundedString("commit SHA", observation.GetCommitSha(), MaxCommitSHABytes); err != nil {
+		return err
+	}
+	if observation.GetDurationUsec() < 0 {
+		return status.InvalidArgumentError("duration_usec must not be negative")
+	}
+	if observation.GetEventTimeUsec() <= 0 {
+		return status.InvalidArgumentError("event_time_usec must be greater than zero")
+	}
+	if observation.GetObservationId() == "" {
+		return status.InvalidArgumentError("observation_id is required")
+	}
+	if err := identity.ValidateBoundedString("observation ID", observation.GetObservationId(), MaxObservationIDBytes); err != nil {
+		return err
+	}
+	if err := identity.ValidateBoundedString("failure message", observation.GetFailureMessage(), MaxFailureMessageBytes); err != nil {
+		return err
+	}
+	if err := identity.ValidateBoundedString("source URL", observation.GetSourceUrl(), MaxSourceURLBytes); err != nil {
+		return err
+	}
+	u, err := url.ParseRequestURI(observation.GetSourceUrl())
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return status.InvalidArgumentError("source_url must be an absolute HTTP(S) URL")
+	}
+	return nil
+}
+
+func normalizeObservation(input *tbpb.TestObservation) (*tbpb.TestObservation, error) {
+	if err := validateObservation(input); err != nil {
+		return nil, err
+	}
+	return proto.Clone(input).(*tbpb.TestObservation), nil
+}
+
+func (r *Report) reject(kind RecordKind, index int, reason RejectionReason, err error) {
+	r.Rejected.add(kind)
+	if len(r.Rejections) < MaxRetainedRejections {
+		r.Rejections = append(r.Rejections, Rejection{
+			Kind: kind, RecordIndex: index, Reason: reason, Message: err.Error(),
+		})
+	}
+}

--- a/server/test_buddy/normalize/normalize.go
+++ b/server/test_buddy/normalize/normalize.go
@@ -1,0 +1,156 @@
+// Package normalize validates reported test observations.
+package normalize
+
+import (
+	"net/url"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/buildbuddy-io/buildbuddy/server/test_buddy/identity"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"google.golang.org/protobuf/proto"
+
+	tbpb "github.com/buildbuddy-io/buildbuddy/proto/test_buddy"
+)
+
+const (
+	maxFailureMessageBytes = 512
+	maxSourceURLBytes      = 2048
+	maxIdempotencyBytes    = 128
+	maxCommitSHABytes      = 128
+	maxRetainedRejections  = 100
+)
+
+type Observation struct {
+	Address     identity.Address
+	Observation *tbpb.TestObservation
+}
+
+type Rejection struct {
+	RecordIndex      int
+	Identity         *tbpb.TestIdentity
+	IdempotencyToken string
+	Message          string
+}
+
+type Report struct {
+	RepositoryURL string
+	Source        tbpb.TestObservationSource
+	SourceURL     string
+	CommitSHA     string
+	Observations  []*Observation
+	Rejections    []Rejection
+	RejectedCount int
+}
+
+func Normalize(request *tbpb.ReportTestResultsRequest) (*Report, error) {
+	if request == nil {
+		return nil, status.InvalidArgumentError("report is required")
+	}
+	repository, err := identity.NormalizeRepositoryURL(request.GetRepoUrl())
+	if err != nil {
+		return nil, err
+	}
+	if request.GetSource() != tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR {
+		return nil, status.InvalidArgumentError("source must be MONITOR")
+	}
+	if err := validateBoundedString("commit SHA", request.GetCommitSha(), maxCommitSHABytes); err != nil {
+		return nil, err
+	}
+	if request.GetCommitSha() == "" {
+		return nil, status.InvalidArgumentError("commit_sha is required")
+	}
+	if err := validateSourceURL(request.GetSourceUrl()); err != nil {
+		return nil, err
+	}
+
+	report := &Report{
+		RepositoryURL: repository,
+		Source:        request.GetSource(),
+		SourceURL:     request.GetSourceUrl(),
+		CommitSHA:     request.GetCommitSha(),
+	}
+	for i, input := range request.GetObservations() {
+		observation, err := normalizeObservation(repository, input)
+		if err != nil {
+			report.reject(i, input, err)
+			continue
+		}
+		report.Observations = append(report.Observations, observation)
+	}
+	return report, nil
+}
+
+func normalizeObservation(repository string, input *tbpb.TestObservation) (*Observation, error) {
+	if input == nil {
+		return nil, status.InvalidArgumentError("observation is required")
+	}
+	address, err := identity.Canonicalize(repository, input.GetIdentity())
+	if err != nil {
+		return nil, err
+	}
+	switch input.GetOutcome() {
+	case tbpb.TestOutcome_TEST_OUTCOME_PASS,
+		tbpb.TestOutcome_TEST_OUTCOME_FAIL,
+		tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT,
+		tbpb.TestOutcome_TEST_OUTCOME_BROKEN:
+	default:
+		return nil, status.InvalidArgumentErrorf("invalid outcome %d", input.GetOutcome())
+	}
+	if input.GetDurationUsec() < 0 {
+		return nil, status.InvalidArgumentError("duration_usec must not be negative")
+	}
+	if input.GetEventTimeUsec() <= 0 {
+		return nil, status.InvalidArgumentError("event_time_usec must be greater than zero")
+	}
+	if input.GetIdempotencyToken() == "" {
+		return nil, status.InvalidArgumentError("idempotency_token is required")
+	}
+	if err := validateBoundedString("idempotency token", input.GetIdempotencyToken(), maxIdempotencyBytes); err != nil {
+		return nil, err
+	}
+	if err := validateBoundedString("failure message", input.GetFailureMessage(), maxFailureMessageBytes); err != nil {
+		return nil, err
+	}
+
+	normalized := proto.Clone(input).(*tbpb.TestObservation)
+	normalized.Identity = address.Proto()
+	return &Observation{Address: address, Observation: normalized}, nil
+}
+
+func validateSourceURL(raw string) error {
+	if err := validateBoundedString("source URL", raw, maxSourceURLBytes); err != nil {
+		return err
+	}
+	u, err := url.ParseRequestURI(raw)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return status.InvalidArgumentError("source_url must be an absolute HTTP(S) URL")
+	}
+	return nil
+}
+
+func validateBoundedString(name, value string, maxBytes int) error {
+	if len(value) > maxBytes {
+		return status.InvalidArgumentErrorf("%s exceeds %d bytes", name, maxBytes)
+	}
+	if !utf8.ValidString(value) {
+		return status.InvalidArgumentErrorf("%s is not valid UTF-8", name)
+	}
+	if strings.ContainsRune(value, '\x00') {
+		return status.InvalidArgumentErrorf("%s contains NUL", name)
+	}
+	return nil
+}
+
+func (r *Report) reject(index int, observation *tbpb.TestObservation, err error) {
+	r.RejectedCount++
+	if len(r.Rejections) >= maxRetainedRejections {
+		return
+	}
+	r.Rejections = append(r.Rejections, Rejection{
+		RecordIndex:      index,
+		Identity:         observation.GetIdentity(),
+		IdempotencyToken: observation.GetIdempotencyToken(),
+		Message:          err.Error(),
+	})
+}

--- a/server/test_buddy/normalize/normalize_test.go
+++ b/server/test_buddy/normalize/normalize_test.go
@@ -1,0 +1,125 @@
+package normalize_test
+
+import (
+	"testing"
+
+	tbpb "github.com/buildbuddy-io/buildbuddy/proto/test_buddy"
+	"github.com/buildbuddy-io/buildbuddy/server/test_buddy/normalize"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const repository = "git@github.com:buildbuddy-io/buildbuddy.git"
+
+func testObservation(outcome tbpb.TestOutcome) *tbpb.TestObservation {
+	return &tbpb.TestObservation{
+		Outcome: outcome, SourceUrl: "https://app.buildbuddy.io/invocation/one",
+		EventTimeUsec: 1_000_000, ObservationId: "observation-1",
+		Source:    tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR,
+		CommitSha: "abc123",
+	}
+}
+
+func caseObservation(outcome tbpb.TestOutcome) *tbpb.TestCaseObservation {
+	return &tbpb.TestCaseObservation{
+		Identity: &tbpb.TestCaseIdentity{
+			Target: &tbpb.TestTargetIdentity{TargetLabel: "//pkg:test"}, CaseName: "TestA",
+		},
+		Observation: testObservation(outcome),
+	}
+}
+
+func targetObservation(outcome tbpb.TestOutcome) *tbpb.TestTargetObservation {
+	return &tbpb.TestTargetObservation{
+		Identity: &tbpb.TestTargetIdentity{TargetLabel: "//pkg:test"}, Observation: testObservation(outcome),
+	}
+}
+
+func TestNormalizeCaseAndTarget(t *testing.T) {
+	caseRecord := caseObservation(tbpb.TestOutcome_TEST_OUTCOME_FAIL)
+	caseRecord.Observation.DurationUsec = 123
+	caseRecord.Observation.FailureMessage = "got 1, want 2"
+	targetRecord := targetObservation(tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT)
+	targetRecord.Observation.DurationUsec = 456
+	report, err := normalize.Normalize(repository, []*tbpb.TestCaseObservation{caseRecord}, []*tbpb.TestTargetObservation{targetRecord})
+	require.NoError(t, err)
+	require.Len(t, report.CaseObservations, 1)
+	require.Len(t, report.TargetObservations, 1)
+	assert.Equal(t, "https://github.com/buildbuddy-io/buildbuddy", report.RepositoryURL)
+	assert.Equal(t, "TestA", report.CaseObservations[0].Observation.GetIdentity().GetCaseName())
+	assert.Equal(t, "//pkg:test", report.CaseObservations[0].Observation.GetIdentity().GetTarget().GetTargetLabel())
+	assert.Equal(t, "https://app.buildbuddy.io/invocation/one", report.CaseObservations[0].Observation.GetObservation().GetSourceUrl())
+	assert.Equal(t, int64(1_000_000), report.CaseObservations[0].Observation.GetObservation().GetEventTimeUsec())
+	assert.Equal(t, "observation-1", report.CaseObservations[0].Observation.GetObservation().GetObservationId())
+	assert.Equal(t, tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR,
+		report.CaseObservations[0].Observation.GetObservation().GetSource())
+	assert.Equal(t, "abc123", report.CaseObservations[0].Observation.GetObservation().GetCommitSha())
+	assert.Equal(t, "got 1, want 2", report.CaseObservations[0].Observation.GetObservation().GetFailureMessage())
+	assert.Equal(t, tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT, report.TargetObservations[0].Observation.GetObservation().GetOutcome())
+}
+
+func TestRepeatedObservationsArePreserved(t *testing.T) {
+	record := caseObservation(tbpb.TestOutcome_TEST_OUTCOME_PASS)
+	report, err := normalize.Normalize(repository, []*tbpb.TestCaseObservation{record, record}, nil)
+	require.NoError(t, err)
+	assert.Len(t, report.CaseObservations, 2)
+	assert.Empty(t, report.Rejections)
+}
+
+func TestRepeatedObservationsMayHaveDifferentOutcomes(t *testing.T) {
+	report, err := normalize.Normalize(repository, []*tbpb.TestCaseObservation{
+		caseObservation(tbpb.TestOutcome_TEST_OUTCOME_PASS), caseObservation(tbpb.TestOutcome_TEST_OUTCOME_FAIL),
+	}, nil)
+	require.NoError(t, err)
+	assert.Len(t, report.CaseObservations, 2)
+	assert.Zero(t, report.Rejected.Cases)
+}
+
+func TestRepeatedTargetObservationsArePreserved(t *testing.T) {
+	report, err := normalize.Normalize(repository, nil, []*tbpb.TestTargetObservation{
+		targetObservation(tbpb.TestOutcome_TEST_OUTCOME_PASS), targetObservation(tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT),
+	})
+	require.NoError(t, err)
+	assert.Len(t, report.TargetObservations, 2)
+	assert.Zero(t, report.Rejected.Targets)
+}
+
+func TestValidation(t *testing.T) {
+	_, err := normalize.Normalize("", nil, nil)
+	assert.Error(t, err)
+
+	invalid := caseObservation(tbpb.TestOutcome(99))
+	report, err := normalize.Normalize(repository, []*tbpb.TestCaseObservation{invalid}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.Rejected.Cases)
+
+	invalid = caseObservation(tbpb.TestOutcome_TEST_OUTCOME_PASS)
+	invalid.Observation.Source = tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_UNKNOWN
+	report, err = normalize.Normalize(repository, []*tbpb.TestCaseObservation{invalid}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.Rejected.Cases)
+
+	invalid = caseObservation(tbpb.TestOutcome_TEST_OUTCOME_PASS)
+	invalid.Observation.CommitSha = ""
+	report, err = normalize.Normalize(repository, []*tbpb.TestCaseObservation{invalid}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.Rejected.Cases)
+
+	invalid = caseObservation(tbpb.TestOutcome_TEST_OUTCOME_PASS)
+	invalid.Observation.SourceUrl = "not a URL"
+	report, err = normalize.Normalize(repository, []*tbpb.TestCaseObservation{invalid}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.Rejected.Cases)
+
+	invalid = caseObservation(tbpb.TestOutcome_TEST_OUTCOME_PASS)
+	invalid.Observation.ObservationId = ""
+	report, err = normalize.Normalize(repository, []*tbpb.TestCaseObservation{invalid}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.Rejected.Cases)
+
+	invalid = caseObservation(tbpb.TestOutcome_TEST_OUTCOME_PASS)
+	invalid.Observation.EventTimeUsec = 0
+	report, err = normalize.Normalize(repository, []*tbpb.TestCaseObservation{invalid}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.Rejected.Cases)
+}

--- a/server/test_buddy/normalize/normalize_test.go
+++ b/server/test_buddy/normalize/normalize_test.go
@@ -1,0 +1,110 @@
+package normalize_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/test_buddy/identity"
+	"github.com/buildbuddy-io/buildbuddy/server/test_buddy/normalize"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	tbpb "github.com/buildbuddy-io/buildbuddy/proto/test_buddy"
+)
+
+func request(observations ...*tbpb.TestObservation) *tbpb.ReportTestResultsRequest {
+	return &tbpb.ReportTestResultsRequest{
+		RepoUrl:      "git@github.com:buildbuddy-io/buildbuddy.git",
+		Source:       tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR,
+		SourceUrl:    "https://app.buildbuddy.io/invocation/one",
+		CommitSha:    "abc123",
+		Observations: observations,
+	}
+}
+
+func observation(caseName string, outcome tbpb.TestOutcome) *tbpb.TestObservation {
+	return &tbpb.TestObservation{
+		Identity: &tbpb.TestIdentity{TargetLabel: "//pkg:test", CaseName: caseName},
+		Outcome:  outcome, DurationUsec: 1_000, EventTimeUsec: 1_000_000,
+		IdempotencyToken: "observation-1",
+	}
+}
+
+func TestNormalize(t *testing.T) {
+	report, err := normalize.Normalize(request(
+		observation("", tbpb.TestOutcome_TEST_OUTCOME_PASS),
+		observation("TestA", tbpb.TestOutcome_TEST_OUTCOME_FAIL),
+	))
+	require.NoError(t, err)
+	require.Len(t, report.Observations, 2)
+	assert.Equal(t, "https://github.com/buildbuddy-io/buildbuddy", report.RepositoryURL)
+	assert.Equal(t, "https://app.buildbuddy.io/invocation/one", report.SourceURL)
+	assert.Equal(t, "abc123", report.CommitSHA)
+	assert.Equal(t, identity.Address{
+		Repository:  "https://github.com/buildbuddy-io/buildbuddy",
+		PackagePath: "pkg", TargetName: "test", CaseName: "TestA",
+	}, report.Observations[1].Address)
+	assert.Equal(t, "//pkg:test", report.Observations[1].Observation.GetIdentity().GetTargetLabel())
+}
+
+func TestNormalizeRejectsInvalidObservationsIndependently(t *testing.T) {
+	invalid := observation("TestInvalid", tbpb.TestOutcome_TEST_OUTCOME_UNKNOWN)
+	invalid.IdempotencyToken = "invalid-token"
+	report, err := normalize.Normalize(request(
+		observation("TestValid", tbpb.TestOutcome_TEST_OUTCOME_PASS),
+		invalid,
+	))
+	require.NoError(t, err)
+	require.Len(t, report.Observations, 1)
+	assert.Equal(t, 1, report.RejectedCount)
+	require.Len(t, report.Rejections, 1)
+	assert.Equal(t, 1, report.Rejections[0].RecordIndex)
+	assert.Equal(t, "invalid-token", report.Rejections[0].IdempotencyToken)
+	assert.Equal(t, "TestInvalid", report.Rejections[0].Identity.GetCaseName())
+}
+
+func TestNormalizeRejectsInvalidReportMetadata(t *testing.T) {
+	for _, mutate := range []func(*tbpb.ReportTestResultsRequest){
+		func(r *tbpb.ReportTestResultsRequest) { r.RepoUrl = "" },
+		func(r *tbpb.ReportTestResultsRequest) {
+			r.Source = tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_UNKNOWN
+		},
+		func(r *tbpb.ReportTestResultsRequest) { r.SourceUrl = "not a URL" },
+		func(r *tbpb.ReportTestResultsRequest) { r.CommitSha = "" },
+	} {
+		report := request(observation("TestA", tbpb.TestOutcome_TEST_OUTCOME_PASS))
+		mutate(report)
+		_, err := normalize.Normalize(report)
+		assert.Error(t, err)
+	}
+}
+
+func TestNormalizeRejectsInvalidObservationFields(t *testing.T) {
+	for _, mutate := range []func(*tbpb.TestObservation){
+		func(o *tbpb.TestObservation) { o.Identity.TargetLabel = "relative:test" },
+		func(o *tbpb.TestObservation) { o.Outcome = tbpb.TestOutcome_TEST_OUTCOME_UNKNOWN },
+		func(o *tbpb.TestObservation) { o.DurationUsec = -1 },
+		func(o *tbpb.TestObservation) { o.EventTimeUsec = 0 },
+		func(o *tbpb.TestObservation) { o.IdempotencyToken = "" },
+		func(o *tbpb.TestObservation) { o.FailureMessage = strings.Repeat("x", 513) },
+	} {
+		input := observation("TestA", tbpb.TestOutcome_TEST_OUTCOME_PASS)
+		mutate(input)
+		report, err := normalize.Normalize(request(input))
+		require.NoError(t, err)
+		assert.Empty(t, report.Observations)
+		assert.Equal(t, 1, report.RejectedCount)
+	}
+}
+
+func TestNormalizeCapsRejectionSamples(t *testing.T) {
+	request := request()
+	for i := 0; i < 200; i++ {
+		request.Observations = append(request.Observations,
+			observation("TestInvalid", tbpb.TestOutcome_TEST_OUTCOME_UNKNOWN))
+	}
+	report, err := normalize.Normalize(request)
+	require.NoError(t, err)
+	assert.Equal(t, 200, report.RejectedCount)
+	assert.Len(t, report.Rejections, 100)
+}


### PR DESCRIPTION
Canonicalizes and validates reported target and case results before they reach storage. This keeps transport-specific input handling outside the analyzer and serving model.