### PR TITLE
Accept subdomains specified via `x-buildbuddy-internal-subdomain` in the gRPC interceptors

### DIFF
--- a/server/rpc/interceptors/BUILD
+++ b/server/rpc/interceptors/BUILD
@@ -50,6 +50,8 @@ go_test(
         "//server/util/log",
         "//server/util/random",
         "//server/util/status",
+        "//server/util/subdomain",
+        "//server/util/testing/flags",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//:grpc",

--- a/server/rpc/interceptors/interceptors.go
+++ b/server/rpc/interceptors/interceptors.go
@@ -114,17 +114,27 @@ func addRequestIdToContext(ctx context.Context) context.Context {
 	return ctx
 }
 
+func clientIsGRPCProxy(env environment.Env, ctx context.Context) bool {
+	cis := env.GetClientIdentityService()
+	if cis == nil {
+		return false
+	}
+	si, err := cis.IdentityFromContext(ctx)
+	if err != nil || si == nil {
+		return false
+	}
+	return si.Client == interfaces.ClientIdentityGRPCProxy
+}
+
 func addClientIPToContext(ctx context.Context, env environment.Env) context.Context {
 	// Use the gRPC proxy-supplied client IP if it is provided and the caller
 	// is trusted, as verified by its clientidentity.
-	if cis := env.GetClientIdentityService(); cis != nil {
-		if si, err := cis.IdentityFromContext(ctx); err == nil && si != nil && si.Client == interfaces.ClientIdentityGRPCProxy {
-			// Require exactly one value: a trusted proxy sets a single header.
-			if hdrs := metadata.ValueFromIncomingContext(ctx, clientip.HeaderName); len(hdrs) == 1 {
-				return context.WithValue(ctx, clientip.ContextKey, hdrs[0])
-			} else if len(hdrs) > 1 {
-				log.CtxWarningf(ctx, "Multiple %q headers present in request from trusted proxy; ignoring", clientip.HeaderName)
-			}
+	if clientIsGRPCProxy(env, ctx) {
+		// Require exactly one value: a trusted proxy sets a single header.
+		if hdrs := metadata.ValueFromIncomingContext(ctx, clientip.HeaderName); len(hdrs) == 1 {
+			return context.WithValue(ctx, clientip.ContextKey, hdrs[0])
+		} else if len(hdrs) > 1 {
+			log.CtxWarningf(ctx, "Multiple %q headers present in request from trusted proxy; ignoring", clientip.HeaderName)
 		}
 	}
 
@@ -170,7 +180,16 @@ func addPeerIPToContext(ctx context.Context) context.Context {
 	return ctx
 }
 
-func addSubdomainToContext(ctx context.Context) context.Context {
+func addSubdomainToContext(ctx context.Context, env environment.Env) context.Context {
+	// Use internal-header-provided subdomains from trusted callers.
+	if clientIsGRPCProxy(env, ctx) {
+		if hdrs := metadata.ValueFromIncomingContext(ctx, subdomain.HeaderName); len(hdrs) == 1 {
+			return subdomain.SetResolved(ctx, hdrs[0])
+		} else if len(hdrs) > 1 {
+			log.CtxWarningf(ctx, "Multiple %q headers present in request from trusted proxy; ignoring", subdomain.HeaderName)
+		}
+	}
+
 	hdrs := metadata.ValueFromIncomingContext(ctx, ":authority")
 	if len(hdrs) == 0 {
 		return ctx
@@ -386,8 +405,10 @@ func clientIPStreamServerInterceptor(env environment.Env) grpc.StreamServerInter
 
 // subdomainStreamServerInterceptor adds customer subdomain information to the
 // context.
-func subdomainStreamServerInterceptor() grpc.StreamServerInterceptor {
-	return contextReplacingStreamServerInterceptor(addSubdomainToContext)
+func subdomainStreamServerInterceptor(env environment.Env) grpc.StreamServerInterceptor {
+	return contextReplacingStreamServerInterceptor(func(ctx context.Context) context.Context {
+		return addSubdomainToContext(ctx, env)
+	})
 }
 
 // clientIPUnaryInterceptor is a server interceptor that inserts the client IP
@@ -400,8 +421,10 @@ func clientIPUnaryServerInterceptor(env environment.Env) grpc.UnaryServerInterce
 
 // subdomainUnaryServerInterceptor adds customer subdomain information to the
 // context.
-func subdomainUnaryServerInterceptor() grpc.UnaryServerInterceptor {
-	return contextReplacingUnaryServerInterceptor(addSubdomainToContext)
+func subdomainUnaryServerInterceptor(env environment.Env) grpc.UnaryServerInterceptor {
+	return contextReplacingUnaryServerInterceptor(func(ctx context.Context) context.Context {
+		return addSubdomainToContext(ctx, env)
+	})
 }
 
 func addInvocationIdToLog(ctx context.Context) context.Context {
@@ -666,7 +689,7 @@ func GetUnaryInterceptor(env environment.Env, extraInterceptors ...grpc.UnarySer
 		identityUnaryServerInterceptor(env),
 		stripInternalHeadersUnaryServerInterceptor(env),
 		clientIPUnaryServerInterceptor(env),
-		subdomainUnaryServerInterceptor(),
+		subdomainUnaryServerInterceptor(env),
 		requestIDUnaryServerInterceptor(),
 		invocationIDLoggerUnaryServerInterceptor(),
 		logRequestUnaryServerInterceptor(),
@@ -694,7 +717,7 @@ func GetStreamInterceptor(env environment.Env, extraInterceptors ...grpc.StreamS
 		identityStreamServerInterceptor(env),
 		stripInternalHeadersStreamServerInterceptor(env),
 		clientIPStreamServerInterceptor(env),
-		subdomainStreamServerInterceptor(),
+		subdomainStreamServerInterceptor(env),
 		requestIDStreamServerInterceptor(),
 		invocationIDLoggerStreamServerInterceptor(),
 		logRequestStreamServerInterceptor(),

--- a/server/rpc/interceptors/interceptors_test.go
+++ b/server/rpc/interceptors/interceptors_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/subdomain"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -28,12 +30,14 @@ import (
 
 type pingServer struct {
 	lastClientIP   string
+	lastSubdomain  string
 	lastIncomingMD metadata.MD
 	lastOutgoingMD metadata.MD
 }
 
 func (p *pingServer) Ping(ctx context.Context, req *pspb.PingRequest) (*pspb.PingResponse, error) {
 	p.lastClientIP = clientip.Get(ctx)
+	p.lastSubdomain = subdomain.Get(ctx)
 	p.lastIncomingMD, _ = metadata.FromIncomingContext(ctx)
 	p.lastOutgoingMD, _ = metadata.FromOutgoingContext(ctx)
 	return &pspb.PingResponse{
@@ -347,6 +351,99 @@ func TestTrustedClientIPInterceptor(t *testing.T) {
 			assert.Equal(t, tc.wantIP, ps.lastClientIP)
 		})
 	}
+}
+
+func TestTrustedSubdomainInterceptor(t *testing.T) {
+	const assertedSubdomain = "acme"
+
+	for _, tc := range []struct {
+		name string
+		// clientIdentity is sent in the client-identity header; "" sends none.
+		clientIdentity string
+		wantSubdomain  string
+	}{
+		{
+			name:           "proxy identity may assert subdomain",
+			clientIdentity: interfaces.ClientIdentityGRPCProxy,
+			wantSubdomain:  assertedSubdomain,
+		},
+		{
+			name:           "app identity may not assert subdomain",
+			clientIdentity: interfaces.ClientIdentityApp,
+			wantSubdomain:  "",
+		},
+		{
+			name:           "cache-proxy identity may not assert subdomain",
+			clientIdentity: interfaces.ClientIdentityCacheProxy,
+			wantSubdomain:  "",
+		},
+		{
+			name:           "untrusted caller without identity may not assert subdomain",
+			clientIdentity: "",
+			wantSubdomain:  "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			flags.Set(t, "app.enable_subdomain_matching", true)
+			listenAddr := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+
+			env := testenv.GetTestEnv(t)
+			env.SetClientIdentityService(&fakeClientIdentityService{})
+
+			grpcServer := grpc.NewServer(grpc_server.CommonGRPCServerOptions(env)...)
+			ps := &pingServer{}
+			pspb.RegisterApiServer(grpcServer, ps)
+
+			lis, err := net.Listen("tcp", listenAddr)
+			require.NoError(t, err)
+			go func() { grpcServer.Serve(lis) }()
+			t.Cleanup(grpcServer.Stop)
+
+			conn, err := grpc.Dial(listenAddr, grpc.WithInsecure())
+			require.NoError(t, err)
+			t.Cleanup(func() { conn.Close() })
+
+			ctx := metadata.AppendToOutgoingContext(context.Background(), subdomain.HeaderName, assertedSubdomain)
+			if tc.clientIdentity != "" {
+				ctx = metadata.AppendToOutgoingContext(ctx, authutil.ClientIdentityHeaderName, tc.clientIdentity)
+			}
+			_, err = pspb.NewApiClient(conn).Ping(ctx, &pspb.PingRequest{Tag: 123})
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantSubdomain, ps.lastSubdomain)
+		})
+	}
+}
+
+// TestSubdomainInterceptorIgnoresHeaderWhenMatchingDisabled verifies that a
+// trusted proxy can't turn on subdomain restrictions for a server that has
+// subdomain matching disabled.
+func TestSubdomainInterceptorIgnoresHeaderWhenMatchingDisabled(t *testing.T) {
+	flags.Set(t, "app.enable_subdomain_matching", false)
+	listenAddr := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+
+	env := testenv.GetTestEnv(t)
+	env.SetClientIdentityService(&fakeClientIdentityService{})
+
+	grpcServer := grpc.NewServer(grpc_server.CommonGRPCServerOptions(env)...)
+	ps := &pingServer{}
+	pspb.RegisterApiServer(grpcServer, ps)
+
+	lis, err := net.Listen("tcp", listenAddr)
+	require.NoError(t, err)
+	go func() { grpcServer.Serve(lis) }()
+	t.Cleanup(grpcServer.Stop)
+
+	conn, err := grpc.Dial(listenAddr, grpc.WithInsecure())
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+
+	ctx := metadata.AppendToOutgoingContext(context.Background(), subdomain.HeaderName, "acme")
+	ctx = metadata.AppendToOutgoingContext(ctx, authutil.ClientIdentityHeaderName, interfaces.ClientIdentityGRPCProxy)
+	_, err = pspb.NewApiClient(conn).Ping(ctx, &pspb.PingRequest{Tag: 123})
+	require.NoError(t, err)
+
+	assert.Equal(t, "", ps.lastSubdomain)
 }
 
 func TestInternalHeadersAreStrippedBeforePropagation(t *testing.T) {

--- a/server/util/clientip/BUILD
+++ b/server/util/clientip/BUILD
@@ -17,6 +17,7 @@ go_test(
     srcs = ["clientip_test.go"],
     deps = [
         ":clientip",
+        "//server/util/authutil",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",
     ],

--- a/server/util/clientip/clientip_test.go
+++ b/server/util/clientip/clientip_test.go
@@ -2,8 +2,10 @@ package clientip_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/clientip"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/require"
@@ -88,4 +90,8 @@ func TestTrustHeaderOverridesTrustedPeers(t *testing.T) {
 	ctx, ok := clientip.SetFromXForwardedForHeader(context.Background(), "1.2.3.4", "11.1.2.3")
 	require.True(t, ok)
 	require.Equal(t, "1.2.3.4", clientip.Get(ctx))
+}
+
+func TestHeaderIsInternal(t *testing.T) {
+	require.True(t, strings.HasPrefix(clientip.HeaderName, authutil.InternalHeaderPrefix))
 }

--- a/server/util/subdomain/BUILD
+++ b/server/util/subdomain/BUILD
@@ -20,6 +20,7 @@ go_test(
     srcs = ["subdomain_test.go"],
     deps = [
         ":subdomain",
+        "//server/util/authutil",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",
     ],

--- a/server/util/subdomain/subdomain.go
+++ b/server/util/subdomain/subdomain.go
@@ -14,7 +14,14 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/urlutil"
 )
 
-const key = "subdomain"
+const (
+	key = "subdomain"
+
+	// HeaderName is the gRPC metadata key a trusted forwarding proxy uses to
+	// assert the subdomain the original request was addressed to. It is an
+	// internal header, so it is stripped when sent by an untrusted caller.
+	HeaderName = "x-buildbuddy-internal-subdomain"
+)
 
 var (
 	enableSubdomainMatching = flag.Bool("app.enable_subdomain_matching", false, "If true, request subdomain will be taken into account when determining what request restrictions should be applied.")
@@ -46,6 +53,13 @@ func SetHost(ctx context.Context, host string) context.Context {
 
 func Context(ctx context.Context, subdomain string) context.Context {
 	return context.WithValue(ctx, key, subdomain)
+}
+
+func SetResolved(ctx context.Context, subdomain string) context.Context {
+	if !*enableSubdomainMatching || subdomain == "" {
+		return ctx
+	}
+	return Context(ctx, subdomain)
 }
 
 // Get returns the subdomain restriction that should be applied or an empty

--- a/server/util/subdomain/subdomain_test.go
+++ b/server/util/subdomain/subdomain_test.go
@@ -3,8 +3,10 @@ package subdomain_test
 import (
 	"context"
 	"net/url"
+	"strings"
 	"testing"
 
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/subdomain"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/require"
@@ -30,4 +32,8 @@ func TestSetHost(t *testing.T) {
 
 	// Subdomains on a different domain shouldn't match.
 	require.Equal(t, "", getSubdomain("sub.notbuildbuddy.io"))
+}
+
+func TestHeaderIsInternal(t *testing.T) {
+	require.True(t, strings.HasPrefix(subdomain.HeaderName, authutil.InternalHeaderPrefix))
 }


### PR DESCRIPTION
We require API keys match the subdomain a request was made to, but this doesn't work for RPCs forwarded through `grpc_forward.go` because that logic drops the subdomain from the forwarded request. This is change 1 of 2 to fix this, it makes the server that does the subdomain matching accept subdomains sent via `x-buildbuddy-internal-subdomain` if the caller is trusted.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7963