### PR TITLE
OOM killer: support executor containers with memory limit unset

### DIFF
--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -474,10 +474,12 @@ func ReadMemoryMax(dir string) (*int64, error) {
 // cgroup setting that limit, taking ancestor cgroup limits into account. It
 // returns an empty path and nil limit if neither the cgroup nor any of its
 // ancestors sets a limit. When the same smallest limit is set at multiple
-// levels, it returns the cgroup nearest to the given path. The walk includes
-// the cgroupfs root. The real cgroup v2 root has no memory.max file and is
-// treated as unlimited, but under a cgroup namespace the root directory is a
-// non-root cgroup on the host, and any limit set on it applies.
+// levels, it returns the outermost such cgroup, because memory charged to an
+// ancestor by siblings counts against the shared limit and should be included
+// when the returned cgroup's usage is measured. The walk includes the cgroupfs
+// root. The real cgroup v2 root has no memory.max file and is treated as
+// unlimited, but under a cgroup namespace the root directory is a non-root
+// cgroup on the host, and any limit set on it applies.
 func ReadEffectiveMemoryLimit(dir string) (string, *int64, error) {
 	var limitCgroupPath string
 	var limit *int64
@@ -489,7 +491,7 @@ func ReadEffectiveMemoryLimit(dir string) (string, *int64, error) {
 			}
 			return "", nil, err
 		}
-		if v != nil && (limit == nil || *v < *limit) {
+		if v != nil && (limit == nil || *v <= *limit) {
 			limitCgroupPath = dir
 			limit = v
 		}

--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -470,13 +470,16 @@ func ReadMemoryMax(dir string) (*int64, error) {
 }
 
 // ReadEffectiveMemoryLimit returns the smallest "memory.max" limit in effect
-// for the cgroup at the given absolute path, taking ancestor cgroup limits
-// into account. It returns nil if neither the cgroup nor any of its ancestors
-// sets a limit. The walk includes the cgroupfs root: the real cgroup v2 root
-// has no memory.max file and is treated as unlimited, but under a cgroup
-// namespace the root directory is a non-root cgroup on the host, and any
-// limit set on it applies.
-func ReadEffectiveMemoryLimit(dir string) (*int64, error) {
+// for the cgroup at the given absolute path and the absolute path of the
+// cgroup setting that limit, taking ancestor cgroup limits into account. It
+// returns an empty path and nil limit if neither the cgroup nor any of its
+// ancestors sets a limit. When the same smallest limit is set at multiple
+// levels, it returns the cgroup nearest to the given path. The walk includes
+// the cgroupfs root. The real cgroup v2 root has no memory.max file and is
+// treated as unlimited, but under a cgroup namespace the root directory is a
+// non-root cgroup on the host, and any limit set on it applies.
+func ReadEffectiveMemoryLimit(dir string) (string, *int64, error) {
+	var limitCgroupPath string
 	var limit *int64
 	for dir = filepath.Clean(dir); dir == RootPath || strings.HasPrefix(dir, RootPath+string(os.PathSeparator)); dir = ParentPath(dir) {
 		v, err := ReadMemoryMax(dir)
@@ -484,16 +487,17 @@ func ReadEffectiveMemoryLimit(dir string) (*int64, error) {
 			if dir == RootPath && os.IsNotExist(err) {
 				break
 			}
-			return nil, err
+			return "", nil, err
 		}
 		if v != nil && (limit == nil || *v < *limit) {
+			limitCgroupPath = dir
 			limit = v
 		}
 		if dir == RootPath {
 			break
 		}
 	}
-	return limit, nil
+	return limitCgroupPath, limit, nil
 }
 
 // ReadMemoryStatField reads the given field from the "memory.stat" file under

--- a/enterprise/server/remote_execution/executor/oomkiller/BUILD
+++ b/enterprise/server/remote_execution/executor/oomkiller/BUILD
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
-# Keep gazelle from merging the VM test into the oomkiller_test target.
-# gazelle:exclude oomkiller_linux_vm_test.go
+# Keep tests in separate targets so the VM test can retain its runner properties.
+# gazelle:go_test file
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -34,10 +34,7 @@ go_library(
 
 go_test(
     name = "oomkiller_test",
-    srcs = [
-        "oomkiller_linux_test.go",
-        "oomkiller_test.go",
-    ],
+    srcs = ["oomkiller_test.go"],
     embed = [":oomkiller"],
     # TODO: enable this test on macOS once bare isolation type is supported.
     target_compatible_with = ["@platforms//os:linux"],
@@ -55,7 +52,7 @@ go_test(
 # host.
 go_test(
     name = "oomkiller_linux_vm_test",
-    srcs = ["oomkiller_linux_vm_test.go"],  # keep
+    srcs = ["oomkiller_linux_vm_test.go"],
     embed = [":oomkiller"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
@@ -63,14 +60,29 @@ go_test(
     },
     tags = ["docker"],
     target_compatible_with = ["@platforms//os:linux"],
-    deps = [
-        # keep
-        "//enterprise/server/remote_execution/cgroup",
-        "//enterprise/server/remote_execution/oom",
-        "//proto:remote_execution_go_proto",
-        "//server/util/testing/flags",
-        "//server/util/uuid",
-        "@com_github_stretchr_testify//require",
-        "@org_golang_x_sys//unix",
-    ],
+    deps = select({
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//enterprise/server/remote_execution/cgroup",
+            "//enterprise/server/remote_execution/oom",
+            "//proto:remote_execution_go_proto",
+            "//server/util/testing/flags",
+            "//server/util/uuid",
+            "@com_github_stretchr_testify//require",
+            "@org_golang_x_sys//unix",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+go_test(
+    name = "oomkiller_linux_test",
+    srcs = ["oomkiller_linux_test.go"],
+    embed = [":oomkiller"],
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = select({
+        "@io_bazel_rules_go//go/platform:linux": [
+            "@com_github_stretchr_testify//require",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux.go
@@ -43,7 +43,7 @@ func NewMemoryMonitor(cgroupPath string) (MemoryMonitor, error) {
 		log.Infof("Executor cgroup does not have the memory controller enabled; the OOM killer will measure system memory usage.")
 		return newSystemMemoryMonitor()
 	}
-	limitBytes, err := cgroup.ReadEffectiveMemoryLimit(dir)
+	limitCgroupPath, limitBytes, err := cgroup.ReadEffectiveMemoryLimit(dir)
 	if err != nil {
 		return nil, fmt.Errorf("read cgroup memory limit: %w", err)
 	}
@@ -51,9 +51,9 @@ func NewMemoryMonitor(cgroupPath string) (MemoryMonitor, error) {
 		log.Infof("Executor cgroup has no memory limit; the OOM killer will measure system memory usage.")
 		return newSystemMemoryMonitor()
 	}
-	log.Infof("Executor OOM killer is measuring memory usage of cgroup %q with effective memory limit %d bytes", cgroupPath, *limitBytes)
+	log.Infof("Executor OOM killer is measuring memory usage of cgroup %q with effective memory limit %d bytes", limitCgroupPath, *limitBytes)
 	return &cgroupMemoryMonitor{
-		dir:        dir,
+		dir:        limitCgroupPath,
 		limitBytes: *limitBytes,
 	}, nil
 }

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux_vm_test.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux_vm_test.go
@@ -159,6 +159,7 @@ func TestVMNewMemoryMonitorReadsCgroupLimit(t *testing.T) {
 	require.NoError(t, err)
 	cgroupMonitor, ok := monitor.(*cgroupMemoryMonitor)
 	require.True(t, ok, "expected a cgroup memory monitor, got %T", monitor)
+	require.Equal(t, cgroupDir, cgroupMonitor.dir)
 	require.Equal(t, int64(536870912), cgroupMonitor.limitBytes)
 }
 
@@ -171,7 +172,7 @@ func TestVMNewMemoryMonitorUsesEffectiveLimitFromAncestors(t *testing.T) {
 
 	// Give the parent cgroup a smaller memory limit than the child. The
 	// kernel enforces the parent limit on the child's memory usage, so the
-	// monitor should use the parent limit as the effective limit.
+	// monitor should measure the parent cgroup against the parent limit.
 	require.NoError(t, os.WriteFile(filepath.Join(parentDir, "memory.max"), []byte("268435456"), 0))
 	require.NoError(t, os.WriteFile(filepath.Join(childDir, "memory.max"), []byte("536870912"), 0))
 
@@ -179,7 +180,69 @@ func TestVMNewMemoryMonitorUsesEffectiveLimitFromAncestors(t *testing.T) {
 	require.NoError(t, err)
 	cgroupMonitor, ok := monitor.(*cgroupMemoryMonitor)
 	require.True(t, ok, "expected a cgroup memory monitor, got %T", monitor)
+	require.Equal(t, parentDir, cgroupMonitor.dir)
 	require.Equal(t, int64(268435456), cgroupMonitor.limitBytes)
+}
+
+func TestVMKillerMeasuresUsageFromLimitedAncestor(t *testing.T) {
+	parentDir := setupTestCgroup(t)
+	require.NoError(t, os.WriteFile(filepath.Join(parentDir, "memory.max"), []byte("268435456"), 0))
+	ctx := t.Context()
+
+	flags.Set(t, "executor.oom_killer.enabled", true)
+	flags.Set(t, "executor.oom_killer.poll_interval", 100*time.Millisecond)
+	flags.Set(t, "executor.oom_killer.memory_usage_threshold", 0.9)
+	flags.Set(t, "executor.enable_oci", true)
+
+	// Fill roughly half of the limited hierarchy from a child cgroup writing to
+	// a shared tmpfs, then remove the child. The pages remain charged to the
+	// hierarchy while the file exists.
+	//
+	// This simulates what happens when a tmpfs-based executor restarts - the
+	// filecache usage stays attributed to the kubepods.slice cgroup, but is not
+	// attributed to the new executor's cgroup.
+	mnt := filepath.Join(t.TempDir(), "tmpfs")
+	require.NoError(t, os.Mkdir(mnt, 0755))
+	require.NoError(t, unix.Mount("tmpfs", mnt, "tmpfs", 0, "size=256m"))
+	t.Cleanup(func() { require.NoError(t, unix.Unmount(mnt, 0)) })
+	writerDir := filepath.Join(parentDir, "writer")
+	require.NoError(t, os.Mkdir(writerDir, 0755))
+	cmd, _ := startBashInCgroup(t, writerDir, fmt.Sprintf("dd if=/dev/zero of=%s/f bs=1M count=120", mnt))
+	require.NoError(t, cmd.Wait())
+	require.NoError(t, os.Remove(writerDir))
+
+	// Start the monitor from a separate child with no local memory limit. The
+	// monitor should enforce the parent's limit using the parent's usage.
+	childDir := filepath.Join(parentDir, "child")
+	require.NoError(t, os.Mkdir(childDir, 0755))
+	t.Cleanup(func() { cleanupCgroup(t, childDir) })
+	require.NoError(t, cgroup.EnableController(childDir, "memory"))
+	monitor, err := NewMemoryMonitor(filepath.Join(filepath.Base(parentDir), "child"))
+	require.NoError(t, err)
+	cgroupMonitor, ok := monitor.(*cgroupMemoryMonitor)
+	require.True(t, ok, "expected a cgroup memory monitor, got %T", monitor)
+	require.Equal(t, parentDir, cgroupMonitor.dir)
+	require.Equal(t, int64(268435456), cgroupMonitor.limitBytes)
+	oomKiller, err := New(ctx, monitor)
+	require.NoError(t, err)
+	task := &vmTestTask{killed: make(chan error, 1)}
+	unregister := oomKiller.Register(ctx, task)
+	defer unregister()
+
+	// Allocate roughly the other half of the parent's limit in the child. The
+	// combined usage should trigger the killer even though the child's local
+	// usage remains below half of the effective limit.
+	_, stdin := startBashInCgroup(t, childDir, `data=$(head -c 120000000 /dev/zero | tr '\0' x) && read -r _`)
+	defer stdin.Close()
+	select {
+	case err := <-task.killed:
+		require.True(t, oom.IsError(err), "expected an OOM error but got %s", err)
+	case <-time.After(60 * time.Second):
+		t.Fatal("task was not killed by the OOM killer")
+	}
+	childUsageBytes, err := cgroup.ReadMemoryCurrent(childDir)
+	require.NoError(t, err)
+	require.Less(t, childUsageBytes, cgroupMonitor.limitBytes/2)
 }
 
 func TestVMNewMemoryMonitorAtRealRootUsesSystemMemory(t *testing.T) {
@@ -201,21 +264,23 @@ func setupTestCgroup(t *testing.T) string {
 	}
 	dir := filepath.Join(cgroup.RootPath, "oomkiller-test-"+uuid.New())
 	require.NoError(t, os.Mkdir(dir, 0755))
-	t.Cleanup(func() {
-		// Kill anything still running in the cgroup. Removal fails until the
-		// kernel has finished tearing down the cgroup, so retry briefly.
-		_ = os.WriteFile(filepath.Join(dir, "cgroup.kill"), []byte("1"), 0)
-		var err error
-		for range 100 {
-			if err = os.Remove(dir); err == nil {
-				return
-			}
-			time.Sleep(50 * time.Millisecond)
-		}
-		t.Errorf("remove test cgroup: %s", err)
-	})
+	t.Cleanup(func() { cleanupCgroup(t, dir) })
 	require.NoError(t, cgroup.EnableController(dir, "memory"))
 	return dir
+}
+
+func cleanupCgroup(t *testing.T, path string) {
+	// cgroup.kill returns before all processes have finished exiting, so retry
+	// removal while the kernel finishes tearing down the cgroup.
+	_ = os.WriteFile(filepath.Join(path, "cgroup.kill"), []byte("1"), 0)
+	var err error
+	for range 100 {
+		if err = os.Remove(path); err == nil {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Errorf("remove cgroup %q failed with %s", path, err)
 }
 
 // startBashInCgroup starts a bash script in the given cgroup. The script only

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux_vm_test.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux_vm_test.go
@@ -184,6 +184,28 @@ func TestVMNewMemoryMonitorUsesEffectiveLimitFromAncestors(t *testing.T) {
 	require.Equal(t, int64(268435456), cgroupMonitor.limitBytes)
 }
 
+func TestVMNewMemoryMonitorPrefersOutermostCgroupWithEqualLimit(t *testing.T) {
+	parentDir := setupTestCgroup(t)
+	childDir := filepath.Join(parentDir, "child")
+	require.NoError(t, os.Mkdir(childDir, 0755))
+	t.Cleanup(func() { require.NoError(t, os.Remove(childDir)) })
+	require.NoError(t, cgroup.EnableController(childDir, "memory"))
+
+	// Set the same memory limit on the parent and the child. Either limit is
+	// equally binding, but memory that siblings charge to the parent counts
+	// against it, so the monitor should measure the parent cgroup to see that
+	// usage.
+	require.NoError(t, os.WriteFile(filepath.Join(parentDir, "memory.max"), []byte("268435456"), 0))
+	require.NoError(t, os.WriteFile(filepath.Join(childDir, "memory.max"), []byte("268435456"), 0))
+
+	monitor, err := NewMemoryMonitor(filepath.Join(filepath.Base(parentDir), "child"))
+	require.NoError(t, err)
+	cgroupMonitor, ok := monitor.(*cgroupMemoryMonitor)
+	require.True(t, ok, "expected a cgroup memory monitor, got %T", monitor)
+	require.Equal(t, parentDir, cgroupMonitor.dir)
+	require.Equal(t, int64(268435456), cgroupMonitor.limitBytes)
+}
+
 func TestVMKillerMeasuresUsageFromLimitedAncestor(t *testing.T) {
 	parentDir := setupTestCgroup(t)
 	require.NoError(t, os.WriteFile(filepath.Join(parentDir, "memory.max"), []byte("268435456"), 0))
@@ -194,8 +216,8 @@ func TestVMKillerMeasuresUsageFromLimitedAncestor(t *testing.T) {
 	flags.Set(t, "executor.oom_killer.memory_usage_threshold", 0.9)
 	flags.Set(t, "executor.enable_oci", true)
 
-	// Fill roughly half of the limited hierarchy from a child cgroup writing to
-	// a shared tmpfs, then remove the child. The pages remain charged to the
+	// Fill 150MB of the limited hierarchy from a child cgroup writing to a
+	// shared tmpfs, then remove the child. The pages remain charged to the
 	// hierarchy while the file exists.
 	//
 	// This simulates what happens when a tmpfs-based executor restarts - the
@@ -207,9 +229,9 @@ func TestVMKillerMeasuresUsageFromLimitedAncestor(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, unix.Unmount(mnt, 0)) })
 	writerDir := filepath.Join(parentDir, "writer")
 	require.NoError(t, os.Mkdir(writerDir, 0755))
-	cmd, _ := startBashInCgroup(t, writerDir, fmt.Sprintf("dd if=/dev/zero of=%s/f bs=1M count=120", mnt))
+	cmd, _ := startBashInCgroup(t, writerDir, fmt.Sprintf("dd if=/dev/zero of=%s/f bs=1M count=150", mnt))
 	require.NoError(t, cmd.Wait())
-	require.NoError(t, os.Remove(writerDir))
+	cleanupCgroup(t, writerDir)
 
 	// Start the monitor from a separate child with no local memory limit. The
 	// monitor should enforce the parent's limit using the parent's usage.
@@ -229,10 +251,14 @@ func TestVMKillerMeasuresUsageFromLimitedAncestor(t *testing.T) {
 	unregister := oomKiller.Register(ctx, task)
 	defer unregister()
 
-	// Allocate roughly the other half of the parent's limit in the child. The
-	// combined usage should trigger the killer even though the child's local
-	// usage remains below half of the effective limit.
-	_, stdin := startBashInCgroup(t, childDir, `data=$(head -c 120000000 /dev/zero | tr '\0' x) && read -r _`)
+	// Write another 90MB to the tmpfs from the monitored child. tmpfs pages
+	// are charged once as they are written, so unlike building up the data in
+	// a shell variable, this cannot transiently overshoot and trip the kernel
+	// OOM killer. The combined 240MB usage crosses the 90% kill threshold
+	// (230MB) but stays under memory.max (256MB), so only the userspace killer
+	// fires, even though the child's local usage stays below half of the
+	// effective limit.
+	_, stdin := startBashInCgroup(t, childDir, fmt.Sprintf("dd if=/dev/zero of=%s/g bs=1M count=90 && read -r _", mnt))
 	defer stdin.Close()
 	select {
 	case err := <-task.killed:
@@ -240,6 +266,9 @@ func TestVMKillerMeasuresUsageFromLimitedAncestor(t *testing.T) {
 	case <-time.After(60 * time.Second):
 		t.Fatal("task was not killed by the OOM killer")
 	}
+	// The child's usage is bounded by its 90MB tmpfs file, so it stays below
+	// half of the 256MB limit no matter when we sample it. This confirms the
+	// kill was driven by the parent hierarchy's usage, not the child's.
 	childUsageBytes, err := cgroup.ReadMemoryCurrent(childDir)
 	require.NoError(t, err)
 	require.Less(t, childUsageBytes, cgroupMonitor.limitBytes/2)


### PR DESCRIPTION
*TLDR: when the OOM killer computes the memory utilization `current/total`, it reads `total` from one cgroup, but `current` from a different cgroup, which is technically incorrect. This issue is not causing problems now, but it's a blocker for a change I'm planning to make, which should allow us to improve tmpfs executor memory utilization. So: this PR fixes the incorrect behavior by reading `current` from the same cgroup that we read `total` from.*

---

Context: We run some executors where the filecache is stored on tmpfs. When the executor restarts/rolls out, its pod cgroup is recreated. As a result, all of the tmpfs usage from the previous executor is no longer charged to the executor cgroup. It *is* still charged to the parent cgroup (which is the parent cgroup for all pods - `/sys/fs/cgroup/kubepods.slice`)

This behavior is problematic for the OOM killer, because the implementation only looks at the executor container's cgroup when computing the `current/total` memory usage fraction. This means that it's not counting the previous executor's filecache usage, even though that filecache usage is taking up memory on the node.

My proposed fix is:
1. Instead of tracking the executor cgroup's memory usage, track the memory usage of `kubepods.slice` (the executor pod's parent cgroup), which has the filecache usage consistently attributed to it, even across executor restarts. Note: k8s (or at least, GKE) sets `memory.max` on this `kubepods.slice` cgroup, so this is the actual limit we need to stay under, *not* the system total memory.
2. Stop setting a memory limit on the executor cgroup, so that the OOM killer sees the effective memory limit as the `kubepods.slice` memory limit instead, and also make sure we read the current memory usage from that cgroup.

This fix cannot be implemented without some code changes, because the current implementation prevents (2) from working as described. When initializing the OOM killer, we do walk up the cgroup tree to determine the effective memory limit that we need to stay under. However, we then measure the memory usage by reading the executor container's cgroup. This is not a problem currently because the executor container's cgroup always has a memory limit set. However with (2), we will no longer be setting the memory limit, so we should be reading the current memory usage from `kubepods.slice` instead. This PR fixes the issue by having `cgroup.ReadEffectiveMemoryLimit` return the cgroup path, instead of just the limit. The OOM killer then reads the memory usage from that cgroup path, instead of the executor's starting cgroup path.

Some more discussion here: https://buildbuddy-corp.slack.com/archives/C06N9AHA4JX/p1785353869580969?thread_ts=1785345028.810489&cid=C06N9AHA4JX