### PR TITLE
Optimize distributed cache Get

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -1442,60 +1442,29 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*rspb.ResourceName)
 	return missing, nil
 }
 
-// The first reader with a non-empty value will be returned. If all potential
-// peers for the digest are exhausted, then return a NotFoundError.
-//
-// This is like setting READ_CONSISTENCY = ONE.
-//
-// Values found on a non-primary replica will be backfilled to the primary.
-func (c *Cache) distributedReader(ctx context.Context, rn *rspb.ResourceName, offset, limit int64, metricsLabel string) (io.ReadCloser, error) {
-	ps := c.readPeers(rn)
-	lookups := 0
-	for peer := ps.GetNextPeer(); peer != ""; peer = ps.GetNextPeer() {
-		lookups++
-		r, err := c.remoteReader(ctx, peer, rn, offset, limit)
-		if err == nil {
-			c.backfillPeers(ctx, c.getBackfillOrders(rn, ps))
-			metrics.DistributedCachePeerLookups.WithLabelValues(
-				metricsLabel,
-				metrics.HitStatusLabel,
-			).Observe(float64(lookups))
-			return r, err
-		}
-		if status.IsNotFoundError(err) {
-			c.log.CtxDebugf(ctx, "Reader(%q) not found on peer %s", distributed_client.ResourceIsolationString(rn), peer)
-			continue
-		}
-		c.log.CtxDebugf(ctx, "Reader(%q) error on peer %s: %s", distributed_client.ResourceIsolationString(rn), peer, err)
-
-		// Some other error -- mark this peer as failed and try the next one.
-		ps.MarkPeerAsFailed(peer)
-
-	}
-	metrics.DistributedCachePeerLookups.WithLabelValues(
-		metricsLabel,
-		metrics.MissStatusLabel,
-	).Observe(float64(lookups))
-	c.log.CtxDebugf(ctx, "Exhausted all peers attempting to read %q. Peerset: %+v", rn.GetDigest().GetHash(), ps)
-	return nil, status.NotFoundErrorf("Exhausted all peers attempting to read %q.", rn.GetDigest().GetHash())
-}
-
-// Below, in Get(), this value is the max initial allocatable buffer size.
-// Set it somewhat conservatively so that we're not DOSed by someone crafting
-// remote_instance_names that match this just to use memory.
-const maxInitialByteBufferSize = (1024 * 1024 * 4)
-
 func (c *Cache) Get(ctx context.Context, rn *rspb.ResourceName) ([]byte, error) {
-	r, err := c.distributedReader(ctx, rn, 0, 0, "Get" /*=metricsLabel*/)
-	if err != nil {
-		return nil, err
+	if data, found := c.getLookasideEntry(ctx, rn); found {
+		return data, nil
 	}
-	defer r.Close()
+	readThroughCacheable := c.localReadthroughEnabled() && isLocalReadthroughCacheableResource(rn)
+	if readThroughCacheable {
+		data, err := c.local.Get(ctx, rn)
+		if err == nil {
+			c.addLookasideEntry(ctx, rn, data)
+			return data, nil
+		}
+	}
 
-	bufSize := digest.SafeBufferSize(rn, maxInitialByteBufferSize)
-	buf := bytes.NewBuffer(make([]byte, 0, bufSize))
-	_, err = io.Copy(buf, r)
-	return buf.Bytes(), err
+	data, _, err := c.getWithMetadata(ctx, rn, "Get" /*=metricsLabel*/)
+	if err == nil {
+		c.addLookasideEntry(ctx, rn, data)
+		if readThroughCacheable {
+			if err := c.local.Set(ctx, rn, data); err != nil {
+				c.log.CtxDebugf(ctx, "Error writing to local read-through cache: %s", err)
+			}
+		}
+	}
+	return data, err
 }
 
 func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
@@ -1787,8 +1756,33 @@ func (c *Cache) Delete(ctx context.Context, r *rspb.ResourceName) error {
 	return nil
 }
 
-func (c *Cache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
-	return c.distributedReader(ctx, r, uncompressedOffset, limit, "Reader" /*=metricsLabel*/)
+// The first reader with a non-empty value will be returned. If all potential
+// peers for the digest are exhausted, then return a NotFoundError.
+//
+// This is like setting READ_CONSISTENCY = ONE.
+//
+// Values found on a non-primary replica will be backfilled to the primary.
+func (c *Cache) Reader(ctx context.Context, rn *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
+	ps := c.readPeers(rn)
+	lookups := 0
+	for peer := ps.GetNextPeer(); peer != ""; peer = ps.GetNextPeer() {
+		lookups++
+		r, err := c.remoteReader(ctx, peer, rn, uncompressedOffset, limit)
+		if err == nil {
+			c.backfillPeers(ctx, c.getBackfillOrders(rn, ps))
+			metrics.DistributedCachePeerLookups.WithLabelValues("Reader", metrics.HitStatusLabel).Observe(float64(lookups))
+			return r, err
+		}
+		if status.IsNotFoundError(err) {
+			c.log.CtxDebugf(ctx, "Reader(%q) not found on peer %s", distributed_client.ResourceIsolationString(rn), peer)
+			continue
+		}
+		c.log.CtxDebugf(ctx, "Reader(%q) error on peer %s: %s", distributed_client.ResourceIsolationString(rn), peer, err)
+		ps.MarkPeerAsFailed(peer)
+	}
+	metrics.DistributedCachePeerLookups.WithLabelValues("Reader", metrics.MissStatusLabel).Observe(float64(lookups))
+	c.log.CtxDebugf(ctx, "Exhausted all peers attempting to read %q. Peerset: %+v", rn.GetDigest().GetHash(), ps)
+	return nil, status.NotFoundErrorf("Exhausted all peers attempting to read %q.", rn.GetDigest().GetHash())
 }
 
 func (c *Cache) Writer(ctx context.Context, r *rspb.ResourceName) (interfaces.CommittedWriteCloser, error) {

--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -3426,6 +3426,7 @@ type Op int
 const (
 	Read Op = iota
 	Get
+	GetWithMetadata
 	GetMulti
 	Write
 	Set
@@ -3442,6 +3443,8 @@ func (o Op) String() string {
 		return "READ"
 	case Get:
 		return "GET"
+	case GetWithMetadata:
+		return "GET_WITH_METADATA"
 	case GetMulti:
 		return "GET_MULTI"
 	case Write:
@@ -3514,6 +3517,10 @@ func (t *tracedCache) FindMissing(ctx context.Context, resources []*rspb.Resourc
 func (t *tracedCache) Get(ctx context.Context, r *rspb.ResourceName) ([]byte, error) {
 	t.addOps(Get, r)
 	return t.Cache.Get(ctx, r)
+}
+func (t *tracedCache) GetWithMetadata(ctx context.Context, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	t.addOps(GetWithMetadata, r)
+	return t.Cache.GetWithMetadata(ctx, r)
 }
 func (t *tracedCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
 	t.addOps(GetMulti, resources...)


### PR DESCRIPTION
When fetching from remote, using GetWithMetadata instead of Reader is ~15% faster and allocates ~20% less, because it doesn't need a buffer to read into.

Benchmark results
```
                                          │     base     │              withmeta              │
                                          │    sec/op    │   sec/op     vs base               │
GetSingle/DistPebble10/AC-24                 91.48µ ± 4%   77.05µ ± 2%  -15.77% (p=0.001 n=7)
GetSingle/DistPebble10/CAS-24                89.05µ ± 1%   75.75µ ± 1%  -14.94% (p=0.001 n=7)
GetSingle/DistPebble100/AC-24                91.85µ ± 1%   77.44µ ± 1%  -15.69% (p=0.001 n=7)
GetSingle/DistPebble100/CAS-24               90.09µ ± 1%   76.18µ ± 1%  -15.44% (p=0.001 n=7)
GetSingle/DistPebble1000/AC-24               92.18µ ± 5%   76.88µ ± 2%  -16.59% (p=0.001 n=7)
GetSingle/DistPebble1000/CAS-24              89.97µ ± 1%   75.98µ ± 5%  -15.54% (p=0.001 n=7)
GetSingle/DistPebble10000/AC-24             109.43µ ± 2%   92.84µ ± 4%  -15.16% (p=0.001 n=7)
GetSingle/DistPebble10000/CAS-24            105.73µ ± 2%   91.89µ ± 2%  -13.08% (p=0.001 n=7)
GetSingle/LookasideDistPebble10/AC-24        92.15µ ± 1%   77.82µ ± 1%  -15.55% (p=0.001 n=7)
GetSingle/LookasideDistPebble10/CAS-24       703.0n ± 4%   239.7n ± 4%  -65.90% (p=0.001 n=7)
GetSingle/LookasideDistPebble100/AC-24       92.99µ ± 4%   76.57µ ± 3%  -17.66% (p=0.001 n=7)
GetSingle/LookasideDistPebble100/CAS-24      766.9n ± 2%   247.3n ± 3%  -67.75% (p=0.001 n=7)
GetSingle/LookasideDistPebble1000/AC-24      93.36µ ± 1%   77.46µ ± 7%  -17.03% (p=0.001 n=7)
GetSingle/LookasideDistPebble1000/CAS-24     894.9n ± 3%   252.3n ± 2%  -71.81% (p=0.001 n=7)
GetSingle/LookasideDistPebble10000/AC-24    107.33µ ± 2%   92.96µ ± 3%  -13.38% (p=0.001 n=7)
GetSingle/LookasideDistPebble10000/CAS-24   114.36µ ± 1%   94.28µ ± 2%  -17.56% (p=0.001 n=7)
geomean                                      39.16µ        27.45µ       -29.91%

                                          │     base     │               withmeta                │
                                          │     B/s      │      B/s       vs base                │
GetSingle/DistPebble10/AC-24                107.4Ki ± 0%    127.0Ki ± 0%   +18.18% (p=0.001 n=7)
GetSingle/DistPebble10/CAS-24               107.4Ki ± 0%    127.0Ki ± 0%   +18.18% (p=0.001 n=7)
GetSingle/DistPebble100/AC-24               1.040Mi ± 1%    1.230Mi ± 2%   +18.35% (p=0.001 n=7)
GetSingle/DistPebble100/CAS-24              1.059Mi ± 1%    1.249Mi ± 2%   +18.02% (p=0.001 n=7)
GetSingle/DistPebble1000/AC-24              10.35Mi ± 5%    12.41Mi ± 2%   +19.91% (p=0.001 n=7)
GetSingle/DistPebble1000/CAS-24             10.60Mi ± 1%    12.55Mi ± 5%   +18.35% (p=0.001 n=7)
GetSingle/DistPebble10000/AC-24             87.16Mi ± 2%   102.72Mi ± 4%   +17.86% (p=0.001 n=7)
GetSingle/DistPebble10000/CAS-24            90.20Mi ± 2%   103.78Mi ± 2%   +15.06% (p=0.001 n=7)
GetSingle/LookasideDistPebble10/AC-24       107.4Ki ± 0%    127.0Ki ± 0%   +18.18% (p=0.001 n=7)
GetSingle/LookasideDistPebble10/CAS-24      13.57Mi ± 4%    39.79Mi ± 3%  +193.18% (p=0.001 n=7)
GetSingle/LookasideDistPebble100/AC-24      1.030Mi ± 5%    1.249Mi ± 3%   +21.30% (p=0.001 n=7)
GetSingle/LookasideDistPebble100/CAS-24     124.3Mi ± 2%    385.6Mi ± 3%  +210.06% (p=0.001 n=7)
GetSingle/LookasideDistPebble1000/AC-24     10.21Mi ± 1%    12.31Mi ± 7%   +20.54% (p=0.001 n=7)
GetSingle/LookasideDistPebble1000/CAS-24    1.041Gi ± 3%    3.692Gi ± 2%  +254.72% (p=0.001 n=7)
GetSingle/LookasideDistPebble10000/AC-24    88.86Mi ± 2%   102.59Mi ± 3%   +15.44% (p=0.001 n=7)
GetSingle/LookasideDistPebble10000/CAS-24   83.40Mi ± 1%   101.16Mi ± 2%   +21.29% (p=0.001 n=7)
geomean                                     7.703Mi         10.99Mi        +42.62%

                                          │     base     │              withmeta               │
                                          │     B/op     │     B/op      vs base               │
GetSingle/DistPebble10/AC-24                39.34Ki ± 0%   29.32Ki ± 0%  -25.47% (p=0.001 n=7)
GetSingle/DistPebble10/CAS-24               34.05Ki ± 0%   28.04Ki ± 0%  -17.65% (p=0.001 n=7)
GetSingle/DistPebble100/AC-24               39.47Ki ± 0%   29.51Ki ± 0%  -25.24% (p=0.001 n=7)
GetSingle/DistPebble100/CAS-24              34.28Ki ± 0%   28.22Ki ± 0%  -17.66% (p=0.001 n=7)
GetSingle/DistPebble1000/AC-24              40.42Ki ± 0%   31.07Ki ± 0%  -23.14% (p=0.001 n=7)
GetSingle/DistPebble1000/CAS-24             36.08Ki ± 0%   29.80Ki ± 0%  -17.41% (p=0.001 n=7)
GetSingle/DistPebble10000/AC-24             39.59Ki ± 0%   36.75Ki ± 0%   -7.16% (p=0.001 n=7)
GetSingle/DistPebble10000/CAS-24            44.35Ki ± 0%   35.48Ki ± 0%  -20.01% (p=0.001 n=7)
GetSingle/LookasideDistPebble10/AC-24       39.34Ki ± 0%   29.32Ki ± 0%  -25.46% (p=0.001 n=7)
GetSingle/LookasideDistPebble10/CAS-24        601.0 ± 0%     224.0 ± 0%  -62.73% (p=0.001 n=7)
GetSingle/LookasideDistPebble100/AC-24      39.47Ki ± 0%   29.50Ki ± 0%  -25.28% (p=0.001 n=7)
GetSingle/LookasideDistPebble100/CAS-24       685.0 ± 0%     227.0 ± 0%  -66.86% (p=0.001 n=7)
GetSingle/LookasideDistPebble1000/AC-24     40.43Ki ± 0%   31.08Ki ± 0%  -23.13% (p=0.001 n=7)
GetSingle/LookasideDistPebble1000/CAS-24     1599.0 ± 0%     228.0 ± 0%  -85.74% (p=0.001 n=7)
GetSingle/LookasideDistPebble10000/AC-24    39.58Ki ± 0%   36.77Ki ± 0%   -7.09% (p=0.001 n=7)
GetSingle/LookasideDistPebble10000/CAS-24   58.44Ki ± 0%   35.89Ki ± 0%  -38.60% (p=0.001 n=7)
geomean                                     19.43Ki        12.41Ki       -36.13%

                                          │    base     │             withmeta              │
                                          │  allocs/op  │ allocs/op   vs base               │
GetSingle/DistPebble10/AC-24                 484.0 ± 0%   409.0 ± 0%  -15.50% (p=0.001 n=7)
GetSingle/DistPebble10/CAS-24                466.0 ± 0%   391.0 ± 0%  -16.09% (p=0.001 n=7)
GetSingle/DistPebble100/AC-24                484.0 ± 0%   409.0 ± 0%  -15.50% (p=0.001 n=7)
GetSingle/DistPebble100/CAS-24               466.0 ± 0%   391.0 ± 0%  -16.09% (p=0.001 n=7)
GetSingle/DistPebble1000/AC-24               484.0 ± 0%   409.0 ± 0%  -15.50% (p=0.001 n=7)
GetSingle/DistPebble1000/CAS-24              466.0 ± 0%   391.0 ± 0%  -16.09% (p=0.001 n=7)
GetSingle/DistPebble10000/AC-24              481.0 ± 0%   406.0 ± 0%  -15.59% (p=0.001 n=7)
GetSingle/DistPebble10000/CAS-24             463.0 ± 0%   388.0 ± 0%  -16.20% (p=0.001 n=7)
GetSingle/LookasideDistPebble10/AC-24        484.0 ± 0%   409.0 ± 0%  -15.50% (p=0.001 n=7)
GetSingle/LookasideDistPebble10/CAS-24      11.000 ± 0%   3.000 ± 0%  -72.73% (p=0.001 n=7)
GetSingle/LookasideDistPebble100/AC-24       484.0 ± 0%   409.0 ± 0%  -15.50% (p=0.001 n=7)
GetSingle/LookasideDistPebble100/CAS-24     12.000 ± 0%   4.000 ± 0%  -66.67% (p=0.001 n=7)
GetSingle/LookasideDistPebble1000/AC-24      484.0 ± 0%   409.0 ± 0%  -15.50% (p=0.001 n=7)
GetSingle/LookasideDistPebble1000/CAS-24    12.000 ± 0%   4.000 ± 0%  -66.67% (p=0.001 n=7)
GetSingle/LookasideDistPebble10000/AC-24     481.0 ± 0%   406.0 ± 0%  -15.59% (p=0.001 n=7)
GetSingle/LookasideDistPebble10000/CAS-24    476.0 ± 0%   395.0 ± 0%  -17.02% (p=0.001 n=7)
geomean                                      237.9        166.2       -30.13%
```