### PR TITLE
Create even fewer goroutines in pebble_cache.GetMulti

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2140,7 +2140,7 @@ func (p *PebbleCache) GetMulti(ctx context.Context, resources []*rspb.ResourceNa
 	}
 
 	// Inline resources don't need 1 goroutine per resource. sqrt(inline count)
-	// goroutines seems to be fastests.
+	// goroutines seems to be fastest.
 	inlineResources := 0
 	for _, rn := range resources {
 		if rn.GetDigest().GetSizeBytes() < p.maxInlineFileSizeBytes {

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2096,51 +2096,72 @@ func (p *PebbleCache) GetMulti(ctx context.Context, resources []*rspb.ResourceNa
 	}
 	defer db.Close()
 
-	var mu sync.Mutex
-	foundMap := make(map[*repb.Digest][]byte, len(resources))
-
 	groupID := p.userGroupID(ctx)
 	encryption, err := p.activeEncryption(ctx)
 	if err != nil {
 		return nil, err
 	}
-	eg, ctx := errgroup.WithContext(ctx)
-	maxGoroutines := 10
+
 	var next atomic.Int64
-	for range min(maxGoroutines, len(resources)) {
-		eg.Go(func() error {
-			for {
-				if err := ctx.Err(); err != nil {
-					return err
-				}
-				i := int(next.Add(1)) - 1
-				if i >= len(resources) {
-					return nil
-				}
-				r := resources[i]
-				rc, md, err := p.reader(ctx, db, groupID, encryption, r, 0, 0)
-				if err != nil {
-					if status.IsNotFoundError(err) || os.IsNotExist(err) {
-						continue
-					}
-					return err
-				}
-				buf := bytes.NewBuffer(make([]byte, 0, p.readBufSize(r, md, rc)))
-				_, copyErr := io.Copy(buf, rc)
-				closeErr := rc.Close()
-				if copyErr != nil {
-					log.CtxWarningf(ctx, "[%s] GetMulti encountered error when copying %s: %s", p.name, r.GetDigest().GetHash(), copyErr)
-					continue
-				}
-				if closeErr != nil {
-					log.CtxWarningf(ctx, "[%s] GetMulti cannot close reader when copying %s: %s", p.name, r.GetDigest().GetHash(), closeErr)
-					continue
-				}
-				mu.Lock()
-				foundMap[r.GetDigest()] = buf.Bytes()
-				mu.Unlock()
+	var mu sync.Mutex
+	foundMap := make(map[*repb.Digest][]byte, len(resources))
+	handleBatch := func() error {
+		for {
+			if err := ctx.Err(); err != nil {
+				return err
 			}
-		})
+			i := int(next.Add(1)) - 1
+			if i >= len(resources) {
+				return nil
+			}
+			r := resources[i]
+			rc, md, err := p.reader(ctx, db, groupID, encryption, r, 0, 0)
+			if err != nil {
+				if status.IsNotFoundError(err) || os.IsNotExist(err) {
+					continue
+				}
+				return err
+			}
+			buf := bytes.NewBuffer(make([]byte, 0, p.readBufSize(r, md, rc)))
+			_, copyErr := io.Copy(buf, rc)
+			closeErr := rc.Close()
+			if copyErr != nil {
+				log.CtxWarningf(ctx, "[%s] GetMulti encountered error when copying %s: %s", p.name, r.GetDigest().GetHash(), copyErr)
+				continue
+			}
+			if closeErr != nil {
+				log.CtxWarningf(ctx, "[%s] GetMulti cannot close reader when copying %s: %s", p.name, r.GetDigest().GetHash(), closeErr)
+				continue
+			}
+			mu.Lock()
+			foundMap[r.GetDigest()] = buf.Bytes()
+			mu.Unlock()
+		}
+	}
+
+	// Inline resources don't need 1 goroutine per resource. sqrt(inline count)
+	// goroutines seems to be fastests.
+	inlineResources := 0
+	for _, rn := range resources {
+		if rn.GetDigest().GetSizeBytes() < p.maxInlineFileSizeBytes {
+			inlineResources++
+		}
+	}
+	// Add 1 goroutine per non-inline resource, since they can be slow.
+	maxGoroutines := min(10, int(math.Sqrt(float64(inlineResources)))+(len(resources)-inlineResources))
+	if maxGoroutines <= 1 {
+		// Don't start goroutines if we don't have to.
+		if err := handleBatch(); err != nil {
+			return nil, err
+		}
+		return foundMap, nil
+	}
+
+	// Make sure to set the ctx used inside handleBatch (don't shadow it).
+	var eg *errgroup.Group
+	eg, ctx = errgroup.WithContext(ctx)
+	for range maxGoroutines {
+		eg.Go(handleBatch)
 	}
 	if err := eg.Wait(); err != nil {
 		return nil, err

--- a/enterprise/server/test/performance/cache/cache_test.go
+++ b/enterprise/server/test/performance/cache/cache_test.go
@@ -324,8 +324,8 @@ func benchmarkGet(ctx context.Context, c interfaces.Cache, digestSizeBytes int64
 	}
 }
 
-func benchmarkGetMulti(ctx context.Context, c interfaces.Cache, digestSizeBytes int64, b *testing.B) {
-	digestBufs := makeDigests(b, numDigests, digestSizeBytes, rspb.CacheType_CAS)
+func benchmarkGetMulti(ctx context.Context, c interfaces.Cache, digestSizeBytes int64, batchSize int, b *testing.B) {
+	digestBufs := makeDigests(b, batchSize, digestSizeBytes, rspb.CacheType_CAS)
 	setDigestsInCache(b, ctx, c, digestBufs)
 	digests := make([]*rspb.ResourceName, 0, len(digestBufs))
 	var sumBytes int64
@@ -372,7 +372,7 @@ func getAllCaches(b *testing.B, te environment.Env) []*namedCache {
 	ddc := getDistributedCache(b, te, dc, 0)
 	pc := getPebbleCache(b, te)
 	dpc := getDistributedCache(b, te, pc, 0)
-	lpc := getDistributedCache(b, te, getPebbleCache(b, te), 100_000)
+	// lpc := getDistributedCache(b, te, getPebbleCache(b, te), 100_000)
 
 	time.Sleep(100 * time.Millisecond)
 	caches := []*namedCache{
@@ -381,7 +381,7 @@ func getAllCaches(b *testing.B, te environment.Env) []*namedCache {
 		{ddc, "DistDisk"},
 		{getPebbleCache(b, te), "LocalPebble"},
 		{dpc, "DistPebble"},
-		{lpc, "LookasideDistPebble"},
+		// {lpc, "LookasideDistPebble"},
 		{getMetaCache(b, te), "Meta"},
 		{getMigrationCache(b, te, getPebbleCache(b, te), getPebbleCache(b, te)), "LocalMigration"},
 		{getDistributedCache(b, te, getMigrationCache(b, te, getPebbleCache(b, te), getPebbleCache(b, te)), 0), "DistMigration"},
@@ -441,16 +441,19 @@ func BenchmarkGetSingle(b *testing.B) {
 }
 
 func BenchmarkGetMulti(b *testing.B) {
-	sizes := []int64{10, 100, 1000, 10000}
+	sizes := []int64{100, 10000}
+	batchSizes := []int{1, 2, 3, 5, 10, 25, 50, 100, 500}
 	te := getTestEnv(b)
 	ctx := getUserContext(b, te)
 
 	for _, cache := range getAllCaches(b, te) {
 		for _, size := range sizes {
-			name := fmt.Sprintf("%s%d", cache.Name, size)
-			b.Run(name, func(b *testing.B) {
-				benchmarkGetMulti(ctx, cache, size, b)
-			})
+			for _, batchSize := range batchSizes {
+				name := fmt.Sprintf("%s%d/batch%d", cache.Name, size, batchSize)
+				b.Run(name, func(b *testing.B) {
+					benchmarkGetMulti(ctx, cache, size, batchSize, b)
+				})
+			}
 		}
 	}
 }

--- a/enterprise/server/test/performance/cache/cache_test.go
+++ b/enterprise/server/test/performance/cache/cache_test.go
@@ -324,8 +324,8 @@ func benchmarkGet(ctx context.Context, c interfaces.Cache, digestSizeBytes int64
 	}
 }
 
-func benchmarkGetMulti(ctx context.Context, c interfaces.Cache, digestSizeBytes int64, batchSize int, b *testing.B) {
-	digestBufs := makeDigests(b, batchSize, digestSizeBytes, rspb.CacheType_CAS)
+func benchmarkGetMulti(ctx context.Context, c interfaces.Cache, digestSizeBytes int64, b *testing.B) {
+	digestBufs := makeDigests(b, numDigests, digestSizeBytes, rspb.CacheType_CAS)
 	setDigestsInCache(b, ctx, c, digestBufs)
 	digests := make([]*rspb.ResourceName, 0, len(digestBufs))
 	var sumBytes int64
@@ -372,7 +372,7 @@ func getAllCaches(b *testing.B, te environment.Env) []*namedCache {
 	ddc := getDistributedCache(b, te, dc, 0)
 	pc := getPebbleCache(b, te)
 	dpc := getDistributedCache(b, te, pc, 0)
-	// lpc := getDistributedCache(b, te, getPebbleCache(b, te), 100_000)
+	lpc := getDistributedCache(b, te, getPebbleCache(b, te), 100_000)
 
 	time.Sleep(100 * time.Millisecond)
 	caches := []*namedCache{
@@ -381,7 +381,7 @@ func getAllCaches(b *testing.B, te environment.Env) []*namedCache {
 		{ddc, "DistDisk"},
 		{getPebbleCache(b, te), "LocalPebble"},
 		{dpc, "DistPebble"},
-		// {lpc, "LookasideDistPebble"},
+		{lpc, "LookasideDistPebble"},
 		{getMetaCache(b, te), "Meta"},
 		{getMigrationCache(b, te, getPebbleCache(b, te), getPebbleCache(b, te)), "LocalMigration"},
 		{getDistributedCache(b, te, getMigrationCache(b, te, getPebbleCache(b, te), getPebbleCache(b, te)), 0), "DistMigration"},
@@ -441,19 +441,16 @@ func BenchmarkGetSingle(b *testing.B) {
 }
 
 func BenchmarkGetMulti(b *testing.B) {
-	sizes := []int64{100, 10000}
-	batchSizes := []int{1, 2, 3, 5, 10, 25, 50, 100, 500}
+	sizes := []int64{10, 100, 1000, 10000}
 	te := getTestEnv(b)
 	ctx := getUserContext(b, te)
 
 	for _, cache := range getAllCaches(b, te) {
 		for _, size := range sizes {
-			for _, batchSize := range batchSizes {
-				name := fmt.Sprintf("%s%d/batch%d", cache.Name, size, batchSize)
-				b.Run(name, func(b *testing.B) {
-					benchmarkGetMulti(ctx, cache, size, batchSize, b)
-				})
-			}
+			name := fmt.Sprintf("%s%d", cache.Name, size)
+			b.Run(name, func(b *testing.B) {
+				benchmarkGetMulti(ctx, cache, size, b)
+			})
 		}
 	}
 }

--- a/enterprise/server/test/performance/cache/cache_test.go
+++ b/enterprise/server/test/performance/cache/cache_test.go
@@ -324,8 +324,8 @@ func benchmarkGet(ctx context.Context, c interfaces.Cache, digestSizeBytes int64
 	}
 }
 
-func benchmarkGetMulti(ctx context.Context, c interfaces.Cache, digestSizeBytes int64, b *testing.B) {
-	digestBufs := makeDigests(b, numDigests, digestSizeBytes, rspb.CacheType_CAS)
+func benchmarkGetMulti(ctx context.Context, c interfaces.Cache, digestSizeBytes int64, batchSize int, b *testing.B) {
+	digestBufs := makeDigests(b, batchSize, digestSizeBytes, rspb.CacheType_CAS)
 	setDigestsInCache(b, ctx, c, digestBufs)
 	digests := make([]*rspb.ResourceName, 0, len(digestBufs))
 	var sumBytes int64
@@ -441,16 +441,19 @@ func BenchmarkGetSingle(b *testing.B) {
 }
 
 func BenchmarkGetMulti(b *testing.B) {
-	sizes := []int64{10, 100, 1000, 10000}
+	sizes := []int64{100, 10000}
+	batchSizes := []int{1, 2, 3, 5, 10, 25, 50, 100, 500}
 	te := getTestEnv(b)
 	ctx := getUserContext(b, te)
 
 	for _, cache := range getAllCaches(b, te) {
 		for _, size := range sizes {
-			name := fmt.Sprintf("%s%d", cache.Name, size)
-			b.Run(name, func(b *testing.B) {
-				benchmarkGetMulti(ctx, cache, size, b)
-			})
+			for _, batchSize := range batchSizes {
+				name := fmt.Sprintf("%s%d/batch%d", cache.Name, size, batchSize)
+				b.Run(name, func(b *testing.B) {
+					benchmarkGetMulti(ctx, cache, size, batchSize, b)
+				})
+			}
 		}
 	}
 }


### PR DESCRIPTION
This is following from https://github.com/buildbuddy-io/buildbuddy/pull/12863.

I checked a 40+ traces, and in the vast majority of them, GetMulti only gets 1 or 2 resources, and they are most often small (inlined) tree cache objects. In those cases, creating goroutines is just overhead. Also, for inlined objects, we don't need 1 goroutine per object. This change makes the 1 inlined object fetch 60% faster, and even if that's optimistic, it avoids creating a goroutine.

```
                                      │ /tmp/pebblebase2 │          /tmp/pebble10sc5           │
                                      │      sec/op      │    sec/op     vs base               │
GetMulti/LocalPebble100/batch1-24           6.749µ ±  2%   2.455µ ±  5%  -63.62% (p=0.001 n=7)
GetMulti/LocalPebble100/batch2-24           9.571µ ±  6%   3.811µ ±  2%  -60.18% (p=0.001 n=7)
GetMulti/LocalPebble100/batch3-24          10.835µ ±  4%   5.086µ ±  2%  -53.06% (p=0.001 n=7)
GetMulti/LocalPebble100/batch5-24           14.90µ ±  2%   12.71µ ±  8%  -14.68% (p=0.001 n=7)
GetMulti/LocalPebble100/batch10-24          22.99µ ±  3%   19.34µ ±  4%  -15.89% (p=0.001 n=7)
GetMulti/LocalPebble100/batch25-24          39.63µ ± 14%   34.04µ ±  9%  -14.10% (p=0.007 n=7)
GetMulti/LocalPebble100/batch50-24          63.44µ ± 11%   60.36µ ± 10%        ~ (p=0.097 n=7)
GetMulti/LocalPebble100/batch100-24         86.10µ ± 10%   85.52µ ± 12%        ~ (p=1.000 n=7)
GetMulti/LocalPebble100/batch500-24         319.1µ ± 21%   312.3µ ± 17%        ~ (p=0.383 n=7)
GetMulti/LocalPebble10000/batch1-24        13.660µ ±  3%   9.307µ ±  6%  -31.87% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch2-24         19.57µ ±  8%   18.47µ ±  5%        ~ (p=0.165 n=7)
GetMulti/LocalPebble10000/batch3-24         22.73µ ± 12%   25.16µ ±  2%        ~ (p=0.097 n=7)
GetMulti/LocalPebble10000/batch5-24         33.99µ ± 12%   33.03µ ±  6%        ~ (p=0.511 n=7)
GetMulti/LocalPebble10000/batch10-24        49.39µ ±  9%   51.17µ ±  7%        ~ (p=0.620 n=7)
GetMulti/LocalPebble10000/batch25-24        83.71µ ±  3%   82.43µ ±  5%        ~ (p=0.073 n=7)
GetMulti/LocalPebble10000/batch50-24        122.3µ ±  2%   121.6µ ±  2%        ~ (p=0.300 n=7)
GetMulti/LocalPebble10000/batch100-24       198.3µ ±  2%   198.4µ ±  2%        ~ (p=0.620 n=7)
GetMulti/LocalPebble10000/batch500-24       804.9µ ±  2%   811.5µ ±  2%        ~ (p=0.209 n=7)
geomean                                     43.21µ         35.39µ        -18.11%

                                      │ /tmp/pebblebase2 │            /tmp/pebble10sc5            │
                                      │       B/s        │      B/s        vs base                │
GetMulti/LocalPebble100/batch1-24          14.13Mi ±  2%    38.84Mi ±  4%  +174.83% (p=0.001 n=7)
GetMulti/LocalPebble100/batch2-24          19.93Mi ±  5%    50.05Mi ±  2%  +151.10% (p=0.001 n=7)
GetMulti/LocalPebble100/batch3-24          26.41Mi ±  4%    56.25Mi ±  2%  +113.00% (p=0.001 n=7)
GetMulti/LocalPebble100/batch5-24          32.01Mi ±  2%    37.52Mi ±  9%   +17.22% (p=0.001 n=7)
GetMulti/LocalPebble100/batch10-24         41.48Mi ±  3%    49.31Mi ±  5%   +18.87% (p=0.001 n=7)
GetMulti/LocalPebble100/batch25-24         60.16Mi ± 17%    70.04Mi ± 10%   +16.42% (p=0.007 n=7)
GetMulti/LocalPebble100/batch50-24         75.16Mi ± 12%    79.00Mi ± 11%         ~ (p=0.097 n=7)
GetMulti/LocalPebble100/batch100-24        110.8Mi ±  9%    111.5Mi ± 10%         ~ (p=1.000 n=7)
GetMulti/LocalPebble100/batch500-24        149.5Mi ± 27%    152.7Mi ± 21%         ~ (p=0.383 n=7)
GetMulti/LocalPebble10000/batch1-24        698.2Mi ±  3%   1024.6Mi ±  6%   +46.76% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch2-24        974.8Mi ±  8%   1032.6Mi ±  5%         ~ (p=0.165 n=7)
GetMulti/LocalPebble10000/batch3-24        1.229Gi ± 11%    1.110Gi ±  2%         ~ (p=0.097 n=7)
GetMulti/LocalPebble10000/batch5-24        1.370Gi ± 13%    1.410Gi ±  6%         ~ (p=0.511 n=7)
GetMulti/LocalPebble10000/batch10-24       1.886Gi ±  9%    1.820Gi ±  8%         ~ (p=0.620 n=7)
GetMulti/LocalPebble10000/batch25-24       2.781Gi ±  3%    2.824Gi ±  5%         ~ (p=0.073 n=7)
GetMulti/LocalPebble10000/batch50-24       3.808Gi ±  2%    3.830Gi ±  2%         ~ (p=0.318 n=7)
GetMulti/LocalPebble10000/batch100-24      4.696Gi ±  2%    4.694Gi ±  2%         ~ (p=0.620 n=7)
GetMulti/LocalPebble10000/batch500-24      5.786Gi ±  2%    5.738Gi ±  2%         ~ (p=0.209 n=7)
geomean                                    305.7Mi          373.3Mi         +22.11%

                                      │ /tmp/pebblebase2 │          /tmp/pebble10sc5           │
                                      │       B/op       │     B/op       vs base              │
GetMulti/LocalPebble100/batch1-24          2.582Ki ±  2%   2.399Ki ±  2%  -7.07% (p=0.001 n=7)
GetMulti/LocalPebble100/batch2-24          3.928Ki ±  2%   3.611Ki ±  3%  -8.06% (p=0.001 n=7)
GetMulti/LocalPebble100/batch3-24          5.397Ki ±  2%   4.948Ki ±  2%  -8.32% (p=0.001 n=7)
GetMulti/LocalPebble100/batch5-24          8.223Ki ±  1%   7.707Ki ±  1%  -6.27% (p=0.001 n=7)
GetMulti/LocalPebble100/batch10-24         15.58Ki ±  0%   14.43Ki ±  0%  -7.41% (p=0.001 n=7)
GetMulti/LocalPebble100/batch25-24         35.49Ki ±  1%   34.37Ki ±  1%  -3.15% (p=0.001 n=7)
GetMulti/LocalPebble100/batch50-24         68.57Ki ±  0%   67.52Ki ±  0%  -1.53% (p=0.001 n=7)
GetMulti/LocalPebble100/batch100-24        135.1Ki ±  1%   134.1Ki ±  1%  -0.73% (p=0.002 n=7)
GetMulti/LocalPebble100/batch500-24        682.7Ki ±  0%   681.6Ki ±  0%  -0.16% (p=0.026 n=7)
GetMulti/LocalPebble10000/batch1-24        12.30Ki ± 20%   12.12Ki ± 21%       ~ (p=0.195 n=7)
GetMulti/LocalPebble10000/batch2-24        23.71Ki ±  3%   23.60Ki ±  3%       ~ (p=0.620 n=7)
GetMulti/LocalPebble10000/batch3-24        35.37Ki ±  2%   35.15Ki ±  2%       ~ (p=0.318 n=7)
GetMulti/LocalPebble10000/batch5-24        57.94Ki ±  2%   57.49Ki ±  2%       ~ (p=0.383 n=7)
GetMulti/LocalPebble10000/batch10-24       114.9Ki ±  1%   113.9Ki ±  1%       ~ (p=0.073 n=7)
GetMulti/LocalPebble10000/batch25-24       283.6Ki ±  3%   282.6Ki ±  3%       ~ (p=0.383 n=7)
GetMulti/LocalPebble10000/batch50-24       569.1Ki ±  1%   568.1Ki ±  1%       ~ (p=0.535 n=7)
GetMulti/LocalPebble10000/batch100-24      1.108Mi ±  1%   1.107Mi ±  1%       ~ (p=0.535 n=7)
GetMulti/LocalPebble10000/batch500-24      5.571Mi ±  0%   5.570Mi ±  0%       ~ (p=0.620 n=7)
geomean                                    60.35Ki         58.73Ki        -2.69%

                                      │ /tmp/pebblebase2 │          /tmp/pebble10sc5          │
                                      │    allocs/op     │  allocs/op   vs base               │
GetMulti/LocalPebble100/batch1-24             43.00 ± 0%    38.00 ± 0%  -11.63% (p=0.001 n=7)
GetMulti/LocalPebble100/batch2-24             67.00 ± 0%    60.00 ± 0%  -10.45% (p=0.001 n=7)
GetMulti/LocalPebble100/batch3-24             91.00 ± 0%    82.00 ± 0%   -9.89% (p=0.001 n=7)
GetMulti/LocalPebble100/batch5-24             139.0 ± 0%    131.0 ± 0%   -5.76% (p=0.001 n=7)
GetMulti/LocalPebble100/batch10-24            261.0 ± 0%    244.0 ± 0%   -6.51% (p=0.001 n=7)
GetMulti/LocalPebble100/batch25-24            591.0 ± 0%    576.0 ± 0%   -2.54% (p=0.001 n=7)
GetMulti/LocalPebble100/batch50-24           1.141k ± 0%   1.128k ± 0%   -1.14% (p=0.001 n=7)
GetMulti/LocalPebble100/batch100-24          2.241k ± 0%   2.231k ± 0%   -0.45% (p=0.001 n=7)
GetMulti/LocalPebble100/batch500-24          11.04k ± 0%   11.03k ± 0%   -0.09% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch1-24           46.00 ± 0%    41.00 ± 0%  -10.87% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch2-24           73.00 ± 0%    71.00 ± 0%   -2.74% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch3-24          100.00 ± 0%    97.00 ± 0%   -3.00% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch5-24           154.0 ± 0%    149.0 ± 0%   -3.25% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch10-24          291.0 ± 0%    281.0 ± 0%   -3.44% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch25-24          666.0 ± 0%    656.0 ± 0%   -1.50% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch50-24         1.291k ± 0%   1.281k ± 0%   -0.77% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch100-24        2.542k ± 0%   2.532k ± 0%   -0.39% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch500-24        12.55k ± 0%   12.54k ± 0%   -0.08% (p=0.001 n=7)
geomean                                       398.9         382.1        -4.22%
```