### PR TITLE
Verify references when provided alongside bytes in distributed cache writes

### DIFF
--- a/enterprise/server/util/distributed_client/BUILD
+++ b/enterprise/server/util/distributed_client/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//server/remote_cache/digest",
         "//server/resources",
         "//server/util/authutil",
+        "//server/util/background",
         "//server/util/bytebufferpool",
         "//server/util/compression",
         "//server/util/findmissing",

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/resources"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
+	"github.com/buildbuddy-io/buildbuddy/server/util/background"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bytebufferpool"
 	"github.com/buildbuddy-io/buildbuddy/server/util/compression"
 	"github.com/buildbuddy-io/buildbuddy/server/util/findmissing"
@@ -58,6 +59,10 @@ const (
 	VerificationSuccess = "success"
 	VerificationFailure = "failure"
 	VerificationError   = "error"
+
+	// How long an async write-reference verification may keep running after
+	// the write stream that spawned it completes.
+	referenceVerificationTimeout = 1 * time.Minute
 )
 
 var (
@@ -83,6 +88,11 @@ type Proxy struct {
 	listenAddr            string
 	zone                  string
 	enableCompressedReads bool
+	verificationWG        sync.WaitGroup
+}
+
+func (c *Proxy) WaitForPendingVerificationsForTesting() {
+	c.verificationWG.Wait()
 }
 
 func New(env environment.Env, c interfaces.Cache, listenAddr string) *Proxy {
@@ -422,6 +432,10 @@ func (c *Proxy) Write(stream dcpb.DistributedCache_WriteServer) error {
 
 	var bytesWritten int64
 	var writeCloser interfaces.CommittedWriteCloser
+	// A reference to-be-verified received alongside data bytes, and the
+	// resource to verify it against.
+	var verifyRef *refpb.Reference
+	var verifyRN *rspb.ResourceName
 	var req *dcpb.WriteRequest
 	for {
 		if req == nil {
@@ -447,7 +461,15 @@ func (c *Proxy) Write(stream dcpb.DistributedCache_WriteServer) error {
 				}
 			}
 			if req.GetReference() != nil {
-				return c.writeReference(ctx, stream, req, up)
+				if len(req.GetData()) == 0 {
+					return c.writeReference(ctx, stream, req, up)
+				}
+				// The request carries both bytes and a reference: the bytes
+				// are written and the reference is verified. Clone these
+				// because the request proto is pooled and reused for later
+				// messages.
+				verifyRef = req.GetReference().CloneVT()
+				verifyRN = rn.CloneVT()
 			}
 			wc, err := c.cache.Writer(ctx, rn)
 			if err != nil {
@@ -456,8 +478,6 @@ func (c *Proxy) Write(stream dcpb.DistributedCache_WriteServer) error {
 			}
 			defer wc.Close()
 			writeCloser = wc
-		} else if req.GetReference() != nil {
-			return status.InvalidArgumentError("unexpected reference after data bytes")
 		}
 		n, err := writeCloser.Write(req.GetData())
 		if err != nil {
@@ -467,6 +487,20 @@ func (c *Proxy) Write(stream dcpb.DistributedCache_WriteServer) error {
 		if req.GetFinishWrite() {
 			if err := writeCloser.Commit(); err != nil {
 				return err
+			}
+			if verifyRef != nil {
+				if refCache, ok := c.cache.(interfaces.ReferenceCache); ok {
+					// Verification is observe-only, so don't block the
+					// write response on it. The stream context is canceled
+					// when this handler returns, so extend it.
+					vctx, cancel := background.ExtendContextForFinalization(ctx, referenceVerificationTimeout)
+					c.verificationWG.Add(1)
+					go func() {
+						defer c.verificationWG.Done()
+						defer cancel()
+						c.verifyReferenceWrite(vctx, refCache, verifyRef, verifyRN)
+					}()
+				}
 			}
 			c.log.Debugf("Write(%q) succeeded (user prefix: %s)", ResourceIsolationString(rn), up)
 			return c.finishWrite(ctx, stream, req, bytesWritten)
@@ -495,6 +529,46 @@ func (c *Proxy) writeReference(ctx context.Context, stream dcpb.DistributedCache
 	}
 	c.writeRefLogger.Debugf("Write(%q) succeeded by reference (user prefix: %s)", ResourceIsolationString(rn), userPrefix)
 	return c.finishWrite(ctx, stream, req, req.GetReference().GetMetadata().GetStoredSizeBytes())
+}
+
+// verifyReferenceWrite checks that dereferencing ref yields content that
+// hashes to rn's digest, and logs and counts the outcome.
+func (c *Proxy) verifyReferenceWrite(ctx context.Context, refCache interfaces.ReferenceCache, ref *refpb.Reference, rn *rspb.ResourceName) {
+	if rn.GetCacheType() != rspb.CacheType_CAS {
+		c.log.Errorf("Reference write verification is only supported for CAS cache type, got %q", rn.GetCacheType())
+		metrics.DistributedCacheReferenceWriteVerificationCount.With(
+			prometheus.Labels{metrics.VerificationOutcomeLabel: VerificationError}).Inc()
+		return
+	}
+
+	// Dereference the reference with the IDENTITY compressor to verify its hash
+	identityRN := rn.CloneVT()
+	identityRN.Compressor = repb.Compressor_IDENTITY
+	readCloser, err := refCache.Dereference(ctx, ref, identityRN, 0, 0)
+	if err != nil {
+		c.log.Errorf("Error dereferencing %q for write verification: %s", ResourceIsolationString(rn), err)
+		metrics.DistributedCacheReferenceWriteVerificationCount.With(
+			prometheus.Labels{metrics.VerificationOutcomeLabel: VerificationError}).Inc()
+		return
+	}
+	defer readCloser.Close()
+
+	// Compute the digest of the dereferenced bytes and compare what's expected
+	d, err := digest.Compute(readCloser, rn.GetDigestFunction())
+	if err != nil {
+		c.log.Errorf("Reference write verification error for %q: %s", ResourceIsolationString(rn), err)
+		metrics.DistributedCacheReferenceWriteVerificationCount.With(
+			prometheus.Labels{metrics.VerificationOutcomeLabel: VerificationError}).Inc()
+		return
+	}
+	if d.GetHash() != rn.GetDigest().GetHash() || d.GetSizeBytes() != rn.GetDigest().GetSizeBytes() {
+		c.log.Errorf("Reference write verification failed for %q: expected %s/%d, got %s/%d", ResourceIsolationString(rn), rn.GetDigest().GetHash(), rn.GetDigest().GetSizeBytes(), d.GetHash(), d.GetSizeBytes())
+		metrics.DistributedCacheReferenceWriteVerificationCount.With(
+			prometheus.Labels{metrics.VerificationOutcomeLabel: VerificationFailure}).Inc()
+		return
+	}
+	metrics.DistributedCacheReferenceWriteVerificationCount.With(
+		prometheus.Labels{metrics.VerificationOutcomeLabel: VerificationSuccess}).Inc()
 }
 
 func (c *Proxy) finishWrite(ctx context.Context, stream dcpb.DistributedCache_WriteServer, req *dcpb.WriteRequest, committedSize int64) error {

--- a/enterprise/server/util/distributed_client/distributed_client_test.go
+++ b/enterprise/server/util/distributed_client/distributed_client_test.go
@@ -1601,7 +1601,8 @@ func TestRemoteReadReference(t *testing.T) {
 // references for configured digests and recording accepted reference writes.
 type serverReferenceCache struct {
 	interfaces.Cache
-	refs map[string]*refpb.Reference
+	refs  map[string]*refpb.Reference
+	blobs map[string][]byte
 
 	mu            sync.Mutex
 	writtenRef    *refpb.Reference
@@ -1617,10 +1618,28 @@ func (c *serverReferenceCache) GetReference(ctx context.Context, r *rspb.Resourc
 	return nil, status.NotFoundError("no reference available")
 }
 
-// Dereference is unused by the read server, but the server only offers
-// references if its cache implements the full interfaces.ReferenceCache.
+// Dereference serves the configured blob bytes, standing in for shared
+// storage. The read server never dereferences, but the write server does
+// when reference-write verification is enabled. Like the real
+// implementation, it reconciles the reference's stored compressor with the
+// compressor requested by r.
 func (c *serverReferenceCache) Dereference(ctx context.Context, ref *refpb.Reference, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
-	return nil, status.UnimplementedError("not implemented")
+	data, ok := c.blobs[ref.GetMetadata().GetStorageMetadata().GetGcsMetadata().GetBlobName()]
+	if !ok {
+		return nil, status.NotFoundError("blob not found")
+	}
+	stored := ref.GetMetadata().GetFileRecord().GetCompressor()
+	requested := r.GetCompressor()
+	if stored == repb.Compressor_ZSTD && requested == repb.Compressor_IDENTITY {
+		var err error
+		data, err = compression.DecompressZstd(nil, data)
+		if err != nil {
+			return nil, err
+		}
+	} else if stored == repb.Compressor_IDENTITY && requested == repb.Compressor_ZSTD {
+		data = compression.CompressZstd(nil, data)
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
 }
 
 func (c *serverReferenceCache) WriteReference(ctx context.Context, ref *refpb.Reference, r *rspb.ResourceName, mustClone bool) error {
@@ -1779,7 +1798,7 @@ func TestWriteReferenceAccept(t *testing.T) {
 	ctx, err := prefix.AttachUserPrefixToContext(context.Background(), te.GetAuthenticator())
 	require.NoError(t, err)
 
-	rn, buf := testdigest.RandomCASResourceBuf(t, 100)
+	rn, _ := testdigest.RandomCASResourceBuf(t, 100)
 	ref := makeReference(rn, "blobs/test-blob", repb.Compressor_IDENTITY)
 	ref.Metadata.StoredSizeBytes = 42
 
@@ -1866,24 +1885,44 @@ func TestWriteReferenceAccept(t *testing.T) {
 		require.True(t, status.IsInvalidArgumentError(err), "expected InvalidArgumentError, got %s", err)
 	})
 
-	t.Run("reference with data bytes is rejected", func(t *testing.T) {
-		_, err := writeRawRequests(t, peer, []*dcpb.WriteRequest{{
-			Resource:    rn,
-			Reference:   ref,
-			Data:        buf,
+	t.Run("reference with data bytes writes the bytes", func(t *testing.T) {
+		shadowRN, shadowBuf := testdigest.RandomCASResourceBuf(t, 100)
+		shadowRef := makeReference(shadowRN, "blobs/shadow-blob", repb.Compressor_IDENTITY)
+		rsp, err := writeRawRequests(t, peer, []*dcpb.WriteRequest{{
+			Resource:    shadowRN,
+			Reference:   shadowRef,
+			Data:        shadowBuf,
 			FinishWrite: true,
 		}})
-		require.Error(t, err)
-		require.True(t, status.IsInvalidArgumentError(err), "expected InvalidArgumentError, got %s", err)
+		require.NoError(t, err)
+		require.Equal(t, int64(len(shadowBuf)), rsp.GetCommittedSize())
+		c.WaitForPendingVerificationsForTesting()
+		// The bytes are the write; the reference is not installed.
+		got, err := te.GetCache().Get(ctx, shadowRN)
+		require.NoError(t, err)
+		require.Equal(t, shadowBuf, got)
+		_, gotRN, _ := cache.lastWriteReference()
+		require.NotEqual(t, shadowRN.GetDigest().GetHash(), gotRN.GetDigest().GetHash())
 	})
 
-	t.Run("reference after data bytes is rejected", func(t *testing.T) {
-		_, err := writeRawRequests(t, peer, []*dcpb.WriteRequest{
-			{Resource: rn, Data: buf[:50]},
-			{Resource: rn, Reference: ref, FinishWrite: true},
+	t.Run("reference after data bytes is ignored", func(t *testing.T) {
+		lateRN, lateBuf := testdigest.RandomCASResourceBuf(t, 100)
+		lateRef := makeReference(lateRN, "blobs/late-blob", repb.Compressor_IDENTITY)
+		before := writeVerificationCounts(t)
+		rsp, err := writeRawRequests(t, peer, []*dcpb.WriteRequest{
+			{Resource: lateRN, Data: lateBuf[:50]},
+			{Resource: lateRN, Reference: lateRef, Data: lateBuf[50:], FinishWrite: true},
 		})
-		require.Error(t, err)
-		require.True(t, status.IsInvalidArgumentError(err), "expected InvalidArgumentError, got %s", err)
+		require.NoError(t, err)
+		require.Equal(t, int64(len(lateBuf)), rsp.GetCommittedSize())
+		got, err := te.GetCache().Get(ctx, lateRN)
+		require.NoError(t, err)
+		require.Equal(t, lateBuf, got)
+		// The late reference is neither installed nor verified.
+		c.WaitForPendingVerificationsForTesting()
+		_, gotRN, _ := cache.lastWriteReference()
+		require.NotEqual(t, lateRN.GetDigest().GetHash(), gotRN.GetDigest().GetHash())
+		require.Equal(t, before, writeVerificationCounts(t))
 	})
 
 	t.Run("existing CAS digest still dedupes", func(t *testing.T) {
@@ -1990,6 +2029,167 @@ func verificationCounts(t *testing.T) map[string]float64 {
 		counts[s] = testmetrics.CounterValueForLabels(t, metrics.DistributedCacheReferenceVerificationCount, prometheus.Labels{metrics.VerificationOutcomeLabel: s})
 	}
 	return counts
+}
+
+// writeVerificationCounts returns the current values of the reference write
+// verification counter, keyed by outcome.
+func writeVerificationCounts(t *testing.T) map[string]float64 {
+	counts := map[string]float64{}
+	for _, s := range []string{distributed_client.VerificationSuccess, distributed_client.VerificationFailure, distributed_client.VerificationError} {
+		counts[s] = testmetrics.CounterValueForLabels(t, metrics.DistributedCacheReferenceWriteVerificationCount, prometheus.Labels{metrics.VerificationOutcomeLabel: s})
+	}
+	return counts
+}
+
+func TestWriteReferenceVerification(t *testing.T) {
+	te := getTestEnv(t, emptyUserMap)
+	ctx, err := prefix.AttachUserPrefixToContext(context.Background(), te.GetAuthenticator())
+	require.NoError(t, err)
+
+	const blobName = "blobs/test-blob"
+	rn, buf := testdigest.RandomCASResourceBuf(t, 100)
+	ref := makeReference(rn, blobName, repb.Compressor_IDENTITY)
+
+	newProxy := func(t *testing.T, blobs map[string][]byte) (string, *serverReferenceCache, *distributed_client.Proxy) {
+		cache := &serverReferenceCache{Cache: te.GetCache(), blobs: blobs}
+		peer := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+		c := distributed_client.New(te, cache, peer)
+		require.NoError(t, c.StartListening())
+		waitUntilServerIsAlive(peer)
+		return peer, cache, c
+	}
+	// writeShadow writes rn's bytes with ref riding along on the first
+	// message for verification.
+	writeShadow := func(t *testing.T, peer string, rn *rspb.ResourceName, ref *refpb.Reference, data []byte) error {
+		_, err := writeRawRequests(t, peer, []*dcpb.WriteRequest{{
+			Resource:    rn,
+			Reference:   ref,
+			Data:        data,
+			FinishWrite: true,
+		}})
+		return err
+	}
+	// deltas returns the nonzero outcome-count changes between two
+	// writeVerificationCounts snapshots.
+	deltas := func(before, after map[string]float64) map[string]float64 {
+		d := map[string]float64{}
+		for s, v := range after {
+			if v != before[s] {
+				d[s] = v - before[s]
+			}
+		}
+		return d
+	}
+	// assertBytesWritten asserts the byte write landed and no reference was
+	// installed: the bytes must stay authoritative regardless of the
+	// verification outcome.
+	assertBytesWritten := func(t *testing.T, cache *serverReferenceCache, rn *rspb.ResourceName, data []byte) {
+		got, err := te.GetCache().Get(ctx, rn)
+		require.NoError(t, err)
+		require.Equal(t, data, got)
+		_, gotRN, _ := cache.lastWriteReference()
+		require.Nil(t, gotRN)
+	}
+
+	t.Run("writes without a reference are not verified", func(t *testing.T) {
+		peer, cache, proxy := newProxy(t, map[string][]byte{blobName: buf})
+		before := writeVerificationCounts(t)
+		_, err := writeRawRequests(t, peer, []*dcpb.WriteRequest{{
+			Resource:    rn,
+			Data:        buf,
+			FinishWrite: true,
+		}})
+		require.NoError(t, err)
+		proxy.WaitForPendingVerificationsForTesting()
+		require.Empty(t, deltas(before, writeVerificationCounts(t)))
+		assertBytesWritten(t, cache, rn, buf)
+	})
+
+	t.Run("matching content", func(t *testing.T) {
+		peer, cache, proxy := newProxy(t, map[string][]byte{blobName: buf})
+		before := writeVerificationCounts(t)
+		require.NoError(t, writeShadow(t, peer, rn, ref, buf))
+		proxy.WaitForPendingVerificationsForTesting()
+		require.Equal(t, map[string]float64{distributed_client.VerificationSuccess: 1}, deltas(before, writeVerificationCounts(t)))
+		assertBytesWritten(t, cache, rn, buf)
+	})
+
+	t.Run("mismatched content does not affect the write", func(t *testing.T) {
+		_, wrongBuf := testdigest.RandomCASResourceBuf(t, 100)
+		peer, cache, proxy := newProxy(t, map[string][]byte{blobName: wrongBuf})
+		before := writeVerificationCounts(t)
+		require.NoError(t, writeShadow(t, peer, rn, ref, buf))
+		proxy.WaitForPendingVerificationsForTesting()
+		require.Equal(t, map[string]float64{distributed_client.VerificationFailure: 1}, deltas(before, writeVerificationCounts(t)))
+		assertBytesWritten(t, cache, rn, buf)
+	})
+
+	t.Run("unverifiable content does not affect the write", func(t *testing.T) {
+		peer, cache, proxy := newProxy(t, map[string][]byte{})
+		before := writeVerificationCounts(t)
+		require.NoError(t, writeShadow(t, peer, rn, ref, buf))
+		proxy.WaitForPendingVerificationsForTesting()
+		require.Equal(t, map[string]float64{distributed_client.VerificationError: 1}, deltas(before, writeVerificationCounts(t)))
+		assertBytesWritten(t, cache, rn, buf)
+	})
+
+	t.Run("reference on the first message of a streamed write", func(t *testing.T) {
+		peer, cache, proxy := newProxy(t, map[string][]byte{blobName: buf})
+		before := writeVerificationCounts(t)
+		// The request proto is pooled server-side, so the reference must
+		// survive the arrival of later messages in the stream.
+		_, err := writeRawRequests(t, peer, []*dcpb.WriteRequest{
+			{Resource: rn, Reference: ref, Data: buf[:50]},
+			{Resource: rn, Data: buf[50:], FinishWrite: true},
+		})
+		require.NoError(t, err)
+		proxy.WaitForPendingVerificationsForTesting()
+		require.Equal(t, map[string]float64{distributed_client.VerificationSuccess: 1}, deltas(before, writeVerificationCounts(t)))
+		assertBytesWritten(t, cache, rn, buf)
+	})
+
+	t.Run("compressed writes are verified against decompressed content", func(t *testing.T) {
+		zstdRN := rn.CloneVT()
+		zstdRN.Compressor = repb.Compressor_ZSTD
+		zstdRef := makeReference(zstdRN, blobName, repb.Compressor_ZSTD)
+		compressed := compression.CompressZstd(nil, buf)
+		// Shared storage holds the zstd blob; verification must hash the
+		// decompressed content.
+		peer, _, proxy := newProxy(t, map[string][]byte{blobName: compressed})
+		before := writeVerificationCounts(t)
+		require.NoError(t, writeShadow(t, peer, zstdRN, zstdRef, compressed))
+		proxy.WaitForPendingVerificationsForTesting()
+		require.Equal(t, map[string]float64{distributed_client.VerificationSuccess: 1}, deltas(before, writeVerificationCounts(t)))
+	})
+
+	t.Run("AC writes are unverifiable", func(t *testing.T) {
+		acRN := rn.CloneVT()
+		acRN.CacheType = rspb.CacheType_AC
+		acRef := makeReference(acRN, blobName, repb.Compressor_IDENTITY)
+		peer, _, proxy := newProxy(t, map[string][]byte{blobName: buf})
+		before := writeVerificationCounts(t)
+		require.NoError(t, writeShadow(t, peer, acRN, acRef, buf))
+		proxy.WaitForPendingVerificationsForTesting()
+		require.Equal(t, map[string]float64{distributed_client.VerificationError: 1}, deltas(before, writeVerificationCounts(t)))
+		got, err := te.GetCache().Get(ctx, acRN)
+		require.NoError(t, err)
+		require.Equal(t, buf, got)
+	})
+
+	t.Run("reference-only writes are not verified", func(t *testing.T) {
+		peer, cache, proxy := newProxy(t, map[string][]byte{blobName: buf})
+		before := writeVerificationCounts(t)
+		_, err := writeRawRequests(t, peer, []*dcpb.WriteRequest{{
+			Resource:    rn,
+			Reference:   ref,
+			FinishWrite: true,
+		}})
+		require.NoError(t, err)
+		proxy.WaitForPendingVerificationsForTesting()
+		require.Empty(t, deltas(before, writeVerificationCounts(t)))
+		_, gotRN, _ := cache.lastWriteReference()
+		require.Empty(t, cmp.Diff(rn, gotRN, protocmp.Transform()))
+	})
 }
 
 func TestVerifyingReadCloser(t *testing.T) {

--- a/proto/distributed_cache.proto
+++ b/proto/distributed_cache.proto
@@ -45,8 +45,12 @@ message WriteRequest {
   // Clients should attempt to replicate this data when possible.
   string handoff_peer = 5;
 
-  // If set, this write carries no data bytes. The data should be retrieved
-  // using the provided reference.
+  // A reference to the written data's location in shared storage. If no data
+  // bytes accompany it, the write must be performed from the reference. If
+  // data bytes are also present, the bytes should be written and the reference
+  // should be verified. Like the other fields in this message, the reference
+  // is consulted on the first message of a write stream; values on subsequent
+  // messages are ignored.
   reference.Reference reference = 9;
 
   // If true, the provided reference must be cloned by the server that handles

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1061,6 +1061,21 @@ var (
 		VerificationOutcomeLabel,
 	})
 
+	// DistributedCacheReferenceWriteVerificationCount counts verifications of
+	// references received alongside authoritative data bytes on distributed
+	// cache writes, by outcome: "success" (the dereferenced content hashed to
+	// the written digest), "failure" (the hashes differed), or "error"
+	// (verification could not be run or completed). Verification is
+	// observe-only and never affects the write itself.
+	DistributedCacheReferenceWriteVerificationCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "distributed_cache_reference_write_verification_count",
+		Help:      "Count of reference verifications on distributed cache writes, by outcome.",
+	}, []string{
+		VerificationOutcomeLabel,
+	})
+
 	MigrationNotFoundErrorCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_cache",


### PR DESCRIPTION
This change makes distributed cache nodes perform verification on references which are received alongside data bytes, treating the data bytes as canonical in this case. This allows the distributed cache to perform write verification by having the distributed cache client mint a reference for the bytes to-be-written, and sending that along with the data bytes to one of the peers that will perform the write. I considered some other ways of doing this, like only verifying on one of the nodes, or failing writes that fail verification, but this feels like the safest and simplest option.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7911