### PR TITLE
[UFFD] Set max UFFD poll timeout

### DIFF
--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -320,28 +320,32 @@ func (h *Handler) handle(ctx context.Context, memoryStore *copy_on_write.COWStor
 		if len(deferredPageFaultEvents) > 0 {
 			timeoutMs = deferredPollTimeoutMs
 
-			// Cap the max timeout to prevent the value from overflowing when
-			// unix.Poll converts milliseconds to nanoseconds.
-			deferredPollTimeoutMs = min(timeoutMs*2, maxDeferredPollTimeoutMs)
-
-			if deferredPollTimeoutMs == maxDeferredPollTimeoutMs {
-				if !loggedStallWarning {
-					log.CtxWarningf(ctx, "UFFD handler is stalled on persistent EAGAIN and may trip guest-side RCU-stall / soft-lockup warnings.")
-					loggedStallWarning = true
-				}
+			if timeoutMs >= maxDeferredPollTimeoutMs && !loggedStallWarning {
+				log.CtxWarningf(ctx, "UFFD handler is stalled on persistent EAGAIN and may trip guest-side RCU-stall / soft-lockup warnings.")
+				loggedStallWarning = true
 			}
 		} else {
 			// If EAGAIN retry succeeded, reset the timeout.
 			deferredPollTimeoutMs = initialDeferredPollTimeoutMs
 			loggedStallWarning = false
 		}
-		_, pollErr := unix.Poll(pollFDs, timeoutMs)
+		n, pollErr := unix.Poll(pollFDs, timeoutMs)
 		if pollErr != nil {
 			if pollErr == unix.EINTR {
 				// Poll call was interrupted by another signal - retry
 				continue
 			}
 			return status.WrapError(pollErr, "poll uffd")
+		}
+
+		// If no events were received, increase the polling timeout.
+		if n == 0 {
+			// Cap the max timeout to prevent the value from overflowing when
+			// unix.Poll converts milliseconds to nanoseconds.
+			deferredPollTimeoutMs = min(deferredPollTimeoutMs*2, maxDeferredPollTimeoutMs)
+		} else {
+			// If we received an event, reset the timeout.
+			deferredPollTimeoutMs = initialDeferredPollTimeoutMs
 		}
 
 		// Check for an early termination message

--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -339,13 +339,10 @@ func (h *Handler) handle(ctx context.Context, memoryStore *copy_on_write.COWStor
 		}
 
 		// If no events were received, increase the polling timeout.
+		// Cap the max timeout to prevent the value from overflowing when
+		// unix.Poll converts milliseconds to nanoseconds.
 		if n == 0 {
-			// Cap the max timeout to prevent the value from overflowing when
-			// unix.Poll converts milliseconds to nanoseconds.
 			deferredPollTimeoutMs = min(deferredPollTimeoutMs*2, maxDeferredPollTimeoutMs)
-		} else {
-			// If we received an event, reset the timeout.
-			deferredPollTimeoutMs = initialDeferredPollTimeoutMs
 		}
 
 		// Check for an early termination message

--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -33,6 +33,7 @@ const (
 	UFFDIO_ZEROPAGE = 0xc020aa04
 
 	initialDeferredPollTimeoutMs = 1
+	maxDeferredPollTimeoutMs     = 1000
 )
 
 // uffdMsg is a notification from the userfaultfd object about a change in the
@@ -318,9 +319,12 @@ func (h *Handler) handle(ctx context.Context, memoryStore *copy_on_write.COWStor
 		timeoutMs := -1
 		if len(deferredPageFaultEvents) > 0 {
 			timeoutMs = deferredPollTimeoutMs
-			deferredPollTimeoutMs *= 2
 
-			if deferredPollTimeoutMs > 1000 {
+			// Cap the max timeout to prevent the value from overflowing when
+			// unix.Poll converts milliseconds to nanoseconds.
+			deferredPollTimeoutMs = min(timeoutMs*2, maxDeferredPollTimeoutMs)
+
+			if deferredPollTimeoutMs == maxDeferredPollTimeoutMs {
 				if !loggedStallWarning {
 					log.CtxWarningf(ctx, "UFFD handler is stalled on persistent EAGAIN and may trip guest-side RCU-stall / soft-lockup warnings.")
 					loggedStallWarning = true


### PR DESCRIPTION
Fixes this [error](https://console.cloud.google.com/logs/query;query=resource.labels.namespace_name%3D%22executor-prod%22%0A%22poll%20uffd:%20invalid%20argument%22;pinnedLogId=2025-12-18T02:21:51.846420885Z%2F10nmdtnflig3u3;summaryFields=:false:32:beginning;cursorTimestamp=2026-07-31T07:51:07.246851136Z;histogramBreakdownField=severity;duration=P30D?authuser=0&project=flame-build&pli=1&rapt=AEjHL4PF4BJcEEDC1G180Lvg_ywQVg2jLq6w3PyF_Rw3grLAhcBHAWKjue8Z0KdHdzW8cEGIcAQ2qZXVylbzK3kzzIc8u6-3PWQyTpgQJmWPa6mUgUytrKQ)

The poll could return early if it received EINTR and was interrupted by another signal. Then we could quickly run up the timeout to unreasonable values