### PR TITLE
[WF] Normalize repo URLs when generating instance name

### DIFF
--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -167,6 +167,13 @@ func generateWebhookID() (string, error) {
 }
 
 func instanceName(wf *tables.Workflow, wd *interfaces.WebhookData, workflowActionName string, gitCleanExclude []string) string {
+	// Webhook payloads typically use clone URLs, which may include a ".git"
+	// suffix. Normalize the URL and remove the suffix.
+	pushedRepoURL := wd.PushedRepoURL
+	if normalizedURL, err := gitutil.NormalizeRepoURL(pushedRepoURL); err == nil {
+		pushedRepoURL = normalizedURL.String()
+	}
+
 	// Use a unique remote instance name per repo URL and workflow action name, to help
 	// route workflow tasks to runners which previously executed the same workflow
 	// action.
@@ -179,7 +186,7 @@ func instanceName(wf *tables.Workflow, wd *interfaces.WebhookData, workflowActio
 	// existing runners for the workflow and cause subsequent workflows to be run
 	// from a clean runner.
 	keys := append([]string{
-		wd.PushedRepoURL,
+		pushedRepoURL,
 		workflowActionName,
 		wf.InstanceNameSuffix,
 	}, gitCleanExclude...)

--- a/enterprise/server/workflow/service/service_test.go
+++ b/enterprise/server/workflow/service/service_test.go
@@ -1277,6 +1277,62 @@ actions:
 	require.Zero(t, scheduled.LeaseExpiresUsec)
 }
 
+func TestScheduledWorkflow_SharesInstanceNameWithWebhookEvent(t *testing.T) {
+	ctx := context.Background()
+	te := newTestEnv(t)
+	configureExperiments(t, te, map[string]bool{"remote_execution.enable_scheduled_workflows": true})
+	authCtx, _, gid := authenticate(t, ctx, te)
+	execClient := te.GetRemoteExecutionClient().(*fakeExecutionClient)
+	provider := setupFakeGitProvider(t, te)
+	repoURL := makeTempRepo(t)
+	repo := createWorkflow(t, te, repoURL, gid, false)
+	runBBServer(ctx, t, te)
+	provider.FileContents = map[string]string{
+		config.FilePath: `
+actions:
+  - name: "Test"
+    bazel_commands: [ "test //..." ]
+    triggers:
+      pull_request:
+        branches: [ "*" ]
+      schedule:
+        crons: ["0 * * * *"]
+`,
+	}
+
+	now := threePM
+	te.SetClock(clockwork.NewFakeClockAt(now))
+	// Scheduled workflows have normalize repo URLs (no ".git" suffix).
+	insertScheduledRun(t, te, &tables.ScheduledRun{
+		ScheduleID:  "test",
+		GroupID:     gid,
+		RepoURL:     repoURL,
+		ActionName:  "Test",
+		CronExpr:    "0 * * * *",
+		NextRunUsec: now.UnixMicro(),
+	})
+
+	require.NoError(t, te.GetWorkflowService().RunScheduledWorkflows(t.Context()))
+	scheduledRequest := execClient.NextExecuteRequest().Payload
+
+	// GitHub webhook payloads use clone URLs, which include a ".git" suffix.
+	cloneURL := repoURL + ".git"
+	wd := &interfaces.WebhookData{
+		EventName:               "pull_request",
+		PushedRepoURL:           cloneURL,
+		PushedBranch:            "feature",
+		SHA:                     "c04d68571cb519e095772c865847007ed3e7fea9",
+		TargetRepoURL:           cloneURL,
+		TargetRepoDefaultBranch: "main",
+		TargetBranch:            "main",
+	}
+	require.NoError(t, te.GetWorkflowService().HandleRepositoryEvent(authCtx, repo, wd, "faketoken"))
+	pullRequest := execClient.NextExecuteRequest().Payload
+
+	// Scheduled workflows and webhook events should share the same instance name so runners can be shared.
+	require.Equal(t, scheduledRequest.GetInstanceName(), pullRequest.GetInstanceName())
+}
+
 func TestScheduledWorkflow(t *testing.T) {
 	ctx := context.Background()
 	te := newTestEnv(t)


### PR DESCRIPTION
Fixes https://buildbuddy-corp.slack.com/archives/C0777L0C2UW/p1786134822754059

Unfortunately this will cause snapshot invalidations for most snapshots (current instance name contains non-normalized URL)