### PR TITLE
Fix accumulator blake3 handling

### DIFF
--- a/server/build_event_protocol/accumulator/BUILD
+++ b/server/build_event_protocol/accumulator/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "accumulator",
@@ -16,5 +16,19 @@ go_library(
         "//server/util/log",
         "//server/util/proto",
         "//server/util/timeutil",
+    ],
+)
+
+go_test(
+    name = "accumulator_test",
+    srcs = ["accumulator_test.go"],
+    deps = [
+        ":accumulator",
+        "//proto:build_event_stream_go_proto",
+        "//proto:invocation_go_proto",
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_protobuf//testing/protocmp",
     ],
 )

--- a/server/build_event_protocol/accumulator/accumulator.go
+++ b/server/build_event_protocol/accumulator/accumulator.go
@@ -3,7 +3,7 @@ package accumulator
 import (
 	"context"
 	"net/url"
-	"regexp"
+	"strings"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
@@ -42,7 +42,6 @@ var (
 		"DISABLE_TARGET_TRACKING":         disableTargetTrackingFieldName,
 		"COMMIT_STATUS_LABEL":             commitStatusLabelFieldName,
 	}
-	bytestreamURIPattern = regexp.MustCompile(`^bytestream://.*/blobs/([a-z0-9]{64})/\d+$`)
 )
 
 type Accumulator interface {
@@ -118,20 +117,18 @@ func (v *BEValues) maybeExtractOutputFile(files ...*build_event_stream.File) {
 		if file.GetName() == "" {
 			continue
 		}
-		if m := bytestreamURIPattern.FindStringSubmatch(file.GetUri()); len(m) >= 1 {
-			digestHash := m[1]
-			v.outputFilesMap[digestHash] = proto.Clone(file).(*build_event_stream.File)
+		uri, err := url.Parse(file.GetUri())
+		if err != nil || uri.Scheme != "bytestream" {
+			continue
 		}
+		rn, err := digest.ParseDownloadResourceName(strings.TrimPrefix(uri.Path, "/"))
+		if err != nil {
+			continue
+		}
+		digestHash := rn.GetDigest().GetHash()
+		v.outputFilesMap[digestHash] = proto.Clone(file).(*build_event_stream.File)
 		// Special case: check for kythe output files.
 		if file.GetName() == KytheOutputName {
-			uri, err := url.Parse(file.GetUri())
-			if err != nil {
-				continue
-			}
-			rn, err := digest.ParseDownloadResourceName(uri.Path)
-			if err != nil {
-				continue
-			}
 			v.kytheSSTableResourceName = rn.ToProto()
 		}
 	}

--- a/server/build_event_protocol/accumulator/accumulator_test.go
+++ b/server/build_event_protocol/accumulator/accumulator_test.go
@@ -1,0 +1,56 @@
+package accumulator_test
+
+import (
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/accumulator"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	bespb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
+	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
+)
+
+func TestAddEvent_IndexesBLAKE3OutputFile(t *testing.T) {
+	const hash = "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d"
+	file := &bespb.File{
+		Name: "profile.gz",
+		File: &bespb.File_Uri{Uri: "bytestream://test.buildbuddy.io/test-instance/blobs/blake3/" + hash + "/1234"},
+	}
+	event := &bespb.BuildEvent{
+		Payload: &bespb.BuildEvent_BuildToolLogs{
+			BuildToolLogs: &bespb.BuildToolLogs{Log: []*bespb.File{file}},
+		},
+	}
+	values := accumulator.NewBEValues(&inpb.Invocation{})
+	require.NoError(t, values.AddEvent(event))
+
+	indexedFile, ok := values.OutputFiles()[hash]
+	require.True(t, ok)
+	assert.Empty(t, cmp.Diff(file, indexedFile, protocmp.Transform()))
+}
+
+func TestAddEvent_TrimsLeadingSlashFromResourceInstanceName(t *testing.T) {
+	const hash = "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d"
+	event := &bespb.BuildEvent{
+		Payload: &bespb.BuildEvent_NamedSetOfFiles{
+			NamedSetOfFiles: &bespb.NamedSetOfFiles{Files: []*bespb.File{
+				{
+					Name: accumulator.KytheOutputName,
+					File: &bespb.File_Uri{Uri: "bytestream://test.buildbuddy.io/cache4/blobs/blake3/" + hash + "/1234"},
+				},
+			}},
+		},
+	}
+
+	// Add a Kythe artifact whose URL path begins with the slash separating the
+	// host from the ByteStream resource name.
+	values := accumulator.NewBEValues(&inpb.Invocation{})
+	require.NoError(t, values.AddEvent(event))
+
+	// The URL separator should not become part of the remote instance name.
+	require.NotNil(t, values.KytheSSTableResourceName())
+	assert.Equal(t, "cache4", values.KytheSSTableResourceName().GetInstanceName())
+}

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -528,7 +528,7 @@ func (r *statsRecorder) handleTask(ctx context.Context, task *recordStatsTask) {
 		if cache_api_url.String() != "" && urlutil.GetDomain(uri.Hostname()) != urlutil.GetDomain(cache_api_url.WithPath("").Hostname()) {
 			continue
 		}
-		rn, err := digest.ParseDownloadResourceName(uri.Path)
+		rn, err := digest.ParseDownloadResourceName(strings.TrimPrefix(uri.Path, "/"))
 		if err != nil {
 			log.CtxErrorf(ctx, "Unparseable artifact URI: %s", err)
 			continue

--- a/tools/replay_invocation/replay_invocation.go
+++ b/tools/replay_invocation/replay_invocation.go
@@ -330,7 +330,7 @@ func copyArtifact(ctx context.Context, dst bspb.ByteStreamClient, src interfaces
 	if err != nil {
 		return fmt.Errorf("read blob %q: %w", blobName, err)
 	}
-	rn, err := digest.ParseDownloadResourceName(parsedURL.Path)
+	rn, err := digest.ParseDownloadResourceName(strings.TrimPrefix(parsedURL.Path, "/"))
 	if err != nil {
 		return fmt.Errorf("parse bytestream URI as resource name: %w", err)
 	}


### PR DESCRIPTION
This change has two effects:

- `replay_invocation --copy_artifacts` now copies BLAKE3 artifacts.
- Cache scorecards now associate BLAKE3 BES uploads with their filenames and path prefixes.