### PR TITLE
networking: detect stale veth routes

### DIFF
--- a/server/util/networking/BUILD
+++ b/server/util/networking/BUILD
@@ -42,6 +42,8 @@ go_test(
         "//server/testutil/testnetworking",
         "//server/testutil/testshell",
         "//server/util/testing/flags",
+        "@com_github_rs_zerolog//:zerolog",
+        "@com_github_rs_zerolog//log",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_sync//errgroup",

--- a/server/util/networking/networking.go
+++ b/server/util/networking/networking.go
@@ -185,14 +185,7 @@ func DeleteNetNamespaces(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return deleteNetNamespaces(ctx, string(b), func(ns string) error {
-		_, err := sudoCommand(ctx, "ip", "netns", "delete", ns)
-		return err
-	})
-}
-
-func deleteNetNamespaces(ctx context.Context, output string, deleteNetNamespace func(string) error) error {
-	output = strings.TrimSpace(output)
+	output := strings.TrimSpace(string(b))
 	if len(output) == 0 {
 		return nil
 	}
@@ -214,7 +207,7 @@ func deleteNetNamespaces(ctx context.Context, output string, deleteNetNamespace 
 	var lastErr error
 	deleted := 0
 	for _, ns := range staleNamespaces {
-		if err := deleteNetNamespace(ns); err != nil {
+		if _, err := sudoCommand(ctx, "ip", "netns", "delete", ns); err != nil {
 			lastErr = err
 			continue
 		}

--- a/server/util/networking/networking.go
+++ b/server/util/networking/networking.go
@@ -185,12 +185,9 @@ func DeleteNetNamespaces(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	output := strings.TrimSpace(string(b))
-	if len(output) == 0 {
-		return nil
-	}
-	var staleNamespaces []string
-	for ns := range strings.SplitSeq(output, "\n") {
+	var lastErr error
+	found, deleted := 0, 0
+	for ns := range strings.SplitSeq(strings.TrimSpace(string(b)), "\n") {
 		// Sometimes the output contains spaces, like
 		//     bb-executor-1 (id: 344)
 		// So we get just the first column here.
@@ -198,22 +195,16 @@ func DeleteNetNamespaces(ctx context.Context) error {
 		if len(fields) == 0 || !strings.HasPrefix(fields[0], netNamespacePrefix) {
 			continue
 		}
-		staleNamespaces = append(staleNamespaces, fields[0])
-	}
-	if len(staleNamespaces) == 0 {
-		return nil
-	}
-
-	var lastErr error
-	deleted := 0
-	for _, ns := range staleNamespaces {
-		if _, err := sudoCommand(ctx, "ip", "netns", "delete", ns); err != nil {
+		found++
+		if _, err := sudoCommand(ctx, "ip", "netns", "delete", fields[0]); err != nil {
 			lastErr = err
 			continue
 		}
 		deleted++
 	}
-	log.CtxWarningf(ctx, "Stale executor network resources detected at startup: namespaces=%d cleanup_succeeded=%d cleanup_failed=%d", len(staleNamespaces), deleted, len(staleNamespaces)-deleted)
+	if found > 0 {
+		log.CtxWarningf(ctx, "Cleaned up %d of %d stale executor network namespaces left by a previous process.", deleted, found)
+	}
 	return lastErr
 }
 
@@ -296,12 +287,16 @@ func cleanupStaleVeths(ctx context.Context, ipWithCIDR string) error {
 	return nil
 }
 
-// checkVethRoute verifies that return traffic to the namespaced end of a veth
+// checkVethRoute checks whether return traffic to the namespaced end of a veth
 // pair will be routed through the expected host device. A stale veth left by a
 // killed executor process can install the same connected route and silently
 // blackhole return traffic to the task, including DNS responses.
+//
+// This is a diagnostic only: it logs what it finds and never fails the network
+// setup. Actually removing the conflicting device is gated behind
+// --executor.cleanup_stale_veth_devices.
 func checkVethRoute(ctx context.Context, veth *vethPair) {
-	if veth.network == nil {
+	if veth == nil || veth.network == nil {
 		log.CtxWarningf(ctx, "Network route check failed: cannot check veth route without an assigned network")
 		return
 	}
@@ -334,7 +329,9 @@ func checkVethRoute(ctx context.Context, veth *vethPair) {
 	}
 	log.CtxWarningf(
 		ctx,
-		"Network route conflict: host route to guest IP %s uses device %q (ifindex %d), expected device %q (ifindex %d); route: %+v",
+		"Network route conflict: host route to guest IP %s uses device %q (ifindex %d), expected device %q (ifindex %d); route: %+v. "+
+			"This usually means a killed process left a veth behind holding the same IP range; "+
+			"--executor.cleanup_stale_veth_devices deletes such devices before the range is reused.",
 		guestIP,
 		actualDevice,
 		actualRoute.LinkIndex,

--- a/server/util/networking/networking.go
+++ b/server/util/networking/networking.go
@@ -185,29 +185,42 @@ func DeleteNetNamespaces(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	output := strings.TrimSpace(string(b))
+	return deleteNetNamespaces(ctx, string(b), func(ns string) error {
+		_, err := sudoCommand(ctx, "ip", "netns", "delete", ns)
+		return err
+	})
+}
+
+func deleteNetNamespaces(ctx context.Context, output string, deleteNetNamespace func(string) error) error {
+	output = strings.TrimSpace(output)
 	if len(output) == 0 {
 		return nil
 	}
-	var lastErr error
+	var staleNamespaces []string
 	for ns := range strings.SplitSeq(output, "\n") {
 		// Sometimes the output contains spaces, like
-		//     bb-executor-1
-		//     bb-executor-2
-		//     3fe4313e-eb76-4b6d-9d61-53caf12b87e6 (id: 344)
-		//     2ab15e85-d1c3-47bc-ad40-74e2941157a4 (id: 332)
+		//     bb-executor-1 (id: 344)
 		// So we get just the first column here.
 		fields := strings.Fields(ns)
-		if len(fields) > 0 {
-			ns = fields[0]
-		}
-		if !strings.HasPrefix(ns, netNamespacePrefix) {
+		if len(fields) == 0 || !strings.HasPrefix(fields[0], netNamespacePrefix) {
 			continue
 		}
-		if _, err := sudoCommand(ctx, "ip", "netns", "delete", ns); err != nil {
-			lastErr = err
-		}
+		staleNamespaces = append(staleNamespaces, fields[0])
 	}
+	if len(staleNamespaces) == 0 {
+		return nil
+	}
+
+	var lastErr error
+	deleted := 0
+	for _, ns := range staleNamespaces {
+		if err := deleteNetNamespace(ns); err != nil {
+			lastErr = err
+			continue
+		}
+		deleted++
+	}
+	log.CtxWarningf(ctx, "Stale executor network resources detected at startup: namespaces=%d cleanup_succeeded=%d cleanup_failed=%d", len(staleNamespaces), deleted, len(staleNamespaces)-deleted)
 	return lastErr
 }
 
@@ -288,6 +301,54 @@ func cleanupStaleVeths(ctx context.Context, ipWithCIDR string) error {
 		}
 	}
 	return nil
+}
+
+// checkVethRoute verifies that return traffic to the namespaced end of a veth
+// pair will be routed through the expected host device. A stale veth left by a
+// killed executor process can install the same connected route and silently
+// blackhole return traffic to the task, including DNS responses.
+func checkVethRoute(ctx context.Context, veth *vethPair) {
+	if veth.network == nil {
+		log.CtxWarningf(ctx, "Network route check failed: cannot check veth route without an assigned network")
+		return
+	}
+
+	expectedLink, err := netlink.LinkByName(veth.hostDevice)
+	if err != nil {
+		log.CtxWarningf(ctx, "Network route check failed: could not look up expected host device %q: %s", veth.hostDevice, err)
+		return
+	}
+
+	guestIP := net.ParseIP(veth.network.NamespacedIP())
+	routes, err := netlink.RouteGet(guestIP)
+	if err != nil {
+		log.CtxWarningf(ctx, "Network route check failed: could not resolve host route to guest IP %s via expected device %q: %s", guestIP, veth.hostDevice, err)
+		return
+	}
+	if len(routes) == 0 {
+		log.CtxWarningf(ctx, "Network route check failed: no host route found to guest IP %s via expected device %q", guestIP, veth.hostDevice)
+		return
+	}
+
+	actualRoute := routes[0]
+	if actualRoute.LinkIndex == expectedLink.Attrs().Index {
+		return
+	}
+
+	actualDevice := fmt.Sprintf("ifindex-%d", actualRoute.LinkIndex)
+	if actualLink, err := netlink.LinkByIndex(actualRoute.LinkIndex); err == nil {
+		actualDevice = actualLink.Attrs().Name
+	}
+	log.CtxWarningf(
+		ctx,
+		"Network route conflict: host route to guest IP %s uses device %q (ifindex %d), expected device %q (ifindex %d); route: %+v",
+		guestIP,
+		actualDevice,
+		actualRoute.LinkIndex,
+		veth.hostDevice,
+		expectedLink.Attrs().Index,
+		actualRoute,
+	)
 }
 
 // createRandomVethPair attempts to create a veth pair with random names, the
@@ -439,6 +500,7 @@ func (p *VethNetworkPool[T]) Get(ctx context.Context) T {
 		log.CtxWarningf(ctx, "Failed to set up default route in namespace: %s", err)
 		return zero
 	}
+	checkVethRoute(ctx, n.getVethPair())
 
 	// Record a new baseline for network stats, so that the stats reported for
 	// the action only reflect the accumulated stats relative to the baseline.
@@ -794,6 +856,7 @@ func setupVethPair(ctx context.Context, netns *Namespace, enableExternalNetworki
 	if err != nil {
 		return nil, status.WrapError(err, "add default route in namespace")
 	}
+	checkVethRoute(ctx, vp)
 
 	if IsSecondaryNetworkEnabled() {
 		err = runCommand(ctx, "ip", "rule", "add", "from", vp.network.NamespacedIP(), "lookup", routingTableName)

--- a/server/util/networking/networking.go
+++ b/server/util/networking/networking.go
@@ -293,8 +293,7 @@ func cleanupStaleVeths(ctx context.Context, ipWithCIDR string) error {
 // blackhole return traffic to the task, including DNS responses.
 //
 // This is a diagnostic only: it logs what it finds and never fails the network
-// setup. Actually removing the conflicting device is gated behind
-// --executor.cleanup_stale_veth_devices.
+// setup.
 func checkVethRoute(ctx context.Context, veth *vethPair) {
 	if veth == nil || veth.network == nil {
 		log.CtxWarningf(ctx, "Network route check failed: cannot check veth route without an assigned network")
@@ -329,9 +328,7 @@ func checkVethRoute(ctx context.Context, veth *vethPair) {
 	}
 	log.CtxWarningf(
 		ctx,
-		"Network route conflict: host route to guest IP %s uses device %q (ifindex %d), expected device %q (ifindex %d); route: %+v. "+
-			"This usually means a killed process left a veth behind holding the same IP range; "+
-			"--executor.cleanup_stale_veth_devices deletes such devices before the range is reused.",
+		"Network route conflict: host route to guest IP %s uses device %q (ifindex %d), expected device %q (ifindex %d); route: %+v",
 		guestIP,
 		actualDevice,
 		actualRoute.LinkIndex,

--- a/server/util/networking/networking_test.go
+++ b/server/util/networking/networking_test.go
@@ -259,28 +259,17 @@ fi
 exec "$@"
 `), 0o755))
 	t.Setenv("PATH", fakeBin+":"+os.Getenv("PATH"))
-
-	previousLogger := zerologlog.Logger
-	var logBuffer bytes.Buffer
-	zerologlog.Logger = zerolog.New(&logBuffer).Level(zerolog.WarnLevel)
-	t.Cleanup(func() {
-		zerologlog.Logger = previousLogger
-	})
+	logs := captureWarnings(t)
 
 	require.Error(t, networking.DeleteNetNamespaces(context.Background()))
-	assert.Contains(t, logBuffer.String(), "Stale executor network resources detected at startup: namespaces=2 cleanup_succeeded=1 cleanup_failed=1")
+	assert.Contains(t, logs.String(), "Cleaned up 1 of 2 stale executor network namespaces")
 }
 
 func TestContainerNetworkPool_LogsRouteConflict(t *testing.T) {
 	flags.Set(t, "executor.task_ip_range", "198.18.0.0/16")
 	flags.Set(t, "executor.cleanup_stale_veth_devices", false)
 	testnetworking.Setup(t)
-	previousLogger := zerologlog.Logger
-	var logBuffer bytes.Buffer
-	zerologlog.Logger = zerolog.New(&logBuffer).Level(zerolog.WarnLevel)
-	t.Cleanup(func() {
-		zerologlog.Logger = previousLogger
-	})
+	logs := captureWarnings(t)
 
 	ctx := context.Background()
 	pool := networking.NewContainerNetworkPool(1)
@@ -292,9 +281,10 @@ func TestContainerNetworkPool_LogsRouteConflict(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, pool.Add(ctx, cn), "add network to pool")
 
-	// The first allocation uses .5/30. Returning it to the pool releases that
-	// range, and the next allocation uses .13/30. Leave a veth with that next
-	// address behind, simulating an executor killed before network cleanup.
+	// The allocator hands out /30s in order and doesn't rewind when one is
+	// released, so the pooled network (which took .5/30) will be reassigned
+	// .13/30 on the way out of the pool. Leave a veth holding that address
+	// behind, simulating an executor killed before network cleanup.
 	staleDevice := createStaleVeth(t, "198.18.0.13/30")
 
 	cn = pool.Get(ctx)
@@ -303,9 +293,22 @@ func TestContainerNetworkPool_LogsRouteConflict(t *testing.T) {
 		require.NoError(t, cn.Cleanup(context.Background()))
 	})
 
-	assert.Contains(t, logBuffer.String(), "Network route conflict:")
-	assert.Contains(t, logBuffer.String(), staleDevice)
-	assert.Contains(t, logBuffer.String(), cn.HostDevice())
+	assert.Contains(t, logs.String(), "Network route conflict:")
+	assert.Contains(t, logs.String(), staleDevice)
+	assert.Contains(t, logs.String(), cn.HostDevice())
+}
+
+// captureWarnings redirects warning-level logs to a buffer for the duration of
+// the test.
+func captureWarnings(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	previousLogger := zerologlog.Logger
+	zerologlog.Logger = zerolog.New(buf).Level(zerolog.WarnLevel)
+	t.Cleanup(func() {
+		zerologlog.Logger = previousLogger
+	})
+	return buf
 }
 
 func createStaleVeth(t *testing.T, hostIPWithCIDR string) string {
@@ -317,8 +320,8 @@ func createStaleVeth(t *testing.T, hostIPWithCIDR string) string {
 
 	runIP(t, "netns", "add", netNamespace)
 	t.Cleanup(func() {
-		_ = exec.Command("ip", "link", "delete", hostDevice).Run()
-		_ = exec.Command("ip", "netns", "delete", netNamespace).Run()
+		_ = ipCommand("link", "delete", hostDevice).Run()
+		_ = ipCommand("netns", "delete", netNamespace).Run()
 	})
 	runIP(t, "link", "add", hostDevice, "type", "veth", "peer", "name", peerDevice)
 	runIP(t, "link", "set", peerDevice, "netns", netNamespace)
@@ -330,8 +333,18 @@ func createStaleVeth(t *testing.T, hostIPWithCIDR string) string {
 
 func runIP(t *testing.T, args ...string) {
 	t.Helper()
-	output, err := exec.Command("ip", args...).CombinedOutput()
+	output, err := ipCommand(args...).CombinedOutput()
 	require.NoError(t, err, "ip %s: %s", strings.Join(args, " "), output)
+}
+
+// ipCommand builds an 'ip' invocation, prepending sudo when not running as
+// root. testnetworking.Setup only guarantees passwordless sudo, not root.
+func ipCommand(args ...string) *exec.Cmd {
+	args = append([]string{"ip"}, args...)
+	if os.Getuid() != 0 {
+		args = append([]string{"sudo", "--non-interactive"}, args...)
+	}
+	return exec.Command(args[0], args[1:]...)
 }
 
 func TestNetworkStats(t *testing.T) {

--- a/server/util/networking/networking_test.go
+++ b/server/util/networking/networking_test.go
@@ -233,38 +233,6 @@ func TestContainerNetworkPool(t *testing.T) {
 	netnsExec(t, cn.NamespacePath(), `ping -c 1 -W 3 8.8.8.8`)
 }
 
-func TestDeleteNetNamespaces_LogsCleanupResult(t *testing.T) {
-	fakeBin := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(fakeBin, "ip"), []byte(`#!/bin/sh
-case "$*" in
-  "netns list")
-    printf '%s\n' unrelated 'bb-executor-success (id: 1)' bb-executor-failure
-    ;;
-  "netns delete bb-executor-success")
-    ;;
-  "netns delete bb-executor-failure")
-    echo 'delete failed' >&2
-    exit 1
-    ;;
-  *)
-    echo "unexpected ip command: $*" >&2
-    exit 2
-    ;;
-esac
-`), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(fakeBin, "sudo"), []byte(`#!/bin/sh
-if [ "$1" = "-A" ]; then
-  shift
-fi
-exec "$@"
-`), 0o755))
-	t.Setenv("PATH", fakeBin+":"+os.Getenv("PATH"))
-	logs := captureWarnings(t)
-
-	require.Error(t, networking.DeleteNetNamespaces(context.Background()))
-	assert.Contains(t, logs.String(), "Cleaned up 1 of 2 stale executor network namespaces")
-}
-
 func TestContainerNetworkPool_LogsRouteConflict(t *testing.T) {
 	flags.Set(t, "executor.task_ip_range", "198.18.0.0/16")
 	flags.Set(t, "executor.cleanup_stale_veth_devices", false)

--- a/server/util/networking/networking_test.go
+++ b/server/util/networking/networking_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testshell"
 	"github.com/buildbuddy-io/buildbuddy/server/util/networking"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/rs/zerolog"
+	zerologlog "github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -229,6 +231,107 @@ func TestContainerNetworkPool(t *testing.T) {
 	require.NotNil(t, cn, "take from pool")
 
 	netnsExec(t, cn.NamespacePath(), `ping -c 1 -W 3 8.8.8.8`)
+}
+
+func TestDeleteNetNamespaces_LogsCleanupResult(t *testing.T) {
+	fakeBin := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(fakeBin, "ip"), []byte(`#!/bin/sh
+case "$*" in
+  "netns list")
+    printf '%s\n' unrelated 'bb-executor-success (id: 1)' bb-executor-failure
+    ;;
+  "netns delete bb-executor-success")
+    ;;
+  "netns delete bb-executor-failure")
+    echo 'delete failed' >&2
+    exit 1
+    ;;
+  *)
+    echo "unexpected ip command: $*" >&2
+    exit 2
+    ;;
+esac
+`), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(fakeBin, "sudo"), []byte(`#!/bin/sh
+if [ "$1" = "-A" ]; then
+  shift
+fi
+exec "$@"
+`), 0o755))
+	t.Setenv("PATH", fakeBin+":"+os.Getenv("PATH"))
+
+	previousLogger := zerologlog.Logger
+	var logBuffer bytes.Buffer
+	zerologlog.Logger = zerolog.New(&logBuffer).Level(zerolog.WarnLevel)
+	t.Cleanup(func() {
+		zerologlog.Logger = previousLogger
+	})
+
+	require.Error(t, networking.DeleteNetNamespaces(context.Background()))
+	assert.Contains(t, logBuffer.String(), "Stale executor network resources detected at startup: namespaces=2 cleanup_succeeded=1 cleanup_failed=1")
+}
+
+func TestContainerNetworkPool_LogsRouteConflict(t *testing.T) {
+	flags.Set(t, "executor.task_ip_range", "198.18.0.0/16")
+	flags.Set(t, "executor.cleanup_stale_veth_devices", false)
+	testnetworking.Setup(t)
+	previousLogger := zerologlog.Logger
+	var logBuffer bytes.Buffer
+	zerologlog.Logger = zerolog.New(&logBuffer).Level(zerolog.WarnLevel)
+	t.Cleanup(func() {
+		zerologlog.Logger = previousLogger
+	})
+
+	ctx := context.Background()
+	pool := networking.NewContainerNetworkPool(1)
+	t.Cleanup(func() {
+		require.NoError(t, pool.Shutdown(context.Background()))
+	})
+
+	cn, err := networking.CreateContainerNetwork(ctx, false /*=loopbackOnly*/)
+	require.NoError(t, err)
+	require.True(t, pool.Add(ctx, cn), "add network to pool")
+
+	// The first allocation uses .5/30. Returning it to the pool releases that
+	// range, and the next allocation uses .13/30. Leave a veth with that next
+	// address behind, simulating an executor killed before network cleanup.
+	staleDevice := createStaleVeth(t, "198.18.0.13/30")
+
+	cn = pool.Get(ctx)
+	require.NotNil(t, cn, "take network from pool")
+	t.Cleanup(func() {
+		require.NoError(t, cn.Cleanup(context.Background()))
+	})
+
+	assert.Contains(t, logBuffer.String(), "Network route conflict:")
+	assert.Contains(t, logBuffer.String(), staleDevice)
+	assert.Contains(t, logBuffer.String(), cn.HostDevice())
+}
+
+func createStaleVeth(t *testing.T, hostIPWithCIDR string) string {
+	t.Helper()
+	suffix := rand.Intn(1 << 20)
+	hostDevice := fmt.Sprintf("vsh%05x", suffix)
+	peerDevice := fmt.Sprintf("vsp%05x", suffix)
+	netNamespace := fmt.Sprintf("bb-stale-%05x", suffix)
+
+	runIP(t, "netns", "add", netNamespace)
+	t.Cleanup(func() {
+		_ = exec.Command("ip", "link", "delete", hostDevice).Run()
+		_ = exec.Command("ip", "netns", "delete", netNamespace).Run()
+	})
+	runIP(t, "link", "add", hostDevice, "type", "veth", "peer", "name", peerDevice)
+	runIP(t, "link", "set", peerDevice, "netns", netNamespace)
+	runIP(t, "addr", "add", hostIPWithCIDR, "dev", hostDevice)
+	runIP(t, "link", "set", hostDevice, "up")
+	runIP(t, "netns", "exec", netNamespace, "ip", "link", "set", peerDevice, "up")
+	return hostDevice
+}
+
+func runIP(t *testing.T, args ...string) {
+	t.Helper()
+	output, err := exec.Command("ip", args...).CombinedOutput()
+	require.NoError(t, err, "ip %s: %s", strings.Join(args, " "), output)
 }
 
 func TestNetworkStats(t *testing.T) {


### PR DESCRIPTION
An intermittent Firecracker action timed out while Docker waited for
headers from Docker Hub. The error had no HTTP response, so it did
not match Docker Hub's rate-limit signature. Concurrent probes instead
found DNS failures in 3 of 39 executions whose pulls did not complete.

Because existing logs cannot show whether stale executor networking
resources were present, we need direct evidence at the point where
leaked state is cleaned up or affects routing.

The failures disappeared after the next production rollout: a fresh
40-action probe completed every Docker pull and every DNS lookup across
39 executor hosts. A scheduled rollout had been skipped, leaving
the original failing executor running for more than five days. This
suggests an executor-age-dependent resource leak, although it does
not prove the production failure was caused by one.

A deterministic test reproduces the suspected mechanism. A veth left
by an earlier executor can retain a connected route for a reused
/30. Return traffic then follows the stale device instead of the
newly configured veth, blackholing DNS and other guest traffic.

PR [#11391](https://github.com/buildbuddy-io/buildbuddy/pull/11391) added the internal executor.cleanup_stale_veth_devices flag
as an opt-in defense that deletes a conflicting veth before assigning
the reused /30. The flag defaults to false and is currently enabled only
by Firecracker tests, so production executors do not run this cleanup.

Warn when executor startup finds leftover executor network namespaces.
Also verify the selected host route after configuring fresh and
pooled veths, and warn with the expected and selected devices when
they differ.  These diagnostics are intentionally passive: they do
not enable the cleanup flag or send unexpected-event notifications.

