### PR TITLE
raft: refuse DirectWrite/CAS of file-record keys

### DIFF
--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -766,8 +766,22 @@ func (sm *Replica) Open(stopc <-chan struct{}) (uint64, error) {
 	return sm.lastAppliedIndex, nil
 }
 
+// checkNotFileRecordKey refuses generic KV writes to file-record keys. File
+// records must be written through SetRequest (and mutated via UpdateAtime /
+// Delete): those paths validate the key and value, and state derived from
+// record writes relies on them being the only writers of record keyspace.
+func (sm *Replica) checkNotFileRecordKey(key []byte) error {
+	if keys.PartitionIDFromRangeStart(key) != "" {
+		return status.InvalidArgumentErrorf("[%s] cannot direct write file-record key %q; use SetRequest instead", sm.name(), key)
+	}
+	return nil
+}
+
 func (sm *Replica) directWrite(wb pebble.Batch, req *rfpb.DirectWriteRequest) (*rfpb.DirectWriteResponse, error) {
 	kv := req.GetKv()
+	if err := sm.checkNotFileRecordKey(kv.GetKey()); err != nil {
+		return nil, err
+	}
 	err := sm.rangeCheckedSet(wb, kv.Key, kv.Value)
 	return &rfpb.DirectWriteResponse{}, err
 }
@@ -825,6 +839,9 @@ func (sm *Replica) increment(wb pebble.Batch, req *rfpb.IncrementRequest) (*rfpb
 
 func (sm *Replica) cas(wb pebble.Batch, req *rfpb.CASRequest) (*rfpb.CASResponse, error) {
 	kv := req.GetKv()
+	if err := sm.checkNotFileRecordKey(kv.GetKey()); err != nil {
+		return nil, err
+	}
 	var buf []byte
 	var err error
 	buf, err = sm.lookup(wb, kv.GetKey())

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -144,15 +144,9 @@ func writer(t *testing.T, em *entryMaker, r *replica.Replica, h *rfpb.Header, fi
 			LastModifyUsec:  now.UnixMicro(),
 			LastAccessUsec:  now.UnixMicro(),
 		}
-		protoBytes, err := proto.Marshal(md)
-		if err != nil {
-			return err
-		}
-		entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
-			Kv: &rfpb.KV{
-				Key:   fileMetadataKey,
-				Value: protoBytes,
-			},
+		entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.SetRequest{
+			Key:          fileMetadataKey,
+			FileMetadata: md,
 		}))
 		entries := []dbsm.Entry{entry}
 		writeRsp, err := r.Update(entries)
@@ -283,6 +277,67 @@ func TestReplicaDirectReadWrite(t *testing.T) {
 	rsp, err := directRead(t, repl, []byte("key-name"))
 	require.NoError(t, err)
 	require.Equal(t, val, rsp.GetKv().GetValue())
+}
+
+// The generic KV writers must refuse file-record keys: records must be written
+// through SetRequest (and mutated via UpdateAtime/Delete) so validation and any
+// state derived from record writes can rely on those paths being exhaustive.
+func TestDirectWriteRefusesFileRecordKeys(t *testing.T) {
+	repl := testutil.NewTestingReplica(t, 1, 1)
+	require.NotNil(t, repl)
+	t.Cleanup(func() {
+		require.NoError(t, repl.Close())
+	})
+
+	stopc := make(chan struct{})
+	_, err := repl.Open(stopc)
+	require.NoError(t, err)
+	em := newEntryMaker(t)
+	writeDefaultRangeDescriptor(t, em, repl.Replica)
+
+	r, _ := testdigest.RandomCASResourceBuf(t, 100)
+	fileRecord := &sgpb.FileRecord{
+		Isolation: &sgpb.Isolation{
+			CacheType:   rspb.CacheType_CAS,
+			PartitionId: "default",
+			GroupId:     interfaces.AuthAnonymousUser,
+		},
+		Digest:         r.GetDigest(),
+		DigestFunction: repb.DigestFunction_SHA256,
+	}
+	fs := filestore.New()
+	key, err := fs.PebbleKey(fileRecord)
+	require.NoError(t, err)
+	fileMetadataKey, err := key.Bytes(filestore.Version5)
+	require.NoError(t, err)
+
+	entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+		Kv: &rfpb.KV{Key: fileMetadataKey, Value: []byte("unindexed")},
+	}))
+	writeRsp, err := repl.Update([]dbsm.Entry{entry})
+	require.NoError(t, err)
+	err = rbuilder.NewBatchResponse(writeRsp[0].Result.Data).AnyError()
+	require.True(t, status.IsInvalidArgumentError(err), "expected InvalidArgument, got: %v", err)
+
+	// CAS is the same generic writer and must refuse too. rbuilder already
+	// rejects CAS on splittable keys client-side, so hand-roll the batch to
+	// prove the apply-path guard holds for callers that bypass rbuilder.
+	casBatch, err := proto.Marshal(&rfpb.BatchCmdRequest{
+		Union: []*rfpb.RequestUnion{{Value: &rfpb.RequestUnion_Cas{
+			Cas: &rfpb.CASRequest{
+				Kv: &rfpb.KV{Key: fileMetadataKey, Value: []byte("unindexed")},
+			},
+		}}},
+	})
+	require.NoError(t, err)
+	casRsp, err := repl.Update([]dbsm.Entry{{Cmd: casBatch, Index: 3}})
+	require.NoError(t, err)
+	err = rbuilder.NewBatchResponse(casRsp[0].Result.Data).AnyError()
+	require.True(t, status.IsInvalidArgumentError(err), "expected InvalidArgument, got: %v", err)
+
+	// Neither write may have landed.
+	_, err = directRead(t, repl, fileMetadataKey)
+	require.True(t, status.IsNotFoundError(err), "expected NotFound, got: %v", err)
 }
 
 func TestReplicaIncrementSnapshotRestore(t *testing.T) {
@@ -1316,15 +1371,11 @@ func TestFileWriteAndFind(t *testing.T) {
 	require.NoError(t, err)
 	fileMetadataKey, err := key.Bytes(filestore.Version5)
 	require.NoError(t, err)
-	val, err := proto.Marshal(md)
-	require.NoError(t, err)
 
-	// Do a DirectWrite.
-	entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
-		Kv: &rfpb.KV{
-			Key:   fileMetadataKey,
-			Value: val,
-		},
+	// Write the record.
+	entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.SetRequest{
+		Key:          fileMetadataKey,
+		FileMetadata: md,
 	}))
 	entries := []dbsm.Entry{entry}
 	writeRsp, err := repl.Update(entries)
@@ -1384,11 +1435,10 @@ func TestFileFindZeroLengthReportsAbsent(t *testing.T) {
 	require.NoError(t, err)
 	fileMetadataKey, err := key.Bytes(filestore.Version5)
 	require.NoError(t, err)
-	val, err := proto.Marshal(md)
-	require.NoError(t, err)
 
-	entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
-		Kv: &rfpb.KV{Key: fileMetadataKey, Value: val},
+	entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.SetRequest{
+		Key:          fileMetadataKey,
+		FileMetadata: md,
 	}))
 	_, err = repl.Update([]dbsm.Entry{entry})
 	require.NoError(t, err)
@@ -2163,15 +2213,11 @@ func TestUpdateATime(t *testing.T) {
 	require.NoError(t, err)
 	fileMetadataKey, err := key.Bytes(filestore.Version5)
 	require.NoError(t, err)
-	val, err := proto.Marshal(md)
-	require.NoError(t, err)
 
 	// Write the initial file metadata
-	entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
-		Kv: &rfpb.KV{
-			Key:   fileMetadataKey,
-			Value: val,
-		},
+	entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.SetRequest{
+		Key:          fileMetadataKey,
+		FileMetadata: md,
 	}))
 	entries := []dbsm.Entry{entry}
 	writeRsp, err := repl.Update(entries)
@@ -2268,14 +2314,10 @@ func TestUpdateATimeGCSCustomTime(t *testing.T) {
 	require.NoError(t, err)
 	fileMetadataKey, err := key.Bytes(filestore.Version5)
 	require.NoError(t, err)
-	val, err := proto.Marshal(md)
-	require.NoError(t, err)
 
-	entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
-		Kv: &rfpb.KV{
-			Key:   fileMetadataKey,
-			Value: val,
-		},
+	entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.SetRequest{
+		Key:          fileMetadataKey,
+		FileMetadata: md,
 	}))
 	writeRsp, err := repl.Update([]dbsm.Entry{entry})
 	require.NoError(t, err)

--- a/enterprise/server/raft/testutil/BUILD
+++ b/enterprise/server/raft/testutil/BUILD
@@ -32,7 +32,6 @@ go_library(
         "//server/util/disk",
         "//server/util/grpc_server",
         "//server/util/log",
-        "//server/util/proto",
         "//server/util/status",
         "@com_github_google_uuid//:uuid",
         "@com_github_jonboulle_clockwork//:clockwork",

--- a/enterprise/server/raft/testutil/testutil.go
+++ b/enterprise/server/raft/testutil/testutil.go
@@ -27,7 +27,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_server"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
-	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/jonboulle/clockwork"
 	"github.com/lni/dragonboat/v4"
@@ -472,14 +471,9 @@ func WriteRecord(ctx context.Context, t testing.TB, ts *TestingStore, groupID st
 		LastModifyUsec:  now.UnixMicro(),
 		LastAccessUsec:  now.UnixMicro(),
 	}
-	protoBytes, err := proto.Marshal(md)
-	require.NoError(t, err)
-
-	writeReq, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
-		Kv: &rfpb.KV{
-			Key:   key,
-			Value: protoBytes,
-		},
+	writeReq, err := rbuilder.NewBatchBuilder().Add(&rfpb.SetRequest{
+		Key:          key,
+		FileMetadata: md,
 	}).ToProto()
 	require.NoError(t, err)
 	writeRsp, err := ts.Sender().SyncPropose(ctx, key, writeReq)

--- a/enterprise/server/raft/txn/BUILD
+++ b/enterprise/server/raft/txn/BUILD
@@ -35,6 +35,7 @@ go_test(
     tags = ["block-network"],
     deps = [
         ":txn",
+        "//enterprise/server/filestore",
         "//enterprise/server/raft/constants",
         "//enterprise/server/raft/keys",
         "//enterprise/server/raft/logger",
@@ -42,6 +43,9 @@ go_test(
         "//enterprise/server/raft/sender",
         "//enterprise/server/raft/testutil",
         "//proto:raft_go_proto",
+        "//proto:resource_go_proto",
+        "//proto:storage_go_proto",
+        "//server/testutil/testdigest",
         "//server/util/grpc_server",
         "//server/util/proto",
         "//server/util/status",

--- a/enterprise/server/raft/txn/txn_test.go
+++ b/enterprise/server/raft/txn/txn_test.go
@@ -9,12 +9,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/filestore"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/constants"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/keys"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rbuilder"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/sender"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/testutil"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/txn"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_server"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -25,8 +27,78 @@ import (
 
 	_ "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/logger"
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
+	sgpb "github.com/buildbuddy-io/buildbuddy/proto/storage"
 	gstatus "google.golang.org/grpc/status"
 )
+
+// testRecord is a valid file record in partition "default", used for writing
+// data-range keys in transactions. The replica state machine refuses generic
+// KV writes (DirectWrite/CAS) to file-record keyspace -- and every data range
+// is file-record keyspace -- so txn statements against data ranges must carry
+// SetRequests with real records, as production transactions would.
+type testRecord struct {
+	key []byte
+	fr  *sgpb.FileRecord
+}
+
+func newTestRecord(t testing.TB) *testRecord {
+	r, _ := testdigest.RandomCASResourceBuf(t, 100)
+	fr := &sgpb.FileRecord{
+		Isolation: &sgpb.Isolation{
+			CacheType:   rspb.CacheType_CAS,
+			PartitionId: "default",
+		},
+		Digest:         r.GetDigest(),
+		DigestFunction: r.GetDigestFunction(),
+	}
+	pk, err := filestore.New().PebbleKey(fr)
+	require.NoError(t, err)
+	key, err := pk.Bytes(filestore.Version5)
+	require.NoError(t, err)
+	return &testRecord{key: key, fr: fr}
+}
+
+// setRequest returns a SetRequest storing data inline in the record, so tests
+// can distinguish written states the way raw DirectWrite values used to.
+func (r *testRecord) setRequest(data []byte) *rfpb.SetRequest {
+	return &rfpb.SetRequest{
+		Key: r.key,
+		FileMetadata: &sgpb.FileMetadata{
+			FileRecord: r.fr,
+			StorageMetadata: &sgpb.StorageMetadata{
+				InlineMetadata: &sgpb.StorageMetadata_InlineMetadata{Data: data},
+			},
+		},
+	}
+}
+
+func writeRecord(t *testing.T, ctx context.Context, s *sender.Sender, r *testRecord, data []byte) {
+	t.Helper()
+	writeReq, err := rbuilder.NewBatchBuilder().Add(r.setRequest(data)).ToProto()
+	require.NoError(t, err)
+	writeRsp, err := s.SyncPropose(ctx, r.key, writeReq)
+	require.NoError(t, err)
+	require.NoError(t, rbuilder.NewBatchResponseFromProto(writeRsp).AnyError())
+}
+
+// verifyRecordValue asserts that the record at key holds data inline.
+func verifyRecordValue(t *testing.T, ctx context.Context, s *sender.Sender, key, data []byte) {
+	t.Helper()
+	readReq, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectReadRequest{
+		Key: key,
+	}).ToProto()
+	require.NoError(t, err)
+	readRsp, err := s.SyncRead(ctx, key, readReq)
+	require.NoError(t, err)
+	readBatch := rbuilder.NewBatchResponseFromProto(readRsp)
+	require.NoError(t, readBatch.AnyError())
+	directRead, err := readBatch.DirectReadResponse(0)
+	require.NoError(t, err)
+	md := &sgpb.FileMetadata{}
+	require.NoError(t, proto.Unmarshal(directRead.GetKv().GetValue(), md))
+	require.Equal(t, data, md.GetStorageMetadata().GetInlineMetadata().GetData())
+}
 
 func TestCommitPreparedTxn(t *testing.T) {
 	sf := testutil.NewStoreFactory(t)
@@ -34,27 +106,11 @@ func TestCommitPreparedTxn(t *testing.T) {
 	ctx := context.Background()
 	sf.StartShard(t, ctx, store)
 
-	{ // Do a DirectWrite.
-		key := []byte("PTdefault/f11")
-		writeReq, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
-			Kv: &rfpb.KV{
-				Key:   key,
-				Value: []byte("bar"),
-			},
-		}).ToProto()
-		require.NoError(t, err)
-		writeRsp, err := store.Sender().SyncPropose(ctx, key, writeReq)
-		require.NoError(t, err)
-		err = rbuilder.NewBatchResponseFromProto(writeRsp).AnyError()
-		require.NoError(t, err)
-	}
+	// Write the initial record value.
+	rec := newTestRecord(t)
+	writeRecord(t, ctx, store.Sender(), rec, []byte("bar"))
 
-	batch := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
-		Kv: &rfpb.KV{
-			Key:   []byte("PTdefault/f11"),
-			Value: []byte("zoo"),
-		},
-	})
+	batch := rbuilder.NewBatchBuilder().Add(rec.setRequest([]byte("zoo")))
 	testutil.WaitForRangeLease(t, ctx, []*testutil.TestingStore{store}, 2)
 	rd := store.GetRange(2)
 	tb := rbuilder.NewTxn()
@@ -105,35 +161,12 @@ func TestCommitPreparedTxn(t *testing.T) {
 		require.True(t, status.IsNotFoundError(err))
 	}
 
-	{ // Do a DirectRead and verify the value is updated.
-		key := []byte("PTdefault/f11")
-		readReq, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectReadRequest{
-			Key: key,
-		}).ToProto()
-		require.NoError(t, err)
-		readRsp, err := store.Sender().SyncRead(ctx, key, readReq)
-		require.NoError(t, err)
-		readBatch := rbuilder.NewBatchResponseFromProto(readRsp)
-		require.NoError(t, readBatch.AnyError())
-		directRead, err := readBatch.DirectReadResponse(0)
-		require.NoError(t, err)
-		require.Equal(t, []byte("zoo"), directRead.GetKv().GetValue())
-	}
+	// Verify the value is updated.
+	verifyRecordValue(t, ctx, store.Sender(), rec.key, []byte("zoo"))
 
-	{ // Do a DirectWrite, and it should succeed since the txn is committed.
-		key := []byte("PTdefault/f11")
-		writeReq, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
-			Kv: &rfpb.KV{
-				Key:   key,
-				Value: []byte("bar2"),
-			},
-		}).ToProto()
-		require.NoError(t, err)
-		writeRsp, err := store.Sender().SyncPropose(ctx, key, writeReq)
-		require.NoError(t, err)
-		err = rbuilder.NewBatchResponseFromProto(writeRsp).AnyError()
-		require.NoError(t, err)
-	}
+	// Another write should succeed since the txn is committed (the key is
+	// unlocked again).
+	writeRecord(t, ctx, store.Sender(), rec, []byte("bar2"))
 }
 
 func TestRecoverTxnToUpdateRangeDescriptor(t *testing.T) {
@@ -278,17 +311,9 @@ func TestRunTxn(t *testing.T) {
 	stores := []*testutil.TestingStore{s1, s2, s3}
 	sf.StartShard(t, ctx, stores...)
 
-	batch := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
-		Kv: &rfpb.KV{
-			Key:   []byte("PTdefault/f11"),
-			Value: []byte("zoo"),
-		},
-	}).Add(&rfpb.DirectWriteRequest{
-		Kv: &rfpb.KV{
-			Key:   []byte("PTdefault/bar"),
-			Value: []byte("foo"),
-		},
-	})
+	batch := rbuilder.NewBatchBuilder().
+		Add(newTestRecord(t).setRequest([]byte("zoo"))).
+		Add(newTestRecord(t).setRequest([]byte("foo")))
 
 	metaBatch := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
 		Kv: &rfpb.KV{
@@ -492,17 +517,8 @@ func setupPendingRollbackTxnForRecovery(
 	ctx := context.Background()
 	sf.StartShard(t, ctx, stores...)
 
-	userKey := []byte("PTdefault/f11")
-	writeReq, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
-		Kv: &rfpb.KV{
-			Key:   userKey,
-			Value: []byte("before"),
-		},
-	}).ToProto()
-	require.NoError(t, err)
-	writeRsp, err := s1.Sender().SyncPropose(ctx, userKey, writeReq)
-	require.NoError(t, err)
-	require.NoError(t, rbuilder.NewBatchResponseFromProto(writeRsp).AnyError())
+	rec := newTestRecord(t)
+	writeRecord(t, ctx, s1.Sender(), rec, []byte("before"))
 
 	metaKey := keys.MakeKey(constants.SystemPrefix, []byte("rollback-cas"))
 	metaStore := testutil.GetStoreWithRangeLease(t, ctx, stores, 1)
@@ -510,12 +526,7 @@ func setupPendingRollbackTxnForRecovery(
 	dataStore := testutil.GetStoreWithRangeLease(t, ctx, stores, 2)
 	dataRD := dataStore.GetRange(2)
 
-	dataBatch := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
-		Kv: &rfpb.KV{
-			Key:   userKey,
-			Value: []byte("after"),
-		},
-	})
+	dataBatch := rbuilder.NewBatchBuilder().Add(rec.setRequest([]byte("after")))
 	metaBatch := rbuilder.NewBatchBuilder().Add(&rfpb.CASRequest{
 		Kv: &rfpb.KV{
 			Key:   metaKey,
@@ -542,7 +553,7 @@ func setupPendingRollbackTxnForRecovery(
 	}
 	require.NoError(t, tc.WriteTxnRecord(ctx, txnRecord))
 
-	return ctx, s1, tc, txnProto, txnRecord, userKey, metaKey
+	return ctx, s1, tc, txnProto, txnRecord, rec.key, metaKey
 }
 
 func verifyDirectReadValue(t *testing.T, ctx context.Context, s *sender.Sender, key, value []byte) {
@@ -650,17 +661,8 @@ func TestTxnRollbackRetryIsIdempotent(t *testing.T) {
 
 	sf.StartShard(t, ctx, stores...)
 
-	userKey := []byte("PTdefault/f11")
-	writeReq, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
-		Kv: &rfpb.KV{
-			Key:   userKey,
-			Value: []byte("before"),
-		},
-	}).ToProto()
-	require.NoError(t, err)
-	writeRsp, err := s1.Sender().SyncPropose(ctx, userKey, writeReq)
-	require.NoError(t, err)
-	require.NoError(t, rbuilder.NewBatchResponseFromProto(writeRsp).AnyError())
+	rec := newTestRecord(t)
+	writeRecord(t, ctx, s1.Sender(), rec, []byte("before"))
 
 	metaKey := keys.MakeKey(constants.SystemPrefix, []byte("rollback-cas"))
 	metaStore := testutil.GetStoreWithRangeLease(t, ctx, stores, 1)
@@ -668,12 +670,7 @@ func TestTxnRollbackRetryIsIdempotent(t *testing.T) {
 	dataStore := testutil.GetStoreWithRangeLease(t, ctx, stores, 2)
 	dataRD := dataStore.GetRange(2)
 
-	dataBatch := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
-		Kv: &rfpb.KV{
-			Key:   userKey,
-			Value: []byte("after"),
-		},
-	})
+	dataBatch := rbuilder.NewBatchBuilder().Add(rec.setRequest([]byte("after")))
 	metaBatch := rbuilder.NewBatchBuilder().Add(&rfpb.CASRequest{
 		Kv: &rfpb.KV{
 			Key:   metaKey,
@@ -694,7 +691,7 @@ func TestTxnRollbackRetryIsIdempotent(t *testing.T) {
 	require.Error(t, err)
 
 	verifyTxnRecordNotExist(t, ctx, s1.Sender(), txnProto.GetTransactionId())
-	verifyDirectReadValue(t, ctx, s1.Sender(), userKey, []byte("before"))
+	verifyRecordValue(t, ctx, s1.Sender(), rec.key, []byte("before"))
 	verifyDirectReadNotFound(t, ctx, s1.Sender(), metaKey)
 	harness.assertFired(t)
 }
@@ -760,7 +757,7 @@ func TestRecoverRollbackTxnRetryMatrix(t *testing.T) {
 			require.NoError(t, coordinator.RecoverTxnRecordForTest(ctx, txnRecord))
 
 			verifyTxnRecordNotExist(t, ctx, store.Sender(), txnProto.GetTransactionId())
-			verifyDirectReadValue(t, ctx, store.Sender(), userKey, []byte("before"))
+			verifyRecordValue(t, ctx, store.Sender(), userKey, []byte("before"))
 			verifyDirectReadNotFound(t, ctx, store.Sender(), metaKey)
 			harness.assertFired(t)
 		})
@@ -776,17 +773,8 @@ func TestStalePendingJanitorHelpsCommit(t *testing.T) {
 	ctx := context.Background()
 	sf.StartShard(t, ctx, stores...)
 
-	userKey := []byte("PTdefault/f11")
-	writeReq, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
-		Kv: &rfpb.KV{
-			Key:   userKey,
-			Value: []byte("before"),
-		},
-	}).ToProto()
-	require.NoError(t, err)
-	writeRsp, err := s1.Sender().SyncPropose(ctx, userKey, writeReq)
-	require.NoError(t, err)
-	require.NoError(t, rbuilder.NewBatchResponseFromProto(writeRsp).AnyError())
+	rec := newTestRecord(t)
+	writeRecord(t, ctx, s1.Sender(), rec, []byte("before"))
 
 	metaKey := keys.MakeKey(constants.SystemPrefix, []byte("stale-pending-commit"))
 	metaStore := testutil.GetStoreWithRangeLease(t, ctx, stores, 1)
@@ -794,12 +782,7 @@ func TestStalePendingJanitorHelpsCommit(t *testing.T) {
 	dataStore := testutil.GetStoreWithRangeLease(t, ctx, stores, 2)
 	dataRD := dataStore.GetRange(2)
 
-	dataBatch := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
-		Kv: &rfpb.KV{
-			Key:   userKey,
-			Value: []byte("after"),
-		},
-	})
+	dataBatch := rbuilder.NewBatchBuilder().Add(rec.setRequest([]byte("after")))
 	metaBatch := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
 		Kv: &rfpb.KV{
 			Key:   metaKey,
@@ -834,7 +817,7 @@ func TestStalePendingJanitorHelpsCommit(t *testing.T) {
 	require.NoError(t, tc.RecoverTxnRecordForTest(ctx, stalePendingRecord))
 
 	verifyTxnRecordNotExist(t, ctx, s1.Sender(), txnProto.GetTransactionId())
-	verifyDirectReadValue(t, ctx, s1.Sender(), userKey, []byte("after"))
+	verifyRecordValue(t, ctx, s1.Sender(), rec.key, []byte("after"))
 	verifyDirectReadValue(t, ctx, s1.Sender(), metaKey, []byte("committed"))
 }
 
@@ -847,17 +830,8 @@ func TestRollbackNotFoundPreventsLatePrepare(t *testing.T) {
 	ctx := context.Background()
 	sf.StartShard(t, ctx, stores...)
 
-	userKey := []byte("PTdefault/f11")
-	writeReq, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
-		Kv: &rfpb.KV{
-			Key:   userKey,
-			Value: []byte("before"),
-		},
-	}).ToProto()
-	require.NoError(t, err)
-	writeRsp, err := s1.Sender().SyncPropose(ctx, userKey, writeReq)
-	require.NoError(t, err)
-	require.NoError(t, rbuilder.NewBatchResponseFromProto(writeRsp).AnyError())
+	rec := newTestRecord(t)
+	writeRecord(t, ctx, s1.Sender(), rec, []byte("before"))
 
 	metaKey := keys.MakeKey(constants.SystemPrefix, []byte("rollback-marker-late-prepare"))
 	metaStore := testutil.GetStoreWithRangeLease(t, ctx, stores, 1)
@@ -865,12 +839,7 @@ func TestRollbackNotFoundPreventsLatePrepare(t *testing.T) {
 	dataStore := testutil.GetStoreWithRangeLease(t, ctx, stores, 2)
 	dataRD := dataStore.GetRange(2)
 
-	dataBatch := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
-		Kv: &rfpb.KV{
-			Key:   userKey,
-			Value: []byte("after"),
-		},
-	})
+	dataBatch := rbuilder.NewBatchBuilder().Add(rec.setRequest([]byte("after")))
 	metaBatch := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
 		Kv: &rfpb.KV{
 			Key:   metaKey,
@@ -897,7 +866,7 @@ func TestRollbackNotFoundPreventsLatePrepare(t *testing.T) {
 
 	require.NoError(t, coordinator.RecoverTxnRecordForTest(ctx, txnRecord))
 	verifyTxnRecordNotExist(t, ctx, s1.Sender(), txnProto.GetTransactionId())
-	verifyDirectReadValue(t, ctx, s1.Sender(), userKey, []byte("before"))
+	verifyRecordValue(t, ctx, s1.Sender(), rec.key, []byte("before"))
 	verifyDirectReadNotFound(t, ctx, s1.Sender(), metaKey)
 
 	// B is a normal write that would prepare successfully if rollback had not
@@ -916,23 +885,15 @@ func TestRollbackMarkerStampedWithFinalizeTime(t *testing.T) {
 	ctx := context.Background()
 	sf.StartShard(t, ctx, stores...)
 
-	userKey := []byte("PTdefault/f11")
-	writeReq, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
-		Kv: &rfpb.KV{Key: userKey, Value: []byte("before")},
-	}).ToProto()
-	require.NoError(t, err)
-	writeRsp, err := s1.Sender().SyncPropose(ctx, userKey, writeReq)
-	require.NoError(t, err)
-	require.NoError(t, rbuilder.NewBatchResponseFromProto(writeRsp).AnyError())
+	rec := newTestRecord(t)
+	writeRecord(t, ctx, s1.Sender(), rec, []byte("before"))
 
 	dataStore := testutil.GetStoreWithRangeLease(t, ctx, stores, 2)
 	dataRD := dataStore.GetRange(2)
 	metaStore := testutil.GetStoreWithRangeLease(t, ctx, stores, 1)
 	metaRD := metaStore.GetRange(1)
 
-	dataBatch := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
-		Kv: &rfpb.KV{Key: userKey, Value: []byte("after")},
-	})
+	dataBatch := rbuilder.NewBatchBuilder().Add(rec.setRequest([]byte("after")))
 	metaKey := keys.MakeKey(constants.SystemPrefix, []byte("rollback-marker-finalize-ts"))
 	metaBatch := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
 		Kv: &rfpb.KV{Key: metaKey, Value: []byte("x")},
@@ -965,7 +926,7 @@ func TestRollbackMarkerStampedWithFinalizeTime(t *testing.T) {
 	// rollback marker on each range stamped with the finalize timestamp.
 	require.NoError(t, coordinator.RecoverTxnRecordForTest(ctx, txnRecord))
 	verifyTxnRecordNotExist(t, ctx, s1.Sender(), txnProto.GetTransactionId())
-	verifyDirectReadValue(t, ctx, s1.Sender(), userKey, []byte("before"))
+	verifyRecordValue(t, ctx, s1.Sender(), rec.key, []byte("before"))
 
 	repl, err := dataStore.GetReplica(2)
 	require.NoError(t, err)

--- a/enterprise/server/raft/txn/txn_test.go
+++ b/enterprise/server/raft/txn/txn_test.go
@@ -82,24 +82,6 @@ func writeRecord(t *testing.T, ctx context.Context, s *sender.Sender, r *testRec
 	require.NoError(t, rbuilder.NewBatchResponseFromProto(writeRsp).AnyError())
 }
 
-// verifyRecordValue asserts that the record at key holds data inline.
-func verifyRecordValue(t *testing.T, ctx context.Context, s *sender.Sender, key, data []byte) {
-	t.Helper()
-	readReq, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectReadRequest{
-		Key: key,
-	}).ToProto()
-	require.NoError(t, err)
-	readRsp, err := s.SyncRead(ctx, key, readReq)
-	require.NoError(t, err)
-	readBatch := rbuilder.NewBatchResponseFromProto(readRsp)
-	require.NoError(t, readBatch.AnyError())
-	directRead, err := readBatch.DirectReadResponse(0)
-	require.NoError(t, err)
-	md := &sgpb.FileMetadata{}
-	require.NoError(t, proto.Unmarshal(directRead.GetKv().GetValue(), md))
-	require.Equal(t, data, md.GetStorageMetadata().GetInlineMetadata().GetData())
-}
-
 func TestCommitPreparedTxn(t *testing.T) {
 	sf := testutil.NewStoreFactory(t)
 	store := sf.NewStore(t, testutil.StoreOptions{})
@@ -556,7 +538,7 @@ func setupPendingRollbackTxnForRecovery(
 	return ctx, s1, tc, txnProto, txnRecord, rec.key, metaKey
 }
 
-func verifyDirectReadValue(t *testing.T, ctx context.Context, s *sender.Sender, key, value []byte) {
+func directReadValue(t *testing.T, ctx context.Context, s *sender.Sender, key []byte) []byte {
 	t.Helper()
 	readReq, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectReadRequest{
 		Key: key,
@@ -568,7 +550,14 @@ func verifyDirectReadValue(t *testing.T, ctx context.Context, s *sender.Sender, 
 	require.NoError(t, readBatch.AnyError())
 	directRead, err := readBatch.DirectReadResponse(0)
 	require.NoError(t, err)
-	require.Equal(t, value, directRead.GetKv().GetValue())
+	return directRead.GetKv().GetValue()
+}
+
+func verifyRecordValue(t *testing.T, ctx context.Context, s *sender.Sender, key, data []byte) {
+	t.Helper()
+	md := &sgpb.FileMetadata{}
+	require.NoError(t, proto.Unmarshal(directReadValue(t, ctx, s, key), md))
+	require.Equal(t, data, md.GetStorageMetadata().GetInlineMetadata().GetData())
 }
 
 func verifyDirectReadNotFound(t *testing.T, ctx context.Context, s *sender.Sender, key []byte) {
@@ -818,7 +807,7 @@ func TestStalePendingJanitorHelpsCommit(t *testing.T) {
 
 	verifyTxnRecordNotExist(t, ctx, s1.Sender(), txnProto.GetTransactionId())
 	verifyRecordValue(t, ctx, s1.Sender(), rec.key, []byte("after"))
-	verifyDirectReadValue(t, ctx, s1.Sender(), metaKey, []byte("committed"))
+	require.Equal(t, []byte("committed"), directReadValue(t, ctx, s1.Sender(), metaKey))
 }
 
 func TestRollbackNotFoundPreventsLatePrepare(t *testing.T) {

--- a/enterprise/server/raft/txn/txn_test.go
+++ b/enterprise/server/raft/txn/txn_test.go
@@ -59,8 +59,7 @@ func newTestRecord(t testing.TB) *testRecord {
 	return &testRecord{key: key, fr: fr}
 }
 
-// setRequest returns a SetRequest storing data inline in the record, so tests
-// can distinguish written states the way raw DirectWrite values used to.
+// setRequest returns a SetRequest storing data inline in the record.
 func (r *testRecord) setRequest(data []byte) *rfpb.SetRequest {
 	return &rfpb.SetRequest{
 		Key: r.key,


### PR DESCRIPTION
File records must be written through `SetRequest` (and mutated via `UpdateAtime`/`Delete`): those paths validate the key and value, and state derived from record writes — such as the atime-ordered eviction index proposed in #12877, which this PR is groundwork for — relies on them being the only writers of record keyspace.

This closes the back door in the state machine:

- `directWrite` and `cas` now return `InvalidArgument` for keys in file-record (`PT`-prefixed) keyspace, via a shared `checkNotFileRecordKey`. `directDelete` and `increment` already confine themselves to replica-local keys.
- rbuilder already rejects CAS on splittable keys client-side; the apply-path check covers callers that bypass rbuilder (the new test exercises both paths, hand-rolling the CAS batch).
- No production caller wrote records this way, but tests did: `testutil.WriteRecord` and five replica_test sites are converted from `DirectWrite` to `SetRequest`, so test-created records take the production write path.

Rollout note: the rejection is deterministic (a pure function of the request), so replicas cannot diverge on state they both apply. During a mixed-version rollout an old binary would accept a PT-key DirectWrite that a new binary rejects — only a hazard if some proposer sent one, and none does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXYBJn6XbQgy8g6pYPZ44T