### PR TITLE
snapshots: allow-remote-snaps behind property

### DIFF
--- a/cli/box/box.go
+++ b/cli/box/box.go
@@ -265,6 +265,7 @@ func handleCreate(args []string) (int, error) {
 		"network=external",
 		"container-image=" + ensureDockerPrefix(*imageFlag),
 		platform.DockerUserPropertyName + "=buildbuddy",
+		"allow-remote-snapshots=true",
 	}
 	execProps = append(execProps,
 		"recycle-runner=true",

--- a/cli/box/box.go
+++ b/cli/box/box.go
@@ -265,7 +265,7 @@ func handleCreate(args []string) (int, error) {
 		"network=external",
 		"container-image=" + ensureDockerPrefix(*imageFlag),
 		platform.DockerUserPropertyName + "=buildbuddy",
-		"allow-remote-snapshots=true",
+		platform.AllowRemoteSnapshotsPropertyName + "=true",
 	}
 	execProps = append(execProps,
 		"recycle-runner=true",
@@ -274,10 +274,6 @@ func handleCreate(args []string) (int, error) {
 		// scheduling, so that resumes hit its warm local snapshot. (The
 		// server caps this via remote_execution.max_scheduling_delay.)
 		platform.RunnerRecyclingMaxWaitPropertyName+"=5s",
-		// By default, firecracker only saves a snapshot for non-CI
-		// actions if none exists yet, which would freeze the box's state
-		// at its first session. Always save so that changes made in each
-		// session persist to the next one.
 		platform.SnapshotSavePolicyPropertyName+"="+platform.AlwaysSaveSnapshot,
 		// The always-save policy above only covers the remote snapshot:
 		// the local manifest on a warm executor can lag one session

--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -310,6 +310,7 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 				{Name: platform.EstimatedFreeDiskPropertyName, Value: "20000000000"}, // 20GB
 				{Name: platform.DockerUserPropertyName, Value: user},
 				{Name: platform.RetryPropertyName, Value: fmt.Sprintf("%v", retry)},
+				{Name: platform.AllowRemoteSnapshotsPropertyName, Value: "true"},
 			},
 		},
 	}

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -824,7 +824,7 @@ func NewContainer(ctx context.Context, env environment.Env, task *repb.Execution
 		c.vmIdx = opts.ForceVMIdx
 	}
 
-	allowsRemoteSnapshots := platform.AllowsRemoteSnapshots(task.GetCommand(), platform.GetProto(task.GetAction(), task.GetCommand()))
+	allowsRemoteSnapshots := platform.AllowsRemoteSnapshots(task)
 	c.supportsRemoteSnapshots = *snaputil.EnableRemoteSnapshotSharing && (allowsRemoteSnapshots || *forceRemoteSnapshotting)
 	if span.IsRecording() {
 		span.SetAttributes(attribute.Bool("supports_remote_snapshots", c.supportsRemoteSnapshots))
@@ -1208,7 +1208,7 @@ func (c *FirecrackerContainer) shouldSaveLocalSnapshot(ctx context.Context) bool
 		return false
 	}
 	// For RBE actions, we don't save another snapshot if one already exists.
-	if c.createFromSnapshot && !platform.AllowsRemoteSnapshots(c.task.GetCommand(), platform.GetProto(c.task.GetAction(), c.task.GetCommand())) {
+	if c.createFromSnapshot && !platform.AllowsRemoteSnapshots(c.task) {
 		return false
 	}
 

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -824,9 +824,8 @@ func NewContainer(ctx context.Context, env environment.Env, task *repb.Execution
 		c.vmIdx = opts.ForceVMIdx
 	}
 
-	isCICommand := platform.IsCICommand(task.GetCommand(), platform.GetProto(task.GetAction(), task.GetCommand()))
-	isDevboxCommand := strings.HasPrefix(task.GetExecuteRequest().GetInstanceName(), snaputil.DevboxPartitionPrefix)
-	c.supportsRemoteSnapshots = *snaputil.EnableRemoteSnapshotSharing && (isCICommand || isDevboxCommand || *forceRemoteSnapshotting)
+	allowsRemoteSnapshots := platform.AllowsRemoteSnapshots(task.GetCommand(), platform.GetProto(task.GetAction(), task.GetCommand()))
+	c.supportsRemoteSnapshots = *snaputil.EnableRemoteSnapshotSharing && (allowsRemoteSnapshots || *forceRemoteSnapshotting)
 	if span.IsRecording() {
 		span.SetAttributes(attribute.Bool("supports_remote_snapshots", c.supportsRemoteSnapshots))
 	}
@@ -1209,7 +1208,7 @@ func (c *FirecrackerContainer) shouldSaveLocalSnapshot(ctx context.Context) bool
 		return false
 	}
 	// For RBE actions, we don't save another snapshot if one already exists.
-	if c.createFromSnapshot && !platform.IsCICommand(c.task.GetCommand(), platform.GetProto(c.task.GetAction(), c.task.GetCommand())) {
+	if c.createFromSnapshot && !platform.AllowsRemoteSnapshots(c.task.GetCommand(), platform.GetProto(c.task.GetAction(), c.task.GetCommand())) {
 		return false
 	}
 

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -1698,7 +1698,7 @@ printf '%s' $ATTEMPT_NUMBER | tee ./attempts
 	run("A", "2", 1) // Should resume from previous, and increment the counter
 }
 
-func TestFirecracker_RemoteSnapshotSharing_DevboxInstanceName(t *testing.T) {
+func TestFirecracker_RemoteSnapshotSharing_Devbox(t *testing.T) {
 	ctx := context.Background()
 	env := getTestEnv(ctx, t, envOpts{})
 	cfg := getExecutorConfig(t)
@@ -1725,6 +1725,7 @@ func TestFirecracker_RemoteSnapshotSharing_DevboxInstanceName(t *testing.T) {
 			Arguments: []string{"sh"},
 			Platform: &repb.Platform{Properties: []*repb.Platform_Property{
 				{Name: "recycle-runner", Value: "true"},
+				{Name: "allow-remote-snapshots", Value: "true"},
 			}},
 		},
 	}

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -972,7 +972,8 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 		if err != nil {
 			return nil, err
 		}
-		envVars, err = gcplink.ExchangeRefreshTokenForAuthToken(ctx, envVars, platform.IsCICommand(command, platform.GetProto(action, command)))
+		isCIRunner := platform.IsCIRunner(command, platform.GetProto(action, command))
+		envVars, err = gcplink.ExchangeRefreshTokenForAuthToken(ctx, envVars, /*shouldExchangeToken=*/isCIRunner)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -973,7 +973,7 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 			return nil, err
 		}
 		isCIRunner := platform.IsCIRunner(command, platform.GetProto(action, command))
-		envVars, err = gcplink.ExchangeRefreshTokenForAuthToken(ctx, envVars, /*shouldExchangeToken=*/isCIRunner)
+		envVars, err = gcplink.ExchangeRefreshTokenForAuthToken(ctx, envVars, isCIRunner/*=shouldExchangeToken*/)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -973,7 +973,7 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 			return nil, err
 		}
 		isCIRunner := platform.IsCIRunner(command, platform.GetProto(action, command))
-		envVars, err = gcplink.ExchangeRefreshTokenForAuthToken(ctx, envVars, isCIRunner/*=shouldExchangeToken*/)
+		envVars, err = gcplink.ExchangeRefreshTokenForAuthToken(ctx, envVars, isCIRunner /*=shouldExchangeToken*/)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -157,7 +157,7 @@ func parseTimeouts(task *repb.ExecutionTask) (*executionTimeouts, error) {
 
 func isClientBazel(task *repb.ExecutionTask) bool {
 	// TODO(bduffany): Find a more reliable way to determine this.
-	return !platform.IsCICommand(task.GetCommand(), platform.GetProto(task.GetAction(), task.GetCommand()))
+	return !platform.IsCIRunner(task.GetCommand(), platform.GetProto(task.GetAction(), task.GetCommand()))
 }
 
 func shouldRetry(task *repb.ExecutionTask, taskError error) bool {

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -337,7 +337,7 @@ func (r *taskRunner) DownloadInputs(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if platform.IsCICommand(r.task.GetCommand(), platform.GetProto(r.task.GetAction(), r.task.GetCommand())) &&
+	if platform.IsCIRunner(r.task.GetCommand(), platform.GetProto(r.task.GetAction(), r.task.GetCommand())) &&
 		!ci_runner_util.CanInitFromCache(r.PlatformProperties.OS, r.PlatformProperties.Arch) {
 		if err := r.Workspace.AddRemoteRunnerBinaries(ctx); err != nil {
 			return err

--- a/enterprise/server/scheduling/task_router/task_router.go
+++ b/enterprise/server/scheduling/task_router/task_router.go
@@ -425,7 +425,7 @@ type ciRunnerRouter struct {
 func (*ciRunnerRouter) Applies(_ context.Context, params routingParams) bool {
 	// TODO: pass parsed platform into routingParams and avoid manual parsing
 	// here.
-	return platform.IsCICommand(params.cmd, params.platform) && platform.IsTrue(platform.FindValue(params.platform, "recycle-runner"))
+	return platform.IsCIRunner(params.cmd, params.platform) && platform.IsTrue(platform.FindValue(params.platform, "recycle-runner"))
 }
 
 func (c *ciRunnerRouter) GetPreferredHostIDs(ctx context.Context, routingKey string) ([]string, error) {
@@ -471,7 +471,7 @@ func (*ciRunnerRouter) routingKeys(params routingParams) ([]string, error) {
 	// For workflow tasks, route using git branch name so that when re-running the
 	// workflow multiple times using the same branch, the runs are more likely
 	// to hit an executor with a warmer snapshot cache.
-	if platform.IsCICommand(params.cmd, params.platform) {
+	if platform.IsCIRunner(params.cmd, params.platform) {
 		envVarNames := []string{"GIT_BRANCH"}
 		if *defaultBranchRoutingEnabled {
 			envVarNames = append(envVarNames, "GIT_BASE_BRANCH", "GIT_REPO_DEFAULT_BRANCH")

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1233,6 +1233,7 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 				{Name: platform.EstimatedMemoryPropertyName, Value: workflowAction.ResourceRequests.GetEstimatedMemory()},
 				{Name: platform.EstimatedCPUPropertyName, Value: workflowAction.ResourceRequests.GetEstimatedCPU()},
 				{Name: platform.RetryPropertyName, Value: fmt.Sprintf("%v", retry)},
+				{Name: platform.AllowRemoteSnapshotsPropertyName, Value: "true"},
 			},
 		},
 	}

--- a/server/util/platform/platform.go
+++ b/server/util/platform/platform.go
@@ -863,8 +863,11 @@ func IsRecyclingEnabled(task *repb.ExecutionTask) bool {
 // AllowsRemoteSnapshots returns whether the given task may use remote
 // snapshots. This is true if the `allow-remote-snapshots` platform property is
 // set, and for CI runner commands, which have always been allowed to use them.
-func AllowsRemoteSnapshots(cmd *repb.Command, platform *repb.Platform) bool {
-	return IsTrue(FindValue(platform, allowRemoteSnapshotsPropertyName)) || IsCIRunner(cmd, platform)
+func AllowsRemoteSnapshots(task *repb.ExecutionTask) bool {
+	if IsTrue(FindEffectiveValue(task, allowRemoteSnapshotsPropertyName)) {
+		return true
+	}
+	return IsCIRunner(task.GetCommand(), GetProto(task.GetAction(), task.GetCommand()))
 }
 
 // IsCIRunner returns whether the given command is either a BuildBuddy workflow

--- a/server/util/platform/platform.go
+++ b/server/util/platform/platform.go
@@ -82,7 +82,7 @@ const (
 	RunnerRecyclingMaxWaitPropertyName       = "runner-recycling-max-wait"
 	runnerCrashedExitCodesPropertyName       = "runner-crashed-exit-codes"
 	transientErrorExitCodes                  = "transient-error-exit-codes"
-	allowRemoteSnapshotsPropertyName         = "allow-remote-snapshots"
+	AllowRemoteSnapshotsPropertyName         = "allow-remote-snapshots"
 	SnapshotSavePolicyPropertyName           = "remote-snapshot-save-policy"
 	SnapshotReadPolicyPropertyName           = "snapshot-read-policy"
 	MaxStaleFallbackSnapshotAgePropertyName  = "max-stale-fallback-snapshot-age"
@@ -864,7 +864,7 @@ func IsRecyclingEnabled(task *repb.ExecutionTask) bool {
 // snapshots. This is true if the `allow-remote-snapshots` platform property is
 // set, and for CI runner commands, which have always been allowed to use them.
 func AllowsRemoteSnapshots(task *repb.ExecutionTask) bool {
-	if IsTrue(FindEffectiveValue(task, allowRemoteSnapshotsPropertyName)) {
+	if IsTrue(FindEffectiveValue(task, AllowRemoteSnapshotsPropertyName)) {
 		return true
 	}
 	return IsCIRunner(task.GetCommand(), GetProto(task.GetAction(), task.GetCommand()))

--- a/server/util/platform/platform.go
+++ b/server/util/platform/platform.go
@@ -82,6 +82,7 @@ const (
 	RunnerRecyclingMaxWaitPropertyName       = "runner-recycling-max-wait"
 	runnerCrashedExitCodesPropertyName       = "runner-crashed-exit-codes"
 	transientErrorExitCodes                  = "transient-error-exit-codes"
+	allowRemoteSnapshotsPropertyName         = "allow-remote-snapshots"
 	SnapshotSavePolicyPropertyName           = "remote-snapshot-save-policy"
 	SnapshotReadPolicyPropertyName           = "snapshot-read-policy"
 	MaxStaleFallbackSnapshotAgePropertyName  = "max-stale-fallback-snapshot-age"
@@ -859,10 +860,17 @@ func IsRecyclingEnabled(task *repb.ExecutionTask) bool {
 	return parsed.RecycleRunner
 }
 
-// IsCICommand returns whether the given command is either a BuildBuddy workflow
+// AllowsRemoteSnapshots returns whether the given task may use remote
+// snapshots. This is true if the `allow-remote-snapshots` platform property is
+// set, and for CI runner commands, which have always been allowed to use them.
+func AllowsRemoteSnapshots(cmd *repb.Command, platform *repb.Platform) bool {
+	return IsTrue(FindValue(platform, allowRemoteSnapshotsPropertyName)) || IsCIRunner(cmd, platform)
+}
+
+// IsCIRunner returns whether the given command is either a BuildBuddy workflow
 // or a GitHub Actions runner task. These commands are longer-running and may
 // themselves invoke bazel.
-func IsCICommand(cmd *repb.Command, platform *repb.Platform) bool {
+func IsCIRunner(cmd *repb.Command, platform *repb.Platform) bool {
 	if len(cmd.GetArguments()) > 0 && cmd.GetArguments()[0] == "./buildbuddy_ci_runner" {
 		return true
 	}


### PR DESCRIPTION
1) Introduce a property `allow-remote-snapshots`, which, when set, allows any remote execution to save a snapshot to the remote cache.
2) Allow resaving local snapshots (behind the allow-remote-snapshots flag) if the snapshot save policy is always.