### PR TITLE
Don't auto-load large compact exec logs in action page

### DIFF
--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -47,7 +47,7 @@ import { Cancelable, CancelablePromise, default as rpcService } from "../service
 import TerminalComponent from "../terminal/terminal";
 import { Profile, readProfile } from "../trace/compact_trace";
 import TraceViewer from "../trace/trace_viewer";
-import { digestToString, parseActionDigest } from "../util/cache";
+import { digestToString, isBytestreamURL, parseActionDigest, parseBytestreamURL } from "../util/cache";
 import { copyToClipboard } from "../util/clipboard";
 import { BuildBuddyError, HTTPStatusError } from "../util/errors";
 import { MessageClass, timestampToDate } from "../util/proto";
@@ -123,7 +123,7 @@ interface State {
 
   isExecutionLogLoading: boolean;
   allowLoadingLargeExecutionLog: boolean;
-  executionLogError?: BuildBuddyError;
+  executionLogError?: any;
 }
 
 interface ServerLog {
@@ -155,6 +155,8 @@ export default class InvocationActionCardComponent extends React.Component<Props
 
   private executionDownloadsContainerRef = React.createRef<HTMLDivElement>();
   private treeShaToChildrenPromiseMap = new Map<string, Promise<TreeNode[]>>();
+
+  private executionLogFetch?: CancelablePromise;
 
   componentDidMount() {
     this.fetchAction();
@@ -190,9 +192,8 @@ export default class InvocationActionCardComponent extends React.Component<Props
   }
 
   getExecutionLogSize() {
-    const executionLogFileUri = this.props.model.getExecutionLogFileUri();
-    const sizeSegment = executionLogFileUri?.split("/").pop();
-    return sizeSegment ? Number(sizeSegment) : undefined;
+    const uri = this.props.model.getExecutionLogFileUri();
+    return isBytestreamURL(uri) ? Number(parseBytestreamURL(uri).digest.sizeBytes) : undefined;
   }
 
   isExecutionLogTooLarge() {
@@ -201,7 +202,8 @@ export default class InvocationActionCardComponent extends React.Component<Props
   }
 
   fetchSpawnMetrics() {
-    this.setState({ isExecutionLogLoading: true });
+    this.executionLogFetch?.cancel();
+    this.setState({ isExecutionLogLoading: true, executionLogError: undefined, measuredMemoryPeakBytes: undefined });
     const actionDigestParam = this.props.search.get("actionDigest");
     if (
       !actionDigestParam ||
@@ -209,24 +211,21 @@ export default class InvocationActionCardComponent extends React.Component<Props
       this.getExecutionId() ||
       this.isExecutionLogTooLarge()
     ) {
-      this.setState({ isExecutionLogLoading: false, measuredMemoryPeakBytes: undefined });
+      this.setState({ isExecutionLogLoading: false });
       return;
     }
 
     const actionDigest = parseActionDigest(actionDigestParam);
     if (!actionDigest) {
-      this.setState({ isExecutionLogLoading: false, measuredMemoryPeakBytes: undefined });
+      this.setState({ isExecutionLogLoading: false });
       return;
     }
 
     const model = this.props.model;
     const actionDigestString = digestToString(actionDigest);
     const actionDigestHasSize = actionDigestParam.includes("/");
-    model
-      .getExecutionLog()
+    this.executionLogFetch = new CancelablePromise(model.getExecutionLog())
       .then((log) => {
-        if (this.props.model !== model || this.props.search.get("actionDigest") !== actionDigestParam) return;
-
         const spawn = log.find((entry) => {
           const spawnDigest = entry.spawn?.digest;
           if (!spawnDigest || spawnDigest.hash !== actionDigest.hash) return false;
@@ -236,12 +235,8 @@ export default class InvocationActionCardComponent extends React.Component<Props
           measuredMemoryPeakBytes: Number(spawn?.spawn?.metrics?.measuredMemoryPeakBytes || 0) || undefined,
         });
       })
-      .catch((e) => {
-        this.setState({ executionLogError: BuildBuddyError.parse(e) });
-      })
-      .finally(() => {
-        this.setState({ isExecutionLogLoading: false });
-      });
+      .catch((e) => this.setState({ executionLogError: e }))
+      .finally(() => this.setState({ isExecutionLogLoading: false }));
   }
 
   fetchAction() {
@@ -1508,7 +1503,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
       return (
         <>
           <div className="metadata-title">Resource usage</div>
-          <div className="error-text">Failed to load execution log: {this.state.executionLogError}</div>
+          <div className="error-text">Failed to load execution log: {String(this.state.executionLogError)}</div>
         </>
       );
     }

--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -61,6 +61,13 @@ import InvocationModel from "./invocation_model";
 type IDigest = build.bazel.remote.execution.v2.IDigest;
 type ITimestamp = google_timestamp.protobuf.ITimestamp;
 
+/**
+ * Size of the compact execution log above which we don't auto-load the log.
+ * This is the zstd-compressed size, and we unpack the decompressed log as JS
+ * objects, so the required browser memory can be much larger than this.
+ */
+const LARGE_EXECUTION_LOG_THRESHOLD_BYTES = 10e6;
+
 const executionDownloadsPageSize = 100;
 
 interface InputFileReference {
@@ -113,6 +120,10 @@ interface State {
   executionDownloads: cache.ExecutionDownload[];
   executionDownloadsLoading: boolean;
   executionDownloadsNextPageToken: string;
+
+  isExecutionLogLoading: boolean;
+  allowLoadingLargeExecutionLog: boolean;
+  executionLogError?: BuildBuddyError;
 }
 
 interface ServerLog {
@@ -138,6 +149,8 @@ export default class InvocationActionCardComponent extends React.Component<Props
     executionDownloads: [],
     executionDownloadsLoading: false,
     executionDownloadsNextPageToken: "",
+    isExecutionLogLoading: false,
+    allowLoadingLargeExecutionLog: false,
   };
 
   private executionDownloadsContainerRef = React.createRef<HTMLDivElement>();
@@ -176,16 +189,33 @@ export default class InvocationActionCardComponent extends React.Component<Props
     }
   }
 
+  getExecutionLogSize() {
+    const executionLogFileUri = this.props.model.getExecutionLogFileUri();
+    const sizeSegment = executionLogFileUri?.split("/").pop();
+    return sizeSegment ? Number(sizeSegment) : undefined;
+  }
+
+  isExecutionLogTooLarge() {
+    if (this.state.allowLoadingLargeExecutionLog) return false;
+    return (this.getExecutionLogSize() ?? 0) > LARGE_EXECUTION_LOG_THRESHOLD_BYTES;
+  }
+
   fetchSpawnMetrics() {
+    this.setState({ isExecutionLogLoading: true });
     const actionDigestParam = this.props.search.get("actionDigest");
-    if (!actionDigestParam || !this.props.model.hasExecutionLog() || this.getExecutionId()) {
-      this.setState({ measuredMemoryPeakBytes: undefined });
+    if (
+      !actionDigestParam ||
+      !this.props.model.hasExecutionLog() ||
+      this.getExecutionId() ||
+      this.isExecutionLogTooLarge()
+    ) {
+      this.setState({ isExecutionLogLoading: false, measuredMemoryPeakBytes: undefined });
       return;
     }
 
     const actionDigest = parseActionDigest(actionDigestParam);
     if (!actionDigest) {
-      this.setState({ measuredMemoryPeakBytes: undefined });
+      this.setState({ isExecutionLogLoading: false, measuredMemoryPeakBytes: undefined });
       return;
     }
 
@@ -206,7 +236,12 @@ export default class InvocationActionCardComponent extends React.Component<Props
           measuredMemoryPeakBytes: Number(spawn?.spawn?.metrics?.measuredMemoryPeakBytes || 0) || undefined,
         });
       })
-      .catch((e) => console.error("Failed to fetch execution log:", e));
+      .catch((e) => {
+        this.setState({ executionLogError: BuildBuddyError.parse(e) });
+      })
+      .finally(() => {
+        this.setState({ isExecutionLogLoading: false });
+      });
   }
 
   fetchAction() {
@@ -1460,6 +1495,40 @@ export default class InvocationActionCardComponent extends React.Component<Props
 
   private renderSpawnResourceUsage() {
     if (this.getExecutionId()) return null;
+
+    if (this.state.isExecutionLogLoading) {
+      return (
+        <>
+          <div className="metadata-title">Resource usage</div>
+          <Spinner />
+        </>
+      );
+    }
+    if (this.state.executionLogError) {
+      return (
+        <>
+          <div className="metadata-title">Resource usage</div>
+          <div className="error-text">Failed to load execution log: {this.state.executionLogError}</div>
+        </>
+      );
+    }
+    if (this.isExecutionLogTooLarge()) {
+      return (
+        <>
+          <div className="metadata-title">Resource usage</div>
+          <div>
+            <TextLink
+              href="#"
+              onClick={(e) => {
+                e.preventDefault();
+                this.setState({ allowLoadingLargeExecutionLog: true }, () => this.fetchSpawnMetrics());
+              }}>
+              Load execution log ({format.bytesIEC(this.getExecutionLogSize() ?? 0)})
+            </TextLink>
+          </div>
+        </>
+      );
+    }
 
     const measuredMemoryPeakBytes = this.state.measuredMemoryPeakBytes;
     if (!measuredMemoryPeakBytes || measuredMemoryPeakBytes <= 0) return null;

--- a/app/util/cache.tsx
+++ b/app/util/cache.tsx
@@ -59,6 +59,8 @@ type RequiredNonNullable<T> = { [k in keyof T]: NonNullable<T[k]> };
 export interface BytestreamURL extends RequiredNonNullable<resource.IResourceName> {
   /** Bytestream service address host or host:port. */
   address: string;
+
+  digest: Digest;
 }
 
 /**


### PR DESCRIPTION
Show this instead of trying to load huge logs, which can crash the browser tab:

<img width="509" height="58" alt="image" src="https://github.com/user-attachments/assets/a859ff2f-70a5-473e-879f-c080509bec9d" />
