### PR TITLE
[CLI] Fix bugs with build remotely run locally

### DIFF
--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -140,9 +140,16 @@ type RunOpts struct {
 	// Whether the remotely built target should be fetched and run locally.
 	RunOutputLocally bool
 	// If RunOutputLocally=true, execution arguments for running the target locally.
-	ExecArgs          []string
-	WorkingDirectory  string
-	WorkspaceFilePath string
+	ExecArgs []string
+
+	// RelativeWorkspaceDir is the Bazel workspace directory relative to the Git repository root (applies to both the remote runner and the local machine).
+	// This is a relative path so that the remote runner can navigate to it, despite having a different absolute filesystem path.
+	RelativeWorkspaceDir string
+	// AbsLocalWorkspaceDir is the absolute path to the Bazel workspace on the local machine.
+	AbsLocalWorkspaceDir string
+	// AbsLocalWorkingDirectory is the absolute path from which the user invoked the CLI on the local machine.
+	// This can be different from AbsWorkspaceDir if the CLI was invoked from a subdirectory.
+	AbsLocalWorkingDirectory string
 }
 
 type gitRemote struct {
@@ -877,6 +884,7 @@ func downloadOutputs(ctx context.Context, env environment.Env, mainOutputs []*be
 			outFile = filepath.Join(outFile, p)
 		}
 		outFile = filepath.Join(outFile, f.GetName())
+		log.Debugf("Downloading output %q to %q with mode %s", f.GetName(), outFile, mode)
 		if err := downloadFile(ctx, bsClient, r, outFile, mode); err != nil {
 			return "", fmt.Errorf("download output %q: %w", f.GetName(), err)
 		}
@@ -951,21 +959,26 @@ func downloadedExecutablePath(downloadedFiles map[string]struct{}, outputBaseDir
 	return binPath, nil
 }
 
-// envWithRunfilesDir ensures a locally-run target (build-remotely-run-locally) resolves
-// runfiles from the downloaded runfiles directory. The runfiles manifest contains absolute paths from the
-// remote runner, and inherited runfiles variables may refer to the bb binary's
-// own runfiles, so remove those settings and explicitly set the runfiles directory.
-func envWithRunfilesDir(env []string, runfilesDir string) []string {
-	filteredEnv := make([]string, 0, len(env)+1)
+// envForLocalRun ensures a locally-run target (build-remotely-run-locally)
+// resolves runfiles from the downloaded runfiles directory and sees the local
+// Bazel workspace. The runfiles manifest contains absolute paths from the
+// remote runner, and inherited runfiles and workspace variables may refer to
+// the bb binary's own environment, so replace them with local values.
+func envForLocalRun(env []string, runfilesDir, workspaceDir, workingDir string) []string {
+	filteredEnv := make([]string, 0, len(env)+3)
 	for _, entry := range env {
 		name, _, _ := strings.Cut(entry, "=")
 		switch name {
-		case "RUNFILES_DIR", "RUNFILES_MANIFEST_FILE", "RUNFILES_MANIFEST_ONLY", "PYTHON_RUNFILES", "JAVA_RUNFILES":
+		case "RUNFILES_DIR", "RUNFILES_MANIFEST_FILE", "RUNFILES_MANIFEST_ONLY", "PYTHON_RUNFILES", "JAVA_RUNFILES", "BUILD_WORKSPACE_DIRECTORY", "BUILD_WORKING_DIRECTORY":
 			continue
 		}
 		filteredEnv = append(filteredEnv, entry)
 	}
-	return append(filteredEnv, "RUNFILES_DIR="+runfilesDir)
+	return append(filteredEnv,
+		"RUNFILES_DIR="+runfilesDir,
+		"BUILD_WORKSPACE_DIRECTORY="+workspaceDir,
+		"BUILD_WORKING_DIRECTORY="+workingDir,
+	)
 }
 
 // removeRunfilesManifests removes runfile manifests whose absolute paths refer to the
@@ -1104,7 +1117,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 
 	req := &rnpb.RunRequest{
 		Name:             opts.Name,
-		WorkingDirectory: opts.WorkingDirectory,
+		WorkingDirectory: opts.RelativeWorkspaceDir,
 		GitRepo: &gitpb.GitRepo{
 			RepoUrl:                 repoConfig.URL,
 			UseSystemGitCredentials: *useSystemGitCredentials,
@@ -1237,7 +1250,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 					return 1, fmt.Errorf("lookup invocation outputs for %q: %w", childIID, err)
 				}
 			}
-			outputsBaseDir := filepath.Dir(opts.WorkspaceFilePath)
+			outputsBaseDir := opts.AbsLocalWorkspaceDir
 			downloadedFiles, err := downloadOutputs(ctx, env, mainOutputs, runfiles, runfileDirectories, outputsBaseDir)
 			if err != nil {
 				return 1, fmt.Errorf("download invocation outputs for %q: %w", childIID, err)
@@ -1277,10 +1290,10 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 				execArgs := defaultRunArgs
 				// Pass through extra arguments (-- --foo=bar) from the command line.
 				execArgs = append(execArgs, opts.ExecArgs...)
-				log.Debugf("Executing %q with arguments %s", absBinPath, execArgs)
+				log.Printf("Running downloaded executable %q locally (working directory %q)", absBinPath, runfilesWorkDir)
 				cmd := exec.CommandContext(ctx, absBinPath, execArgs...)
 				cmd.Dir = runfilesWorkDir
-				cmd.Env = envWithRunfilesDir(os.Environ(), runfilesDir)
+				cmd.Env = envForLocalRun(os.Environ(), runfilesDir, opts.AbsLocalWorkspaceDir, opts.AbsLocalWorkingDirectory)
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr
 				err = cmd.Run()
@@ -1453,6 +1466,10 @@ func HandleRemoteBazel(commandLineArgs []string) (int, error) {
 	if err != nil {
 		return 1, status.WrapError(err, "determine working directory")
 	}
+	localWorkingDirectory, err := os.Getwd()
+	if err != nil {
+		return 1, status.WrapError(err, "determine local working directory")
+	}
 
 	cmd := ""
 	remoteRunName := "remote run"
@@ -1506,14 +1523,15 @@ func HandleRemoteBazel(commandLineArgs []string) (int, error) {
 	ctx = metadata.AppendToOutgoingContext(ctx, "x-buildbuddy-api-key", apiKey)
 
 	exitCode, err := Run(ctx, RunOpts{
-		Server:            runner,
-		Name:              remoteRunName,
-		Command:           cmd,
-		RunOutputLocally:  runOutputLocally,
-		ExecArgs:          localExecArgs,
-		WorkingDirectory:  workingDirectory,
-		FetchOutputs:      fetchOutputs,
-		WorkspaceFilePath: wsFilePath,
+		Server:                   runner,
+		Name:                     remoteRunName,
+		Command:                  cmd,
+		RunOutputLocally:         runOutputLocally,
+		ExecArgs:                 localExecArgs,
+		RelativeWorkspaceDir:     workingDirectory,
+		FetchOutputs:             fetchOutputs,
+		AbsLocalWorkspaceDir:     filepath.Dir(wsFilePath),
+		AbsLocalWorkingDirectory: localWorkingDirectory,
 	}, repoConfig)
 	if err != nil && strings.Contains(err.Error(), "context canceled") {
 		return exitCode, nil
@@ -1556,21 +1574,31 @@ func parseArgs(commandLineArgs []string) ([]string, []string, error) {
 		"--config=buildbuddy_bes_results_url",
 		"--config=buildbuddy_remote_cache",
 	}
+	var requiredArgs []string
 
 	// If the CLI needs to fetch build outputs, make sure the remote runner uploads them.
 	bazelCmd := bazelArgsStruct.GetCommand()
 	if (!*runRemotely && bazelCmd == "run") || bazelCmd == "build" {
-		extraArgs = append(extraArgs, "--remote_upload_local_results")
+		requiredArgs = append(requiredArgs,
+			"--remote_upload_local_results",
+		)
 	}
 	// To support building the target on the remote runner and running it locally,
 	// have Bazel write out a run script using the --script_path flag so we can
 	// extract run options (i.e. args, runfile information) from the generated run script.
 	if !*runRemotely && bazelCmd == "run" {
-		extraArgs = append(extraArgs, runScriptPathFlag)
+		requiredArgs = append(requiredArgs, runScriptPathFlag)
 	}
 	for _, extraArg := range extraArgs {
 		if err := bazelArgsStruct.Prepend(extraArg); err != nil {
 			return nil, nil, fmt.Errorf("add remote bazel arg: %w", err)
+		}
+	}
+	// These flags are required for fetching or locally running outputs, so append
+	// them after user flags and config expansions to ensure they take precedence.
+	for _, requiredArg := range requiredArgs {
+		if err := bazelArgsStruct.Append(requiredArg); err != nil {
+			return nil, nil, fmt.Errorf("add required remote bazel arg: %w", err)
 		}
 	}
 

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -876,6 +876,7 @@ func downloadOutputs(ctx context.Context, env environment.Env, mainOutputs []*be
 			outFile = filepath.Join(outFile, p)
 		}
 		outFile = filepath.Join(outFile, f.GetName())
+		log.Debugf("Downloading output %q to %q with mode %s", f.GetName(), outFile, mode)
 		if err := downloadFile(ctx, bsClient, r, outFile, mode); err != nil {
 			return "", fmt.Errorf("download output %q: %w", f.GetName(), err)
 		}
@@ -939,21 +940,25 @@ func findExecutableOutput(outputs []string, outputBaseDir, executablePath string
 	return "", fmt.Errorf("run executable %q not found among downloaded artifacts", executablePath)
 }
 
-// envWithRunfilesDir ensures a locally-run target (build-remotely-run-locally) resolves
-// runfiles from the downloaded runfiles directory. The runfiles manifest contains absolute paths from the
-// remote runner, and inherited runfiles variables may refer to the bb binary's
-// own runfiles, so remove those settings and explicitly set the runfiles directory.
-func envWithRunfilesDir(env []string, runfilesDir string) []string {
-	filteredEnv := make([]string, 0, len(env)+1)
+// envForLocalRun ensures a locally-run target (build-remotely-run-locally)
+// resolves runfiles from the downloaded runfiles directory and sees the local
+// Bazel workspace. The runfiles manifest contains absolute paths from the
+// remote runner, and inherited runfiles and workspace variables may refer to
+// the bb binary's own environment, so replace them with local values.
+func envForLocalRun(env []string, runfilesDir, workspaceDir string) []string {
+	filteredEnv := make([]string, 0, len(env)+2)
 	for _, entry := range env {
 		name, _, _ := strings.Cut(entry, "=")
 		switch name {
-		case "RUNFILES_DIR", "RUNFILES_MANIFEST_FILE", "RUNFILES_MANIFEST_ONLY", "PYTHON_RUNFILES", "JAVA_RUNFILES":
+		case "RUNFILES_DIR", "RUNFILES_MANIFEST_FILE", "RUNFILES_MANIFEST_ONLY", "PYTHON_RUNFILES", "JAVA_RUNFILES", "BUILD_WORKSPACE_DIRECTORY":
 			continue
 		}
 		filteredEnv = append(filteredEnv, entry)
 	}
-	return append(filteredEnv, "RUNFILES_DIR="+runfilesDir)
+	return append(filteredEnv,
+		"RUNFILES_DIR="+runfilesDir,
+		"BUILD_WORKSPACE_DIRECTORY="+workspaceDir,
+	)
 }
 
 // removeRunfilesManifests removes runfile manifests whose absolute paths refer to the
@@ -1224,6 +1229,10 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 				return 1, fmt.Errorf("download invocation outputs for %q: %w", childIID, err)
 			}
 			if opts.RunOutputLocally {
+				workspaceDir, err := filepath.Abs(outputsBaseDir)
+				if err != nil {
+					return 1, fmt.Errorf("compute absolute workspace directory: %w", err)
+				}
 				binPath, err := findExecutableOutput(outputs, outputsBaseDir, executablePath)
 				if err != nil {
 					return 1, err
@@ -1261,9 +1270,10 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 				log.Debugf("Executing %q with arguments %s", absBinPath, execArgs)
 				cmd := exec.CommandContext(ctx, absBinPath, execArgs...)
 				cmd.Dir = runfilesWorkDir
-				cmd.Env = envWithRunfilesDir(os.Environ(), runfilesDir)
+				cmd.Env = envForLocalRun(os.Environ(), runfilesDir, workspaceDir)
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr
+				log.Printf("Running downloaded executable %q locally (working directory %q)", absBinPath, runfilesWorkDir)
 				err = cmd.Run()
 				if e, ok := err.(*exec.ExitError); ok {
 					return e.ExitCode(), nil
@@ -1537,21 +1547,33 @@ func parseArgs(commandLineArgs []string) ([]string, []string, error) {
 		"--config=buildbuddy_bes_results_url",
 		"--config=buildbuddy_remote_cache",
 	}
+	var requiredArgs []string
 
 	// If the CLI needs to fetch build outputs, make sure the remote runner uploads them.
 	bazelCmd := bazelArgsStruct.GetCommand()
 	if (!*runRemotely && bazelCmd == "run") || bazelCmd == "build" {
-		extraArgs = append(extraArgs, "--remote_upload_local_results")
+		requiredArgs = append(requiredArgs,
+			"--remote_upload_local_results",
+			// Ensure locally generated outputs, including symlink targets, are uploaded to the cache.
+			"--remote_build_event_upload=all",
+		)
 	}
 	// To support building the target on the remote runner and running it locally,
 	// have Bazel write out a run script using the --script_path flag so we can
 	// extract run options (i.e. args, runfile information) from the generated run script.
 	if !*runRemotely && bazelCmd == "run" {
-		extraArgs = append(extraArgs, runScriptPathFlag)
+		requiredArgs = append(requiredArgs, runScriptPathFlag)
 	}
 	for _, extraArg := range extraArgs {
 		if err := bazelArgsStruct.Prepend(extraArg); err != nil {
 			return nil, nil, fmt.Errorf("add remote bazel arg: %w", err)
+		}
+	}
+	// These flags are required for fetching or locally running outputs, so append
+	// them after user flags and config expansions to ensure they take precedence.
+	for _, requiredArg := range requiredArgs {
+		if err := bazelArgsStruct.Append(requiredArg); err != nil {
+			return nil, nil, fmt.Errorf("add required remote bazel arg: %w", err)
 		}
 	}
 

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -140,9 +140,16 @@ type RunOpts struct {
 	// Whether the remotely built target should be fetched and run locally.
 	RunOutputLocally bool
 	// If RunOutputLocally=true, execution arguments for running the target locally.
-	ExecArgs          []string
-	WorkingDirectory  string
-	WorkspaceFilePath string
+	ExecArgs []string
+
+	// RelativeWorkspaceDir is the Bazel workspace directory relative to the Git repository root (applies to both the remote runner and the local machine).
+	// This is a relative path so that the remote runner can navigate to it, despite having a different absolute filesystem path.
+	RelativeWorkspaceDir string
+	// AbsLocalWorkspaceDir is the absolute path to the Bazel workspace on the local machine.
+	AbsLocalWorkspaceDir string
+	// AbsLocalWorkingDirectory is the absolute path from which the user invoked the CLI on the local machine.
+	// This can be different from AbsWorkspaceDir if the CLI was invoked from a subdirectory.
+	AbsLocalWorkingDirectory string
 }
 
 type gitRemote struct {
@@ -945,12 +952,12 @@ func findExecutableOutput(outputs []string, outputBaseDir, executablePath string
 // Bazel workspace. The runfiles manifest contains absolute paths from the
 // remote runner, and inherited runfiles and workspace variables may refer to
 // the bb binary's own environment, so replace them with local values.
-func envForLocalRun(env []string, runfilesDir, workspaceDir string) []string {
-	filteredEnv := make([]string, 0, len(env)+2)
+func envForLocalRun(env []string, runfilesDir, workspaceDir, workingDir string) []string {
+	filteredEnv := make([]string, 0, len(env)+3)
 	for _, entry := range env {
 		name, _, _ := strings.Cut(entry, "=")
 		switch name {
-		case "RUNFILES_DIR", "RUNFILES_MANIFEST_FILE", "RUNFILES_MANIFEST_ONLY", "PYTHON_RUNFILES", "JAVA_RUNFILES", "BUILD_WORKSPACE_DIRECTORY":
+		case "RUNFILES_DIR", "RUNFILES_MANIFEST_FILE", "RUNFILES_MANIFEST_ONLY", "PYTHON_RUNFILES", "JAVA_RUNFILES", "BUILD_WORKSPACE_DIRECTORY", "BUILD_WORKING_DIRECTORY":
 			continue
 		}
 		filteredEnv = append(filteredEnv, entry)
@@ -958,6 +965,7 @@ func envForLocalRun(env []string, runfilesDir, workspaceDir string) []string {
 	return append(filteredEnv,
 		"RUNFILES_DIR="+runfilesDir,
 		"BUILD_WORKSPACE_DIRECTORY="+workspaceDir,
+		"BUILD_WORKING_DIRECTORY="+workingDir,
 	)
 }
 
@@ -1097,7 +1105,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 
 	req := &rnpb.RunRequest{
 		Name:             opts.Name,
-		WorkingDirectory: opts.WorkingDirectory,
+		WorkingDirectory: opts.RelativeWorkspaceDir,
 		GitRepo: &gitpb.GitRepo{
 			RepoUrl:                 repoConfig.URL,
 			UseSystemGitCredentials: *useSystemGitCredentials,
@@ -1223,16 +1231,12 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 			if err != nil {
 				return 1, fmt.Errorf("lookup invocation outputs for %q: %w", childIID, err)
 			}
-			outputsBaseDir := filepath.Dir(opts.WorkspaceFilePath)
+			outputsBaseDir := opts.AbsLocalWorkspaceDir
 			outputs, err := downloadOutputs(ctx, env, mainOutputs, runfiles, runfileDirectories, outputsBaseDir)
 			if err != nil {
 				return 1, fmt.Errorf("download invocation outputs for %q: %w", childIID, err)
 			}
 			if opts.RunOutputLocally {
-				workspaceDir, err := filepath.Abs(outputsBaseDir)
-				if err != nil {
-					return 1, fmt.Errorf("compute absolute workspace directory: %w", err)
-				}
 				binPath, err := findExecutableOutput(outputs, outputsBaseDir, executablePath)
 				if err != nil {
 					return 1, err
@@ -1267,13 +1271,12 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 				execArgs := defaultRunArgs
 				// Pass through extra arguments (-- --foo=bar) from the command line.
 				execArgs = append(execArgs, opts.ExecArgs...)
-				log.Debugf("Executing %q with arguments %s", absBinPath, execArgs)
+				log.Printf("Running downloaded executable %q locally (working directory %q)", absBinPath, runfilesWorkDir)
 				cmd := exec.CommandContext(ctx, absBinPath, execArgs...)
 				cmd.Dir = runfilesWorkDir
-				cmd.Env = envForLocalRun(os.Environ(), runfilesDir, workspaceDir)
+				cmd.Env = envForLocalRun(os.Environ(), runfilesDir, opts.AbsLocalWorkspaceDir, opts.AbsLocalWorkingDirectory)
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr
-				log.Printf("Running downloaded executable %q locally (working directory %q)", absBinPath, runfilesWorkDir)
 				err = cmd.Run()
 				if e, ok := err.(*exec.ExitError); ok {
 					return e.ExitCode(), nil
@@ -1444,6 +1447,10 @@ func HandleRemoteBazel(commandLineArgs []string) (int, error) {
 	if err != nil {
 		return 1, status.WrapError(err, "determine working directory")
 	}
+	localWorkingDirectory, err := os.Getwd()
+	if err != nil {
+		return 1, status.WrapError(err, "determine local working directory")
+	}
 
 	cmd := ""
 	remoteRunName := "remote run"
@@ -1497,14 +1504,15 @@ func HandleRemoteBazel(commandLineArgs []string) (int, error) {
 	ctx = metadata.AppendToOutgoingContext(ctx, "x-buildbuddy-api-key", apiKey)
 
 	exitCode, err := Run(ctx, RunOpts{
-		Server:            runner,
-		Name:              remoteRunName,
-		Command:           cmd,
-		RunOutputLocally:  runOutputLocally,
-		ExecArgs:          localExecArgs,
-		WorkingDirectory:  workingDirectory,
-		FetchOutputs:      fetchOutputs,
-		WorkspaceFilePath: wsFilePath,
+		Server:                   runner,
+		Name:                     remoteRunName,
+		Command:                  cmd,
+		RunOutputLocally:         runOutputLocally,
+		ExecArgs:                 localExecArgs,
+		RelativeWorkspaceDir:     workingDirectory,
+		FetchOutputs:             fetchOutputs,
+		AbsLocalWorkspaceDir:     filepath.Dir(wsFilePath),
+		AbsLocalWorkingDirectory: localWorkingDirectory,
 	}, repoConfig)
 	if err != nil && strings.Contains(err.Error(), "context canceled") {
 		return exitCode, nil

--- a/cli/remotebazel/remotebazel_test.go
+++ b/cli/remotebazel/remotebazel_test.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -779,10 +778,6 @@ func TestParseArgs_RunAddsRemoteArgsBeforeExecutableArgs(t *testing.T) {
 		"buildbuddy_remote_cache",
 	}, arg.GetMulti(forwardedBazelArgs, "config"))
 	require.Contains(t, forwardedBazelArgs, "--remote_upload_local_results")
-	require.Greater(t,
-		slices.Index(forwardedBazelArgs, "--remote_upload_local_results"),
-		slices.Index(forwardedBazelArgs, "--noremote_upload_local_results"),
-	)
 	require.Equal(t, "all", arg.Get(forwardedBazelArgs, "remote_build_event_upload"))
 	require.Equal(t,
 		"$BUILDBUDDY_CI_RUNNER_ROOT_DIR/bazel-run-scripts/run.sh",
@@ -807,6 +802,7 @@ func TestEnvForLocalRun(t *testing.T) {
 		"RUNFILES_MANIFEST_FILE=/old/MANIFEST",
 		"RUNFILES_MANIFEST_ONLY=1",
 		"BUILD_WORKSPACE_DIRECTORY=/old/workspace",
+		"BUILD_WORKING_DIRECTORY=/old/working-directory",
 		"USER=test",
 	}
 
@@ -815,7 +811,8 @@ func TestEnvForLocalRun(t *testing.T) {
 		"USER=test",
 		"RUNFILES_DIR=/new/runfiles",
 		"BUILD_WORKSPACE_DIRECTORY=/new/workspace",
-	}, envForLocalRun(env, "/new/runfiles", "/new/workspace"))
+		"BUILD_WORKING_DIRECTORY=/new/working-directory",
+	}, envForLocalRun(env, "/new/runfiles", "/new/workspace", "/new/working-directory"))
 }
 
 func TestQuoteRemoteBazelArgs_RunScriptEnvVarExpanded(t *testing.T) {

--- a/cli/remotebazel/remotebazel_test.go
+++ b/cli/remotebazel/remotebazel_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -754,6 +755,9 @@ func TestParseArgs_RunAddsRemoteArgsBeforeExecutableArgs(t *testing.T) {
 
 	bazelArgs, execArgs, err := parseArgs([]string{
 		"run",
+		"--noremote_upload_local_results",
+		"--remote_build_event_upload=minimal",
+		"--script_path=/tmp/custom-run-script.sh",
 		"@bazel-diff//cli:bazel-diff",
 		"generate-hashes",
 		"--",
@@ -775,6 +779,11 @@ func TestParseArgs_RunAddsRemoteArgsBeforeExecutableArgs(t *testing.T) {
 		"buildbuddy_remote_cache",
 	}, arg.GetMulti(forwardedBazelArgs, "config"))
 	require.Contains(t, forwardedBazelArgs, "--remote_upload_local_results")
+	require.Greater(t,
+		slices.Index(forwardedBazelArgs, "--remote_upload_local_results"),
+		slices.Index(forwardedBazelArgs, "--noremote_upload_local_results"),
+	)
+	require.Equal(t, "all", arg.Get(forwardedBazelArgs, "remote_build_event_upload"))
 	require.Equal(t,
 		"$BUILDBUDDY_CI_RUNNER_ROOT_DIR/bazel-run-scripts/run.sh",
 		arg.Get(forwardedBazelArgs, "script_path"),
@@ -791,12 +800,13 @@ func TestParseArgs_RunAddsRemoteArgsBeforeExecutableArgs(t *testing.T) {
 	)
 }
 
-func TestEnvWithRunfilesDir(t *testing.T) {
+func TestEnvForLocalRun(t *testing.T) {
 	env := []string{
 		"PATH=/usr/bin",
 		"RUNFILES_DIR=/old/runfiles",
 		"RUNFILES_MANIFEST_FILE=/old/MANIFEST",
 		"RUNFILES_MANIFEST_ONLY=1",
+		"BUILD_WORKSPACE_DIRECTORY=/old/workspace",
 		"USER=test",
 	}
 
@@ -804,7 +814,8 @@ func TestEnvWithRunfilesDir(t *testing.T) {
 		"PATH=/usr/bin",
 		"USER=test",
 		"RUNFILES_DIR=/new/runfiles",
-	}, envWithRunfilesDir(env, "/new/runfiles"))
+		"BUILD_WORKSPACE_DIRECTORY=/new/workspace",
+	}, envForLocalRun(env, "/new/runfiles", "/new/workspace"))
 }
 
 func TestQuoteRemoteBazelArgs_RunScriptEnvVarExpanded(t *testing.T) {

--- a/cli/remotebazel/remotebazel_test.go
+++ b/cli/remotebazel/remotebazel_test.go
@@ -754,6 +754,9 @@ func TestParseArgs_RunAddsRemoteArgsBeforeExecutableArgs(t *testing.T) {
 
 	bazelArgs, execArgs, err := parseArgs([]string{
 		"run",
+		"--noremote_upload_local_results",
+		"--remote_build_event_upload=minimal",
+		"--script_path=/tmp/custom-run-script.sh",
 		"@bazel-diff//cli:bazel-diff",
 		"generate-hashes",
 		"--",
@@ -775,6 +778,7 @@ func TestParseArgs_RunAddsRemoteArgsBeforeExecutableArgs(t *testing.T) {
 		"buildbuddy_remote_cache",
 	}, arg.GetMulti(forwardedBazelArgs, "config"))
 	require.Contains(t, forwardedBazelArgs, "--remote_upload_local_results")
+	require.Equal(t, "minimal", arg.Get(forwardedBazelArgs, "remote_build_event_upload"))
 	require.Equal(t,
 		"$BUILDBUDDY_CI_RUNNER_ROOT_DIR/bazel-run-scripts/run.sh",
 		arg.Get(forwardedBazelArgs, "script_path"),
@@ -791,12 +795,14 @@ func TestParseArgs_RunAddsRemoteArgsBeforeExecutableArgs(t *testing.T) {
 	)
 }
 
-func TestEnvWithRunfilesDir(t *testing.T) {
+func TestEnvForLocalRun(t *testing.T) {
 	env := []string{
 		"PATH=/usr/bin",
 		"RUNFILES_DIR=/old/runfiles",
 		"RUNFILES_MANIFEST_FILE=/old/MANIFEST",
 		"RUNFILES_MANIFEST_ONLY=1",
+		"BUILD_WORKSPACE_DIRECTORY=/old/workspace",
+		"BUILD_WORKING_DIRECTORY=/old/working-directory",
 		"USER=test",
 	}
 
@@ -804,7 +810,9 @@ func TestEnvWithRunfilesDir(t *testing.T) {
 		"PATH=/usr/bin",
 		"USER=test",
 		"RUNFILES_DIR=/new/runfiles",
-	}, envWithRunfilesDir(env, "/new/runfiles"))
+		"BUILD_WORKSPACE_DIRECTORY=/new/workspace",
+		"BUILD_WORKING_DIRECTORY=/new/working-directory",
+	}, envForLocalRun(env, "/new/runfiles", "/new/workspace", "/new/working-directory"))
 }
 
 func TestQuoteRemoteBazelArgs_RunScriptEnvVarExpanded(t *testing.T) {

--- a/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
+++ b/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
@@ -349,9 +349,9 @@ func TestCancel(t *testing.T) {
 		_, runErr := remotebazel.Run(
 			ctxWithCancel,
 			remotebazel.RunOpts{
-				Server:            bbServer.GRPCAddress(),
-				Command:           "echo STARTING && sleep 2147483647",
-				WorkspaceFilePath: wsFilePath,
+				Server:               bbServer.GRPCAddress(),
+				Command:              "echo STARTING && sleep 2147483647",
+				AbsLocalWorkspaceDir: filepath.Dir(wsFilePath),
 			}, repoConfig)
 		runErrCh <- runErr
 	}()


### PR DESCRIPTION
* Set BUILD_WORKSPACE_DIRECTORY on the local machine
* Ensure required flags take precedence over user-defined flags