### PR TITLE
devbox: add a gateway watch API and use it

### DIFF
--- a/cli/box/box.go
+++ b/cli/box/box.go
@@ -418,24 +418,26 @@ func startAndAwaitReady(ctx context.Context, env environment.Env, arn *rspb.Reso
 	}
 }
 
-// waitForPeer polls the gateway's List RPC until a peer whose session ID
-// matches the box's invocation ID appears — i.e. the moment the VM's
-// ssh-server registers with the gateway.
+// waitForPeer waits until a peer whose session ID matches the box's
+// invocation ID appears with a completed WireGuard handshake — i.e. the
+// moment the tunnel is actually usable, not just requested — using the
+// gateway's streaming Watch RPC.
 func waitForPeer(ctx context.Context, gwClient gwsvcpb.GatewayServiceClient, sessionID string) (*gwpb.Peer, error) {
+	stream, err := gwClient.Watch(ctx, &gwpb.WatchRequest{SessionId: sessionID})
+	if err != nil {
+		return nil, err
+	}
 	for {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(500 * time.Millisecond):
-		}
-		resp, err := gwClient.List(ctx, &gwpb.ListRequest{})
+		rsp, err := stream.Recv()
 		if err != nil {
-			continue
+			return nil, err
 		}
-		for _, p := range resp.GetPeers() {
-			if p.GetSessionId() == sessionID {
-				return p, nil
-			}
+		// Require a completed WireGuard handshake, not just a gateway
+		// registration: the VM registers before it validates its tunnel, and
+		// a box with a dark tunnel will exit shortly afterwards (see
+		// ssh-server's --wg_health_timeout).
+		if p := rsp.GetPeer(); p.GetLastHandshakeTime() != nil {
+			return p, nil
 		}
 	}
 }

--- a/enterprise/gateway/server/BUILD
+++ b/enterprise/gateway/server/BUILD
@@ -33,6 +33,7 @@ go_library(
         "@dev_gvisor_gvisor//pkg/tcpip/transport/icmp",
         "@dev_gvisor_gvisor//pkg/tcpip/transport/tcp",
         "@dev_gvisor_gvisor//pkg/tcpip/transport/udp",
+        "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )

--- a/enterprise/gateway/server/gateway.go
+++ b/enterprise/gateway/server/gateway.go
@@ -29,6 +29,7 @@ import (
 	"github.com/miekg/dns"
 	"golang.zx2c4.com/wireguard/conn"
 	"golang.zx2c4.com/wireguard/device"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	gwpb "github.com/buildbuddy-io/buildbuddy/proto/gateway"
@@ -36,11 +37,12 @@ import (
 )
 
 var (
-	udpListenPort     = flag.Int("gateway.udp_listen_port", 51820, "UDP port for the WireGuard device")
-	publicHost        = flag.String("gateway.public_host", "localhost", "Public hostname returned to clients as the WireGuard endpoint")
-	stalePeerTimeout  = flag.Duration("gateway.stale_peer_timeout", 5*time.Minute, "Time after the last WireGuard handshake before a peer is removed. WireGuard re-handshakes every 3 minutes, so this should be at least that.")
-	cleanupInterval   = flag.Duration("gateway.cleanup_interval", time.Minute, "How often to scan for and remove stale peers.")
-	heartbeatInterval = flag.Duration("gateway.connect_heartbeat_interval", 30*time.Second, "How often Connect streams send an empty heartbeat message. Should be well under typical intermediary idle timeouts (usually 60s+).")
+	udpListenPort             = flag.Int("gateway.udp_listen_port", 51820, "UDP port for the WireGuard device")
+	publicHost                = flag.String("gateway.public_host", "localhost", "Public hostname returned to clients as the WireGuard endpoint")
+	stalePeerTimeout          = flag.Duration("gateway.stale_peer_timeout", 5*time.Minute, "Time after the last WireGuard handshake before a peer is removed. WireGuard re-handshakes every 3 minutes, so this should be at least that.")
+	cleanupInterval           = flag.Duration("gateway.cleanup_interval", time.Minute, "How often to scan for and remove stale peers.")
+	heartbeatInterval         = flag.Duration("gateway.connect_heartbeat_interval", 30*time.Second, "How often Connect streams send an empty heartbeat message. Should be well under typical intermediary idle timeouts (usually 60s+).")
+	watchFallbackPollInterval = flag.Duration("gateway.watch_fallback_poll_interval", time.Second, "How often Watch streams re-check the watched peer's state without being woken by an event. A backstop: registration changes and WireGuard handshake activity wake watchers directly.")
 )
 
 // networkState holds IP allocation and peer name state for one
@@ -81,6 +83,14 @@ type Gateway struct {
 	publicHost    string
 	udpListenPort int
 	done          chan struct{}
+
+	// watchMu guards stateChanged. Separate from mu so that notifyWatchers is
+	// safe to call from anywhere: under mu (peer add/remove) and from the
+	// WireGuard device's own goroutines (via the logger hook).
+	watchMu sync.Mutex
+	// stateChanged is closed and replaced whenever peer state may have
+	// changed, waking all Watch streams (see watchSignal).
+	stateChanged chan struct{}
 }
 
 // New creates a Gateway with a single shared WireGuard device.
@@ -92,9 +102,33 @@ func New(env environment.Env) (*Gateway, error) {
 
 	tunDev := newMuxTUN(1420)
 
+	gw := &Gateway{
+		env:           env,
+		tun:           tunDev,
+		networks:      make(map[string]*networkState),
+		peers:         make(map[string]*peerInfo),
+		publicHost:    *publicHost,
+		udpListenPort: *udpListenPort,
+		done:          make(chan struct{}),
+		stateChanged:  make(chan struct{}),
+	}
+
 	logger := &device.Logger{
-		Verbosef: func(format string, args ...any) { log.Debugf("wg: "+format, args...) },
-		Errorf:   func(format string, args ...any) { log.Errorf("wg: "+format, args...) },
+		Verbosef: func(format string, args ...any) {
+			log.Debugf("wg: "+format, args...)
+			// Handshake activity wakes Watch streams. The device logs a
+			// keepalive/handshake line at the moment a peer's last-handshake
+			// time is stamped (wireguard-go receive.go: timersHandshakeComplete
+			// runs, then "Receiving keepalive packet" is logged), so watchers
+			// learn of a completed handshake immediately. The match is
+			// deliberately loose: Watch re-reads real state on every wake, so a
+			// spurious wake is free and a missed one only costs latency (see
+			// watchFallbackPollInterval).
+			if strings.Contains(format, "handshake") || strings.Contains(format, "keepalive") {
+				gw.notifyWatchers()
+			}
+		},
+		Errorf: func(format string, args ...any) { log.Errorf("wg: "+format, args...) },
 	}
 	dev := device.NewDevice(tunDev, conn.NewDefaultBind(), logger)
 
@@ -111,17 +145,8 @@ func New(env environment.Env) (*Gateway, error) {
 	pubKey := serverPrivKey.PublicKey().Hex()
 	log.Infof("WireGuard device up on port %d (pubkey %s...)", *udpListenPort, pubKey[:8])
 
-	gw := &Gateway{
-		env:           env,
-		dev:           dev,
-		tun:           tunDev,
-		pubKey:        pubKey,
-		networks:      make(map[string]*networkState),
-		peers:         make(map[string]*peerInfo),
-		publicHost:    *publicHost,
-		udpListenPort: *udpListenPort,
-		done:          make(chan struct{}),
-	}
+	gw.dev = dev
+	gw.pubKey = pubKey
 	go gw.cleanupLoop()
 	return gw, nil
 }
@@ -310,6 +335,99 @@ func (g *Gateway) Connect(req *gwpb.ConnectRequest, stream gwsvcpb.GatewayServic
 	}
 }
 
+// Watch streams state changes for the peer connection with the requested
+// session ID in the caller's group. A message is sent when the peer first
+// appears (which may be after the watch starts) and whenever its state
+// changes, e.g. when its first WireGuard handshake completes. Once a
+// previously-reported peer is removed, the stream ends with NotFound.
+// Watching a session that never appears blocks until the caller gives up;
+// sessions in other groups are indistinguishable from nonexistent ones.
+func (g *Gateway) Watch(req *gwpb.WatchRequest, stream gwsvcpb.GatewayService_WatchServer) error {
+	claims, err := g.env.GetAuthenticator().AuthenticatedUser(stream.Context())
+	if err != nil {
+		return err
+	}
+	groupID := claims.GetGroupID()
+	sessionID := req.GetSessionId()
+	if sessionID == "" {
+		return status.InvalidArgumentError("session_id is required")
+	}
+
+	ticker := time.NewTicker(*watchFallbackPollInterval)
+	defer ticker.Stop()
+
+	var last *gwpb.Peer
+	for {
+		// Arm the signal before snapshotting: a state change landing after
+		// the snapshot closes the already-obtained channel, so the select
+		// below wakes instead of missing it.
+		signal := g.watchSignal()
+		peer := g.snapshotPeer(groupID, sessionID)
+		if peer == nil && last != nil {
+			return status.NotFoundErrorf("session %q is no longer registered", sessionID)
+		}
+		if peer != nil && !proto.Equal(peer, last) {
+			if err := stream.Send(&gwpb.WatchResponse{Peer: peer}); err != nil {
+				return err
+			}
+			last = peer
+		}
+		select {
+		case <-stream.Context().Done():
+			return nil
+		case <-signal:
+		case <-ticker.C:
+		}
+	}
+}
+
+// notifyWatchers wakes all Watch streams so they re-check peer state.
+// Closing the channel broadcasts to every waiter; a fresh channel re-arms
+// the signal. Unlike sync.Cond, a channel can be waited on in a select
+// alongside the stream context and the fallback ticker.
+func (g *Gateway) notifyWatchers() {
+	g.watchMu.Lock()
+	close(g.stateChanged)
+	g.stateChanged = make(chan struct{})
+	g.watchMu.Unlock()
+}
+
+// watchSignal returns a channel that is closed on the next state change.
+// Callers must obtain the channel before reading the state they act on, so
+// that a change landing between the read and the wait still wakes them.
+func (g *Gateway) watchSignal() <-chan struct{} {
+	g.watchMu.Lock()
+	defer g.watchMu.Unlock()
+	return g.stateChanged
+}
+
+// snapshotPeer returns the current state of the peer with the given session
+// ID in groupID, or nil if no such peer is registered.
+func (g *Gateway) snapshotPeer(groupID, sessionID string) *gwpb.Peer {
+	handshakeTimes, err := g.lastHandshakeTimes()
+	if err != nil {
+		log.Errorf("Watch: %s", err)
+		// Proceed without handshake info; last_handshake_time is left unset.
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	for pubKeyHex, info := range g.peers {
+		if info.sessionID != sessionID || info.networkState.groupID != groupID {
+			continue
+		}
+		p := &gwpb.Peer{
+			Name:      info.assignedName,
+			Ip:        info.ip.String(),
+			SessionId: info.sessionID,
+		}
+		if t, ok := handshakeTimes[pubKeyHex]; ok {
+			p.LastHandshakeTime = timestamppb.New(t)
+		}
+		return p
+	}
+	return nil
+}
+
 // addPeerLocked allocates an IP in ns, registers it with the TUN and the
 // WireGuard device, and records the peer. assignedName and sessionID must
 // already be validated (and checked for conflicts) by the caller. Must be
@@ -348,6 +466,7 @@ func (g *Gateway) addPeerLocked(ns *networkState, pubKeyHex, assignedName, sessi
 		registeredAt: time.Now(),
 		cancel:       cancel,
 	}
+	g.notifyWatchers()
 	return assignedIP, nil
 }
 
@@ -544,6 +663,7 @@ func (g *Gateway) removePeerLocked(pubKeyHex string, info *peerInfo) {
 	if info.cancel != nil {
 		info.cancel()
 	}
+	g.notifyWatchers()
 	log.Infof("Removed peer %s... (ip=%s name=%q session=%s)", pubKeyHex[:8], info.ip, info.assignedName, info.sessionID)
 }
 

--- a/enterprise/gateway/server/gateway.go
+++ b/enterprise/gateway/server/gateway.go
@@ -342,6 +342,8 @@ func (g *Gateway) Connect(req *gwpb.ConnectRequest, stream gwsvcpb.GatewayServic
 // previously-reported peer is removed, the stream ends with NotFound.
 // Watching a session that never appears blocks until the caller gives up;
 // sessions in other groups are indistinguishable from nonexistent ones.
+// While the watched peer is quiet the stream carries periodic empty
+// heartbeat messages (as Connect does); clients ignore them.
 func (g *Gateway) Watch(req *gwpb.WatchRequest, stream gwsvcpb.GatewayService_WatchServer) error {
 	claims, err := g.env.GetAuthenticator().AuthenticatedUser(stream.Context())
 	if err != nil {
@@ -355,14 +357,23 @@ func (g *Gateway) Watch(req *gwpb.WatchRequest, stream gwsvcpb.GatewayService_Wa
 
 	ticker := time.NewTicker(*watchFallbackPollInterval)
 	defer ticker.Stop()
+	heartbeat := time.NewTicker(*heartbeatInterval)
+	defer heartbeat.Stop()
 
 	var last *gwpb.Peer
+	loggedSnapshotErr := false
 	for {
 		// Arm the signal before snapshotting: a state change landing after
 		// the snapshot closes the already-obtained channel, so the select
 		// below wakes instead of missing it.
 		signal := g.watchSignal()
-		peer := g.snapshotPeer(groupID, sessionID)
+		peer, err := g.snapshotPeer(groupID, sessionID)
+		if err != nil && !loggedSnapshotErr {
+			// Log once per stream: this runs on every wake, and a
+			// persistently failing IpcGet would otherwise flood the log.
+			log.Errorf("Watch: %s", err)
+			loggedSnapshotErr = true
+		}
 		if peer == nil && last != nil {
 			return status.NotFoundErrorf("session %q is no longer registered", sessionID)
 		}
@@ -377,6 +388,12 @@ func (g *Gateway) Watch(req *gwpb.WatchRequest, stream gwsvcpb.GatewayService_Wa
 			return nil
 		case <-signal:
 		case <-ticker.C:
+		case <-heartbeat.C:
+			// Keep the stream alive through idle-sensitive intermediaries
+			// while the watched peer is quiet or not yet registered.
+			if err := stream.Send(&gwpb.WatchResponse{}); err != nil {
+				return err
+			}
 		}
 	}
 }
@@ -402,30 +419,40 @@ func (g *Gateway) watchSignal() <-chan struct{} {
 }
 
 // snapshotPeer returns the current state of the peer with the given session
-// ID in groupID, or nil if no such peer is registered.
-func (g *Gateway) snapshotPeer(groupID, sessionID string) *gwpb.Peer {
-	handshakeTimes, err := g.lastHandshakeTimes()
-	if err != nil {
-		log.Errorf("Watch: %s", err)
-		// Proceed without handshake info; last_handshake_time is left unset.
-	}
+// ID in groupID, or nil if no such peer is registered. A non-nil error
+// reports a failure to read handshake state; the returned peer is still
+// valid, with last_handshake_time left unset.
+func (g *Gateway) snapshotPeer(groupID, sessionID string) (*gwpb.Peer, error) {
+	// Locate the peer before touching the WireGuard device: dumping device
+	// state (lastHandshakeTimes) is O(all peers), and the common case for a
+	// watch on a still-booting session is that the peer doesn't exist yet.
+	var p *gwpb.Peer
+	var pubKeyHex string
 	g.mu.Lock()
-	defer g.mu.Unlock()
-	for pubKeyHex, info := range g.peers {
+	for k, info := range g.peers {
 		if info.sessionID != sessionID || info.networkState.groupID != groupID {
 			continue
 		}
-		p := &gwpb.Peer{
+		pubKeyHex = k
+		p = &gwpb.Peer{
 			Name:      info.assignedName,
 			Ip:        info.ip.String(),
 			SessionId: info.sessionID,
 		}
-		if t, ok := handshakeTimes[pubKeyHex]; ok {
-			p.LastHandshakeTime = timestamppb.New(t)
-		}
-		return p
+		break
 	}
-	return nil
+	g.mu.Unlock()
+	if p == nil {
+		return nil, nil
+	}
+	handshakeTimes, err := g.lastHandshakeTimes()
+	if err != nil {
+		return p, err
+	}
+	if t, ok := handshakeTimes[pubKeyHex]; ok {
+		p.LastHandshakeTime = timestamppb.New(t)
+	}
+	return p, nil
 }
 
 // addPeerLocked allocates an IP in ns, registers it with the TUN and the

--- a/enterprise/gateway/server/gateway_e2e_test.go
+++ b/enterprise/gateway/server/gateway_e2e_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/buildbuddy-io/buildbuddy/server/util/wgkeys"
 	"github.com/stretchr/testify/require"
 	"golang.zx2c4.com/wireguard/conn"
@@ -36,6 +37,7 @@ type tunnelPeer struct {
 	net          *netstack.Net
 	addr         netip.Addr
 	assignedName string
+	sessionID    string
 }
 
 // sessionCounter generates unique session IDs for e2e peers: the gateway
@@ -55,11 +57,12 @@ func registerAndConnect(t testing.TB, gw *Gateway, ctx context.Context, networkN
 	privKey, err := wgkeys.GeneratePrivateKey()
 	require.NoError(t, err)
 
+	sessionID := fmt.Sprintf("e2e-session-%d", sessionCounter.Add(1))
 	resp, _, _ := startConnect(t, gw, ctx, &gwpb.ConnectRequest{
 		NetworkName: networkName,
 		PeerName:    peerName,
 		PublicKey:   privKey.PublicKey().Hex(),
-		SessionId:   fmt.Sprintf("e2e-session-%d", sessionCounter.Add(1)),
+		SessionId:   sessionID,
 	})
 
 	addr := netip.MustParseAddr(resp.GetAssignedIp())
@@ -88,7 +91,40 @@ func registerAndConnect(t testing.TB, gw *Gateway, ctx context.Context, networkN
 
 	// Peer names are unique under Connect, so the assigned name is always
 	// the requested name.
-	return tunnelPeer{net: tnet, addr: addr, assignedName: peerName}
+	return tunnelPeer{net: tnet, addr: addr, assignedName: peerName, sessionID: sessionID}
+}
+
+// TestEndToEnd_WatchReportsHandshake verifies that a Watch stream reports the
+// watched peer's first completed WireGuard handshake. The fallback poll is
+// set long so the test can only pass via the device-logger wake path.
+func TestEndToEnd_WatchReportsHandshake(t *testing.T) {
+	flags.Set(t, "gateway.watch_fallback_poll_interval", time.Minute)
+	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
+	gw := setupGateway(t, ta)
+
+	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
+	require.NoError(t, err)
+
+	peer := registerAndConnect(t, gw, ctx, "net1", "peer-a")
+	stream, cancelWatch, _ := startWatch(t, gw, ctx, peer.sessionID)
+	defer cancelWatch()
+
+	// registerAndConnect's persistent keepalive triggers the handshake; the
+	// watch must eventually report a peer with a handshake time, woken by
+	// the WireGuard device's log events rather than the (long) fallback
+	// poll.
+	deadline := time.After(30 * time.Second)
+	for {
+		select {
+		case rsp := <-stream.responses:
+			require.Equal(t, peer.sessionID, rsp.GetPeer().GetSessionId())
+			if rsp.GetPeer().GetLastHandshakeTime() != nil {
+				return
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for Watch to report a completed handshake")
+		}
+	}
 }
 
 // TestEndToEnd_PeersCanCommunicate verifies that two peers in the same network

--- a/enterprise/gateway/server/gateway_e2e_test.go
+++ b/enterprise/gateway/server/gateway_e2e_test.go
@@ -54,10 +54,15 @@ var sessionCounter atomic.Int64
 // gateway to initiate one.
 func registerAndConnect(t testing.TB, gw *Gateway, ctx context.Context, networkName, peerName string) tunnelPeer {
 	t.Helper()
+	sessionID := fmt.Sprintf("e2e-session-%d", sessionCounter.Add(1))
+	return registerAndConnectWithSessionID(t, gw, ctx, networkName, peerName, sessionID)
+}
+
+func registerAndConnectWithSessionID(t testing.TB, gw *Gateway, ctx context.Context, networkName, peerName, sessionID string) tunnelPeer {
+	t.Helper()
 	privKey, err := wgkeys.GeneratePrivateKey()
 	require.NoError(t, err)
 
-	sessionID := fmt.Sprintf("e2e-session-%d", sessionCounter.Add(1))
 	resp, _, _ := startConnect(t, gw, ctx, &gwpb.ConnectRequest{
 		NetworkName: networkName,
 		PeerName:    peerName,
@@ -96,7 +101,9 @@ func registerAndConnect(t testing.TB, gw *Gateway, ctx context.Context, networkN
 
 // TestEndToEnd_WatchReportsHandshake verifies that a Watch stream reports the
 // watched peer's first completed WireGuard handshake. The fallback poll is
-// set long so the test can only pass via the device-logger wake path.
+// set long so events can only arrive via push — the registration broadcast
+// or the device-logger wake, whichever the handshake's timing exercises —
+// never the poll.
 func TestEndToEnd_WatchReportsHandshake(t *testing.T) {
 	flags.Set(t, "gateway.watch_fallback_poll_interval", time.Minute)
 	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
@@ -105,19 +112,24 @@ func TestEndToEnd_WatchReportsHandshake(t *testing.T) {
 	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
 	require.NoError(t, err)
 
-	peer := registerAndConnect(t, gw, ctx, "net1", "peer-a")
-	stream, cancelWatch, _ := startWatch(t, gw, ctx, peer.sessionID)
+	// Watch before the peer exists so the stream observes the full
+	// lifecycle: registration first, then the handshake.
+	sessionID := fmt.Sprintf("e2e-session-%d", sessionCounter.Add(1))
+	stream, cancelWatch, _ := startWatch(t, gw, ctx, sessionID)
 	defer cancelWatch()
 
-	// registerAndConnect's persistent keepalive triggers the handshake; the
-	// watch must eventually report a peer with a handshake time, woken by
-	// the WireGuard device's log events rather than the (long) fallback
-	// poll.
+	registerAndConnectWithSessionID(t, gw, ctx, "net1", "peer-a", sessionID)
+
+	// The peer's persistent keepalive triggers the handshake; the watch must
+	// eventually report a peer with a handshake time.
 	deadline := time.After(30 * time.Second)
 	for {
 		select {
 		case rsp := <-stream.responses:
-			require.Equal(t, peer.sessionID, rsp.GetPeer().GetSessionId())
+			if rsp.GetPeer() == nil {
+				continue // heartbeat
+			}
+			require.Equal(t, sessionID, rsp.GetPeer().GetSessionId())
 			if rsp.GetPeer().GetLastHandshakeTime() != nil {
 				return
 			}

--- a/enterprise/gateway/server/gateway_test.go
+++ b/enterprise/gateway/server/gateway_test.go
@@ -343,6 +343,122 @@ func TestList_Unauthenticated(t *testing.T) {
 	require.Error(t, err)
 }
 
+// fakeWatchStream implements gwsvcpb.GatewayService_WatchServer for testing.
+// Only Context and Send are used by the Watch handler; the embedded nil
+// grpc.ServerStream panics if anything else is called.
+type fakeWatchStream struct {
+	grpc.ServerStream
+	ctx       context.Context
+	responses chan *gwpb.WatchResponse
+}
+
+func (f *fakeWatchStream) Context() context.Context { return f.ctx }
+func (f *fakeWatchStream) Send(rsp *gwpb.WatchResponse) error {
+	f.responses <- rsp
+	return nil
+}
+
+// startWatch runs gw.Watch on a fake stream in the background. The returned
+// cancel func closes the stream; the done channel receives Watch's return
+// value.
+func startWatch(t testing.TB, gw *Gateway, ctx context.Context, sessionID string) (*fakeWatchStream, context.CancelFunc, chan error) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	stream := &fakeWatchStream{ctx: ctx, responses: make(chan *gwpb.WatchResponse, 16)}
+	done := make(chan error, 1)
+	go func() { done <- gw.Watch(&gwpb.WatchRequest{SessionId: sessionID}, stream) }()
+	return stream, cancel, done
+}
+
+func TestWatch_RequiresSessionID(t *testing.T) {
+	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
+	gw := setupGateway(t, ta)
+
+	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
+	require.NoError(t, err)
+
+	stream := &fakeWatchStream{ctx: ctx, responses: make(chan *gwpb.WatchResponse, 1)}
+	err = gw.Watch(&gwpb.WatchRequest{}, stream)
+	require.True(t, status.IsInvalidArgumentError(err), "expected InvalidArgument, got: %v", err)
+}
+
+func TestWatch_ReportsRegistrationAndRemoval(t *testing.T) {
+	// A long fallback interval ensures this test can only pass via the push
+	// notifications from addPeerLocked/removePeerLocked, not the backstop
+	// ticker.
+	flags.Set(t, "gateway.watch_fallback_poll_interval", time.Minute)
+	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
+	gw := setupGateway(t, ta)
+
+	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
+	require.NoError(t, err)
+
+	// Watch starts before the peer exists.
+	stream, _, watchDone := startWatch(t, gw, ctx, "session-1")
+
+	_, cancelConnect, connectDone := startConnect(t, gw, ctx, &gwpb.ConnectRequest{
+		NetworkName: "net1",
+		PeerName:    "box1",
+		PublicKey:   newPubKeyHex(t),
+		SessionId:   "session-1",
+	})
+
+	// Registration is pushed to the watcher.
+	select {
+	case rsp := <-stream.responses:
+		require.Equal(t, "box1", rsp.GetPeer().GetName())
+		require.Equal(t, "session-1", rsp.GetPeer().GetSessionId())
+		require.NotEmpty(t, rsp.GetPeer().GetIp())
+		require.Nil(t, rsp.GetPeer().GetLastHandshakeTime())
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for registration event")
+	}
+
+	// Removal ends the watch with NotFound.
+	cancelConnect()
+	require.NoError(t, <-connectDone)
+	select {
+	case err := <-watchDone:
+		require.True(t, status.IsNotFoundError(err), "expected NotFound, got: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Watch to report removal")
+	}
+}
+
+func TestWatch_IsolatedByGroup(t *testing.T) {
+	flags.Set(t, "gateway.watch_fallback_poll_interval", 10*time.Millisecond)
+	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1", "user2", "group2"))
+	gw := setupGateway(t, ta)
+
+	ctx1, err := ta.WithAuthenticatedUser(context.Background(), "user1")
+	require.NoError(t, err)
+	ctx2, err := ta.WithAuthenticatedUser(context.Background(), "user2")
+	require.NoError(t, err)
+
+	_, _, _ = startConnect(t, gw, ctx1, &gwpb.ConnectRequest{
+		PublicKey: newPubKeyHex(t),
+		SessionId: "session-1",
+	})
+
+	// A watcher in another group must not see the peer, even across many
+	// poll cycles; its watch behaves exactly like one for a nonexistent
+	// session.
+	stream, cancelWatch, watchDone := startWatch(t, gw, ctx2, "session-1")
+	select {
+	case rsp := <-stream.responses:
+		t.Fatalf("group2 watcher saw group1's peer: %v", rsp)
+	case <-time.After(300 * time.Millisecond):
+	}
+	cancelWatch()
+	select {
+	case err := <-watchDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Watch to return after cancel")
+	}
+}
+
 // fakeConnectStream implements gwsvcpb.GatewayService_ConnectServer for
 // testing. Only Context and Send are used by the Connect handler; the
 // embedded nil grpc.ServerStream panics if anything else is called.

--- a/enterprise/gateway/server/gateway_test.go
+++ b/enterprise/gateway/server/gateway_test.go
@@ -371,6 +371,55 @@ func startWatch(t testing.TB, gw *Gateway, ctx context.Context, sessionID string
 	return stream, cancel, done
 }
 
+func TestWatch_Unauthenticated(t *testing.T) {
+	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
+	gw := setupGateway(t, ta)
+
+	stream := &fakeWatchStream{ctx: context.Background(), responses: make(chan *gwpb.WatchResponse, 1)}
+	err := gw.Watch(&gwpb.WatchRequest{SessionId: "session-1"}, stream)
+	require.Error(t, err)
+}
+
+func TestWatch_MultipleWatchers(t *testing.T) {
+	// A long fallback interval ensures both watchers can only be woken by
+	// the registration/removal broadcast.
+	flags.Set(t, "gateway.watch_fallback_poll_interval", time.Minute)
+	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
+	gw := setupGateway(t, ta)
+
+	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
+	require.NoError(t, err)
+
+	stream1, _, done1 := startWatch(t, gw, ctx, "session-1")
+	stream2, _, done2 := startWatch(t, gw, ctx, "session-1")
+
+	_, cancelConnect, connectDone := startConnect(t, gw, ctx, &gwpb.ConnectRequest{
+		PublicKey: newPubKeyHex(t),
+		SessionId: "session-1",
+	})
+
+	// The broadcast wakes every watcher: both streams report the peer.
+	for i, stream := range []*fakeWatchStream{stream1, stream2} {
+		select {
+		case rsp := <-stream.responses:
+			require.Equal(t, "session-1", rsp.GetPeer().GetSessionId())
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for registration event on watcher %d", i+1)
+		}
+	}
+
+	cancelConnect()
+	require.NoError(t, <-connectDone)
+	for i, done := range []chan error{done1, done2} {
+		select {
+		case err := <-done:
+			require.True(t, status.IsNotFoundError(err), "watcher %d: expected NotFound, got: %v", i+1, err)
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for watcher %d to report removal", i+1)
+		}
+	}
+}
+
 func TestWatch_RequiresSessionID(t *testing.T) {
 	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
 	gw := setupGateway(t, ta)
@@ -436,7 +485,7 @@ func TestWatch_IsolatedByGroup(t *testing.T) {
 	ctx2, err := ta.WithAuthenticatedUser(context.Background(), "user2")
 	require.NoError(t, err)
 
-	_, _, _ = startConnect(t, gw, ctx1, &gwpb.ConnectRequest{
+	startConnect(t, gw, ctx1, &gwpb.ConnectRequest{
 		PublicKey: newPubKeyHex(t),
 		SessionId: "session-1",
 	})

--- a/proto/gateway.proto
+++ b/proto/gateway.proto
@@ -133,3 +133,16 @@ message ListResponse {
   // authenticated for the ListRequest.
   repeated Peer peers = 1;
 }
+
+message WatchRequest {
+  // Required. The session ID of the peer connection to watch (see
+  // ConnectRequest.session_id).
+  string session_id = 1;
+}
+
+// WatchResponse messages are streamed by the Watch RPC, one per observed
+// state change of the watched peer.
+message WatchResponse {
+  // The watched peer's current state.
+  Peer peer = 1;
+}

--- a/proto/gateway.proto
+++ b/proto/gateway.proto
@@ -141,8 +141,10 @@ message WatchRequest {
 }
 
 // WatchResponse messages are streamed by the Watch RPC, one per observed
-// state change of the watched peer.
+// state change of the watched peer. While the watched peer is quiet the
+// stream also carries periodic empty heartbeat messages; clients should
+// ignore messages with no peer.
 message WatchResponse {
-  // The watched peer's current state.
+  // The watched peer's current state. Unset in heartbeat messages.
   Peer peer = 1;
 }

--- a/proto/gateway_service.proto
+++ b/proto/gateway_service.proto
@@ -34,4 +34,11 @@ service GatewayService {
   // Returns the set of currently connected peers owned by the user associated
   // with the provided authentication credentials.
   rpc List(ListRequest) returns (ListResponse);
+
+  // Watch streams the state of the peer connection with the requested
+  // session_id within the caller's group. A message is sent when the peer
+  // first appears (which may be after the watch starts) and whenever its
+  // state changes, e.g. when its first WireGuard handshake completes. If a
+  // previously-reported peer deregisters, the stream ends with NOT_FOUND.
+  rpc Watch(WatchRequest) returns (stream WatchResponse);
 }


### PR DESCRIPTION
This allows clients to open a stream and get a callback when the connection becomes live.