### PR TITLE
k8s discovery: use the StatefulSet pod selector as-is.

### DIFF
--- a/server/util/kubediscovery/kubediscovery.go
+++ b/server/util/kubediscovery/kubediscovery.go
@@ -236,11 +236,7 @@ func getLabelSelectorFromOwner(ctx context.Context, client kubernetes.Interface,
 		if err != nil {
 			return "", false, fmt.Errorf("failed to get ReplicaSet %s: %w", controllerRef.Name, err)
 		}
-		sel, err := labelSelectorString(rs.Spec.Selector)
-		if err != nil {
-			return "", false, fmt.Errorf("ReplicaSet %s: %w", controllerRef.Name, err)
-		}
-		return sel, true, nil
+		return appLabelSelectorString(rs.Spec.Selector), true, nil
 
 	case "StatefulSet":
 		ss, err := client.AppsV1().StatefulSets(namespace).Get(ctx, controllerRef.Name, metav1.GetOptions{})
@@ -258,16 +254,23 @@ func getLabelSelectorFromOwner(ctx context.Context, client kubernetes.Interface,
 	}
 }
 
-// labelSelectorString converts a controller's pod selector into a list/watch
-// selector string for discovering peer pods. pod-template-hash is dropped
-// because it is unique to each ReplicaSet revision of a Deployment, and peers
-// from all revisions should be discovered (e.g. during a rolling update).
+// appLabelSelectorString returns an "app"-label selector for ReplicaSet-managed
+// pods. Only the app label is used because the full ReplicaSet selector
+// includes pod-template-hash, which is unique to each Deployment revision and
+// would hide peers from other revisions during a rolling update.
+func appLabelSelectorString(sel *metav1.LabelSelector) string {
+	if sel == nil {
+		return ""
+	}
+	return "app=" + sel.MatchLabels["app"]
+}
+
+// labelSelectorString converts a StatefulSet's pod selector into a list/watch
+// selector string for discovering peer pods.
 func labelSelectorString(sel *metav1.LabelSelector) (string, error) {
 	if sel == nil {
 		return "", fmt.Errorf("controller has no pod selector")
 	}
-	sel = sel.DeepCopy()
-	delete(sel.MatchLabels, "pod-template-hash")
 	s, err := metav1.LabelSelectorAsSelector(sel)
 	if err != nil {
 		return "", fmt.Errorf("invalid controller pod selector: %w", err)

--- a/server/util/kubediscovery/kubediscovery.go
+++ b/server/util/kubediscovery/kubediscovery.go
@@ -236,25 +236,46 @@ func getLabelSelectorFromOwner(ctx context.Context, client kubernetes.Interface,
 		if err != nil {
 			return "", false, fmt.Errorf("failed to get ReplicaSet %s: %w", controllerRef.Name, err)
 		}
-		return labelSelectorString(rs.Spec.Selector), true, nil
+		sel, err := labelSelectorString(rs.Spec.Selector)
+		if err != nil {
+			return "", false, fmt.Errorf("ReplicaSet %s: %w", controllerRef.Name, err)
+		}
+		return sel, true, nil
 
 	case "StatefulSet":
 		ss, err := client.AppsV1().StatefulSets(namespace).Get(ctx, controllerRef.Name, metav1.GetOptions{})
 		if err != nil {
 			return "", false, fmt.Errorf("failed to get StatefulSet %s: %w", controllerRef.Name, err)
 		}
-		return labelSelectorString(ss.Spec.Selector), false, nil
+		sel, err := labelSelectorString(ss.Spec.Selector)
+		if err != nil {
+			return "", false, fmt.Errorf("StatefulSet %s: %w", controllerRef.Name, err)
+		}
+		return sel, false, nil
 
 	default:
 		return "", false, fmt.Errorf("unsupported controller kind %q for pod %s", controllerRef.Kind, pod.Name)
 	}
 }
 
-func labelSelectorString(sel *metav1.LabelSelector) string {
+// labelSelectorString converts a controller's pod selector into a list/watch
+// selector string for discovering peer pods. pod-template-hash is dropped
+// because it is unique to each ReplicaSet revision of a Deployment, and peers
+// from all revisions should be discovered (e.g. during a rolling update).
+func labelSelectorString(sel *metav1.LabelSelector) (string, error) {
 	if sel == nil {
-		return ""
+		return "", fmt.Errorf("controller has no pod selector")
 	}
-	return "app=" + sel.MatchLabels["app"]
+	sel = sel.DeepCopy()
+	delete(sel.MatchLabels, "pod-template-hash")
+	s, err := metav1.LabelSelectorAsSelector(sel)
+	if err != nil {
+		return "", fmt.Errorf("invalid controller pod selector: %w", err)
+	}
+	if s.Empty() {
+		return "", fmt.Errorf("controller pod selector is empty")
+	}
+	return s.String(), nil
 }
 
 // processEvents handles watch events until the channel closes or an

--- a/server/util/kubediscovery/kubediscovery_test.go
+++ b/server/util/kubediscovery/kubediscovery_test.go
@@ -496,6 +496,39 @@ func TestNodeKeyPodReplaced(t *testing.T) {
 	require.Equal(t, map[string]string{"node-a": "10.0.0.99:7999"}, peers)
 }
 
+func TestAppLabelSelectorString(t *testing.T) {
+	tests := []struct {
+		name string
+		sel  *metav1.LabelSelector
+		want string
+	}{
+		{
+			name: "nil",
+			sel:  nil,
+			want: "",
+		},
+		{
+			name: "single label",
+			sel:  &metav1.LabelSelector{MatchLabels: map[string]string{"app": "cache"}},
+			want: "app=cache",
+		},
+		{
+			name: "only app label used",
+			sel: &metav1.LabelSelector{MatchLabels: map[string]string{
+				"app":               "cache",
+				"pod-template-hash": "abc123",
+			}},
+			want: "app=cache",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := appLabelSelectorString(tc.sel)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestLabelSelectorString(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -514,14 +547,6 @@ func TestLabelSelectorString(t *testing.T) {
 			want: "app=cache",
 		},
 		{
-			name: "pod-template-hash dropped",
-			sel: &metav1.LabelSelector{MatchLabels: map[string]string{
-				"app":               "cache",
-				"pod-template-hash": "abc123",
-			}},
-			want: "app=cache",
-		},
-		{
 			name: "no app label",
 			sel: &metav1.LabelSelector{MatchLabels: map[string]string{
 				"app.kubernetes.io/name":     "buildbuddy-enterprise",
@@ -530,8 +555,8 @@ func TestLabelSelectorString(t *testing.T) {
 			want: "app.kubernetes.io/instance=release,app.kubernetes.io/name=buildbuddy-enterprise",
 		},
 		{
-			name:    "only pod-template-hash",
-			sel:     &metav1.LabelSelector{MatchLabels: map[string]string{"pod-template-hash": "abc123"}},
+			name:    "empty selector",
+			sel:     &metav1.LabelSelector{},
 			wantErr: true,
 		},
 	}

--- a/server/util/kubediscovery/kubediscovery_test.go
+++ b/server/util/kubediscovery/kubediscovery_test.go
@@ -498,14 +498,15 @@ func TestNodeKeyPodReplaced(t *testing.T) {
 
 func TestLabelSelectorString(t *testing.T) {
 	tests := []struct {
-		name string
-		sel  *metav1.LabelSelector
-		want string
+		name    string
+		sel     *metav1.LabelSelector
+		want    string
+		wantErr bool
 	}{
 		{
-			name: "nil",
-			sel:  nil,
-			want: "",
+			name:    "nil",
+			sel:     nil,
+			wantErr: true,
 		},
 		{
 			name: "single label",
@@ -513,17 +514,35 @@ func TestLabelSelectorString(t *testing.T) {
 			want: "app=cache",
 		},
 		{
-			name: "only app label used",
+			name: "pod-template-hash dropped",
 			sel: &metav1.LabelSelector{MatchLabels: map[string]string{
 				"app":               "cache",
 				"pod-template-hash": "abc123",
 			}},
 			want: "app=cache",
 		},
+		{
+			name: "no app label",
+			sel: &metav1.LabelSelector{MatchLabels: map[string]string{
+				"app.kubernetes.io/name":     "buildbuddy-enterprise",
+				"app.kubernetes.io/instance": "release",
+			}},
+			want: "app.kubernetes.io/instance=release,app.kubernetes.io/name=buildbuddy-enterprise",
+		},
+		{
+			name:    "only pod-template-hash",
+			sel:     &metav1.LabelSelector{MatchLabels: map[string]string{"pod-template-hash": "abc123"}},
+			wantErr: true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := labelSelectorString(tc.sel)
+			got, err := labelSelectorString(tc.sel)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
 			require.Equal(t, tc.want, got)
 		})
 	}


### PR DESCRIPTION
I'm trying to add k8s discovery support to the enteprise Helm chart, which currently does not have an "app" label and adding this label is not a backwards compatible change.

The simpler fix is to have k8s discovery respect the original selector set rather than hardcoding the "app" label.