### PR TITLE
Rename `distributed_cache.verify_gcs_references` to `distributed_cache.verify_read_gcs_references`

### DIFF
--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -335,7 +335,7 @@ func (c *Proxy) referenceReadMode(ctx context.Context) (sendReference bool, send
 	if fp == nil {
 		return false, true
 	}
-	if fp.Boolean(ctx, "distributed_cache.verify_gcs_references", false) {
+	if fp.Boolean(ctx, "distributed_cache.verify_read_gcs_references", false) {
 		return true, true
 	}
 	if fp.Boolean(ctx, "distributed_cache.read_gcs_references", false) {

--- a/enterprise/server/util/distributed_client/distributed_client_test.go
+++ b/enterprise/server/util/distributed_client/distributed_client_test.go
@@ -1618,7 +1618,7 @@ func setReferenceReadExperiments(t *testing.T, te *testenv.TestEnv, readReferenc
 			DefaultVariant: "on",
 			Variants:       map[string]any{"on": readReferences},
 		},
-		"distributed_cache.verify_gcs_references": {
+		"distributed_cache.verify_read_gcs_references": {
 			State:          memprovider.Enabled,
 			DefaultVariant: "on",
 			Variants:       map[string]any{"on": verifyReferences},


### PR DESCRIPTION
We will probably need some verification mechanism on the write path, so this just makes it more clear what this experiment is for.