### PR TITLE
cli/printlog: Detect log format automatically

### DIFF
--- a/cli/printlog/BUILD
+++ b/cli/printlog/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//cli/arg",
         "//cli/log",
         "//cli/printlog/compact",
+        "//cli/printlog/detect",
         "//proto:remote_execution_go_proto",
         "//proto:remote_execution_log_go_proto",
         "//server/util/proto",

--- a/cli/printlog/detect/BUILD
+++ b/cli/printlog/detect/BUILD
@@ -32,6 +32,7 @@ go_test(
         "@org_golang_google_genproto_googleapis_rpc//status",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_protobuf//encoding/protodelim",
+        "@org_golang_google_protobuf//encoding/protowire",
         "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/timestamppb",
     ],

--- a/cli/printlog/detect/BUILD
+++ b/cli/printlog/detect/BUILD
@@ -1,0 +1,38 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//cli:__subpackages__"])
+
+go_library(
+    name = "detect",
+    srcs = ["detect.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/printlog/detect",
+    deps = [
+        "//proto:remote_execution_log_go_proto",
+        "//proto:spawn_go_proto",
+        "@com_github_klauspost_compress//zstd",
+        "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//reflect/protoreflect",
+    ],
+)
+
+go_test(
+    name = "detect_test",
+    srcs = ["detect_test.go"],
+    data = [
+        "//cli/explain/compactgraph/testdata:all_logs",
+    ],
+    deps = [
+        ":detect",
+        "//proto:remote_execution_go_proto",
+        "//proto:remote_execution_log_go_proto",
+        "//proto:spawn_go_proto",
+        "@com_github_klauspost_compress//zstd",
+        "@com_github_stretchr_testify//require",
+        "@io_bazel_rules_go//go/runfiles",
+        "@org_golang_google_genproto_googleapis_rpc//status",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_protobuf//encoding/protodelim",
+        "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//types/known/timestamppb",
+    ],
+)

--- a/cli/printlog/detect/detect.go
+++ b/cli/printlog/detect/detect.go
@@ -1,0 +1,177 @@
+// Package detect identifies Bazel log formats supported by bb print.
+package detect
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/klauspost/compress/zstd"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	rlpb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution_log"
+	spb "github.com/buildbuddy-io/buildbuddy/proto/spawn"
+)
+
+// Format is a log file format that `bb print` knows how to print.
+type Format string
+
+const (
+	GRPCLog             Format = "grpc_log"
+	CompactExecutionLog Format = "compact_execution_log"
+)
+
+type candidate struct {
+	format            Format
+	compressed        bool
+	newMessage        func() proto.Message
+	hasRequiredFields func(proto.Message) bool
+}
+
+var candidates = []candidate{
+	{
+		format:            GRPCLog,
+		compressed:        false,
+		newMessage:        func() proto.Message { return &rlpb.LogEntry{} },
+		hasRequiredFields: func(m proto.Message) bool { return strings.Contains(m.(*rlpb.LogEntry).GetMethodName(), "/") },
+	},
+	{
+		format:            CompactExecutionLog,
+		compressed:        true,
+		newMessage:        func() proto.Message { return &spb.ExecLogEntry{} },
+		hasRequiredFields: func(m proto.Message) bool { return m.(*spb.ExecLogEntry).GetType() != nil },
+	},
+}
+
+// File returns the format of the log file at path.
+func File(path string) (Format, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	return Stream(f)
+}
+
+// Stream returns the format of a log stream, reading only as much of r as it
+// needs to decide.
+func Stream(r io.Reader) (Format, error) {
+	frames, compressed, err := sample(r)
+	if err != nil {
+		return "", err
+	}
+	for _, c := range candidates {
+		if c.compressed == compressed && c.matches(frames) {
+			return c.format, nil
+		}
+	}
+	return "", errors.New("unsupported log format (expected output from --remote_grpc_log or --execution_log_compact_file)")
+}
+
+func sample(r io.Reader) (frames [][]byte, compressed bool, err error) {
+	const (
+		zstdMagic    = "\x28\xb5\x2f\xfd"
+		sampleFrames = 8
+		sampleBytes  = 1 << 20
+		maxFrameSize = 256 << 20
+	)
+	br := bufio.NewReader(r)
+	magic, err := br.Peek(len(zstdMagic))
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, false, err
+	}
+	framed := br
+	if string(magic) == zstdMagic {
+		compressed = true
+		// Decode serially; the default reads ~3.6x further ahead than we sample.
+		zr, err := zstd.NewReader(br, zstd.WithDecoderConcurrency(1))
+		if err != nil {
+			return nil, true, err
+		}
+		defer zr.Close()
+		framed = bufio.NewReader(zr)
+	}
+
+	bytesRead := 0
+	for len(frames) < sampleFrames {
+		size, err := binary.ReadUvarint(framed)
+		if err != nil || size > maxFrameSize {
+			break
+		}
+		if len(frames) > 0 && bytesRead+int(size) > sampleBytes {
+			break
+		}
+		// Grow with the bytes actually read. The length prefix is untrusted, so
+		// allocating it up front lets a few bytes of garbage ask for maxFrameSize.
+		var frame bytes.Buffer
+		if _, err := io.CopyN(&frame, framed, int64(size)); err != nil {
+			break
+		}
+		frames = append(frames, frame.Bytes())
+		bytesRead += int(size)
+	}
+	return frames, compressed, nil
+}
+
+func (c candidate) matches(frames [][]byte) bool {
+	sampled, accounted, leading := 0, 0, true
+	for _, frame := range frames {
+		if len(frame) == 0 {
+			continue
+		}
+		sampled++
+		m := c.newMessage()
+		err := proto.Unmarshal(frame, m)
+		if leading {
+			// The first entry pins the format. Bazel writes a recognizable one at
+			// the head of both logs, and checking only it leaves room for later
+			// entries a newer Bazel added.
+			if err != nil || !c.hasRequiredFields(m) {
+				return false
+			}
+			leading = false
+		}
+		if err == nil && unknownBytes(m.ProtoReflect())*10 <= len(frame) {
+			accounted++
+		}
+	}
+	// Tolerate a minority of entries the vendored protos don't know: an
+	// ExecLogEntry oneof case added by a newer Bazel parses as entirely unknown
+	// bytes, and shouldn't sink an otherwise clean sample.
+	return sampled > 0 && accounted*2 > sampled
+}
+
+func unknownBytes(m protoreflect.Message) int {
+	n := len(m.GetUnknown())
+	m.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		switch {
+		case fd.IsMap():
+			if isMessage(fd.MapValue()) {
+				v.Map().Range(func(_ protoreflect.MapKey, mv protoreflect.Value) bool {
+					n += unknownBytes(mv.Message())
+					return true
+				})
+			}
+		case fd.IsList():
+			if isMessage(fd) {
+				l := v.List()
+				for i := range l.Len() {
+					n += unknownBytes(l.Get(i).Message())
+				}
+			}
+		case isMessage(fd):
+			n += unknownBytes(v.Message())
+		}
+		return true
+	})
+	return n
+}
+
+func isMessage(fd protoreflect.FieldDescriptor) bool {
+	return fd.Kind() == protoreflect.MessageKind || fd.Kind() == protoreflect.GroupKind
+}

--- a/cli/printlog/detect/detect.go
+++ b/cli/printlog/detect/detect.go
@@ -48,19 +48,18 @@ var candidates = []candidate{
 	},
 }
 
-// File returns the format of the log file at path.
-func File(path string) (Format, error) {
+// FileFormat returns the format of the log file at path.
+func FileFormat(path string) (Format, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return "", err
 	}
 	defer f.Close()
-	return Stream(f)
+	return StreamFormat(f)
 }
 
-// Stream returns the format of a log stream, reading only as much of r as it
-// needs to decide.
-func Stream(r io.Reader) (Format, error) {
+// StreamFormat returns the format of a log stream.
+func StreamFormat(r io.Reader) (Format, error) {
 	frames, compressed, err := sample(r)
 	if err != nil {
 		return "", err
@@ -73,6 +72,7 @@ func Stream(r io.Reader) (Format, error) {
 	return "", errors.New("unsupported log format (expected output from --remote_grpc_log or --execution_log_compact_file)")
 }
 
+// sample returns a bounded prefix of frames and whether r is zstd-compressed.
 func sample(r io.Reader) (frames [][]byte, compressed bool, err error) {
 	const (
 		zstdMagic    = "\x28\xb5\x2f\xfd"
@@ -118,6 +118,7 @@ func sample(r io.Reader) (frames [][]byte, compressed bool, err error) {
 	return frames, compressed, nil
 }
 
+// matches reports whether the sampled messages identify c's format.
 func (c candidate) matches(frames [][]byte) bool {
 	sampled, accounted, leading := 0, 0, true
 	for _, frame := range frames {
@@ -146,6 +147,7 @@ func (c candidate) matches(frames [][]byte) bool {
 	return sampled > 0 && accounted*2 > sampled
 }
 
+// unknownBytes returns the encoded size of unknown fields in m and nested messages.
 func unknownBytes(m protoreflect.Message) int {
 	n := len(m.GetUnknown())
 	m.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
@@ -172,6 +174,7 @@ func unknownBytes(m protoreflect.Message) int {
 	return n
 }
 
+// isMessage reports whether fd can contain a message value.
 func isMessage(fd protoreflect.FieldDescriptor) bool {
 	return fd.Kind() == protoreflect.MessageKind || fd.Kind() == protoreflect.GroupKind
 }

--- a/cli/printlog/detect/detect_test.go
+++ b/cli/printlog/detect/detect_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/encoding/protodelim"
+	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -100,11 +101,11 @@ func logFile(t *testing.T, format detect.Format, n int) []byte {
 	return b
 }
 
-func TestStream(t *testing.T) {
+func TestStreamFormat(t *testing.T) {
 	for format := range entryForFormat {
 		for _, n := range []int{1, 2, 50} {
 			t.Run(fmt.Sprintf("%s/%d_entries", format, n), func(t *testing.T) {
-				got, err := detect.Stream(bytes.NewReader(logFile(t, format, n)))
+				got, err := detect.StreamFormat(bytes.NewReader(logFile(t, format, n)))
 				require.NoError(t, err)
 				require.Equal(t, format, got)
 			})
@@ -129,7 +130,7 @@ func binaryExecLog(t *testing.T) []byte {
 	return buf.Bytes()
 }
 
-func TestStreamRejectsNonLogs(t *testing.T) {
+func TestStreamFormatRejectsNonLogs(t *testing.T) {
 	var unrelatedProto bytes.Buffer
 	_, err := protodelim.MarshalTo(&unrelatedProto, &repb.Platform{
 		Properties: []*repb.Platform_Property{{Name: "OSFamily", Value: "linux"}},
@@ -154,15 +155,15 @@ func TestStreamRejectsNonLogs(t *testing.T) {
 		{"uncompressed_compact_log", delimited(t, detect.CompactExecutionLog, 4)},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := detect.Stream(bytes.NewReader(tc.contents))
+			_, err := detect.StreamFormat(bytes.NewReader(tc.contents))
 			require.Error(t, err)
 		})
 	}
 }
 
-func TestStreamToleratesUnknownEntryTypes(t *testing.T) {
-	// An entry using oneof case 11, which spawn.proto doesn't define.
-	unknownEntry := []byte{11<<3 | 2, 4, 'a', 'b', 'c', 'd'}
+func TestStreamFormatToleratesUnknownEntryTypes(t *testing.T) {
+	unknownEntry := protowire.AppendTag(nil, protowire.MaxValidNumber, protowire.BytesType)
+	unknownEntry = protowire.AppendBytes(unknownEntry, []byte("abcd"))
 
 	var buf bytes.Buffer
 	writeEntry := func(i int) {
@@ -178,12 +179,12 @@ func TestStreamToleratesUnknownEntryTypes(t *testing.T) {
 		writeEntry(i)
 	}
 
-	format, err := detect.Stream(bytes.NewReader(zstdCompress(t, buf.Bytes())))
+	format, err := detect.StreamFormat(bytes.NewReader(zstdCompress(t, buf.Bytes())))
 	require.NoError(t, err)
 	require.Equal(t, detect.CompactExecutionLog, format)
 }
 
-func TestFileOnRealCompactExecutionLogs(t *testing.T) {
+func TestFileFormatOnRealCompactExecutionLogs(t *testing.T) {
 	dir, err := runfiles.Rlocation("com_github_buildbuddy_io_buildbuddy/cli/explain/compactgraph/testdata")
 	require.NoError(t, err)
 	logs, err := filepath.Glob(filepath.Join(dir, "*", "*.pb.zstd"))
@@ -193,21 +194,21 @@ func TestFileOnRealCompactExecutionLogs(t *testing.T) {
 	for _, log := range logs {
 		name := filepath.Join(filepath.Base(filepath.Dir(log)), filepath.Base(log))
 		t.Run(name, func(t *testing.T) {
-			format, err := detect.File(log)
+			format, err := detect.FileFormat(log)
 			require.NoError(t, err)
 			require.Equal(t, detect.CompactExecutionLog, format)
 		})
 	}
 }
 
-func TestStreamReadsOnlyTheStart(t *testing.T) {
+func TestStreamFormatReadsOnlyTheStart(t *testing.T) {
 	for format := range entryForFormat {
 		t.Run(string(format), func(t *testing.T) {
 			contents := logFile(t, format, 50000)
 			require.Greater(t, len(contents), 512<<10, "test log should be big enough to matter")
 
 			r := &countingReader{Reader: bytes.NewReader(contents)}
-			got, err := detect.Stream(r)
+			got, err := detect.StreamFormat(r)
 			require.NoError(t, err)
 			require.Equal(t, format, got)
 			// Tight enough to catch the zstd decoder reading ahead, which it does

--- a/cli/printlog/detect/detect_test.go
+++ b/cli/printlog/detect/detect_test.go
@@ -1,0 +1,229 @@
+package detect_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/bazelbuild/rules_go/go/runfiles"
+	"github.com/buildbuddy-io/buildbuddy/cli/printlog/detect"
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/encoding/protodelim"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rlpb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution_log"
+	spb "github.com/buildbuddy-io/buildbuddy/proto/spawn"
+	statuspb "google.golang.org/genproto/googleapis/rpc/status"
+)
+
+var entryForFormat = map[detect.Format]func(int) proto.Message{
+	detect.GRPCLog: func(i int) proto.Message {
+		return &rlpb.LogEntry{
+			MethodName: "build.bazel.remote.execution.v2.ActionCache/GetActionResult",
+			Metadata: &repb.RequestMetadata{
+				ToolDetails:             &repb.ToolDetails{ToolName: "bazel", ToolVersion: "9.2.0"},
+				ActionId:                fmt.Sprintf("%064x", i*2654435761),
+				ToolInvocationId:        "66f29b0e-f165-4b0a-b9ee-dafff3263a03",
+				CorrelatedInvocationsId: "208e9d34-a0d3-464a-a51a-4d1f32a024c3",
+			},
+			Status:    &statuspb.Status{Code: int32(codes.NotFound), Message: "not found"},
+			StartTime: timestamppb.New(time.Unix(1700000000, int64(i))),
+			EndTime:   timestamppb.New(time.Unix(1700000001, int64(i))),
+			Details: &rlpb.RpcCallDetails{Details: &rlpb.RpcCallDetails_GetActionResult{
+				GetActionResult: &rlpb.GetActionResultDetails{
+					Request: &repb.GetActionResultRequest{
+						InstanceName: "",
+						ActionDigest: &repb.Digest{Hash: fmt.Sprintf("%064x", i), SizeBytes: int64(i)},
+					},
+				},
+			}},
+		}
+	},
+	detect.CompactExecutionLog: func(i int) proto.Message {
+		if i == 0 {
+			return &spb.ExecLogEntry{
+				Type: &spb.ExecLogEntry_Invocation_{
+					Invocation: &spb.ExecLogEntry_Invocation{
+						HashFunctionName:           "SHA-256",
+						WorkspaceRunfilesDirectory: "_main",
+					},
+				},
+			}
+		}
+		return &spb.ExecLogEntry{
+			Id: uint32(i),
+			Type: &spb.ExecLogEntry_File_{
+				File: &spb.ExecLogEntry_File{
+					Path:   fmt.Sprintf("bazel-out/k8-fastbuild/bin/pkg%d/file%d.o", i%977, i),
+					Digest: &spb.Digest{Hash: fmt.Sprintf("%064x", i*2654435761), SizeBytes: int64(i)},
+				},
+			},
+		}
+	},
+}
+
+func delimited(t *testing.T, format detect.Format, n int) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	for i := range n {
+		_, err := protodelim.MarshalTo(&buf, entryForFormat[format](i))
+		require.NoError(t, err)
+	}
+	return buf.Bytes()
+}
+
+func zstdCompress(t *testing.T, b []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w, err := zstd.NewWriter(&buf)
+	require.NoError(t, err)
+	_, err = w.Write(b)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	return buf.Bytes()
+}
+
+// logFile renders a log the way Bazel writes it, compressing only the compact log.
+func logFile(t *testing.T, format detect.Format, n int) []byte {
+	t.Helper()
+	b := delimited(t, format, n)
+	if format == detect.CompactExecutionLog {
+		return zstdCompress(t, b)
+	}
+	return b
+}
+
+func TestStream(t *testing.T) {
+	for format := range entryForFormat {
+		for _, n := range []int{1, 2, 50} {
+			t.Run(fmt.Sprintf("%s/%d_entries", format, n), func(t *testing.T) {
+				got, err := detect.Stream(bytes.NewReader(logFile(t, format, n)))
+				require.NoError(t, err)
+				require.Equal(t, format, got)
+			})
+		}
+	}
+}
+
+func binaryExecLog(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	for i := range 4 {
+		_, err := protodelim.MarshalTo(&buf, &spb.SpawnExec{
+			CommandArgs:          []string{"/usr/bin/gcc", "-c", fmt.Sprintf("file%d.c", i)},
+			EnvironmentVariables: []*spb.EnvironmentVariable{{Name: "PATH", Value: "/usr/bin"}},
+			Mnemonic:             "CppCompile",
+			TargetLabel:          fmt.Sprintf("//pkg:file%d", i),
+			ListedOutputs:        []string{fmt.Sprintf("bazel-out/k8-fastbuild/bin/file%d.o", i)},
+			Runner:               "remote",
+		})
+		require.NoError(t, err)
+	}
+	return buf.Bytes()
+}
+
+func TestStreamRejectsNonLogs(t *testing.T) {
+	var unrelatedProto bytes.Buffer
+	_, err := protodelim.MarshalTo(&unrelatedProto, &repb.Platform{
+		Properties: []*repb.Platform_Property{{Name: "OSFamily", Value: "linux"}},
+	})
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name     string
+		contents []byte
+	}{
+		{"empty", nil},
+		{"json", []byte(`{"commandArgs": ["/usr/bin/gcc"], "mnemonic": "CppCompile"}`)},
+		{"text", []byte("INFO: Elapsed time: 1.234s, Critical Path: 0.56s\n")},
+		{"random_bytes", bytes.Repeat([]byte{0xFF, 0xFE, 0xFD, 0xFC}, 256)},
+		{"unrelated_proto", unrelatedProto.Bytes()},
+		{"binary_execution_log", binaryExecLog(t)},
+		// Decodes to exactly maxFrameSize, in a 5 byte file.
+		{"oversized_length_prefix", []byte{0x80, 0x80, 0x80, 0x80, 0x01}},
+		// Bazel compresses the compact log and nothing else, and each printer
+		// assumes as much, so a mismatch is deliberately not detected.
+		{"compressed_grpc_log", zstdCompress(t, delimited(t, detect.GRPCLog, 4))},
+		{"uncompressed_compact_log", delimited(t, detect.CompactExecutionLog, 4)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := detect.Stream(bytes.NewReader(tc.contents))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestStreamToleratesUnknownEntryTypes(t *testing.T) {
+	// An entry using oneof case 11, which spawn.proto doesn't define.
+	unknownEntry := []byte{11<<3 | 2, 4, 'a', 'b', 'c', 'd'}
+
+	var buf bytes.Buffer
+	writeEntry := func(i int) {
+		_, err := protodelim.MarshalTo(&buf, entryForFormat[detect.CompactExecutionLog](i))
+		require.NoError(t, err)
+	}
+	writeEntry(0) // Invocation
+	for range 3 {
+		buf.WriteByte(byte(len(unknownEntry)))
+		buf.Write(unknownEntry)
+	}
+	for i := 1; i <= 4; i++ {
+		writeEntry(i)
+	}
+
+	format, err := detect.Stream(bytes.NewReader(zstdCompress(t, buf.Bytes())))
+	require.NoError(t, err)
+	require.Equal(t, detect.CompactExecutionLog, format)
+}
+
+func TestFileOnRealCompactExecutionLogs(t *testing.T) {
+	dir, err := runfiles.Rlocation("com_github_buildbuddy_io_buildbuddy/cli/explain/compactgraph/testdata")
+	require.NoError(t, err)
+	logs, err := filepath.Glob(filepath.Join(dir, "*", "*.pb.zstd"))
+	require.NoError(t, err)
+	require.NotEmpty(t, logs, "no real logs found to test against")
+
+	for _, log := range logs {
+		name := filepath.Join(filepath.Base(filepath.Dir(log)), filepath.Base(log))
+		t.Run(name, func(t *testing.T) {
+			format, err := detect.File(log)
+			require.NoError(t, err)
+			require.Equal(t, detect.CompactExecutionLog, format)
+		})
+	}
+}
+
+func TestStreamReadsOnlyTheStart(t *testing.T) {
+	for format := range entryForFormat {
+		t.Run(string(format), func(t *testing.T) {
+			contents := logFile(t, format, 50000)
+			require.Greater(t, len(contents), 512<<10, "test log should be big enough to matter")
+
+			r := &countingReader{Reader: bytes.NewReader(contents)}
+			got, err := detect.Stream(r)
+			require.NoError(t, err)
+			require.Equal(t, format, got)
+			// Tight enough to catch the zstd decoder reading ahead, which it does
+			// without WithDecoderConcurrency(1).
+			require.Less(t, r.n, 32<<10, "detection read too much of the log")
+		})
+	}
+}
+
+type countingReader struct {
+	io.Reader
+	n int
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	n, err := r.Reader.Read(p)
+	r.n += n
+	return n, err
+}

--- a/cli/printlog/printlog.go
+++ b/cli/printlog/printlog.go
@@ -10,6 +10,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/cli/printlog/compact"
+	"github.com/buildbuddy-io/buildbuddy/cli/printlog/detect"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"google.golang.org/protobuf/encoding/protodelim"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -21,9 +22,9 @@ import (
 
 const (
 	usage = `
-usage: bb print [--grpc_log=PATH] [--compact_execution_log=PATH] [--sort=false] [--raw=false] [--max_entry_size_mb=40]
+usage: bb print [PATH] [--grpc_log=PATH] [--compact_execution_log=PATH] [--sort=false] [--raw=false] [--max_entry_size_mb=40]
 
-Prints a human-readable representation of log files output by Bazel.
+Prints a Bazel log in human-readable form, detecting its format when PATH is provided.
 
 Currently supported log types:
   --grpc_log: Path to a file saved with --experimental_remote_grpc_log.
@@ -51,6 +52,12 @@ func HandlePrint(args []string) (int, error) {
 		}
 		return -1, err
 	}
+	if flags.NArg() > 1 {
+		return -1, fmt.Errorf("expected at most one log file, got %d", flags.NArg())
+	}
+	if flags.NArg() == 1 && (*grpcLog != "" || *compactExecLog != "") {
+		return -1, fmt.Errorf("cannot pass a log file alongside --grpc_log or --compact_execution_log")
+	}
 	if *grpcLog != "" {
 		if err := printLog(*grpcLog, &rlpb.LogEntry{}); err != nil {
 			return -1, err
@@ -63,8 +70,34 @@ func HandlePrint(args []string) (int, error) {
 		}
 		return 0, nil
 	}
+	if flags.NArg() == 1 {
+		if err := printDetected(flags.Arg(0)); err != nil {
+			return -1, err
+		}
+		return 0, nil
+	}
 	log.Print(usage)
 	return 1, nil
+}
+
+func printDetected(path string) error {
+	// Detection reads the file and the printer opens it again, so it has to be
+	// re-readable from the start. A pipe or process substitution isn't.
+	if st, err := os.Stat(path); err == nil && !st.Mode().IsRegular() {
+		return fmt.Errorf("cannot detect the format of %q: not a regular file; pass --grpc_log or --compact_execution_log instead", path)
+	}
+	format, err := detect.File(path)
+	if err != nil {
+		return fmt.Errorf("detect log format for %q: %w", path, err)
+	}
+	switch format {
+	case detect.GRPCLog:
+		return printLog(path, &rlpb.LogEntry{})
+	case detect.CompactExecutionLog:
+		return compact.PrintCompactExecLog(path, *raw, *sort)
+	default:
+		return fmt.Errorf("unsupported log format %q", format)
+	}
 }
 
 func printLog(path string, m proto.Message) error {

--- a/cli/printlog/printlog.go
+++ b/cli/printlog/printlog.go
@@ -86,7 +86,7 @@ func printDetected(path string) error {
 	if st, err := os.Stat(path); err == nil && !st.Mode().IsRegular() {
 		return fmt.Errorf("cannot detect the format of %q: not a regular file; pass --grpc_log or --compact_execution_log instead", path)
 	}
-	format, err := detect.File(path)
+	format, err := detect.FileFormat(path)
 	if err != nil {
 		return fmt.Errorf("detect log format for %q: %w", path, err)
 	}


### PR DESCRIPTION
bb print PATH now distinguishes gRPC logs from compact execution logs on its own, so you no longer have to know which of `--grpc_log` or `--compact_execution_log` matches the file in front of you. Now just `bb print <file>`. 

Both flags still work and take precedence, so **existing usage is unchanged.**

Neither format has a self-describing header; they are both streams of length-delimited protos. So detection parses the leading messages with each candidate descriptor and keeps the one that accounts for the bytes it read. A wrong descriptor leaves unknown fields behind almost immediately, since the two disagree about the wire type, UTF-8 validity, or nested structure of nearly every field. Two things back that up: a field Bazel always sets for each format (LogEntry.method_name, ExecLogEntry.type), and zstd framing, which Bazel applies to the compact log and nothing else.

Detection samples **at most 8 messages / 1MB**. It _does_ open the file twice, once to sniff and once to print. That is a deliberate tradeoff: avoiding it would mean a **new replay buffer below the zstd decoder** to work for the compact log, since detection consumes compressed bytes to inspect frames. This costs ~1ms.