### PR TITLE
[CLI] Extract common bazel utilities to their own package

### DIFF
--- a/cli/detect/BUILD
+++ b/cli/detect/BUILD
@@ -14,7 +14,7 @@ go_library(
         "//cli/explain",
         "//cli/log",
         "//cli/login",
-        "//cli/parser/bazelrc",
+        "//cli/parser/bazel_command",
         "//proto:buildbuddy_service_go_proto",
         "//proto:notification_go_proto",
         "//proto:spawn_diff_go_proto",

--- a/cli/detect/nondeterminism.go
+++ b/cli/detect/nondeterminism.go
@@ -18,7 +18,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/explain"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/cli/login"
-	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazelrc"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazel_command"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/shlex"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -181,7 +181,7 @@ func parseBazelCommand(command string) (*arg.BazelArgs, error) {
 		return nil, fmt.Errorf("parse Bazel command: %w", err)
 	}
 	bazelCommand := bazelArgs.GetCommand()
-	if !bazelrc.IsBazelCommand(bazelCommand) {
+	if !bazel_command.IsCommand(bazelCommand) {
 		return nil, fmt.Errorf("expected a Bazel command like build or test, got %q", bazelCommand)
 	}
 	return bazelArgs, nil

--- a/cli/help/option_definitions/BUILD
+++ b/cli/help/option_definitions/BUILD
@@ -8,7 +8,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/help/option_definitions",
     visibility = ["//visibility:public"],
     deps = [
-        "//cli/parser/bazelrc",
+        "//cli/parser/bazel_command",
         "//cli/parser/options",
     ],
 )

--- a/cli/help/option_definitions/option_definitions.go
+++ b/cli/help/option_definitions/option_definitions.go
@@ -3,7 +3,7 @@ package option_definitions
 import (
 	"slices"
 
-	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazelrc"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazel_command"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/options"
 )
 
@@ -16,6 +16,6 @@ var (
 		options.WithNegative(),
 		options.WithPluginID(options.NativeBuiltinPluginID),
 		options.WithSupportFor("startup"),
-		options.WithSupportFor(slices.Collect(bazelrc.BazelCommands().All())...),
+		options.WithSupportFor(slices.Collect(bazel_command.Commands().All())...),
 	)
 )

--- a/cli/parser/BUILD
+++ b/cli/parser/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//cli/log",
         "//cli/log/option_definitions",
         "//cli/parser/arguments",
+        "//cli/parser/bazel_command",
         "//cli/parser/bazelrc",
         "//cli/parser/options",
         "//cli/parser/parsed",

--- a/cli/parser/bazel_command/BUILD
+++ b/cli/parser/bazel_command/BUILD
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//cli:__subpackages__"])
+
+go_library(
+    name = "bazel_command",
+    srcs = ["bazel_command.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/parser/bazel_command",
+    visibility = ["//visibility:public"],
+    deps = ["//server/util/lib/set"],
+)
+
+go_test(
+    name = "bazel_command_test",
+    srcs = ["bazel_command_test.go"],
+    deps = [
+        ":bazel_command",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/cli/parser/bazel_command/BUILD
+++ b/cli/parser/bazel_command/BUILD
@@ -6,7 +6,6 @@ go_library(
     name = "bazel_command",
     srcs = ["bazel_command.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/parser/bazel_command",
-    visibility = ["//visibility:public"],
     deps = ["//server/util/lib/set"],
 )
 

--- a/cli/parser/bazel_command/bazel_command.go
+++ b/cli/parser/bazel_command/bazel_command.go
@@ -1,0 +1,67 @@
+package bazel_command
+
+import "github.com/buildbuddy-io/buildbuddy/server/util/lib/set"
+
+var (
+	commands = set.Set[string]{
+		"analyze-profile":    {},
+		"aquery":             {},
+		"build":              {},
+		"canonicalize-flags": {},
+		"clean":              {},
+		"config":             {},
+		"coverage":           {},
+		"cquery":             {},
+		"dump":               {},
+		"fetch":              {},
+		"help":               {},
+		"info":               {},
+		"license":            {},
+		"mobile-install":     {},
+		"mod":                {},
+		"print_action":       {},
+		"query":              {},
+		"run":                {},
+		"shutdown":           {},
+		"sync":               {},
+		"test":               {},
+		"vendor":             {},
+		"version":            {},
+	}
+
+	// Inheritance hierarchy: https://bazel.build/run/bazelrc#option-defaults
+	// All commands inherit options from "common".
+	parentByCommand = map[string]string{
+		"aquery":             "build",
+		"canonicalize-flags": "build",
+		"clean":              "build",
+		"config":             "build",
+		"info":               "build",
+		"license":            "build",
+		"mobile-install":     "build",
+		"print_action":       "build",
+		"run":                "build",
+		"test":               "build",
+
+		"coverage": "test",
+		"cquery":   "test",
+		"fetch":    "test",
+		"vendor":   "test",
+	}
+)
+
+// Commands returns a read-only view of all recognized Bazel commands.
+func Commands() set.View[string] {
+	return set.KeyView(commands)
+}
+
+// IsCommand returns whether command is recognized as a Bazel command.
+func IsCommand(command string) bool {
+	return commands.Contains(command)
+}
+
+// Parent returns the command from which command inherits, or an empty string
+// if command has no parent.
+func Parent(command string) string {
+	return parentByCommand[command]
+}

--- a/cli/parser/bazel_command/bazel_command_test.go
+++ b/cli/parser/bazel_command/bazel_command_test.go
@@ -1,0 +1,21 @@
+package bazel_command_test
+
+import (
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazel_command"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommands(t *testing.T) {
+	assert.True(t, bazel_command.IsCommand("build"))
+	assert.True(t, bazel_command.IsCommand("test"))
+	assert.False(t, bazel_command.IsCommand("not-a-bazel-command"))
+}
+
+func TestParent(t *testing.T) {
+	assert.Equal(t, "test", bazel_command.Parent("coverage"))
+	assert.Equal(t, "build", bazel_command.Parent("test"))
+	assert.Empty(t, bazel_command.Parent("build"))
+	assert.Empty(t, bazel_command.Parent("not-a-bazel-command"))
+}

--- a/cli/parser/bazelrc/BUILD
+++ b/cli/parser/bazelrc/BUILD
@@ -10,6 +10,7 @@ go_library(
     deps = [
         "//cli/log",
         "//cli/parser/bazel_command",
+        "//cli/parser/rc_util",
         "//server/util/lib/set",
         "@com_github_google_shlex//:shlex",
     ],

--- a/cli/parser/bazelrc/BUILD
+++ b/cli/parser/bazelrc/BUILD
@@ -9,6 +9,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cli/log",
+        "//cli/parser/bazel_command",
         "//server/util/lib/set",
         "@com_github_google_shlex//:shlex",
     ],

--- a/cli/parser/bazelrc/bazelrc.go
+++ b/cli/parser/bazelrc/bazelrc.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazel_command"
 	"github.com/buildbuddy-io/buildbuddy/server/util/lib/set"
 	"github.com/google/shlex"
 )
@@ -25,52 +26,6 @@ const (
 )
 
 var (
-	bazelCommands = set.Set[string]{
-		"analyze-profile":    {},
-		"aquery":             {},
-		"build":              {},
-		"canonicalize-flags": {},
-		"clean":              {},
-		"config":             {},
-		"coverage":           {},
-		"cquery":             {},
-		"dump":               {},
-		"fetch":              {},
-		"help":               {},
-		"info":               {},
-		"license":            {},
-		"mobile-install":     {},
-		"mod":                {},
-		"print_action":       {},
-		"query":              {},
-		"run":                {},
-		"shutdown":           {},
-		"sync":               {},
-		"test":               {},
-		"vendor":             {},
-		"version":            {},
-	}
-
-	// Inheritance hierarchy: https://bazel.build/run/bazelrc#option-defaults
-	// All commands inherit from "common".
-	parentCommand = map[string]string{
-		"aquery":             "build",
-		"canonicalize-flags": "build",
-		"clean":              "build",
-		"config":             "build",
-		"info":               "build",
-		"license":            "build",
-		"mobile-install":     "build",
-		"print_action":       "build",
-		"run":                "build",
-		"test":               "build",
-
-		"coverage": "test",
-		"cquery":   "test",
-		"fetch":    "test",
-		"vendor":   "test",
-	}
-
 	unconditionalCommandPhases = set.Set[string]{
 		CommonPhase: {},
 		AlwaysPhase: {},
@@ -78,7 +33,7 @@ var (
 
 	allPhases = set.FromSeq(
 		set.Union(
-			bazelCommands,
+			set.FromSeq(bazel_command.Commands().All()),
 			unconditionalCommandPhases,
 			set.From("startup"),
 		),
@@ -117,7 +72,7 @@ func GetPhases(command string) (out []string) {
 			break
 		}
 		out = append(out, command)
-		command = parentCommand[command]
+		command = bazel_command.Parent(command)
 	}
 	slices.Reverse(out)
 	return
@@ -277,23 +232,6 @@ func GetBazelOS() string {
 	default:
 		return runtime.GOOS
 	}
-}
-
-// BazelCommands returns a view of the set of bazel commands.
-func BazelCommands() set.View[string] {
-	return set.KeyView(bazelCommands)
-}
-
-// IsBazelCommand returns whether the given string is recognized as a bazel
-// command.
-func IsBazelCommand(command string) bool {
-	return bazelCommands.Contains(command)
-}
-
-// Parent returns the parent command of the given command, if one exists.
-func Parent(command string) (string, bool) {
-	parent, ok := parentCommand[command]
-	return parent, ok
 }
 
 // IsUnconditionalCommandPhase returns whether or not this is a phase that should always

--- a/cli/parser/bazelrc/bazelrc.go
+++ b/cli/parser/bazelrc/bazelrc.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazel_command"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/rc_util"
 	"github.com/buildbuddy-io/buildbuddy/server/util/lib/set"
 	"github.com/google/shlex"
 )
@@ -20,22 +21,13 @@ import (
 const (
 	EnablePlatformSpecificConfigFlag = "enable_platform_specific_config"
 	workspacePrefix                  = `%workspace%/`
-
-	CommonPhase = "common"
-	AlwaysPhase = "always"
 )
 
 var (
-	unconditionalCommandPhases = set.Set[string]{
-		CommonPhase: {},
-		AlwaysPhase: {},
-	}
-
 	allPhases = set.FromSeq(
 		set.Union(
 			set.FromSeq(bazel_command.Commands().All()),
-			unconditionalCommandPhases,
-			set.From("startup"),
+			set.From(rc_util.CommonPhase, rc_util.AlwaysPhase, "startup"),
 		),
 	)
 
@@ -232,13 +224,6 @@ func GetBazelOS() string {
 	default:
 		return runtime.GOOS
 	}
-}
-
-// IsUnconditionalCommandPhase returns whether or not this is a phase that should always
-// be evaluated, regardless of the command.
-func IsUnconditionalCommandPhase(phase string) bool {
-	_, ok := unconditionalCommandPhases[phase]
-	return ok
 }
 
 // IsPhase returns whether or not this is a valid phase for a bazel rc line.

--- a/cli/parser/options/BUILD
+++ b/cli/parser/options/BUILD
@@ -10,7 +10,7 @@ go_library(
     deps = [
         "//cli/log",
         "//cli/parser/arguments",
-        "//cli/parser/bazelrc",
+        "//cli/parser/bazel_command",
         "//cli/parser/options/flag_form",
         "//proto:bazel_flags_go_proto",
         "//server/util/flagutil",

--- a/cli/parser/options/options.go
+++ b/cli/parser/options/options.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/arguments"
-	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazelrc"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazel_command"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/options/flag_form"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/lib/seq"
@@ -153,7 +153,7 @@ func (d *Definition) SupportedCommands() iter.Seq[string] {
 }
 
 func (d *Definition) Supports(command string) bool {
-	for cmd, ok := command, true; ok; cmd, ok = bazelrc.Parent(cmd) {
+	for cmd := command; cmd != ""; cmd = bazel_command.Parent(cmd) {
 		if d.supportedCommands.Contains(cmd) {
 			return true
 		}

--- a/cli/parser/parsed/BUILD
+++ b/cli/parser/parsed/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//cli/parser/arguments",
         "//cli/parser/bazelrc",
         "//cli/parser/options",
+        "//cli/parser/rc_util",
         "//server/util/lib/set",
         "//server/util/shlex",
     ],

--- a/cli/parser/parsed/parsed.go
+++ b/cli/parser/parsed/parsed.go
@@ -20,6 +20,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/arguments"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazelrc"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/options"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/rc_util"
 	"github.com/buildbuddy-io/buildbuddy/server/util/lib/set"
 	"github.com/buildbuddy-io/buildbuddy/server/util/shlex"
 )
@@ -884,9 +885,9 @@ func appendExpansion(
 		case options.Option:
 			// For the unconditional phases, only append the arg if it's supported by
 			// the command.
-			if bazelrc.IsUnconditionalCommandPhase(phase) && !a.Supports(phases[len(phases)-1]) {
-				if phase == bazelrc.AlwaysPhase {
-					log.Warnf("Inherited '%s' options: %v", bazelrc.AlwaysPhase, arguments.FormatAll(toExpand))
+			if rc_util.IsUnconditionalCommandPhase(phase) && !a.Supports(phases[len(phases)-1]) {
+				if phase == rc_util.AlwaysPhase {
+					log.Warnf("Inherited '%s' options: %v", rc_util.AlwaysPhase, arguments.FormatAll(toExpand))
 					return nil, fmt.Errorf("%[1]s :: Unrecognized option %[1]s", a.Format()[0])
 				}
 				// TODO(zoey): return an error here if the option does not support any

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -19,6 +19,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/cli_command"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/arguments"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazel_command"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazelrc"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/options"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/parsed"
@@ -527,7 +528,7 @@ func (p *Subparser) parseLongNameOption(optName string) (options.Option, error) 
 		if strings.HasPrefix(optName, prefix) {
 			// This is a new starlark definition; let's hang on to it.
 			d := options.NewStarlarkOptionDefinition(optName)
-			d.AddSupportedCommand(slices.Collect(bazelrc.BazelCommands().All())...)
+			d.AddSupportedCommand(slices.Collect(bazel_command.Commands().All())...)
 			// No need to check if this option already exists since we never reach
 			// this code if it does.
 			p.ForceAdd(d)
@@ -1033,7 +1034,7 @@ func (p *Parser) consumeAndParseRCFiles(args *parsed.OrderedArgs, workspaceDir s
 // bazel command, even though "build" is the argument to --output_base.
 func GetBazelCommandAndIndex(args []string) (string, int) {
 	for i, a := range args {
-		if bazelrc.IsBazelCommand(a) {
+		if bazel_command.IsCommand(a) {
 			return a, i
 		}
 	}

--- a/cli/parser/rc_util/BUILD
+++ b/cli/parser/rc_util/BUILD
@@ -1,0 +1,10 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = ["//cli:__subpackages__"])
+
+go_library(
+    name = "rc_util",
+    srcs = ["rc_util.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/parser/rc_util",
+    visibility = ["//visibility:public"],
+)

--- a/cli/parser/rc_util/rc_util.go
+++ b/cli/parser/rc_util/rc_util.go
@@ -1,0 +1,13 @@
+// Package rc_util contains helpers shared by rc file formats.
+package rc_util
+
+const (
+	CommonPhase = "common"
+	AlwaysPhase = "always"
+)
+
+// IsUnconditionalCommandPhase returns whether phase is evaluated regardless
+// of the command.
+func IsUnconditionalCommandPhase(phase string) bool {
+	return phase == CommonPhase || phase == AlwaysPhase
+}


### PR DESCRIPTION
Extract shared logic to its own package so it can be shared by a .bbrc parser. This helps remove some circular dependency issues in the stacked PR too

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>