### PR TITLE
Allow showing/hiding series in trends charts

### DIFF
--- a/enterprise/app/trends/BUILD
+++ b/enterprise/app/trends/BUILD
@@ -1,8 +1,19 @@
-load("//rules/typescript:index.bzl", "ts_library")
+load("//rules/typescript:index.bzl", "ts_jasmine_node_test", "ts_library")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
 exports_files(["trends.css"])
+
+ts_library(
+    name = "chart_series",
+    srcs = ["chart_series.ts"],
+)
+
+ts_jasmine_node_test(
+    name = "chart_series_test",
+    srcs = ["chart_series_test.ts"],
+    deps = [":chart_series"],
+)
 
 ts_library(
     name = "trends",
@@ -83,6 +94,7 @@ ts_library(
         "//:node_modules/recharts",
         "//:node_modules/tslib",
         "//app/format",
+        "//enterprise/app/trends:chart_series",
     ],
 )
 
@@ -149,6 +161,7 @@ ts_library(
         "//:node_modules/recharts",
         "//:node_modules/tslib",
         "//app/format",
+        "//enterprise/app/trends:chart_series",
     ],
 )
 
@@ -174,5 +187,6 @@ ts_library(
         "//:node_modules/react",
         "//:node_modules/recharts",
         "//app/router",
+        "//enterprise/app/trends:chart_series",
     ],
 )

--- a/enterprise/app/trends/cache_chart.tsx
+++ b/enterprise/app/trends/cache_chart.tsx
@@ -14,6 +14,7 @@ import {
 } from "recharts";
 import { CategoricalChartState } from "recharts/types/chart/types";
 import * as format from "../../../app/format/format";
+import { getHiddenSeriesAfterLegendClick } from "./chart_series";
 
 export interface CacheChartProps {
   title: string;
@@ -31,17 +32,26 @@ export interface CacheChartProps {
   onZoomSelection?: (startDate: number, endDate: number) => void;
 }
 
+interface CacheChartDataSeries {
+  name: string;
+  type: "bar" | "line";
+  yAxisId: "hits" | "percent";
+  dataKey: (datum: number) => number;
+  color: string;
+  formatHoverValue: (value: number) => string;
+}
+
 interface State {
   refAreaLeft?: string;
   refAreaRight?: string;
+  hiddenSeries: ReadonlySet<number>;
 }
 
 interface CacheChartTooltipProps extends TooltipProps<any, any> {
   labelFormatter: (datum: number) => string;
   shouldRender: () => boolean;
-  extractHits: (datum: number) => number;
-  secondaryBarName: string;
-  extractSecondary: (datum: number) => number;
+  dataSeries: CacheChartDataSeries[];
+  hiddenSeries: ReadonlySet<number>;
 }
 
 const CacheChartTooltip = ({
@@ -49,9 +59,8 @@ const CacheChartTooltip = ({
   payload,
   labelFormatter,
   shouldRender,
-  extractHits,
-  secondaryBarName,
-  extractSecondary,
+  dataSeries,
+  hiddenSeries,
 }: CacheChartTooltipProps) => {
   if (!active || !payload || payload.length < 1 || !shouldRender()) {
     return null;
@@ -61,20 +70,59 @@ const CacheChartTooltip = ({
     <div className="trend-chart-hover">
       <div className="trend-chart-hover-label">{labelFormatter(data)}</div>
       <div className="trend-chart-hover-value">
-        <div>{extractHits(data) || 0} hits</div>
-        <div>
-          {extractSecondary(data) || 0} {secondaryBarName}
-        </div>
-        <div>
-          {((100 * extractHits(data)) / (extractHits(data) + extractSecondary(data)) || 0).toFixed(2)}% hit percentage
-        </div>
+        {dataSeries.map(
+          (series, index) =>
+            !hiddenSeries.has(index) && <div key={series.name}>{series.formatHoverValue(series.dataKey(data))}</div>
+        )}
       </div>
     </div>
   );
 };
 
 export default class CacheChartComponent extends React.Component<CacheChartProps, State> {
-  state: State = {};
+  state: State = { hiddenSeries: new Set() };
+
+  getDataSeries(): CacheChartDataSeries[] {
+    return [
+      {
+        name: `hits (${format.count(this.props.totalHits)})`,
+        type: "bar",
+        yAxisId: "hits",
+        dataKey: (datum) => this.props.extractHits(datum),
+        color: "#8BC34A",
+        formatHoverValue: (value) => `${value || 0} hits`,
+      },
+      {
+        name: `${this.props.secondaryBarName} (${format.count(this.props.totalSecondary)})`,
+        type: "bar",
+        yAxisId: "hits",
+        dataKey: (datum) => this.props.extractSecondary(datum),
+        color: "#f44336",
+        formatHoverValue: (value) => `${value || 0} ${this.props.secondaryBarName}`,
+      },
+      {
+        name: `hit percentage (${format.percent(this.props.totalHitPercentage)}%)`,
+        type: "line",
+        yAxisId: "percent",
+        dataKey: (datum) =>
+          (100 * this.props.extractHits(datum)) / (this.props.extractHits(datum) + this.props.extractSecondary(datum)),
+        color: "#03A9F4",
+        formatHoverValue: (value) => `${(value || 0).toFixed(2)}% hit percentage`,
+      },
+    ];
+  }
+
+  onLegendClick(_data: unknown, seriesIndex: number, event: React.MouseEvent) {
+    event.stopPropagation();
+    this.setState((state) => ({
+      hiddenSeries: getHiddenSeriesAfterLegendClick(
+        state.hiddenSeries,
+        seriesIndex,
+        this.getDataSeries().length,
+        event.ctrlKey || event.metaKey || event.shiftKey
+      ),
+    }));
+  }
 
   onMouseDown(e: CategoricalChartState) {
     if (!this.props.onZoomSelection || !e) {
@@ -118,6 +166,8 @@ export default class CacheChartComponent extends React.Component<CacheChartProps
   }
 
   render() {
+    const dataSeries = this.getDataSeries();
+
     return (
       <div id={this.props.id} className={`trend-chart ${this.props.onZoomSelection ? "zoomable" : ""}`}>
         <div className="trend-chart-title">{this.props.title}</div>
@@ -128,7 +178,7 @@ export default class CacheChartComponent extends React.Component<CacheChartProps
             onMouseMove={this.props.onZoomSelection && this.onMouseMove.bind(this)}
             onMouseUp={this.props.onZoomSelection && this.onMouseUp.bind(this)}>
             <CartesianGrid strokeDasharray="3 3" />
-            <Legend />
+            <Legend onClick={this.onLegendClick.bind(this)} />
             <XAxis dataKey={(v) => v} tickFormatter={this.props.extractLabel} ticks={this.props.ticks} />
             <YAxis yAxisId="hits" tickFormatter={format.count} allowDecimals={false} />
             <YAxis
@@ -142,37 +192,35 @@ export default class CacheChartComponent extends React.Component<CacheChartProps
                 <CacheChartTooltip
                   labelFormatter={this.props.formatHoverLabel}
                   shouldRender={() => this.shouldRenderTooltip()}
-                  extractHits={this.props.extractHits}
-                  secondaryBarName={this.props.secondaryBarName}
-                  extractSecondary={this.props.extractSecondary}
+                  dataSeries={dataSeries}
+                  hiddenSeries={this.state.hiddenSeries}
                 />
               }
             />
-            <Bar
-              yAxisId="hits"
-              name={`hits (${format.count(this.props.totalHits)})`}
-              dataKey={(datum) => this.props.extractHits(datum)}
-              fill="#8BC34A"
-              isAnimationActive={false}
-            />
-            <Bar
-              yAxisId="hits"
-              name={`${this.props.secondaryBarName} (${format.count(this.props.totalSecondary)})`}
-              dataKey={(datum) => this.props.extractSecondary(datum)}
-              fill="#f44336"
-              isAnimationActive={false}
-            />
-            <Line
-              yAxisId="percent"
-              name={`hit percentage (${format.percent(this.props.totalHitPercentage)}%)`}
-              dot={false}
-              dataKey={(datum) =>
-                (100 * this.props.extractHits(datum)) /
-                (this.props.extractHits(datum) + this.props.extractSecondary(datum))
-              }
-              stroke="#03A9F4"
-              isAnimationActive={false}
-            />
+            {dataSeries.map((series, index) =>
+              series.type === "bar" ? (
+                <Bar
+                  key={series.name}
+                  yAxisId={series.yAxisId}
+                  name={series.name}
+                  dataKey={series.dataKey}
+                  fill={series.color}
+                  hide={this.state.hiddenSeries.has(index)}
+                  isAnimationActive={false}
+                />
+              ) : (
+                <Line
+                  key={series.name}
+                  yAxisId={series.yAxisId}
+                  name={series.name}
+                  dataKey={series.dataKey}
+                  stroke={series.color}
+                  dot={false}
+                  hide={this.state.hiddenSeries.has(index)}
+                  isAnimationActive={false}
+                />
+              )
+            )}
             {this.state.refAreaLeft && this.state.refAreaRight ? (
               <ReferenceArea
                 yAxisId="percent"

--- a/enterprise/app/trends/chart_series.ts
+++ b/enterprise/app/trends/chart_series.ts
@@ -1,0 +1,41 @@
+/**
+ * Returns the hidden series after a legend click.
+ *
+ * Modifier-clicking toggles the clicked series independently. A regular click
+ * isolates the clicked series unless it is already the only visible series, in
+ * which case every series becomes visible.
+ */
+export function getHiddenSeriesAfterLegendClick(
+  hiddenSeries: ReadonlySet<number>,
+  clickedSeries: number,
+  seriesCount: number,
+  modifierKey: boolean
+): Set<number> {
+  if (modifierKey) {
+    const nextHiddenSeries = new Set(hiddenSeries);
+    if (nextHiddenSeries.has(clickedSeries)) {
+      nextHiddenSeries.delete(clickedSeries);
+    } else {
+      nextHiddenSeries.add(clickedSeries);
+    }
+    return nextHiddenSeries;
+  }
+
+  let clickedSeriesIsOnlyVisible = !hiddenSeries.has(clickedSeries);
+  for (let series = 0; series < seriesCount && clickedSeriesIsOnlyVisible; series++) {
+    if (series !== clickedSeries && !hiddenSeries.has(series)) {
+      clickedSeriesIsOnlyVisible = false;
+    }
+  }
+  if (clickedSeriesIsOnlyVisible) {
+    return new Set();
+  }
+
+  const nextHiddenSeries = new Set<number>();
+  for (let series = 0; series < seriesCount; series++) {
+    if (series !== clickedSeries) {
+      nextHiddenSeries.add(series);
+    }
+  }
+  return nextHiddenSeries;
+}

--- a/enterprise/app/trends/chart_series_test.ts
+++ b/enterprise/app/trends/chart_series_test.ts
@@ -2,7 +2,7 @@ import { getHiddenSeriesAfterLegendClick } from "./chart_series";
 
 describe("getHiddenSeriesAfterLegendClick", () => {
   function expectHiddenSeries(actual: ReadonlySet<number>, expected: number[]) {
-    expect([...actual].sort()).toEqual(expected);
+    expect([...actual].sort((a, b) => a - b)).toEqual(expected);
   }
 
   it("isolates a series on regular click when all series are visible", () => {

--- a/enterprise/app/trends/chart_series_test.ts
+++ b/enterprise/app/trends/chart_series_test.ts
@@ -1,0 +1,49 @@
+import { getHiddenSeriesAfterLegendClick } from "./chart_series";
+
+describe("getHiddenSeriesAfterLegendClick", () => {
+  function expectHiddenSeries(actual: ReadonlySet<number>, expected: number[]) {
+    expect([...actual].sort()).toEqual(expected);
+  }
+
+  it("isolates a series on regular click when all series are visible", () => {
+    const hiddenSeries = getHiddenSeriesAfterLegendClick(new Set(), 1, 3, false);
+
+    expectHiddenSeries(hiddenSeries, [0, 2]);
+  });
+
+  it("isolates a series on regular click when another series is hidden", () => {
+    const hiddenSeries = getHiddenSeriesAfterLegendClick(new Set([0]), 1, 3, false);
+
+    expectHiddenSeries(hiddenSeries, [0, 2]);
+  });
+
+  it("isolates a hidden series on regular click", () => {
+    const hiddenSeries = getHiddenSeriesAfterLegendClick(new Set([1]), 1, 3, false);
+
+    expectHiddenSeries(hiddenSeries, [0, 2]);
+  });
+
+  it("shows all series on regular click when the clicked series is the only visible series", () => {
+    const hiddenSeries = getHiddenSeriesAfterLegendClick(new Set([0, 2]), 1, 3, false);
+
+    expectHiddenSeries(hiddenSeries, []);
+  });
+
+  it("isolates a series on regular click when all series are hidden", () => {
+    const hiddenSeries = getHiddenSeriesAfterLegendClick(new Set([0, 1, 2]), 1, 3, false);
+
+    expectHiddenSeries(hiddenSeries, [0, 2]);
+  });
+
+  it("hides a visible series on modifier click", () => {
+    const hiddenSeries = getHiddenSeriesAfterLegendClick(new Set([0]), 1, 3, true);
+
+    expectHiddenSeries(hiddenSeries, [0, 1]);
+  });
+
+  it("shows a hidden series on modifier click", () => {
+    const hiddenSeries = getHiddenSeriesAfterLegendClick(new Set([0, 1]), 1, 3, true);
+
+    expectHiddenSeries(hiddenSeries, [0]);
+  });
+});

--- a/enterprise/app/trends/percentile_chart.tsx
+++ b/enterprise/app/trends/percentile_chart.tsx
@@ -14,6 +14,7 @@ import {
 } from "recharts";
 import { CategoricalChartState } from "recharts/types/chart/types";
 import * as format from "../../../app/format/format";
+import { getHiddenSeriesAfterLegendClick } from "./chart_series";
 
 export interface PercentilesChartProps {
   title: string;
@@ -31,14 +32,43 @@ export interface PercentilesChartProps {
   onZoomSelection?: (startDate: number, endDate: number) => void;
 }
 
+interface PercentileDataSeries {
+  name: string;
+  dataKey: (datum: number) => number;
+  stroke: string;
+}
+
 interface State {
   refAreaLeft?: string;
   refAreaRight?: string;
+  hiddenSeries: ReadonlySet<number>;
 }
 
 export default class PercentilesChartComponent extends React.Component<PercentilesChartProps, State> {
-  state: State = {};
+  state: State = { hiddenSeries: new Set() };
   private lastDataFromHover?: number;
+
+  getDataSeries(): PercentileDataSeries[] {
+    return [
+      { name: "P50", dataKey: (datum) => this.props.extractP50(datum), stroke: "#067BC2" },
+      { name: "P75", dataKey: (datum) => this.props.extractP75(datum), stroke: "#84BCDA" },
+      { name: "P90", dataKey: (datum) => this.props.extractP90(datum), stroke: "#ECC30B" },
+      { name: "P95", dataKey: (datum) => this.props.extractP95(datum), stroke: "#F37748" },
+      { name: "P99", dataKey: (datum) => this.props.extractP99(datum), stroke: "#D56062" },
+    ];
+  }
+
+  onLegendClick(_data: unknown, seriesIndex: number, event: React.MouseEvent) {
+    event.stopPropagation();
+    this.setState((state) => ({
+      hiddenSeries: getHiddenSeriesAfterLegendClick(
+        state.hiddenSeries,
+        seriesIndex,
+        this.getDataSeries().length,
+        event.ctrlKey || event.metaKey || event.shiftKey
+      ),
+    }));
+  }
 
   handleRowClick() {
     if (!this.props.onColumnClicked || !this.lastDataFromHover) {
@@ -89,6 +119,8 @@ export default class PercentilesChartComponent extends React.Component<Percentil
   }
 
   render() {
+    const dataSeries = this.getDataSeries();
+
     return (
       <div id={this.props.id} className={`trend-chart ${this.props.onZoomSelection ? "zoomable" : ""}`}>
         <div className="trend-chart-title">{this.props.title}</div>
@@ -101,7 +133,7 @@ export default class PercentilesChartComponent extends React.Component<Percentil
             onMouseMove={this.props.onZoomSelection && this.onMouseMove.bind(this)}
             onMouseUp={this.props.onZoomSelection && this.onMouseUp.bind(this)}>
             <CartesianGrid strokeDasharray="3 3" />
-            <Legend />
+            <Legend onClick={this.onLegendClick.bind(this)} />
             <XAxis dataKey={(v) => v} tickFormatter={this.props.extractLabel} ticks={this.props.ticks} />
             <YAxis yAxisId="duration" tickFormatter={format.durationSec} allowDecimals={false} width={84} />
             <Tooltip
@@ -109,55 +141,24 @@ export default class PercentilesChartComponent extends React.Component<Percentil
                 <PercentilesChartTooltip
                   labelFormatter={this.props.formatHoverLabel}
                   shouldRender={() => this.shouldRenderTooltip()}
-                  extractP50={this.props.extractP50}
-                  extractP75={this.props.extractP75}
-                  extractP90={this.props.extractP90}
-                  extractP95={this.props.extractP95}
-                  extractP99={this.props.extractP99}
+                  dataSeries={dataSeries}
+                  hiddenSeries={this.state.hiddenSeries}
                   triggerCallback={(data) => (this.lastDataFromHover = data)}
                 />
               }
             />
-            <Line
-              yAxisId="duration"
-              name="P50"
-              dataKey={(datum) => this.props.extractP50(datum)}
-              stroke="#067BC2"
-              dot={false}
-              isAnimationActive={false}
-            />
-            <Line
-              yAxisId="duration"
-              name="P75"
-              dataKey={(datum) => this.props.extractP75(datum)}
-              stroke="#84BCDA"
-              dot={false}
-              isAnimationActive={false}
-            />
-            <Line
-              yAxisId="duration"
-              name="P90"
-              dataKey={(datum) => this.props.extractP90(datum)}
-              stroke="#ECC30B"
-              dot={false}
-              isAnimationActive={false}
-            />
-            <Line
-              yAxisId="duration"
-              name="P95"
-              dataKey={(datum) => this.props.extractP95(datum)}
-              stroke="#F37748"
-              dot={false}
-              isAnimationActive={false}
-            />
-            <Line
-              yAxisId="duration"
-              name="P99"
-              dataKey={(datum) => this.props.extractP99(datum)}
-              stroke="#D56062"
-              dot={false}
-              isAnimationActive={false}
-            />
+            {dataSeries.map((series, index) => (
+              <Line
+                key={series.name}
+                yAxisId="duration"
+                name={series.name}
+                dataKey={series.dataKey}
+                stroke={series.stroke}
+                dot={false}
+                hide={this.state.hiddenSeries.has(index)}
+                isAnimationActive={false}
+              />
+            ))}
             {this.state.refAreaLeft && this.state.refAreaRight ? (
               <ReferenceArea
                 yAxisId="duration"
@@ -177,11 +178,8 @@ export default class PercentilesChartComponent extends React.Component<Percentil
 interface PercentilesChartTooltipProps extends TooltipProps<any, any> {
   labelFormatter: (datum: number) => string;
   shouldRender: () => boolean;
-  extractP50: (datum: number) => number;
-  extractP75: (datum: number) => number;
-  extractP90: (datum: number) => number;
-  extractP95: (datum: number) => number;
-  extractP99: (datum: number) => number;
+  dataSeries: PercentileDataSeries[];
+  hiddenSeries: ReadonlySet<number>;
   triggerCallback: (datum: number) => void;
 }
 
@@ -206,11 +204,17 @@ class PercentilesChartTooltip extends React.Component<PercentilesChartTooltipPro
       <div className="trend-chart-hover">
         <div className="trend-chart-hover-label">{this.props.labelFormatter(data)}</div>
         <div className="trend-chart-hover-value">
-          <div>p99: {format.durationSec(this.props.extractP99(data))}</div>
-          <div>p95: {format.durationSec(this.props.extractP95(data))}</div>
-          <div>p90: {format.durationSec(this.props.extractP90(data))}</div>
-          <div>p75: {format.durationSec(this.props.extractP75(data))}</div>
-          <div>p50: {format.durationSec(this.props.extractP50(data))}</div>
+          {this.props.dataSeries
+            .map((series, index) => ({ series, index }))
+            .reverse()
+            .map(
+              ({ series, index }) =>
+                !this.props.hiddenSeries.has(index) && (
+                  <div key={series.name}>
+                    {series.name.toLowerCase()}: {format.durationSec(series.dataKey(data))}
+                  </div>
+                )
+            )}
         </div>
       </div>
     );

--- a/enterprise/app/trends/trends.css
+++ b/enterprise/app/trends/trends.css
@@ -50,6 +50,14 @@
   color: var(--color-text-primary);
 }
 
+.trend-chart .recharts-legend-item {
+  cursor: pointer;
+}
+
+.trend-chart .recharts-legend-item.inactive {
+  opacity: 0.5;
+}
+
 /* margin is given to heatmap so that y axis can render nicely. */
 .drilldown-chart-title {
   font-weight: 600;

--- a/enterprise/app/trends/trends_chart.tsx
+++ b/enterprise/app/trends/trends_chart.tsx
@@ -175,7 +175,7 @@ export default class TrendsChartComponent extends React.Component<Props, State> 
     return !Boolean(this.state.refAreaLeft);
   }
 
-  renderDataSeries(ds: ChartDataSeries, index: number): JSX.Element {
+  renderDataSeries(ds: ChartDataSeries, seriesIndex: number): JSX.Element {
     const axis = ds.usesSecondaryAxis ? "secondary" : "primary";
     if (ds.isLine) {
       return (
@@ -186,7 +186,7 @@ export default class TrendsChartComponent extends React.Component<Props, State> 
           dot={false}
           dataKey={ds.extractValue}
           isAnimationActive={false}
-          hide={this.state.hiddenSeries.has(index)}
+          hide={this.state.hiddenSeries.has(seriesIndex)}
           stroke={getResolvedColor(ds.color ?? ChartColor.BLUE)}
         />
       );
@@ -201,13 +201,13 @@ export default class TrendsChartComponent extends React.Component<Props, State> 
         name={ds.name}
         dataKey={ds.extractValue}
         isAnimationActive={false}
-        hide={this.state.hiddenSeries.has(index)}
+        hide={this.state.hiddenSeries.has(seriesIndex)}
         stackId={ds.stackId}
         fill={getResolvedColor(color)}>
-        {this.props.data.map((date, index) => (
+        {this.props.data.map((date, datumIndex) => (
           <Cell
             cursor={ds.onClick ? "pointer" : "default"}
-            key={`cell-${index}`}
+            key={`cell-${datumIndex}`}
             onClick={!this.props.onZoomSelection && ds.onClick ? ds.onClick.bind(this, date) : undefined}
           />
         ))}

--- a/enterprise/app/trends/trends_chart.tsx
+++ b/enterprise/app/trends/trends_chart.tsx
@@ -16,6 +16,7 @@ import {
 } from "recharts";
 import { CategoricalChartState } from "recharts/types/chart/types";
 import { TrendsChartId } from "../../../app/router/router";
+import { getHiddenSeriesAfterLegendClick } from "./chart_series";
 
 interface ChartDataSeries {
   name: string;
@@ -52,6 +53,7 @@ interface Props {
 interface State {
   refAreaLeft?: string;
   refAreaRight?: string;
+  hiddenSeries: ReadonlySet<number>;
 }
 
 interface TrendsChartTooltipProps extends TooltipProps<any, any> {
@@ -118,7 +120,19 @@ function TrendsChartTooltip({ active, payload, labelFormatter, shouldRender, dat
 }
 
 export default class TrendsChartComponent extends React.Component<Props, State> {
-  state: State = {};
+  state: State = { hiddenSeries: new Set() };
+
+  onLegendClick(_data: unknown, seriesIndex: number, event: React.MouseEvent) {
+    event.stopPropagation();
+    this.setState((state) => ({
+      hiddenSeries: getHiddenSeriesAfterLegendClick(
+        state.hiddenSeries,
+        seriesIndex,
+        this.props.dataSeries.length,
+        event.ctrlKey || event.metaKey || event.shiftKey
+      ),
+    }));
+  }
 
   onMouseDown(e: CategoricalChartState) {
     if (!this.props.onZoomSelection || !e) {
@@ -172,6 +186,7 @@ export default class TrendsChartComponent extends React.Component<Props, State> 
           dot={false}
           dataKey={ds.extractValue}
           isAnimationActive={false}
+          hide={this.state.hiddenSeries.has(index)}
           stroke={getResolvedColor(ds.color ?? ChartColor.BLUE)}
         />
       );
@@ -186,6 +201,7 @@ export default class TrendsChartComponent extends React.Component<Props, State> 
         name={ds.name}
         dataKey={ds.extractValue}
         isAnimationActive={false}
+        hide={this.state.hiddenSeries.has(index)}
         stackId={ds.stackId}
         fill={getResolvedColor(color)}>
         {this.props.data.map((date, index) => (
@@ -216,7 +232,7 @@ export default class TrendsChartComponent extends React.Component<Props, State> 
             onMouseMove={this.props.onZoomSelection && this.onMouseMove.bind(this)}
             onMouseUp={this.props.onZoomSelection && this.onMouseUp.bind(this)}>
             <CartesianGrid strokeDasharray="3 3" />
-            <Legend />
+            <Legend onClick={this.onLegendClick.bind(this)} />
             <XAxis dataKey={(v) => v} tickFormatter={this.props.formatXAxisLabel} ticks={this.props.ticks} />
             <YAxis
               yAxisId="primary"
@@ -240,7 +256,7 @@ export default class TrendsChartComponent extends React.Component<Props, State> 
                 <TrendsChartTooltip
                   labelFormatter={this.props.formatHoverXAxisLabel}
                   shouldRender={() => this.shouldRenderTooltip()}
-                  dataSeries={this.props.dataSeries}
+                  dataSeries={this.props.dataSeries.filter((_, index) => !this.state.hiddenSeries.has(index))}
                 />
               }
             />


### PR DESCRIPTION
Allows clicking data series in chart legends to toggle them on/off.

New interactions:
- `Click`: toggles between a series being "isolated" (showing only that series). If the series is not currently isolated, isolates it; otherwise shows all series.
- `Ctrl+Click`, `Command+Click`, or `Shift+Click`: toggles visibility of a single series, preserving visibility of all other series.

(Edge case: if there's only one series, normal clicking does nothing, and modifier+click toggles its visibility. Not really very useful to hide the only timeseries, but it simplifies things to have it behave that way.)

The Y-axis is rescaled to accomodate the visible series. For example, if p99 has an extremely high peak, making p50, p75 etc. all appear to be ~0, then `Ctrl+Clicking` on p99 will hide it, and the Y-axis is rescaled to fit the lower quantiles within the new bounds.