### PR TITLE
[RB] Fix build remotely run locally for runfile symlinks

### DIFF
--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -925,18 +925,10 @@ func downloadOutputs(ctx context.Context, env environment.Env, mainOutputs []*be
 		}
 		relArtifacts = append(relArtifacts, "  "+rp)
 	}
-	fmt.Printf("Downloaded artifacts:\n%s\n", strings.Join(relArtifacts, "\n"))
-	return mainLocalArtifacts, nil
-}
-
-func findExecutableOutput(outputs []string, outputBaseDir, executablePath string) (string, error) {
-	expectedPath := filepath.Clean(filepath.Join(outputBaseDir, BuildBuddyArtifactDir, executablePath))
-	for _, output := range outputs {
-		if filepath.Clean(output) == expectedPath {
-			return output, nil
-		}
+	if len(relArtifacts) > 0 {
+		fmt.Printf("Downloaded artifacts:\n%s\n", strings.Join(relArtifacts, "\n"))
 	}
-	return "", fmt.Errorf("run executable %q not found among downloaded artifacts", executablePath)
+	return mainLocalArtifacts, nil
 }
 
 // envWithRunfilesDir ensures a locally-run target (build-remotely-run-locally) resolves
@@ -1214,19 +1206,26 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 			env.SetByteStreamClient(bspb.NewByteStreamClient(conn))
 			env.SetContentAddressableStorageClient(repb.NewContentAddressableStorageClient(conn))
 
-			mainOutputs, err := lookupBazelInvocationOutputs(ctx, bbClient, childIID)
-			if err != nil {
-				return 1, fmt.Errorf("lookup invocation outputs for %q: %w", childIID, err)
+			// For build-remotely run-locally, the main output is the executable and will be included
+			// by the ci_runner in the runfiles entries, so doesn't need to be explicitly downloaded as a
+			// `mainOutput`. (Even though the executable's path is not
+			// within the runfiles directory, we do this to ensure it is always uploaded to the cache).
+			var mainOutputs []*bespb.File
+			if !opts.RunOutputLocally {
+				mainOutputs, err = lookupBazelInvocationOutputs(ctx, bbClient, childIID)
+				if err != nil {
+					return 1, fmt.Errorf("lookup invocation outputs for %q: %w", childIID, err)
+				}
 			}
 			outputsBaseDir := filepath.Dir(opts.WorkspaceFilePath)
-			outputs, err := downloadOutputs(ctx, env, mainOutputs, runfiles, runfileDirectories, outputsBaseDir)
+			_, err = downloadOutputs(ctx, env, mainOutputs, runfiles, runfileDirectories, outputsBaseDir)
 			if err != nil {
 				return 1, fmt.Errorf("download invocation outputs for %q: %w", childIID, err)
 			}
 			if opts.RunOutputLocally {
-				binPath, err := findExecutableOutput(outputs, outputsBaseDir, executablePath)
-				if err != nil {
-					return 1, err
+				binPath := filepath.Join(outputsBaseDir, BuildBuddyArtifactDir, executablePath)
+				if _, err := os.Stat(binPath); err != nil {
+					return 1, fmt.Errorf("locate downloaded executable %q: %w", binPath, err)
 				}
 				absBinPath, err := filepath.Abs(binPath)
 				if err != nil {

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -862,10 +862,11 @@ func bytestreamURIToResourceName(uri string) (*digest.CASResourceName, error) {
 
 // TODO(vadim): add interactive progress bar for downloads
 // TODO(vadim): parallelize downloads
-func downloadOutputs(ctx context.Context, env environment.Env, mainOutputs []*bespb.File, runfiles []*bespb.Runfile, supportingDirs []*bespb.Tree, outputBaseDir string) ([]string, error) {
+func downloadOutputs(ctx context.Context, env environment.Env, mainOutputs []*bespb.File, runfiles []*bespb.Runfile, supportingDirs []*bespb.Tree, outputBaseDir string) (map[string]struct{}, error) {
 	bsClient := env.GetByteStreamClient()
 
 	var mainLocalArtifacts []string
+	downloadedFiles := make(map[string]struct{})
 	download := func(f *bespb.File, mode os.FileMode) (string, error) {
 		r, err := bytestreamURIToResourceName(f.GetUri())
 		if err != nil {
@@ -879,6 +880,7 @@ func downloadOutputs(ctx context.Context, env environment.Env, mainOutputs []*be
 		if err := downloadFile(ctx, bsClient, r, outFile, mode); err != nil {
 			return "", fmt.Errorf("download output %q: %w", f.GetName(), err)
 		}
+		downloadedFiles[filepath.Clean(outFile)] = struct{}{}
 		return outFile, nil
 	}
 	for _, f := range mainOutputs {
@@ -928,7 +930,25 @@ func downloadOutputs(ctx context.Context, env environment.Env, mainOutputs []*be
 	if len(relArtifacts) > 0 {
 		fmt.Printf("Downloaded artifacts:\n%s\n", strings.Join(relArtifacts, "\n"))
 	}
-	return mainLocalArtifacts, nil
+	return downloadedFiles, nil
+}
+
+func downloadedExecutablePath(downloadedFiles map[string]struct{}, outputBaseDir, executablePath string) (string, error) {
+	if executablePath == "" {
+		return "", fmt.Errorf("run executable path is empty")
+	}
+	binPath := filepath.Join(outputBaseDir, BuildBuddyArtifactDir, executablePath)
+	if _, ok := downloadedFiles[filepath.Clean(binPath)]; !ok {
+		return "", fmt.Errorf("run executable %q was not downloaded", executablePath)
+	}
+	info, err := os.Lstat(binPath)
+	if err != nil {
+		return "", fmt.Errorf("locate downloaded executable %q: %w", binPath, err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("downloaded executable %q is not a regular file", binPath)
+	}
+	return binPath, nil
 }
 
 // envWithRunfilesDir ensures a locally-run target (build-remotely-run-locally) resolves
@@ -1218,14 +1238,14 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 				}
 			}
 			outputsBaseDir := filepath.Dir(opts.WorkspaceFilePath)
-			_, err = downloadOutputs(ctx, env, mainOutputs, runfiles, runfileDirectories, outputsBaseDir)
+			downloadedFiles, err := downloadOutputs(ctx, env, mainOutputs, runfiles, runfileDirectories, outputsBaseDir)
 			if err != nil {
 				return 1, fmt.Errorf("download invocation outputs for %q: %w", childIID, err)
 			}
 			if opts.RunOutputLocally {
-				binPath := filepath.Join(outputsBaseDir, BuildBuddyArtifactDir, executablePath)
-				if _, err := os.Stat(binPath); err != nil {
-					return 1, fmt.Errorf("locate downloaded executable %q: %w", binPath, err)
+				binPath, err := downloadedExecutablePath(downloadedFiles, outputsBaseDir, executablePath)
+				if err != nil {
+					return 1, err
 				}
 				absBinPath, err := filepath.Abs(binPath)
 				if err != nil {

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1456,6 +1456,12 @@ type runfile struct {
 func collectRunfiles(runfilesDir string) ([]*runfile, map[string]string, error) {
 	var runfiles []*runfile
 	dirsToUpload := make(map[string]string)
+	if _, err := os.Stat(runfilesDir); err != nil {
+		if os.IsNotExist(err) {
+			return runfiles, dirsToUpload, nil
+		}
+		return nil, nil, status.UnknownErrorf("could not setup runtime files: %s", err)
+	}
 	err := filepath.WalkDir(runfilesDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -1497,10 +1503,10 @@ func collectRunfiles(runfilesDir string) ([]*runfile, map[string]string, error) 
 		})
 		return nil
 	})
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil {
 		return nil, nil, status.UnknownErrorf("could not setup runtime files: %s", err)
 	}
-	return runfiles, dirsToUpload, err
+	return runfiles, dirsToUpload, nil
 }
 
 func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir, executablePath string) ([]*bespb.File, []*bespb.Tree, []*bespb.Runfile, error) {

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1443,12 +1443,18 @@ type runInfo struct {
 }
 
 type runfile struct {
-	path         string
+	// logicalPath is the path the executable expects to find inside its runfiles tree
+	// For a symlink, this could be different from the physical path where the file's bytes
+	// physically live on the remote runner. Many logical paths can map to the same physical path.
+	logicalPath string
+	// physicalPath is the path where the file's bytes actually live.
+	physicalPath string
+	digest       *repb.Digest
 	isExecutable bool
 }
 
-func collectRunfiles(runfilesDir string) (map[digest.Key]*runfile, map[string]string, error) {
-	fileDigestMap := make(map[digest.Key]*runfile)
+func collectRunfiles(runfilesDir string) ([]*runfile, map[string]string, error) {
+	var runfiles []*runfile
 	dirsToUpload := make(map[string]string)
 	err := filepath.WalkDir(runfilesDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -1457,54 +1463,51 @@ func collectRunfiles(runfilesDir string) (map[digest.Key]*runfile, map[string]st
 		if d.IsDir() {
 			return nil
 		}
+
 		// Get file metadata for symlinks.
-		var info fs.FileInfo
+		physicalPath := path
 		if d.Type()&fs.ModeSymlink != 0 {
-			t, err := os.Readlink(path)
+			// Resolve all symlinks.
+			physicalPath, err = filepath.EvalSymlinks(path)
 			if err != nil {
 				return err
 			}
-			targetPath := t
-			if !filepath.IsAbs(targetPath) {
-				targetPath = filepath.Join(filepath.Dir(path), targetPath)
-			}
-			info, err = os.Stat(targetPath)
+			info, err := os.Stat(physicalPath)
 			if err != nil {
 				return err
 			}
 			if info.IsDir() {
-				dirsToUpload[path] = targetPath
+				dirsToUpload[path] = physicalPath
 				return nil
 			}
 		}
-		// Get file metadata for regular files.
-		if info == nil {
-			info, err = d.Info()
-			if err != nil {
-				return err
-			}
-		}
-		rn, err := cachetools.ComputeFileDigest(path, *remoteInstanceName, repb.DigestFunction_SHA256)
+		info, err := os.Stat(physicalPath)
 		if err != nil {
 			return err
 		}
-		fileDigestMap[digest.NewKey(rn.GetDigest())] = &runfile{
-			path:         path,
-			isExecutable: info.Mode()&0111 != 0,
+		rn, err := cachetools.ComputeFileDigest(physicalPath, *remoteInstanceName, repb.DigestFunction_SHA256)
+		if err != nil {
+			return err
 		}
+		runfiles = append(runfiles, &runfile{
+			logicalPath:  path,
+			physicalPath: physicalPath,
+			digest:       rn.GetDigest(),
+			isExecutable: info.Mode()&0111 != 0,
+		})
 		return nil
 	})
 	if err != nil && !os.IsNotExist(err) {
 		return nil, nil, status.UnknownErrorf("could not setup runtime files: %s", err)
 	}
-	return fileDigestMap, dirsToUpload, err
+	return runfiles, dirsToUpload, err
 }
 
-func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*bespb.File, []*bespb.Tree, []*bespb.Runfile, error) {
+func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir, executablePath string) ([]*bespb.File, []*bespb.Tree, []*bespb.Runfile, error) {
 	healthChecker := healthcheck.NewHealthChecker("ci-runner")
 	env := real_environment.NewRealEnv(healthChecker)
 
-	fileDigestMap, dirs, err := collectRunfiles(runfilesDir)
+	runfileMetadata, dirs, err := collectRunfiles(runfilesDir)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -1522,21 +1525,32 @@ func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*
 	}
 	bytestreamURIPrefix := "bytestream://" + backendURL.Host
 
-	var digests []*repb.Digest
+	// We keep separate fields for digests to upload because the same digest may appear at multiple logical paths,
+	// but only needs one upload.
+	digestToPhysicalPath := make(map[string]string)
+	var digestsToUpload []*repb.Digest
+	// The runfiles slices should contain an entry for every logical path, even if the same digest appears multiple times,
+	// so we can recreate the entire runfiles tree.
 	var runfiles []*bespb.File
 	var runfileEntries []*bespb.Runfile
-	for d, runfileInfo := range fileDigestMap {
-		digests = append(digests, d.ToDigest())
-		relPath, err := filepath.Rel(workspaceRoot, runfileInfo.path)
+	for _, runfileInfo := range runfileMetadata {
+		d := runfileInfo.digest
+		if _, ok := digestToPhysicalPath[d.GetHash()]; !ok {
+			digestToPhysicalPath[d.GetHash()] = runfileInfo.physicalPath
+			digestsToUpload = append(digestsToUpload, d)
+		}
+		relPath, err := filepath.Rel(workspaceRoot, runfileInfo.logicalPath)
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		downloadString := digest.NewCASResourceName(d.ToDigest(), *remoteInstanceName, repb.DigestFunction_SHA256).DownloadString()
+		downloadString := digest.NewCASResourceName(d, *remoteInstanceName, repb.DigestFunction_SHA256).DownloadString()
 		if !strings.HasPrefix(downloadString, "/") {
 			downloadString = "/" + downloadString
 		}
 		runfile := &bespb.File{
-			Name: relPath,
+			Name:   relPath,
+			Digest: d.GetHash(),
+			Length: d.GetSizeBytes(),
 			File: &bespb.File_Uri{
 				Uri: fmt.Sprintf("%s%s", bytestreamURIPrefix, downloadString),
 			},
@@ -1547,9 +1561,49 @@ func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*
 			IsExecutable: runfileInfo.isExecutable,
 		})
 	}
+
+	// The executable may itself be a symlink. Ensure its physical contents are uploaded
+	// to the cache so that they can be downloaded.
+	resolvedExecutablePath, err := filepath.EvalSymlinks(executablePath)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	executableRN, err := cachetools.ComputeFileDigest(resolvedExecutablePath, *remoteInstanceName, repb.DigestFunction_SHA256)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	executableDigest := executableRN.GetDigest()
+	if _, ok := digestToPhysicalPath[executableDigest.GetHash()]; !ok {
+		digestToPhysicalPath[executableDigest.GetHash()] = resolvedExecutablePath
+		digestsToUpload = append(digestsToUpload, executableDigest)
+	}
+	executableRelPath, err := filepath.Rel(workspaceRoot, executablePath)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	executableDownloadString := digest.NewCASResourceName(executableDigest, *remoteInstanceName, repb.DigestFunction_SHA256).DownloadString()
+	if !strings.HasPrefix(executableDownloadString, "/") {
+		executableDownloadString = "/" + executableDownloadString
+	}
+	executableFile := &bespb.File{
+		Name:   executableRelPath,
+		Digest: executableDigest.GetHash(),
+		Length: executableDigest.GetSizeBytes(),
+		File: &bespb.File_Uri{
+			Uri: fmt.Sprintf("%s%s", bytestreamURIPrefix, executableDownloadString),
+		},
+	}
+	// Include the executable in the runfiles event, even though it's a top-level output and
+	// is uploaded separately by bazel, to guarantee it is always uploaded to the cache.
+	runfiles = append(runfiles, executableFile)
+	runfileEntries = append(runfileEntries, &bespb.Runfile{
+		File:         executableFile,
+		IsExecutable: true,
+	})
+
 	rsp, err := env.GetContentAddressableStorageClient().FindMissingBlobs(ctx, &repb.FindMissingBlobsRequest{
 		InstanceName: *remoteInstanceName,
-		BlobDigests:  digests,
+		BlobDigests:  digestsToUpload,
 		Purpose:      repb.FindMissingBlobsRequest_CI_RUNNER_UPLOAD,
 	})
 	if err != nil {
@@ -1561,12 +1615,12 @@ func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*
 	u := cachetools.NewBatchCASUploader(ctx, env, *remoteInstanceName, repb.DigestFunction_SHA256, nil /*=chunkingParams*/)
 
 	for _, d := range missingDigests {
-		runfileInfo, ok := fileDigestMap[digest.NewKey(d)]
+		uploadPath, ok := digestToPhysicalPath[d.GetHash()]
 		if !ok {
 			// not supposed to happen...
 			return nil, nil, nil, status.InternalErrorf("missing digest not in our digest map")
 		}
-		f, err := os.Open(runfileInfo.path)
+		f, err := os.Open(uploadPath)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -1609,7 +1663,6 @@ func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*
 	if err := eg.Wait(); err != nil {
 		return nil, nil, nil, err
 	}
-
 	return runfiles, runfileDirs, runfileEntries, nil
 }
 
@@ -1668,7 +1721,7 @@ func processRunScript(ctx context.Context, runScript string) (*runInfo, error) {
 	}
 
 	runfilesDir := bin + ".runfiles"
-	runfiles, runfileDirs, runfileEntries, err := uploadRunfiles(ctx, wsRoot, runfilesDir)
+	runfiles, runfileDirs, runfileEntries, err := uploadRunfiles(ctx, wsRoot, runfilesDir, bin)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/cmd/ci_runner/main_test.go
+++ b/enterprise/server/cmd/ci_runner/main_test.go
@@ -35,7 +35,9 @@ func TestCollectRunfiles_RelativeDirectorySymlink(t *testing.T) {
 	files, dirs, err := collectRunfiles(runfilesDir)
 	assert.NoError(t, err)
 	assert.Empty(t, files)
-	assert.Equal(t, map[string]string{linkPath: targetDir}, dirs)
+	resolvedTargetDir, err := filepath.EvalSymlinks(targetDir)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{linkPath: resolvedTargetDir}, dirs)
 }
 
 func TestCollectRunfiles_ExecutableMetadata(t *testing.T) {
@@ -51,12 +53,45 @@ func TestCollectRunfiles_ExecutableMetadata(t *testing.T) {
 
 	executableByPath := make(map[string]bool, len(files))
 	for _, runfile := range files {
-		executableByPath[runfile.path] = runfile.isExecutable
+		executableByPath[runfile.logicalPath] = runfile.isExecutable
 	}
 	assert.Equal(t, map[string]bool{
 		executablePath:    true,
 		nonExecutablePath: false,
 	}, executableByPath)
+}
+
+func TestCollectRunfiles_ResolvesFileSymlinks(t *testing.T) {
+	rootDir := t.TempDir()
+	targetPath := filepath.Join(rootDir, "target")
+	require.NoError(t, os.WriteFile(targetPath, []byte("contents"), 0755))
+
+	runfilesDir := filepath.Join(rootDir, "binary.runfiles")
+	require.NoError(t, os.Mkdir(runfilesDir, 0755))
+	firstLink := filepath.Join(runfilesDir, "first")
+	secondLink := filepath.Join(runfilesDir, "second")
+	require.NoError(t, os.Symlink(targetPath, firstLink))
+	require.NoError(t, os.Symlink(targetPath, secondLink))
+
+	files, dirs, err := collectRunfiles(runfilesDir)
+	require.NoError(t, err)
+	require.Empty(t, dirs)
+	// Output should still contain two entries, one for each symlink,
+	// even though the physical path is the same.
+	require.Len(t, files, 2)
+
+	filesByPath := make(map[string]*runfile, len(files))
+	for _, f := range files {
+		filesByPath[f.logicalPath] = f
+	}
+	for _, logicalPath := range []string{firstLink, secondLink} {
+		f := filesByPath[logicalPath]
+		require.NotNil(t, f)
+		require.Equal(t, targetPath, f.physicalPath)
+		require.True(t, f.isExecutable)
+		require.NotNil(t, f.digest)
+	}
+	require.Equal(t, filesByPath[firstLink].digest, filesByPath[secondLink].digest)
 }
 
 type stallingReadCloser struct {

--- a/enterprise/server/cmd/ci_runner/main_test.go
+++ b/enterprise/server/cmd/ci_runner/main_test.go
@@ -84,10 +84,12 @@ func TestCollectRunfiles_ResolvesFileSymlinks(t *testing.T) {
 	for _, f := range files {
 		filesByPath[f.logicalPath] = f
 	}
+	resolvedTargetPath, err := filepath.EvalSymlinks(targetPath)
+	require.NoError(t, err)
 	for _, logicalPath := range []string{firstLink, secondLink} {
 		f := filesByPath[logicalPath]
 		require.NotNil(t, f)
-		require.Equal(t, targetPath, f.physicalPath)
+		require.Equal(t, resolvedTargetPath, f.physicalPath)
 		require.True(t, f.isExecutable)
 		require.NotNil(t, f.digest)
 	}

--- a/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
+++ b/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
@@ -662,12 +662,15 @@ func TestBuildRemotelyRunLocally_ExecutableRunfile(t *testing.T) {
 		"BUILD": `
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
+# Even though bazel does not upload the targets to the cache,
+# the CI runner should still upload them.
 genrule(
     name = "generated_script",
     srcs = ["main.sh"],
     outs = ["main-generated.sh"],
     cmd = "cp $< $@",
     executable = True,
+    tags = ["no-remote-cache"],
 )
 
 genrule(
@@ -675,6 +678,7 @@ genrule(
     srcs = ["helper.sh"],
     outs = ["helper-generated.sh"],
     cmd = "cp $< $@ && chmod +x $@",
+    tags = ["no-remote-cache"],
 )
 
 sh_binary(
@@ -705,6 +709,7 @@ echo "Hello from an executable runfile!"
 		"--run_remotely=0",
 		"run",
 		":main",
+		"--remote_build_event_upload=minimal",
 		fmt.Sprintf("--remote_header=x-buildbuddy-api-key=%s", env.APIKey1))
 	require.Contains(t, output, "Hello from an executable runfile!")
 }


### PR DESCRIPTION
For build remotely run locally, if the runfiles directory contains symlinks, make sure the underlying files are uploaded to the cache so we can fetch them locally

Also fixes a bug where before we had a runfiles map keyed by digest. If multiple runfiles had the same digest, they'd clobber each other and the runfiles directory might be missing files