### PR TITLE
test_buddy: add reporting and query commands

### DIFF
--- a/cli/cli_command/register/BUILD
+++ b/cli/cli_command/register/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//cli/search",
         "//cli/ssh",
         "//cli/ssh_server",
+        "//cli/testbuddy",
         "//cli/ui",
         "//cli/update",
         "//cli/upload",

--- a/cli/cli_command/register/register.go
+++ b/cli/cli_command/register/register.go
@@ -24,6 +24,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/search"
 	"github.com/buildbuddy-io/buildbuddy/cli/ssh"
 	"github.com/buildbuddy-io/buildbuddy/cli/ssh_server"
+	"github.com/buildbuddy-io/buildbuddy/cli/testbuddy"
 	"github.com/buildbuddy-io/buildbuddy/cli/ui"
 	"github.com/buildbuddy-io/buildbuddy/cli/update"
 	"github.com/buildbuddy-io/buildbuddy/cli/upload"
@@ -97,6 +98,12 @@ func register() {
 			Handler: fix.HandleFix,
 			Flags:   fix.Flags,
 		},
+		{
+			Name:    "get-tests",
+			Help:    "Lists reported tests and their health.",
+			Handler: testbuddy.HandleGetTests,
+			Flags:   testbuddy.GetTestsFlags,
+		},
 		// Handle 'help' command separately to avoid circular dependency with `cli_command`
 		// package
 		{
@@ -157,6 +164,12 @@ func register() {
 			Help:    "Runs an SSH server on a user-mode wireguard network.",
 			Handler: ssh_server.HandleSSHServer,
 			Flags:   ssh_server.Flags,
+		},
+		{
+			Name:    "test-report",
+			Help:    "Reports Bazel test.xml results to BuildBuddy.",
+			Handler: testbuddy.HandleTestReport,
+			Flags:   testbuddy.TestReportFlags,
 		},
 		{
 			Name:    "index",

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -71,8 +71,14 @@ func StartupDebug(start time.Time) {
 // We template this top support different types of Option slices; for example,
 // []*parsed.IndexedOption
 func Configure[T options.Option](bbOpts []T) {
+	// Seed with the enum variant, not a bool: with no --verbose on the command
+	// line the accumulator is never written, so it must end up empty. Seeding
+	// with false instead made GetBool succeed and passed "0" to log.Configure,
+	// which then treated verbosity as explicitly set and never consulted
+	// BB_VERBOSE. An actual --verbose still wins, because SetBool and SetEnum
+	// each clear the other.
 	verbose, err := options.AccumulateValues[T](
-		*options.NewBoolOrEnum(false),
+		*options.NewBoolOrEnum(""),
 		seq.Filter(bbOpts, options.NameFilter[T](logoptdef.Verbose.Name())),
 	)
 	if err != nil {

--- a/cli/testbuddy/BUILD
+++ b/cli/testbuddy/BUILD
@@ -1,0 +1,57 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//cli:__subpackages__"])
+
+go_library(
+    name = "testbuddy",
+    srcs = ["testbuddy.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/testbuddy",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cli/arg",
+        "//cli/flaghistory",
+        "//cli/log",
+        "//cli/login",
+        "//cli/util/download",
+        "//cli/workspace",
+        "//proto:build_event_stream_go_proto",
+        "//proto:buildbuddy_service_go_proto",
+        "//proto:invocation_go_proto",
+        "//proto:target_go_proto",
+        "//proto:test_buddy_go_proto",
+        "//proto/api/v1:common_go_proto",
+        "//server/test_buddy/identity",
+        "//server/test_buddy/junit",
+        "//server/test_buddy/normalize",
+        "//server/util/git",
+        "//server/util/grpc_client",
+        "//server/util/status",
+        "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
+        "@org_golang_google_grpc//metadata",
+        "@org_golang_google_protobuf//encoding/protowire",
+        "@org_golang_google_protobuf//proto",
+        "@org_golang_x_sync//errgroup",
+    ],
+)
+
+go_test(
+    name = "testbuddy_test",
+    srcs = ["testbuddy_test.go"],
+    deps = [
+        ":testbuddy",
+        "//cli/util/download/downloadtest",
+        "//proto:build_event_stream_go_proto",
+        "//proto:buildbuddy_service_go_proto",
+        "//proto:invocation_go_proto",
+        "//proto:target_go_proto",
+        "//proto:test_buddy_go_proto",
+        "//proto/api/v1:common_go_proto",
+        "//server/test_buddy/junit",
+        "//server/test_buddy/normalize",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//types/known/durationpb",
+        "@org_golang_google_protobuf//types/known/timestamppb",
+    ],
+)

--- a/cli/testbuddy/testbuddy.go
+++ b/cli/testbuddy/testbuddy.go
@@ -1,0 +1,1276 @@
+// Package testbuddy implements the test-report and get-tests CLI commands.
+package testbuddy
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/arg"
+	"github.com/buildbuddy-io/buildbuddy/cli/flaghistory"
+	"github.com/buildbuddy-io/buildbuddy/cli/log"
+	"github.com/buildbuddy-io/buildbuddy/cli/login"
+	"github.com/buildbuddy-io/buildbuddy/cli/util/download"
+	"github.com/buildbuddy-io/buildbuddy/cli/workspace"
+	cmpb "github.com/buildbuddy-io/buildbuddy/proto/api/v1/common"
+	bespb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
+	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
+	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
+	trpb "github.com/buildbuddy-io/buildbuddy/proto/target"
+	tbpb "github.com/buildbuddy-io/buildbuddy/proto/test_buddy"
+	"github.com/buildbuddy-io/buildbuddy/server/test_buddy/identity"
+	"github.com/buildbuddy-io/buildbuddy/server/test_buddy/junit"
+	"github.com/buildbuddy-io/buildbuddy/server/test_buddy/normalize"
+	gitutil "github.com/buildbuddy-io/buildbuddy/server/util/git"
+	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	bspb "google.golang.org/genproto/googleapis/bytestream"
+)
+
+var bazelTestOutputLayout = regexp.MustCompile(
+	`^(?:run_[1-9][0-9]*_of_([1-9][0-9]*)|shard_[1-9][0-9]*_of_([1-9][0-9]*)(?:_run_[1-9][0-9]*_of_([1-9][0-9]*))?)$`,
+)
+
+// ReportRequestTargetBytes bounds one client-stream message.
+//
+// The gRPC receive limit is 50 MB, so this only has to be under that — but
+// filling the limit would make both sides hold a 50 MB message, and a single
+// failed send would cost the whole 50 MB again on retry. 8 MiB keeps peak
+// memory per in-flight message small on the CLI and on the server, which
+// processes each message synchronously before reading the next.
+//
+// A report larger than the budget spans several messages; it is never
+// truncated. One observation cannot exceed the budget on its own:
+// normalization bounds every component — a failure message to 512 bytes and a
+// source URL to 2,048 — so an observation is kilobytes, not megabytes.
+const ReportRequestTargetBytes = 8 << 20
+
+const invocationReportConcurrency = 8
+
+// DiagnosticLog accumulates what the JUnit parser could not use, across every
+// file in one report.
+//
+// The counts distinguish dropped cases, ignored fields, and reports whose text
+// had to be normalized. Only dropped cases are invisible downstream.
+//
+// detail is called once per diagnostic and may be nil. The CLI passes the debug
+// logger, which discards unless verbose, so the listing costs nothing to leave
+// wired up; the parser caps diagnostics per file, and anything past that cap is
+// counted in Truncated rather than silently lost.
+type DiagnosticLog struct {
+	Dropped    int
+	Ignored    int
+	Normalized int
+	Truncated  int
+	detail     func(string)
+}
+
+func NewDiagnosticLog(detail func(string)) *DiagnosticLog {
+	return &DiagnosticLog{detail: detail}
+}
+
+func (l *DiagnosticLog) Add(xmlPath, targetLabel string, report *junit.Report) {
+	l.Truncated += report.DroppedDiagnostics
+	for _, diagnostic := range report.Diagnostics {
+		if diagnostic.Code == junit.DiagnosticInvalidUTF8 {
+			l.Normalized++
+		} else if diagnostic.Code.DropsCase() {
+			l.Dropped++
+		} else {
+			l.Ignored++
+		}
+		if l.detail != nil {
+			l.detail(diagnosticLine(xmlPath, targetLabel, diagnostic))
+		}
+	}
+	// The cap is per file, so an over-cap file still reports its own count.
+	if report.DroppedDiagnostics > 0 && l.detail != nil {
+		l.detail(fmt.Sprintf("%d more diagnostics in %s were not recorded (per-file cap)",
+			report.DroppedDiagnostics, xmlPath))
+	}
+}
+
+func diagnosticLine(xmlPath, targetLabel string, diagnostic junit.Diagnostic) string {
+	if diagnostic.Code == junit.DiagnosticInvalidUTF8 {
+		return fmt.Sprintf("normalized report %s %s (%s)", targetLabel, diagnostic.Code, xmlPath)
+	}
+	kind := "ignored field"
+	if diagnostic.Code.DropsCase() {
+		kind = "dropped case"
+	}
+	name := diagnostic.CaseName
+	if name == "" {
+		name = "<unnamed>"
+	}
+	where := xmlPath
+	if diagnostic.CaseIndex >= 0 {
+		where = fmt.Sprintf("%s case %d", xmlPath, diagnostic.CaseIndex)
+	}
+	return fmt.Sprintf("%s %s %q %s (%s)", kind, targetLabel, name, diagnostic.Code, where)
+}
+
+// Summary is the one line printed without verbose. It is empty when the parser
+// used everything.
+func (l *DiagnosticLog) Summary() string {
+	total := l.Dropped + l.Ignored + l.Normalized
+	if total == 0 && l.Truncated == 0 {
+		return ""
+	}
+	summary := fmt.Sprintf("%d JUnit diagnostics: %d cases dropped, %d fields ignored",
+		total, l.Dropped, l.Ignored)
+	if l.Normalized > 0 {
+		summary += fmt.Sprintf(", normalized reports: %d", l.Normalized)
+	}
+	if l.Truncated > 0 {
+		summary += fmt.Sprintf(", %d beyond the per-file cap", l.Truncated)
+	}
+	// The flag is a bare boolean: "--verbose=1" is rejected by the parser.
+	return summary + "\nrerun with --verbose (or BB_VERBOSE=1) to list them"
+}
+
+// ReportBatcher packs observations into client-stream messages that stay within
+// ReportRequestTargetBytes, sending each one as soon as it is full.
+//
+// Sizing is exact rather than estimated: an observation contributes its encoded
+// size plus the tag and length prefix that carry it in the enclosing message,
+// which is what the receiver measures against its limit.
+type ReportBatcher struct {
+	repository string
+	send       func(*tbpb.ReportTestResultsRequest) error
+	batch      *tbpb.ReportTestResultsRequest
+	size       int
+	count      int
+}
+
+func NewReportBatcher(repository string, send func(*tbpb.ReportTestResultsRequest) error) *ReportBatcher {
+	b := &ReportBatcher{repository: repository, send: send}
+	b.reset()
+	return b
+}
+
+func (b *ReportBatcher) reset() {
+	b.batch = &tbpb.ReportTestResultsRequest{RepoUrl: b.repository}
+	b.size = protowire.SizeTag(1) + protowire.SizeBytes(len(b.repository))
+	b.count = 0
+}
+
+// makeRoom flushes the pending message if observation would push it over budget.
+// An observation is never split, so an empty message always accepts one.
+func (b *ReportBatcher) makeRoom(field protowire.Number, observation proto.Message) (int, error) {
+	wireSize := protowire.SizeTag(field) + protowire.SizeBytes(proto.Size(observation))
+	if b.count > 0 && b.size+wireSize > ReportRequestTargetBytes {
+		if err := b.Flush(); err != nil {
+			return 0, err
+		}
+	}
+	return wireSize, nil
+}
+
+func (b *ReportBatcher) AddTargetObservation(observation *tbpb.TestTargetObservation) error {
+	wireSize, err := b.makeRoom(3, observation)
+	if err != nil {
+		return err
+	}
+	b.batch.TargetObservations = append(b.batch.TargetObservations, observation)
+	b.size += wireSize
+	b.count++
+	return nil
+}
+
+func (b *ReportBatcher) AddCaseObservation(observation *tbpb.TestCaseObservation) error {
+	wireSize, err := b.makeRoom(2, observation)
+	if err != nil {
+		return err
+	}
+	b.batch.CaseObservations = append(b.batch.CaseObservations, observation)
+	b.size += wireSize
+	b.count++
+	return nil
+}
+
+// Flush sends the pending message, if any. Sending an empty message would
+// charge the server a round trip to learn nothing.
+func (b *ReportBatcher) Flush() error {
+	if b.count == 0 {
+		return nil
+	}
+	if err := b.send(b.batch); err != nil {
+		return err
+	}
+	b.reset()
+	return nil
+}
+
+var (
+	TestReportFlags = flag.NewFlagSet("test-report", flag.ContinueOnError)
+	reportTarget    = TestReportFlags.String("target", "", "BuildBuddy gRPC target; defaults to grpc://127.0.0.1:1985.")
+	reportRepo      = TestReportFlags.String("repo_url", "", "Repository URL; defaults to git remote.origin.url.")
+	reportSourceURL = TestReportFlags.String(
+		"source_url", "", "Observation URL; defaults to the most recent bb test invocation.")
+	reportSource = TestReportFlags.String(
+		"source", "monitor", "Observation source: presubmit, postsubmit, or monitor.")
+	reportTargetLabel  = TestReportFlags.String("target_label", "", "Bazel target label; inferred from bazel-testlogs paths by default.")
+	reportInvocationID = TestReportFlags.String("invocation_id", "", "BuildBuddy invocation whose remote test.xml outputs should be reported.")
+	reportAPITarget    = TestReportFlags.String("buildbuddy_target", "", "BuildBuddy gRPC API containing --invocation_id; defaults to the most recent BES backend.")
+
+	GetTestsFlags  = flag.NewFlagSet("get-tests", flag.ContinueOnError)
+	getTarget      = GetTestsFlags.String("target", "", "BuildBuddy gRPC target; defaults to grpc://127.0.0.1:1985.")
+	getRepo        = GetTestsFlags.String("repo_url", "", "Repository URL; defaults to git remote.origin.url.")
+	getPath        = GetTestsFlags.String("path", "", "Repository directory prefix.")
+	getLimit       = GetTestsFlags.Int("limit", 100, "Maximum number of tests to print.")
+	getTargetLabel = GetTestsFlags.String("target_label", "", "Exact Bazel target label.")
+	getCaseName    = GetTestsFlags.String("case_name", "", "Exact test case name.")
+)
+
+func HandleTestReport(args []string) (int, error) {
+	sourceExplicit := false
+	for _, token := range args {
+		if token == "--source" || token == "-source" ||
+			strings.HasPrefix(token, "--source=") || strings.HasPrefix(token, "-source=") {
+			sourceExplicit = true
+			break
+		}
+	}
+	if err := arg.ParseFlagSet(TestReportFlags, args); err != nil {
+		if err == flag.ErrHelp {
+			log.Print("usage: bb test-report [flags] [test.xml or directory ...]")
+			return 0, nil
+		}
+		return 1, err
+	}
+	source, err := ParseObservationSource(*reportSource)
+	if err != nil {
+		return 1, err
+	}
+	target, err := backend(*reportTarget)
+	if err != nil {
+		return 1, err
+	}
+	conn, err := grpc_client.DialSimple(target)
+	if err != nil {
+		return 1, err
+	}
+	defer conn.Close()
+	ctx, err := authenticatedContext(context.Background(), target)
+	if err != nil {
+		return 1, err
+	}
+	stream, err := tbpb.NewTestBuddyServiceClient(conn).ReportTestResults(ctx)
+	if err != nil {
+		return 1, err
+	}
+	defer stream.CloseSend()
+	diagnostics := NewDiagnosticLog(func(line string) { log.Debug(line) })
+	var sourceURL string
+	reportDescription := ""
+	if *reportInvocationID != "" {
+		if TestReportFlags.NArg() != 0 || *reportTargetLabel != "" {
+			return 1, status.InvalidArgumentError(
+				"--invocation_id does not accept XML paths or --target_label")
+		}
+		apiTarget, err := download.ResolveTarget(*reportAPITarget)
+		if err != nil {
+			return 1, err
+		}
+		apiConn, err := grpc_client.DialSimple(apiTarget)
+		if err != nil {
+			return 1, err
+		}
+		defer apiConn.Close()
+		apiContext, err := authenticatedContext(context.Background(), apiTarget)
+		if err != nil {
+			return 1, err
+		}
+		apiClient := bbspb.NewBuildBuddyServiceClient(apiConn)
+		invocation, err := GetInvocationReportMetadata(apiContext, apiClient, *reportInvocationID)
+		if err != nil {
+			return 1, err
+		}
+		repository := invocation.Repository
+		if *reportRepo != "" {
+			repository = *reportRepo
+		}
+		if repository == "" {
+			return 1, status.FailedPreconditionError(
+				"invocation has no repository URL; pass --repo_url")
+		}
+		if invocation.CommitSHA == "" {
+			return 1, status.FailedPreconditionError("invocation has no commit SHA")
+		}
+		if !sourceExplicit {
+			source = invocation.DefaultObservationSource(source)
+		}
+		sourceURL, err = observationURL(*reportSourceURL, *reportInvocationID)
+		if err != nil {
+			return 1, err
+		}
+		metadata := ObservationMetadata{
+			SourceURL: sourceURL, Source: source, CommitSHA: invocation.CommitSHA,
+			WorkspaceDirty: invocation.WorkspaceDirty,
+		}
+		targetsReportedByBES := invocation.TargetsReportedByBES(target, apiTarget)
+		batcher := NewReportBatcher(repository, stream.Send)
+		stats, err := ForEachInvocationTestReport(
+			apiContext, apiClient, download.NewByteStreamDownloader(bspb.NewByteStreamClient(apiConn)),
+			*reportInvocationID, invocation.CreatedAtUsec,
+			func(remote *InvocationTestReport) error {
+				diagnostics.Add(remote.XMLURI, remote.TargetLabel, remote.Report)
+				targetObservation, caseObservations, err := ObservationsForParsedReport(
+					remote.TargetLabel, metadata, remote.Report, remote.Context)
+				if err != nil {
+					return err
+				}
+				if !targetsReportedByBES {
+					if err := batcher.AddTargetObservation(targetObservation); err != nil {
+						return err
+					}
+				}
+				for _, observation := range caseObservations {
+					if err := batcher.AddCaseObservation(observation); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+		if err != nil {
+			return 1, err
+		}
+		if err := batcher.Flush(); err != nil {
+			return 1, err
+		}
+		reportDescription = fmt.Sprintf("%d test attempts (%d XML reports)",
+			stats.AttemptCount, stats.XMLCount)
+	} else {
+		workspacePath, err := workspace.Path()
+		if err != nil {
+			return 1, err
+		}
+		commitSHA, workspaceDirty, err := WorkspaceRevision(workspacePath)
+		if err != nil {
+			return 1, err
+		}
+		repository, err := repositoryURL(workspacePath, *reportRepo)
+		if err != nil {
+			return 1, err
+		}
+		sourceURL, err = observationURL(*reportSourceURL, "")
+		if err != nil {
+			return 1, err
+		}
+		metadata := ObservationMetadata{
+			SourceURL: sourceURL, Source: source,
+			CommitSHA: commitSHA, WorkspaceDirty: workspaceDirty,
+		}
+		inputs := TestReportFlags.Args()
+		if len(inputs) == 0 {
+			inputs = []string{"bazel-testlogs"}
+		}
+		paths, err := FindTestXMLFiles(inputs)
+		if err != nil {
+			return 1, err
+		}
+		if len(paths) == 0 {
+			return 1, status.InvalidArgumentError("the supplied paths contain no test.xml files")
+		}
+		batcher := NewReportBatcher(repository, stream.Send)
+		for _, path := range paths {
+			targetLabel := *reportTargetLabel
+			if targetLabel == "" {
+				targetLabel, err = TargetLabelFromXMLPath(workspacePath, path)
+				if err != nil {
+					return 1, err
+				}
+			}
+			file, err := os.Open(path)
+			if err != nil {
+				return 1, err
+			}
+			report, parseErr := junit.Parse(context.Background(), file, junit.Options{TargetLabel: targetLabel})
+			closeErr := file.Close()
+			if parseErr != nil {
+				return 1, parseErr
+			}
+			if closeErr != nil {
+				return 1, closeErr
+			}
+			diagnostics.Add(path, targetLabel, report)
+			targetObservation, caseObservations, err := ObservationsForReport(path, targetLabel, metadata, report)
+			if err != nil {
+				return 1, err
+			}
+			if err := batcher.AddTargetObservation(targetObservation); err != nil {
+				return 1, err
+			}
+			for _, observation := range caseObservations {
+				if err := batcher.AddCaseObservation(observation); err != nil {
+					return 1, err
+				}
+			}
+		}
+		if err := batcher.Flush(); err != nil {
+			return 1, err
+		}
+		reportDescription = fmt.Sprintf("%d XML files", len(paths))
+	}
+	rsp, err := stream.CloseAndRecv()
+	if err != nil {
+		return 1, err
+	}
+	fmt.Printf("reported %d test results (%d rejected) from %s\n",
+		rsp.GetAcceptedCount(), rsp.GetRejectedCount(), reportDescription)
+	fmt.Printf("source %s\n", sourceURL)
+	if summary := diagnostics.Summary(); summary != "" {
+		fmt.Println(summary)
+	}
+	if rsp.GetAcceptedCount() == 0 {
+		return 1, nil
+	}
+	return 0, nil
+}
+
+func ParseObservationSource(value string) (tbpb.TestObservationSource, error) {
+	switch strings.ToLower(value) {
+	case "presubmit":
+		return tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_PRESUBMIT, nil
+	case "postsubmit":
+		return tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_POSTSUBMIT, nil
+	case "monitor":
+		return tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR, nil
+	default:
+		return tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_UNKNOWN,
+			status.InvalidArgumentError("--source must be presubmit, postsubmit, or monitor")
+	}
+}
+
+type ObservationMetadata struct {
+	SourceURL      string
+	Source         tbpb.TestObservationSource
+	CommitSHA      string
+	WorkspaceDirty bool
+}
+
+type ReportContext struct {
+	ExecutionContext   string
+	TargetOutcome      tbpb.TestOutcome
+	EventTimeUsec      int64
+	TargetDurationUsec int64
+	FailureMessage     string
+}
+
+type InvocationReportMetadata struct {
+	Repository     string
+	CommitSHA      string
+	WorkspaceDirty bool
+	CreatedAtUsec  int64
+	Role           string
+	BranchName     string
+}
+
+func (m *InvocationReportMetadata) IsCI() bool {
+	return m.Role == "CI"
+}
+
+func (m *InvocationReportMetadata) TargetsReportedByBES(reportTarget, invocationTarget string) bool {
+	reportTarget = strings.TrimSuffix(reportTarget, "/")
+	invocationTarget = strings.TrimSuffix(invocationTarget, "/")
+	return m.IsCI() && reportTarget == invocationTarget
+}
+
+func (m *InvocationReportMetadata) DefaultObservationSource(fallback tbpb.TestObservationSource) tbpb.TestObservationSource {
+	if !m.IsCI() {
+		return fallback
+	}
+	branch := strings.TrimPrefix(m.BranchName, "refs/heads/")
+	if branch == "main" || branch == "master" {
+		return tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_POSTSUBMIT
+	}
+	return tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_PRESUBMIT
+}
+
+type InvocationTestReport struct {
+	TargetLabel string
+	XMLURI      string
+	Report      *junit.Report
+	Context     ReportContext
+}
+
+type InvocationReportStats struct {
+	AttemptCount int
+	XMLCount     int
+}
+
+type invocationTarget struct {
+	label  string
+	events []*bespb.BuildEvent
+}
+
+type invocationTargetPage struct {
+	token     string
+	status    cmpb.Status
+	hasStatus bool
+}
+
+func GetInvocationReportMetadata(ctx context.Context, client bbspb.BuildBuddyServiceClient, invocationID string) (*InvocationReportMetadata, error) {
+	if invocationID == "" {
+		return nil, status.InvalidArgumentError("invocation ID is required")
+	}
+	rsp, err := client.GetInvocation(ctx, &inpb.GetInvocationRequest{
+		Lookup: &inpb.InvocationLookup{InvocationId: invocationID},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(rsp.GetInvocation()) == 0 {
+		return nil, status.NotFoundErrorf("invocation %q was not found", invocationID)
+	}
+	invocation := rsp.GetInvocation()[0]
+	metadata := &InvocationReportMetadata{
+		Repository: invocation.GetRepoUrl(), CommitSHA: invocation.GetCommitSha(),
+		CreatedAtUsec: invocation.GetCreatedAtUsec(), Role: invocation.GetRole(),
+		BranchName: invocation.GetBranchName(),
+	}
+	for _, event := range invocation.GetEvent() {
+		for _, item := range event.GetBuildEvent().GetWorkspaceStatus().GetItem() {
+			if item.GetKey() == "GIT_TREE_STATUS" && strings.EqualFold(item.GetValue(), "Modified") {
+				metadata.WorkspaceDirty = true
+			}
+		}
+	}
+	return metadata, nil
+}
+
+// ForEachInvocationTestReport downloads and parses the test reports attached
+// to a BuildBuddy invocation. Downloads are bounded and concurrent; visitor is
+// called serially so callers can write directly to a report stream.
+func ForEachInvocationTestReport(ctx context.Context, client bbspb.BuildBuddyServiceClient, downloader download.Downloader, invocationID string, fallbackEventTimeUsec int64, visitor func(*InvocationTestReport) error) (InvocationReportStats, error) {
+	if invocationID == "" {
+		return InvocationReportStats{}, status.InvalidArgumentError("invocation ID is required")
+	}
+	if visitor == nil {
+		return InvocationReportStats{}, status.InvalidArgumentError("visitor is required")
+	}
+	groupContext, cancel := context.WithCancel(ctx)
+	defer cancel()
+	group, groupContext := errgroup.WithContext(groupContext)
+	jobs := make(chan invocationTarget)
+	results := make(chan *InvocationTestReport, invocationReportConcurrency)
+
+	group.Go(func() error {
+		defer close(jobs)
+		pages := []invocationTargetPage{{}}
+		seenPages := map[invocationTargetPage]bool{{}: true}
+		seenTargets := make(map[string]bool)
+		for len(pages) > 0 {
+			page := pages[0]
+			pages = pages[1:]
+			req := &trpb.GetTargetRequest{
+				InvocationId: invocationID, PageToken: page.token, IncludeTestResultEvents: true,
+			}
+			if page.hasStatus {
+				req.Status = &page.status
+			}
+			rsp, err := client.GetTarget(groupContext, req)
+			if err != nil {
+				return err
+			}
+			for _, targetGroup := range rsp.GetTargetGroups() {
+				if !isTestTargetStatus(targetGroup.GetStatus()) {
+					continue
+				}
+				if token := targetGroup.GetNextPageToken(); token != "" {
+					next := invocationTargetPage{token: token, status: targetGroup.GetStatus(), hasStatus: true}
+					if !seenPages[next] {
+						seenPages[next] = true
+						pages = append(pages, next)
+					}
+				}
+				for _, target := range targetGroup.GetTargets() {
+					label := target.GetMetadata().GetLabel()
+					if label == "" || seenTargets[label] {
+						continue
+					}
+					seenTargets[label] = true
+					select {
+					case jobs <- invocationTarget{label: label, events: target.GetTestResultEvents()}:
+					case <-groupContext.Done():
+						return groupContext.Err()
+					}
+				}
+			}
+		}
+		return nil
+	})
+	for range invocationReportConcurrency {
+		group.Go(func() error {
+			for job := range jobs {
+				events := job.events
+				if len(events) == 0 {
+					rsp, err := client.GetTarget(groupContext, &trpb.GetTargetRequest{
+						InvocationId: invocationID, TargetLabel: job.label,
+					})
+					if err != nil {
+						return err
+					}
+					for _, targetGroup := range rsp.GetTargetGroups() {
+						for _, target := range targetGroup.GetTargets() {
+							events = append(events, target.GetTestResultEvents()...)
+						}
+					}
+				}
+				for _, event := range events {
+					if event.GetId().GetTestResult() == nil || event.GetTestResult() == nil {
+						continue
+					}
+					report, err := invocationTestReport(
+						groupContext, downloader, invocationID, fallbackEventTimeUsec,
+						job.label, event)
+					if err != nil {
+						return err
+					}
+					select {
+					case results <- report:
+					case <-groupContext.Done():
+						return groupContext.Err()
+					}
+				}
+			}
+			return nil
+		})
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- group.Wait()
+		close(results)
+	}()
+
+	stats := InvocationReportStats{}
+	var visitorErr error
+	for report := range results {
+		stats.AttemptCount++
+		if report.XMLURI != "" {
+			stats.XMLCount++
+		}
+		if visitorErr == nil {
+			if err := visitor(report); err != nil {
+				visitorErr = err
+				cancel()
+			}
+		}
+	}
+	groupErr := <-done
+	if visitorErr != nil {
+		return stats, visitorErr
+	}
+	if groupErr != nil {
+		return stats, groupErr
+	}
+	return stats, nil
+}
+
+func isTestTargetStatus(targetStatus cmpb.Status) bool {
+	switch targetStatus {
+	case cmpb.Status_STATUS_UNSPECIFIED, cmpb.Status_BUILDING, cmpb.Status_BUILT,
+		cmpb.Status_FAILED_TO_BUILD, cmpb.Status_SKIPPED:
+		return false
+	default:
+		return true
+	}
+}
+
+func invocationTestReport(ctx context.Context, downloader download.Downloader, invocationID string, fallbackEventTimeUsec int64, targetLabel string, event *bespb.BuildEvent) (*InvocationTestReport, error) {
+	eventID := event.GetId().GetTestResult()
+	result := event.GetTestResult()
+	executionContext := observationID(invocationID, targetLabel,
+		eventID.GetConfiguration().GetId(), strconv.Itoa(int(eventID.GetRun())),
+		strconv.Itoa(int(eventID.GetShard())), strconv.Itoa(int(eventID.GetAttempt())))
+	eventTimeUsec := fallbackEventTimeUsec
+	if timestamp := result.GetTestAttemptStart(); timestamp != nil && timestamp.CheckValid() == nil {
+		eventTimeUsec = timestamp.AsTime().UnixMicro()
+	} else if result.GetTestAttemptStartMillisEpoch() > 0 {
+		eventTimeUsec = result.GetTestAttemptStartMillisEpoch() * 1_000
+	}
+	durationUsec := result.GetTestAttemptDurationMillis() * 1_000
+	if duration := result.GetTestAttemptDuration(); duration != nil && duration.CheckValid() == nil {
+		durationUsec = duration.AsDuration().Microseconds()
+	}
+	xmlURI := testXMLURI(result)
+	report := &junit.Report{}
+	if xmlURI != "" {
+		reader, writer := io.Pipe()
+		downloadDone := make(chan error, 1)
+		go func() {
+			err := downloader.GetBytestreamFile(ctx, xmlURI, writer)
+			_ = writer.CloseWithError(err)
+			downloadDone <- err
+		}()
+		parsed, parseErr := junit.Parse(ctx, reader, junit.Options{TargetLabel: targetLabel})
+		if parseErr != nil {
+			_ = reader.CloseWithError(parseErr)
+		}
+		downloadErr := <-downloadDone
+		if downloadErr != nil {
+			return nil, fmt.Errorf("download test.xml for %s: %w", targetLabel, downloadErr)
+		}
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse test.xml for %s: %w", targetLabel, parseErr)
+		}
+		report = parsed
+	}
+	return &InvocationTestReport{
+		TargetLabel: targetLabel, XMLURI: xmlURI, Report: report,
+		Context: ReportContext{
+			ExecutionContext: executionContext, TargetOutcome: bazelTestResultOutcome(result, xmlURI != ""),
+			EventTimeUsec: eventTimeUsec, TargetDurationUsec: durationUsec,
+			FailureMessage: truncateUTF8(result.GetStatusDetails(), normalize.MaxFailureMessageBytes),
+		},
+	}, nil
+}
+
+func testXMLURI(result *bespb.TestResult) string {
+	for _, output := range result.GetTestActionOutput() {
+		if output.GetName() == "test.xml" {
+			return output.GetUri()
+		}
+	}
+	return ""
+}
+
+func bazelTestResultOutcome(result *bespb.TestResult, hasXML bool) tbpb.TestOutcome {
+	switch result.GetStatus() {
+	case bespb.TestStatus_TIMEOUT:
+		return tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT
+	case bespb.TestStatus_NO_STATUS:
+		return tbpb.TestOutcome_TEST_OUTCOME_UNKNOWN
+	case bespb.TestStatus_PASSED, bespb.TestStatus_FLAKY:
+		return tbpb.TestOutcome_TEST_OUTCOME_PASS
+	default:
+		if hasXML {
+			return tbpb.TestOutcome_TEST_OUTCOME_PASS
+		}
+		return tbpb.TestOutcome_TEST_OUTCOME_FAIL
+	}
+}
+
+func truncateUTF8(value string, maxBytes int) string {
+	if len(value) <= maxBytes {
+		return value
+	}
+	value = value[:maxBytes]
+	for !utf8.ValidString(value) {
+		value = value[:len(value)-1]
+	}
+	return value
+}
+
+func WorkspaceRevision(workspacePath string) (string, bool, error) {
+	head := exec.Command("git", "rev-parse", "HEAD")
+	head.Dir = workspacePath
+	output, err := head.Output()
+	if err != nil {
+		return "", false, status.FailedPreconditionErrorf("could not read git HEAD: %s", err)
+	}
+	commitSHA := strings.TrimSpace(string(output))
+	if commitSHA == "" {
+		return "", false, status.FailedPreconditionError("git HEAD is empty")
+	}
+	statusCommand := exec.Command("git", "status", "--porcelain=v1", "--untracked-files=normal")
+	statusCommand.Dir = workspacePath
+	output, err = statusCommand.Output()
+	if err != nil {
+		return "", false, status.FailedPreconditionErrorf("could not inspect git status: %s", err)
+	}
+	return commitSHA, len(output) > 0, nil
+}
+
+func ObservationsForReport(xmlPath, targetLabel string, metadata ObservationMetadata, report *junit.Report) (*tbpb.TestTargetObservation, []*tbpb.TestCaseObservation, error) {
+	targetOutcome, err := BazelTargetOutcome(xmlPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	eventTimeUsec := report.EventTimeUsec
+	if eventTimeUsec <= 0 {
+		info, err := os.Stat(xmlPath)
+		if err != nil {
+			return nil, nil, err
+		}
+		eventTimeUsec = info.ModTime().UnixMicro()
+	}
+	if eventTimeUsec <= 0 {
+		return nil, nil, status.InvalidArgumentError("a positive report event time is required")
+	}
+	return ObservationsForParsedReport(targetLabel, metadata, report, ReportContext{
+		ExecutionContext: observationContext(xmlPath), TargetOutcome: targetOutcome,
+		EventTimeUsec: eventTimeUsec,
+	})
+}
+
+func ObservationsForParsedReport(targetLabel string, metadata ObservationMetadata, report *junit.Report, reportContext ReportContext) (*tbpb.TestTargetObservation, []*tbpb.TestCaseObservation, error) {
+	if report == nil {
+		return nil, nil, status.InvalidArgumentError("parsed JUnit report is required")
+	}
+	eventTimeUsec := report.EventTimeUsec
+	if eventTimeUsec <= 0 {
+		eventTimeUsec = reportContext.EventTimeUsec
+	}
+	if eventTimeUsec <= 0 {
+		return nil, nil, status.InvalidArgumentError("a positive report event time is required")
+	}
+	durationUsec := report.DurationUsec
+	if durationUsec <= 0 {
+		durationUsec = reportContext.TargetDurationUsec
+	}
+	target := &tbpb.TestTargetObservation{
+		Identity: &tbpb.TestTargetIdentity{TargetLabel: targetLabel},
+		Observation: &tbpb.TestObservation{
+			Outcome: reportContext.TargetOutcome, DurationUsec: durationUsec, SourceUrl: metadata.SourceURL,
+			EventTimeUsec:  eventTimeUsec,
+			ObservationId:  observationID("target", metadata.SourceURL, targetLabel, reportContext.ExecutionContext),
+			Source:         metadata.Source,
+			CommitSha:      metadata.CommitSHA,
+			WorkspaceDirty: metadata.WorkspaceDirty,
+			FailureMessage: reportContext.FailureMessage,
+		},
+	}
+	if reportContext.TargetOutcome == tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT {
+		if target.Observation.FailureMessage == "" {
+			target.Observation.FailureMessage = "Bazel test target timed out"
+		}
+		return target, nil, nil
+	}
+	if report.UnattributedFailure {
+		target.Observation.Outcome = tbpb.TestOutcome_TEST_OUTCOME_FAIL
+		target.Observation.FailureMessage = "test target failed without an attributable test case"
+	}
+	caseObservations := make([]*tbpb.TestCaseObservation, 0, len(report.Cases))
+	for _, testCase := range report.Cases {
+		caseEventTimeUsec := testCase.EventTimeUsec
+		if caseEventTimeUsec <= 0 {
+			caseEventTimeUsec = eventTimeUsec
+		}
+		caseObservations = append(caseObservations, &tbpb.TestCaseObservation{
+			Identity: &tbpb.TestCaseIdentity{
+				Target: &tbpb.TestTargetIdentity{TargetLabel: testCase.TargetLabel}, CaseName: testCase.CaseName,
+			},
+			Observation: &tbpb.TestObservation{
+				Outcome: testCase.Outcome, DurationUsec: testCase.DurationUsec,
+				FailureMessage: testCase.FailureMessage, SourceUrl: metadata.SourceURL,
+				EventTimeUsec: caseEventTimeUsec,
+				ObservationId: observationID("case", metadata.SourceURL, targetLabel, testCase.CaseName,
+					reportContext.ExecutionContext, strconv.Itoa(testCase.OccurrenceIndex)),
+				Source:         metadata.Source,
+				CommitSha:      metadata.CommitSHA,
+				WorkspaceDirty: metadata.WorkspaceDirty,
+			},
+		})
+	}
+	return target, caseObservations, nil
+}
+
+func observationContext(path string) string {
+	path = filepath.ToSlash(filepath.Clean(path))
+	for _, marker := range []string{"bazel-testlogs/", "testlogs/"} {
+		if index := strings.LastIndex(path, marker); index >= 0 {
+			return path[index+len(marker):]
+		}
+	}
+	return path
+}
+
+func observationID(parts ...string) string {
+	h := sha256.New()
+	var size [8]byte
+	for _, part := range parts {
+		binary.BigEndian.PutUint64(size[:], uint64(len(part)))
+		_, _ = h.Write(size[:])
+		_, _ = io.WriteString(h, part)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func BazelTargetOutcome(xmlPath string) (tbpb.TestOutcome, error) {
+	logPath := filepath.Join(filepath.Dir(xmlPath), "test.log")
+	file, err := os.Open(logPath)
+	if os.IsNotExist(err) {
+		return tbpb.TestOutcome_TEST_OUTCOME_PASS, nil
+	}
+	if err != nil {
+		return tbpb.TestOutcome_TEST_OUTCOME_UNKNOWN, err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return tbpb.TestOutcome_TEST_OUTCOME_UNKNOWN, err
+	}
+	const tailBytes = 64 << 10
+	if info.Size() > tailBytes {
+		if _, err := file.Seek(-tailBytes, io.SeekEnd); err != nil {
+			return tbpb.TestOutcome_TEST_OUTCOME_UNKNOWN, err
+		}
+	}
+	tail, err := io.ReadAll(file)
+	if err != nil {
+		return tbpb.TestOutcome_TEST_OUTCOME_UNKNOWN, err
+	}
+	if bytes.Contains(tail, []byte("-- Test timed out at ")) {
+		return tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT, nil
+	}
+	return tbpb.TestOutcome_TEST_OUTCOME_PASS, nil
+}
+
+func HandleGetTests(args []string) (int, error) {
+	if err := arg.ParseFlagSet(GetTestsFlags, args); err != nil {
+		if err == flag.ErrHelp {
+			log.Print("usage: bb get-tests [--path=directory] [--limit=100]")
+			return 0, nil
+		}
+		return 1, err
+	}
+	if GetTestsFlags.NArg() != 0 {
+		return 1, status.InvalidArgumentError("get-tests does not accept positional arguments")
+	}
+	workspacePath, err := workspace.Path()
+	if err != nil {
+		return 1, err
+	}
+	repository, err := repositoryURL(workspacePath, *getRepo)
+	if err != nil {
+		return 1, err
+	}
+	target, err := backend(*getTarget)
+	if err != nil {
+		return 1, err
+	}
+	conn, err := grpc_client.DialSimple(target)
+	if err != nil {
+		return 1, err
+	}
+	defer conn.Close()
+	ctx, err := authenticatedContext(context.Background(), target)
+	if err != nil {
+		return 1, err
+	}
+	client := tbpb.NewTestBuddyServiceClient(conn)
+	if *getTargetLabel != "" || *getCaseName != "" {
+		if *getTargetLabel == "" || *getCaseName == "" {
+			return 1, status.InvalidArgumentError("--target_label and --case_name must be specified together")
+		}
+		rsp, err := client.GetTestCase(ctx, &tbpb.GetTestCaseRequest{
+			RepoUrl: repository,
+			Identity: &tbpb.TestCaseIdentity{
+				Target:   &tbpb.TestTargetIdentity{TargetLabel: *getTargetLabel},
+				CaseName: *getCaseName,
+			},
+		})
+		if err != nil {
+			return 1, err
+		}
+		printSummary(rsp.GetTest())
+		fmt.Println("RECENT OBSERVATIONS")
+		fmt.Println("TYPE\tSOURCE\tOUTCOME\tDURATION\tFAILURE")
+		for _, observation := range rsp.GetRecentObservations() {
+			fmt.Printf("%s\t%s\t%s\t%s\t%s\n",
+				strings.TrimPrefix(observation.GetSource().String(), "TEST_OBSERVATION_SOURCE_"),
+				observation.GetSourceUrl(),
+				strings.TrimPrefix(observation.GetOutcome().String(), "TEST_OUTCOME_"),
+				time.Duration(observation.GetDurationUsec())*time.Microsecond,
+				observation.GetFailureMessage())
+		}
+		fmt.Println("STATE CHANGES")
+		fmt.Println("TIME\tPREVIOUS\tCURRENT")
+		for _, transition := range rsp.GetTransitions() {
+			fmt.Printf("%s\t%s\t%s\n",
+				time.UnixMicro(transition.GetEventTimeUsec()).Format(time.RFC3339),
+				strings.TrimPrefix(transition.GetPreviousHealth().String(), "TEST_HEALTH_"),
+				strings.TrimPrefix(transition.GetHealth().String(), "TEST_HEALTH_"))
+		}
+		return 0, nil
+	}
+	if *getLimit <= 0 {
+		return 1, status.InvalidArgumentError("--limit must be greater than zero")
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	stream, err := client.GetTests(ctx, &tbpb.GetTestsRequest{
+		RepoUrl: repository, PackagePrefix: *getPath,
+	})
+	if err != nil {
+		return 1, err
+	}
+	fmt.Println("HEALTH\tPASS RATE\tMEAN\tTARGET\tCASE")
+	printed := 0
+	for printed < *getLimit {
+		rsp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return 1, err
+		}
+		for _, test := range rsp.GetTests() {
+			summary := test.GetSummary()
+			health := strings.TrimPrefix(summary.GetHealth().String(), "TEST_HEALTH_")
+			fmt.Printf("%s\t%.1f%%\t%s\t%s\t%s\n",
+				health, summary.GetPassRate()*100,
+				time.Duration(summary.GetMeanDurationUsec())*time.Microsecond,
+				test.GetIdentity().GetTarget().GetTargetLabel(), test.GetIdentity().GetCaseName())
+			printed++
+			if printed == *getLimit {
+				cancel()
+				break
+			}
+		}
+	}
+	return 0, nil
+}
+
+func printSummary(test *tbpb.TestCaseSummary) {
+	summary := test.GetSummary()
+	fmt.Println("HEALTH\tPASS RATE\tMEAN\tTARGET\tCASE")
+	fmt.Printf("%s\t%.1f%%\t%s\t%s\t%s\n",
+		strings.TrimPrefix(summary.GetHealth().String(), "TEST_HEALTH_"),
+		summary.GetPassRate()*100,
+		time.Duration(summary.GetMeanDurationUsec())*time.Microsecond,
+		test.GetIdentity().GetTarget().GetTargetLabel(),
+		test.GetIdentity().GetCaseName())
+}
+
+func TargetLabelFromXMLPath(workspacePath, path string) (string, error) {
+	absolute := path
+	if !filepath.IsAbs(absolute) {
+		absolute = filepath.Join(workspacePath, path)
+	}
+	slashed := filepath.ToSlash(absolute)
+	marker := "/bazel-testlogs/"
+	index := strings.LastIndex(slashed, marker)
+	if index < 0 {
+		marker = "/testlogs/"
+		index = strings.LastIndex(slashed, marker)
+	}
+	if index < 0 || !strings.HasSuffix(slashed, "/test.xml") {
+		return "", status.InvalidArgumentErrorf(
+			"cannot infer a Bazel target from %q; pass --target_label", path)
+	}
+	relative := strings.TrimSuffix(slashed[index+len(marker):], "/test.xml")
+	parts := strings.Split(relative, "/")
+	if _, ok := testOutputLayout(parts[len(parts)-1]); len(parts) > 1 && ok {
+		parts = parts[:len(parts)-1]
+	}
+	if len(parts) == 0 || parts[len(parts)-1] == "" {
+		return "", status.InvalidArgumentErrorf("cannot infer a Bazel target from %q", path)
+	}
+	targetName := parts[len(parts)-1]
+	packagePath := strings.Join(parts[:len(parts)-1], "/")
+	targetLabel, err := identity.CanonicalizeTargetLabel("//" + packagePath + ":" + targetName)
+	if err != nil {
+		return "", status.InvalidArgumentErrorf(
+			"cannot infer a Bazel target from %q: %s", path, err)
+	}
+	return targetLabel, nil
+}
+
+type testXMLLayout struct {
+	paths  map[string]struct{}
+	newest time.Time
+}
+
+func FindTestXMLFiles(inputs []string) ([]string, error) {
+	explicit := make(map[string]struct{})
+	layouts := make(map[string]map[string]*testXMLLayout)
+	addDiscovered := func(path string) error {
+		info, err := os.Stat(path)
+		if err != nil {
+			return err
+		}
+		parent := filepath.Dir(path)
+		targetRoot := parent
+		layoutName := "direct"
+		if layout, ok := testOutputLayout(filepath.Base(parent)); ok {
+			targetRoot = filepath.Dir(parent)
+			layoutName = layout
+		}
+		if layouts[targetRoot] == nil {
+			layouts[targetRoot] = make(map[string]*testXMLLayout)
+		}
+		layout := layouts[targetRoot][layoutName]
+		if layout == nil {
+			layout = &testXMLLayout{paths: make(map[string]struct{})}
+			layouts[targetRoot][layoutName] = layout
+		}
+		layout.paths[path] = struct{}{}
+		if info.ModTime().After(layout.newest) {
+			layout.newest = info.ModTime()
+		}
+		return nil
+	}
+	for _, input := range inputs {
+		info, err := os.Stat(input)
+		if err != nil {
+			return nil, err
+		}
+		if !info.IsDir() {
+			explicit[input] = struct{}{}
+			continue
+		}
+		root, err := filepath.EvalSymlinks(input)
+		if err != nil {
+			return nil, err
+		}
+		err = filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if !entry.IsDir() && entry.Name() == "test.xml" {
+				return addDiscovered(path)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	paths := explicit
+	for root, targetLayouts := range layouts {
+		var selectedName string
+		var selected *testXMLLayout
+		for name, layout := range targetLayouts {
+			if selected == nil || layout.newest.After(selected.newest) ||
+				(layout.newest.Equal(selected.newest) && name < selectedName) {
+				selectedName = name
+				selected = layout
+			}
+		}
+		if len(targetLayouts) > 1 {
+			ignored := make([]string, 0, len(targetLayouts)-1)
+			for name, layout := range targetLayouts {
+				if name != selectedName {
+					ignored = append(ignored, fmt.Sprintf("%s (%d files)", name, len(layout.paths)))
+				}
+			}
+			sort.Strings(ignored)
+			log.Debugf("selected %s (%d files) for %s; ignored older output: %s",
+				selectedName, len(selected.paths), root, strings.Join(ignored, ", "))
+		}
+		for path := range selected.paths {
+			paths[path] = struct{}{}
+		}
+	}
+	sorted := make([]string, 0, len(paths))
+	for path := range paths {
+		sorted = append(sorted, path)
+	}
+	sort.Strings(sorted)
+	return sorted, nil
+}
+
+func testOutputLayout(directory string) (string, bool) {
+	match := bazelTestOutputLayout.FindStringSubmatch(directory)
+	if match == nil {
+		return "", false
+	}
+	if match[1] != "" {
+		return "runs:" + match[1], true
+	}
+	layout := "shards:" + match[2]
+	if match[3] != "" {
+		layout += ":runs:" + match[3]
+	}
+	return layout, true
+}
+
+func repositoryURL(workspacePath, override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+	cmd := exec.Command("git", "config", "--get", "remote.origin.url")
+	cmd.Dir = workspacePath
+	output, err := cmd.Output()
+	if err != nil {
+		return "", status.FailedPreconditionError(
+			"could not read git remote.origin.url; pass --repo_url")
+	}
+	repository := gitutil.StripRepoURLCredentials(strings.TrimSpace(string(output)))
+	if repository == "" {
+		return "", status.FailedPreconditionError("git remote.origin.url is empty; pass --repo_url")
+	}
+	return repository, nil
+}
+
+func observationURL(override, requestedInvocationID string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+	invocationID := requestedInvocationID
+	if invocationID == "" {
+		var err error
+		invocationID, err = flaghistory.GetPreviousFlag(flaghistory.InvocationIDFlagName)
+		if err != nil {
+			return "", err
+		}
+	}
+	base, err := flaghistory.GetPreviousFlag(flaghistory.BesResultsUrlFlagName)
+	if err != nil {
+		return "", err
+	}
+	if invocationID == "" || base == "" {
+		return "", status.FailedPreconditionError(
+			"could not determine the most recent invocation URL; pass --source_url")
+	}
+	parsed, err := url.Parse(base)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", status.FailedPreconditionError(
+			"could not determine the invocation URL; pass --source_url")
+	}
+	const marker = "/invocation/"
+	if index := strings.Index(parsed.Path, marker); index >= 0 {
+		parsed.Path = parsed.Path[:index+len(marker)] + invocationID
+	} else {
+		parsed.Path = strings.TrimSuffix(parsed.Path, "/") + marker + invocationID
+	}
+	parsed.RawPath = ""
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String(), nil
+}
+
+func backend(override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+	return "grpc://127.0.0.1:1985", nil
+}
+
+func authenticatedContext(ctx context.Context, target string) (context.Context, error) {
+	if strings.Contains(target, "localhost") || strings.Contains(target, "127.0.0.1") ||
+		strings.HasPrefix(target, "unix://") {
+		return ctx, nil
+	}
+	apiKey, err := login.GetAPIKey()
+	if err != nil {
+		return nil, err
+	}
+	if apiKey == "" {
+		return nil, status.UnauthenticatedError("not logged in; run bb login")
+	}
+	return metadata.AppendToOutgoingContext(ctx, "x-buildbuddy-api-key", apiKey), nil
+}

--- a/cli/testbuddy/testbuddy_test.go
+++ b/cli/testbuddy/testbuddy_test.go
@@ -1,0 +1,618 @@
+package testbuddy_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/util/download/downloadtest"
+	cmpb "github.com/buildbuddy-io/buildbuddy/proto/api/v1/common"
+	bespb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
+	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
+	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
+	trpb "github.com/buildbuddy-io/buildbuddy/proto/target"
+	tbpb "github.com/buildbuddy-io/buildbuddy/proto/test_buddy"
+	"github.com/buildbuddy-io/buildbuddy/server/test_buddy/junit"
+	"github.com/buildbuddy-io/buildbuddy/server/test_buddy/normalize"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/testbuddy"
+)
+
+type fakeBuildBuddyClient struct {
+	bbspb.BuildBuddyServiceClient
+	invocation *inpb.GetInvocationResponse
+	targets    map[string]*trpb.GetTargetResponse
+}
+
+func (f *fakeBuildBuddyClient) GetInvocation(ctx context.Context, req *inpb.GetInvocationRequest, opts ...grpc.CallOption) (*inpb.GetInvocationResponse, error) {
+	return f.invocation, nil
+}
+
+func (f *fakeBuildBuddyClient) GetTarget(ctx context.Context, req *trpb.GetTargetRequest, opts ...grpc.CallOption) (*trpb.GetTargetResponse, error) {
+	if req.GetTargetLabel() != "" {
+		return f.targets[req.GetTargetLabel()], nil
+	}
+	if !req.GetIncludeTestResultEvents() {
+		return nil, errors.New("result events were not requested")
+	}
+	if req.Status != nil {
+		return f.targets[fmt.Sprintf("%d:%s", req.GetStatus(), req.GetPageToken())], nil
+	}
+	return f.targets[req.GetPageToken()], nil
+}
+
+func observationMetadata(source tbpb.TestObservationSource) testbuddy.ObservationMetadata {
+	return testbuddy.ObservationMetadata{
+		SourceURL: "https://app.buildbuddy.io/invocation/one", Source: source,
+		CommitSHA: "abc123",
+	}
+}
+
+func TestTargetLabelFromXMLPath(t *testing.T) {
+	for _, test := range []struct {
+		path  string
+		label string
+	}{
+		{
+			path:  "bazel-testlogs/server/foo/foo_test/test.xml",
+			label: "//server/foo:foo_test",
+		},
+		{
+			path:  "bazel-out/k8-fastbuild/testlogs/root_test/test.xml",
+			label: "//:root_test",
+		},
+		{
+			path:  "bazel-testlogs/server/foo/foo_test/run_1_of_100/test.xml",
+			label: "//server/foo:foo_test",
+		},
+		{
+			path:  "bazel-testlogs/server/foo/foo_test/shard_2_of_4/test.xml",
+			label: "//server/foo:foo_test",
+		},
+		{
+			path:  "bazel-testlogs/server/foo/foo_test/shard_2_of_4_run_37_of_100/test.xml",
+			label: "//server/foo:foo_test",
+		},
+	} {
+		t.Run(test.path, func(t *testing.T) {
+			label, err := testbuddy.TargetLabelFromXMLPath("/workspace", test.path)
+			require.NoError(t, err)
+			require.Equal(t, test.label, label)
+		})
+	}
+}
+
+func TestXMLPathsSelectsTheMostRecentlyWrittenBazelLayout(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		olderLayout   []string
+		currentLayout []string
+	}{
+		{
+			name: "runs increased",
+			olderLayout: []string{
+				"run_1_of_3", "run_2_of_3", "run_3_of_3",
+			},
+			currentLayout: []string{
+				"run_1_of_5", "run_2_of_5", "run_3_of_5", "run_4_of_5", "run_5_of_5",
+			},
+		},
+		{
+			name: "runs decreased",
+			olderLayout: []string{
+				"run_1_of_5", "run_2_of_5", "run_3_of_5", "run_4_of_5", "run_5_of_5",
+			},
+			currentLayout: []string{
+				"run_1_of_3", "run_2_of_3", "run_3_of_3",
+			},
+		},
+		{
+			name: "shards and runs changed",
+			olderLayout: []string{
+				"shard_1_of_2_run_1_of_2", "shard_1_of_2_run_2_of_2",
+				"shard_2_of_2_run_1_of_2", "shard_2_of_2_run_2_of_2",
+			},
+			currentLayout: []string{
+				"shard_1_of_3_run_1_of_1", "shard_2_of_3_run_1_of_1", "shard_3_of_3_run_1_of_1",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := filepath.Join(t.TempDir(), "bazel-testlogs", "pkg", "unit_test")
+			older := time.Unix(1_000, 0)
+			current := older.Add(time.Minute)
+			write := func(layout string, modified time.Time) string {
+				path := filepath.Join(root, layout, "test.xml")
+				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+				require.NoError(t, os.WriteFile(path, []byte("<testsuite/>"), 0o644))
+				require.NoError(t, os.Chtimes(path, modified, modified))
+				return path
+			}
+			for _, layout := range test.olderLayout {
+				write(layout, older)
+			}
+			want := make([]string, 0, len(test.currentLayout))
+			for _, layout := range test.currentLayout {
+				want = append(want, write(layout, current))
+			}
+			sort.Strings(want)
+
+			got, err := testbuddy.FindTestXMLFiles([]string{filepath.Dir(filepath.Dir(root))})
+			require.NoError(t, err)
+			require.Equal(t, want, got)
+		})
+	}
+}
+
+func TestXMLPathsSelectsDirectOutputWhenItIsNewest(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "bazel-testlogs", "pkg", "unit_test")
+	stale := filepath.Join(root, "run_1_of_2", "test.xml")
+	direct := filepath.Join(root, "test.xml")
+	for _, path := range []string{stale, direct} {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte("<testsuite/>"), 0o644))
+	}
+	older := time.Unix(1_000, 0)
+	require.NoError(t, os.Chtimes(stale, older, older))
+	require.NoError(t, os.Chtimes(direct, older.Add(time.Minute), older.Add(time.Minute)))
+
+	got, err := testbuddy.FindTestXMLFiles([]string{filepath.Dir(filepath.Dir(root))})
+	require.NoError(t, err)
+	require.Equal(t, []string{direct}, got)
+
+	// Explicit files remain explicit even if a directory scan would select a
+	// different layout.
+	got, err = testbuddy.FindTestXMLFiles([]string{stale})
+	require.NoError(t, err)
+	require.Equal(t, []string{stale}, got)
+}
+
+func TestBazelTargetOutcome(t *testing.T) {
+	dir := t.TempDir()
+	xmlPath := filepath.Join(dir, "test.xml")
+	require.NoError(t, os.WriteFile(xmlPath, []byte("<testsuite/>"), 0o644))
+
+	outcome, err := testbuddy.BazelTargetOutcome(xmlPath)
+	require.NoError(t, err)
+	require.Equal(t, tbpb.TestOutcome_TEST_OUTCOME_PASS, outcome)
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "test.log"),
+		[]byte("test output\n-- Test timed out at 2026-07-30 12:00:00 UTC --\n"),
+		0o644))
+	outcome, err = testbuddy.BazelTargetOutcome(xmlPath)
+	require.NoError(t, err)
+	require.Equal(t, tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT, outcome)
+
+	target, cases, err := testbuddy.ObservationsForReport(
+		xmlPath, "//pkg:timeout_test",
+		observationMetadata(tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR), &junit.Report{
+			EventTimeUsec: 1_700_000,
+			DurationUsec:  1_000_000,
+			Cases: []normalize.CaseRecord{{
+				TargetLabel: "//pkg:timeout_test", CaseName: "TestTimeout",
+				Outcome: tbpb.TestOutcome_TEST_OUTCOME_FAIL,
+			}},
+		})
+	require.NoError(t, err)
+	require.Equal(t, tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT, target.GetObservation().GetOutcome())
+	require.Equal(t, int64(1_000_000), target.GetObservation().GetDurationUsec())
+	require.Equal(t, int64(1_700_000), target.GetObservation().GetEventTimeUsec())
+	require.Len(t, target.GetObservation().GetObservationId(), 64)
+	require.Empty(t, cases)
+
+	require.NoError(t, os.Remove(filepath.Join(dir, "test.log")))
+	target, cases, err = testbuddy.ObservationsForReport(
+		xmlPath, "//pkg:harness_test",
+		observationMetadata(tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR),
+		&junit.Report{EventTimeUsec: 1_700_000, UnattributedFailure: true})
+	require.NoError(t, err)
+	require.Equal(t, tbpb.TestOutcome_TEST_OUTCOME_FAIL, target.GetObservation().GetOutcome())
+	require.Empty(t, cases)
+}
+
+func TestObservationsForReportRetainsTimeAndStableIdentity(t *testing.T) {
+	report := &junit.Report{
+		EventTimeUsec: 1_000_000,
+		Cases: []normalize.CaseRecord{
+			{TargetLabel: "//pkg:test", CaseName: "TestCase", Outcome: tbpb.TestOutcome_TEST_OUTCOME_PASS, OccurrenceIndex: 0},
+			{TargetLabel: "//pkg:test", CaseName: "TestCase", Outcome: tbpb.TestOutcome_TEST_OUTCOME_PASS, EventTimeUsec: 2_000_000, OccurrenceIndex: 1},
+		},
+	}
+	pathA := filepath.Join(t.TempDir(), "bazel-testlogs/pkg/test/run_1_of_2/test.xml")
+	pathB := filepath.Join(t.TempDir(), "bazel-testlogs/pkg/test/run_1_of_2/test.xml")
+	targetA, casesA, err := testbuddy.ObservationsForReport(
+		pathA, "//pkg:test",
+		observationMetadata(tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_PRESUBMIT), report)
+	require.NoError(t, err)
+	targetB, casesB, err := testbuddy.ObservationsForReport(
+		pathB, "//pkg:test",
+		observationMetadata(tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_PRESUBMIT), report)
+	require.NoError(t, err)
+	require.Equal(t, targetA.GetObservation().GetObservationId(), targetB.GetObservation().GetObservationId())
+	require.Equal(t, int64(1_000_000), targetA.GetObservation().GetEventTimeUsec())
+	require.Equal(t, tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_PRESUBMIT, targetA.GetObservation().GetSource())
+	require.Equal(t, "abc123", targetA.GetObservation().GetCommitSha())
+	require.False(t, targetA.GetObservation().GetWorkspaceDirty())
+	require.Equal(t, casesA[0].GetObservation().GetObservationId(), casesB[0].GetObservation().GetObservationId())
+	require.NotEqual(t, casesA[0].GetObservation().GetObservationId(), casesA[1].GetObservation().GetObservationId())
+	require.Equal(t, int64(1_000_000), casesA[0].GetObservation().GetEventTimeUsec())
+	require.Equal(t, int64(2_000_000), casesA[1].GetObservation().GetEventTimeUsec())
+}
+
+func TestObservationsForReportUsesStableFileTimeWhenJUnitHasNoTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	xmlPath := filepath.Join(dir, "test.xml")
+	require.NoError(t, os.WriteFile(xmlPath, []byte("<testsuite/>"), 0o644))
+	modified := time.Unix(1_700_000_000, 123_456_000)
+	require.NoError(t, os.Chtimes(xmlPath, modified, modified))
+	report := &junit.Report{Cases: []normalize.CaseRecord{{
+		TargetLabel: "//pkg:test", CaseName: "TestCase",
+		Outcome: tbpb.TestOutcome_TEST_OUTCOME_PASS,
+	}}}
+
+	targetA, casesA, err := testbuddy.ObservationsForReport(
+		xmlPath, "//pkg:test",
+		observationMetadata(tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR), report)
+	require.NoError(t, err)
+	targetB, casesB, err := testbuddy.ObservationsForReport(
+		xmlPath, "//pkg:test",
+		observationMetadata(tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR), report)
+	require.NoError(t, err)
+
+	require.True(t, proto.Equal(targetA, targetB))
+	require.Len(t, casesA, 1)
+	require.Len(t, casesB, 1)
+	require.True(t, proto.Equal(casesA[0], casesB[0]))
+	require.Equal(t, modified.UnixMicro(), targetA.GetObservation().GetEventTimeUsec())
+	require.Equal(t, modified.UnixMicro(), casesA[0].GetObservation().GetEventTimeUsec())
+}
+
+func TestParseObservationSource(t *testing.T) {
+	require.Equal(t, "monitor", testbuddy.TestReportFlags.Lookup("source").DefValue)
+	for value, want := range map[string]tbpb.TestObservationSource{
+		"presubmit":  tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_PRESUBMIT,
+		"postsubmit": tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_POSTSUBMIT,
+		"monitor":    tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR,
+	} {
+		got, err := testbuddy.ParseObservationSource(value)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	}
+	_, err := testbuddy.ParseObservationSource("local")
+	require.ErrorContains(t, err, "presubmit, postsubmit, or monitor")
+}
+
+func TestWorkspaceRevision(t *testing.T) {
+	dir := t.TempDir()
+	run := func(args ...string) string {
+		command := exec.Command("git", args...)
+		command.Dir = dir
+		output, err := command.CombinedOutput()
+		require.NoError(t, err, "%s", output)
+		return strings.TrimSpace(string(output))
+	}
+	run("init")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file"), []byte("one"), 0o644))
+	run("add", "file")
+	run("commit", "-m", "initial")
+	wantCommit := run("rev-parse", "HEAD")
+
+	commitSHA, dirty, err := testbuddy.WorkspaceRevision(dir)
+	require.NoError(t, err)
+	require.Equal(t, wantCommit, commitSHA)
+	require.False(t, dirty)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file"), []byte("two"), 0o644))
+	commitSHA, dirty, err = testbuddy.WorkspaceRevision(dir)
+	require.NoError(t, err)
+	require.Equal(t, wantCommit, commitSHA)
+	require.True(t, dirty)
+}
+
+func TestInvocationReportMetadata(t *testing.T) {
+	client := &fakeBuildBuddyClient{invocation: &inpb.GetInvocationResponse{
+		Invocation: []*inpb.Invocation{{
+			InvocationId: "invocation-one", RepoUrl: "https://github.com/acme/repo",
+			CommitSha: "abc123", CreatedAtUsec: 1_700_000, Role: "CI", BranchName: "main",
+			Event: []*inpb.InvocationEvent{{BuildEvent: &bespb.BuildEvent{
+				Payload: &bespb.BuildEvent_WorkspaceStatus{WorkspaceStatus: &bespb.WorkspaceStatus{
+					Item: []*bespb.WorkspaceStatus_Item{{Key: "GIT_TREE_STATUS", Value: "Modified"}},
+				}},
+			}}},
+		}},
+	}}
+
+	metadata, err := testbuddy.GetInvocationReportMetadata(context.Background(), client, "invocation-one")
+	require.NoError(t, err)
+	require.Equal(t, "https://github.com/acme/repo", metadata.Repository)
+	require.Equal(t, "abc123", metadata.CommitSHA)
+	require.Equal(t, int64(1_700_000), metadata.CreatedAtUsec)
+	require.True(t, metadata.WorkspaceDirty)
+	require.True(t, metadata.TargetsReportedByBES(
+		"grpcs://buildbuddy.example", "grpcs://buildbuddy.example/"))
+	require.False(t, metadata.TargetsReportedByBES(
+		"grpc://127.0.0.1:1985", "grpcs://buildbuddy.example"))
+	require.Equal(t, tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_POSTSUBMIT,
+		metadata.DefaultObservationSource(tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR))
+	metadata.BranchName = "feature"
+	require.Equal(t, tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_PRESUBMIT,
+		metadata.DefaultObservationSource(tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR))
+	metadata.Role = ""
+	require.False(t, metadata.TargetsReportedByBES(
+		"grpcs://buildbuddy.example", "grpcs://buildbuddy.example"))
+	require.Equal(t, tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR,
+		metadata.DefaultObservationSource(tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR))
+}
+
+func TestInvocationReportsArePagedDeduplicatedAndParsed(t *testing.T) {
+	const (
+		invocationID = "invocation-one"
+		targetOne    = "//pkg:one_test"
+		targetTwo    = "//pkg:two_test"
+		xmlURI       = "bytestream://cache/blobs/abc/123"
+	)
+	event := func(label, uri string, status bespb.TestStatus, run int32) *bespb.BuildEvent {
+		result := &bespb.TestResult{
+			Status: status, TestAttemptStart: timestamppb.New(time.Unix(1_700_000_000, 0)),
+			TestAttemptDuration: durationpb.New(2 * time.Second),
+		}
+		if uri != "" {
+			result.TestActionOutput = []*bespb.File{{
+				Name: "test.xml", File: &bespb.File_Uri{Uri: uri},
+			}}
+		}
+		return &bespb.BuildEvent{
+			Id: &bespb.BuildEventId{Id: &bespb.BuildEventId_TestResult{
+				TestResult: &bespb.BuildEventId_TestResultId{
+					Label: label, Configuration: &bespb.BuildEventId_ConfigurationId{Id: "cfg"},
+					Run: run, Shard: 1, Attempt: 1,
+				},
+			}},
+			Payload: &bespb.BuildEvent_TestResult{TestResult: result},
+		}
+	}
+	passing := event(targetOne, xmlURI, bespb.TestStatus_PASSED, 1)
+	timeout := event(targetTwo, "", bespb.TestStatus_TIMEOUT, 1)
+	target := func(label string, events ...*bespb.BuildEvent) *trpb.Target {
+		return &trpb.Target{Metadata: &trpb.TargetMetadata{Label: label}, TestResultEvents: events}
+	}
+	client := &fakeBuildBuddyClient{targets: map[string]*trpb.GetTargetResponse{
+		"": {TargetGroups: []*trpb.TargetGroup{
+			{
+				Status: cmpb.Status_PASSED, Targets: []*trpb.Target{target(targetOne, passing)}, NextPageToken: "next",
+			},
+			{
+				Status: cmpb.Status_TIMED_OUT, NextPageToken: "next",
+			},
+		}},
+		fmt.Sprintf("%d:next", cmpb.Status_PASSED): {TargetGroups: []*trpb.TargetGroup{{
+			Status: cmpb.Status_PASSED, Targets: []*trpb.Target{target(targetOne)},
+		}}},
+		fmt.Sprintf("%d:next", cmpb.Status_TIMED_OUT): {TargetGroups: []*trpb.TargetGroup{{
+			Status: cmpb.Status_TIMED_OUT, Targets: []*trpb.Target{target(targetTwo)},
+		}}},
+		targetOne: {TargetGroups: []*trpb.TargetGroup{{
+			Status: cmpb.Status_PASSED, Targets: []*trpb.Target{target(targetOne, passing)},
+		}}},
+		targetTwo: {TargetGroups: []*trpb.TargetGroup{{
+			Status: cmpb.Status_TIMED_OUT, Targets: []*trpb.Target{target(targetTwo, timeout)},
+		}}},
+	}}
+	downloader := downloadtest.New().Add(xmlURI, []byte(
+		`<testsuite><testcase name="TestCaseName" time="0.25"/></testsuite>`))
+
+	var reports []*testbuddy.InvocationTestReport
+	stats, err := testbuddy.ForEachInvocationTestReport(
+		context.Background(), client, downloader, invocationID, 1_600_000,
+		func(report *testbuddy.InvocationTestReport) error {
+			reports = append(reports, report)
+			return nil
+		})
+	require.NoError(t, err)
+	require.Equal(t, testbuddy.InvocationReportStats{AttemptCount: 2, XMLCount: 1}, stats)
+	require.Len(t, reports, 2)
+	sort.Slice(reports, func(i, j int) bool { return reports[i].TargetLabel < reports[j].TargetLabel })
+
+	require.Equal(t, targetOne, reports[0].TargetLabel)
+	require.Equal(t, xmlURI, reports[0].XMLURI)
+	require.Len(t, reports[0].Report.Cases, 1)
+	require.Equal(t, tbpb.TestOutcome_TEST_OUTCOME_PASS, reports[0].Context.TargetOutcome)
+	require.Equal(t, int64(2*time.Second/time.Microsecond), reports[0].Context.TargetDurationUsec)
+	require.Equal(t, time.Unix(1_700_000_000, 0).UnixMicro(), reports[0].Context.EventTimeUsec)
+
+	require.Equal(t, targetTwo, reports[1].TargetLabel)
+	require.Empty(t, reports[1].XMLURI)
+	require.Empty(t, reports[1].Report.Cases)
+	require.Equal(t, tbpb.TestOutcome_TEST_OUTCOME_TIMEOUT, reports[1].Context.TargetOutcome)
+
+	metadata := observationMetadata(tbpb.TestObservationSource_TEST_OBSERVATION_SOURCE_MONITOR)
+	targetObservation, cases, err := testbuddy.ObservationsForParsedReport(
+		reports[0].TargetLabel, metadata, reports[0].Report, reports[0].Context)
+	require.NoError(t, err)
+	require.Equal(t, targetOne, targetObservation.GetIdentity().GetTargetLabel())
+	require.Equal(t, time.Unix(1_700_000_000, 0).UnixMicro(), targetObservation.GetObservation().GetEventTimeUsec())
+	require.Len(t, targetObservation.GetObservation().GetObservationId(), 64)
+	require.Len(t, cases, 1)
+	require.Equal(t, "TestCaseName", cases[0].GetIdentity().GetCaseName())
+}
+
+func TestReportBatcherKeepsMessagesWithinBudget(t *testing.T) {
+	// Enough observations that no single message can hold them all.
+	const caseCount = 40_000
+	var sent []*tbpb.ReportTestResultsRequest
+	batcher := testbuddy.NewReportBatcher("https://github.com/acme/repo",
+		func(req *tbpb.ReportTestResultsRequest) error {
+			sent = append(sent, req)
+			return nil
+		})
+	require.NoError(t, batcher.AddTargetObservation(&tbpb.TestTargetObservation{
+		Identity: &tbpb.TestTargetIdentity{TargetLabel: "//pkg:test"},
+		Observation: &tbpb.TestObservation{
+			Outcome:       tbpb.TestOutcome_TEST_OUTCOME_FAIL,
+			SourceUrl:     "https://app.buildbuddy.io/invocation/one",
+			ObservationId: "target-observation",
+		},
+	}))
+	for i := range caseCount {
+		require.NoError(t, batcher.AddCaseObservation(&tbpb.TestCaseObservation{
+			Identity: &tbpb.TestCaseIdentity{
+				Target:   &tbpb.TestTargetIdentity{TargetLabel: "//pkg:test"},
+				CaseName: fmt.Sprintf("TestCase%05d", i),
+			},
+			Observation: &tbpb.TestObservation{
+				Outcome:        tbpb.TestOutcome_TEST_OUTCOME_FAIL,
+				DurationUsec:   1_000,
+				SourceUrl:      "https://app.buildbuddy.io/invocation/one",
+				ObservationId:  fmt.Sprintf("case-observation-%05d", i),
+				FailureMessage: strings.Repeat("f", normalize.MaxFailureMessageBytes),
+			},
+		}))
+	}
+	require.NoError(t, batcher.Flush())
+
+	// The report spans messages rather than being truncated to one.
+	require.Greater(t, len(sent), 1)
+	seen := 0
+	caseNames := make(map[string]bool, caseCount)
+	for _, req := range sent {
+		require.LessOrEqual(t, proto.Size(req), testbuddy.ReportRequestTargetBytes)
+		// Every message must carry the repository; it is not sent once.
+		require.Equal(t, "https://github.com/acme/repo", req.GetRepoUrl())
+		seen += len(req.GetCaseObservations()) + len(req.GetTargetObservations())
+		for _, observation := range req.GetCaseObservations() {
+			caseNames[observation.GetIdentity().GetCaseName()] = true
+		}
+	}
+	// Nothing is dropped and nothing is duplicated across the split.
+	require.Equal(t, caseCount+1, seen)
+	require.Len(t, caseNames, caseCount)
+
+	// Flushing again sends nothing: an empty message costs a round trip.
+	before := len(sent)
+	require.NoError(t, batcher.Flush())
+	require.Len(t, sent, before)
+}
+
+func TestReportBatcherSendsOneMessageForASmallReport(t *testing.T) {
+	var sent []*tbpb.ReportTestResultsRequest
+	batcher := testbuddy.NewReportBatcher("https://github.com/acme/repo",
+		func(req *tbpb.ReportTestResultsRequest) error {
+			sent = append(sent, req)
+			return nil
+		})
+	require.NoError(t, batcher.AddTargetObservation(&tbpb.TestTargetObservation{
+		Identity:    &tbpb.TestTargetIdentity{TargetLabel: "//pkg:test"},
+		Observation: &tbpb.TestObservation{Outcome: tbpb.TestOutcome_TEST_OUTCOME_PASS},
+	}))
+	require.NoError(t, batcher.AddCaseObservation(&tbpb.TestCaseObservation{
+		Identity: &tbpb.TestCaseIdentity{
+			Target:   &tbpb.TestTargetIdentity{TargetLabel: "//pkg:test"},
+			CaseName: "TestCase",
+		},
+		Observation: &tbpb.TestObservation{Outcome: tbpb.TestOutcome_TEST_OUTCOME_PASS},
+	}))
+	require.Empty(t, sent, "nothing is sent before the report is complete")
+	require.NoError(t, batcher.Flush())
+	require.Len(t, sent, 1)
+	require.Len(t, sent[0].GetTargetObservations(), 1)
+	require.Len(t, sent[0].GetCaseObservations(), 1)
+}
+
+func TestReportBatcherReportsSendFailure(t *testing.T) {
+	batcher := testbuddy.NewReportBatcher("https://github.com/acme/repo",
+		func(*tbpb.ReportTestResultsRequest) error {
+			return errors.New("stream closed")
+		})
+	require.NoError(t, batcher.AddTargetObservation(&tbpb.TestTargetObservation{
+		Identity:    &tbpb.TestTargetIdentity{TargetLabel: "//pkg:test"},
+		Observation: &tbpb.TestObservation{Outcome: tbpb.TestOutcome_TEST_OUTCOME_PASS},
+	}))
+	require.ErrorContains(t, batcher.Flush(), "stream closed")
+}
+
+func TestDiagnosticLogSeparatesDroppedCasesFromIgnoredFields(t *testing.T) {
+	var lines []string
+	diagnostics := testbuddy.NewDiagnosticLog(func(line string) { lines = append(lines, line) })
+	diagnostics.Add("bazel-testlogs/pkg/test/test.xml", "//pkg:test", &junit.Report{
+		Diagnostics: []junit.Diagnostic{
+			{Code: junit.DiagnosticMissingName, CaseIndex: 4},
+			{Code: junit.DiagnosticInvalidIdentity, CaseIndex: 5, CaseName: "Test\tTab"},
+			{Code: junit.DiagnosticInvalidDuration, CaseIndex: 6, CaseName: "TestSlow"},
+			{Code: junit.DiagnosticInvalidTimestamp, CaseIndex: -1},
+			{Code: junit.DiagnosticInvalidUTF8, CaseIndex: -1},
+		},
+	})
+
+	require.Equal(t, 2, diagnostics.Dropped)
+	require.Equal(t, 2, diagnostics.Ignored)
+	require.Equal(t, 1, diagnostics.Normalized)
+	require.Equal(t, 0, diagnostics.Truncated)
+
+	require.Len(t, lines, 5)
+	// A case with no usable name is still located by file and index.
+	require.Equal(t,
+		`dropped case //pkg:test "<unnamed>" missing_name (bazel-testlogs/pkg/test/test.xml case 4)`, lines[0])
+	// An unusable name is quoted so control characters are visible.
+	require.Equal(t,
+		`dropped case //pkg:test "Test\tTab" invalid_identity (bazel-testlogs/pkg/test/test.xml case 5)`, lines[1])
+	require.Equal(t,
+		`ignored field //pkg:test "TestSlow" invalid_duration (bazel-testlogs/pkg/test/test.xml case 6)`, lines[2])
+	// A file-level diagnostic belongs to no case, so it names no index.
+	require.Equal(t,
+		`ignored field //pkg:test "<unnamed>" invalid_timestamp (bazel-testlogs/pkg/test/test.xml)`, lines[3])
+	require.Equal(t,
+		`normalized report //pkg:test invalid_utf8 (bazel-testlogs/pkg/test/test.xml)`, lines[4])
+
+	summary := diagnostics.Summary()
+	require.Contains(t, summary, "5 JUnit diagnostics: 2 cases dropped, 2 fields ignored, normalized reports: 1")
+	// The bb parser rejects "--verbose=1"; the flag is a bare boolean.
+	require.Contains(t, summary, "rerun with --verbose (or BB_VERBOSE=1) to list them")
+	require.NotContains(t, summary, "--verbose=1")
+}
+
+func TestDiagnosticLogReportsTheParserCap(t *testing.T) {
+	var lines []string
+	diagnostics := testbuddy.NewDiagnosticLog(func(line string) { lines = append(lines, line) })
+	diagnostics.Add("a.xml", "//pkg:test", &junit.Report{
+		Diagnostics:        []junit.Diagnostic{{Code: junit.DiagnosticMissingName, CaseIndex: 0}},
+		DroppedDiagnostics: 17,
+	})
+	require.Equal(t, 17, diagnostics.Truncated)
+	require.Contains(t, lines[len(lines)-1], "17 more diagnostics in a.xml were not recorded")
+	require.Contains(t, diagnostics.Summary(), "17 beyond the per-file cap")
+}
+
+func TestDiagnosticLogIsSilentWhenEverythingParsed(t *testing.T) {
+	diagnostics := testbuddy.NewDiagnosticLog(nil)
+	diagnostics.Add("a.xml", "//pkg:test", &junit.Report{})
+	require.Empty(t, diagnostics.Summary())
+}
+
+func TestDiagnosticCodesThatDropTheCase(t *testing.T) {
+	require.True(t, junit.DiagnosticMissingName.DropsCase())
+	require.True(t, junit.DiagnosticInvalidIdentity.DropsCase())
+	for _, code := range []junit.DiagnosticCode{
+		junit.DiagnosticInvalidDuration,
+		junit.DiagnosticInvalidTimestamp,
+		junit.DiagnosticUnknownStatus,
+		junit.DiagnosticInvalidDisabled,
+		junit.DiagnosticInvalidUTF8,
+	} {
+		require.False(t, code.DropsCase(), code)
+	}
+}


### PR DESCRIPTION
Adds bb test-report for submitting Bazel test XML and bb get-tests for inspecting reported health. The commands use the TestBuddy API without embedding product policy into bb test.