### PR TITLE
Add a bit to the distributed cache protocol that the coordinator can use to instruct peers to clone references

### DIFF
--- a/proto/distributed_cache.proto
+++ b/proto/distributed_cache.proto
@@ -29,7 +29,7 @@ message ReadResponse {
   reference.Reference reference = 2;
 }
 
-// Next Tag: 10
+// Next Tag: 11
 message WriteRequest {
   option (vtproto.mempool) = true;
   reserved 1, 2, 6;
@@ -48,6 +48,17 @@ message WriteRequest {
   // If set, this write carries no data bytes. The data should be retrieved
   // using the provided reference.
   reference.Reference reference = 9;
+
+  // If true, the provided reference must be cloned by the server that handles
+  // this request. Because eviction is not synchronized across distributed cache
+  // peers, each peer must store its own copy of data in GCS to coordinate
+  // eviction between its pebble cache and GCS. This means that if writes are
+  // done using references, at most one of the distributed cache peers may
+  // assume ownership of the reference that is written. The other peers must
+  // clone the reference to obtain their own copy. This bit is set by the
+  // distributed cache coordinator (the pod serving the client's write) to
+  // indicate which peers must clone the provided reference.
+  bool reference_must_be_cloned = 10;
 }
 
 message WriteResponse {


### PR DESCRIPTION
Today, we avoid cache consistency issues caused by asynchronous eviction between distributed cache peers by writing large blobs to GCS once per pod that owns the associated artifact (the "owners"). When we move to writing via reference, the pod that serves the request (the "coordinator," which is not necessarily one of the owners) will write the data to GCS to convert it into a reference and then pass that reference to each of the owners. This introduces a new write to GCS, the coordinator's. Without a signal from the coordinator, the owners cannot determine which (if any) owner may use the provided GCS reference directly, so each owner needs to clone the GCS reference for its own use. This increases the number of GCS writes on the write path by 1/3.

This PR adds a bit to the `distributed_cache.WriteRequest` allowing the coordinator to specifically instruct owners that they must clone references they receive. We can use this on the write path to prevent unnecessary clones.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7911