### PR TITLE
Honor CPU/memory hints provided via exec properties

### DIFF
--- a/server/resources/BUILD
+++ b/server/resources/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//server/util/flag",
         "//server/util/flagutil",
         "//server/util/log",
+        "//server/util/platform",
         "//server/util/status",
         "@com_github_elastic_gosigar//:gosigar",
         "@com_google_cloud_go_compute_metadata//:metadata",

--- a/server/resources/resources.go
+++ b/server/resources/resources.go
@@ -14,6 +14,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/platform"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/elastic/gosigar"
 
@@ -174,6 +175,13 @@ func Configure(mmapLRUEnabled bool) error {
 	// Note: disk capacity is configured separately via ConfigureDiskCapacity,
 	// which must run after the build root directory exists.
 	allocatedDiskBytes = *diskBytes
+
+	for _, r := range *customResources {
+		if r.Name == platform.BazelCPUResourceName || r.Name == platform.BazelMemoryResourceName {
+			log.Warningf("executor.custom_resources registers %q, but the %q exec property is now interpreted as a task size estimate and no longer claims a custom resource. Rename this resource if tasks should still be gated on it.",
+				r.Name, "resources:"+r.Name)
+		}
+	}
 
 	log.Debugf("Set allocatedRAMBytes to %d", allocatedRAMBytes)
 	log.Debugf("Set allocatedCPUMillis to %d", allocatedCPUMillis)

--- a/server/util/platform/platform.go
+++ b/server/util/platform/platform.go
@@ -183,6 +183,14 @@ const (
 	// Property name prefix indicating a custom resource assignment.
 	customResourcePrefix = "resources:"
 
+	// Names that Bazel uses for its two built-in resources, both in an action's
+	// `resource_set` and in "resources:"-prefixed exec properties. Bazel
+	// measures "cpu" in cores and "memory" in MiB.
+	//
+	// https://github.com/bazelbuild/bazel/blob/d2c57c67d49e051a5e7b2feb457c00b4ca531267/src/main/java/com/google/devtools/build/lib/actions/ResourceSet.java#L45-L46
+	bazelCPUResourceName    = "cpu"
+	bazelMemoryResourceName = "memory"
+
 // If you add a container type, also add it to KnownContainerTypes
 )
 
@@ -483,14 +491,27 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 		return nil, err
 	}
 
-	// Parse custom resources
+	// Parse custom resources.
+	//
+	// Bazel actions can be annotated with "resources:"-prefixed exec properties, which mention both custom resources
+	// and the well-known resources "cpu" and "memory". The former are controlled by the user and affect scheduling, the
+	// latter are used as resource estimates.
 	var customResources []*scpb.CustomResource
+	var bazelMilliCPU, bazelMemoryBytes int64
 	for k, v := range m {
 		if after, ok := strings.CutPrefix(k, customResourcePrefix); ok {
 			name := after
 			value, err := strconv.ParseFloat(v, 32)
 			if err != nil {
 				return nil, status.InvalidArgumentErrorf("parse execution property %q: value is not a valid float32", k)
+			}
+			switch name {
+			case bazelCPUResourceName:
+				bazelMilliCPU = int64(value * 1000)
+				continue
+			case bazelMemoryResourceName:
+				bazelMemoryBytes = int64(value * 1024 * 1024)
+				continue
 			}
 			customResources = append(customResources, &scpb.CustomResource{
 				Name:  name,
@@ -552,8 +573,8 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 		PoolType:                  poolType,
 		OriginalPool:              stringProp(m, originalPoolPropertyName, ""),
 		EstimatedComputeUnits:     float64Prop(m, EstimatedComputeUnitsPropertyName, 0),
-		EstimatedMemoryBytes:      iecBytesProp(m, EstimatedMemoryPropertyName, 0),
-		EstimatedMilliCPU:         milliCPUProp(m, EstimatedCPUPropertyName, 0),
+		EstimatedMemoryBytes:      iecBytesProp(m, EstimatedMemoryPropertyName, bazelMemoryBytes),
+		EstimatedMilliCPU:         milliCPUProp(m, EstimatedCPUPropertyName, bazelMilliCPU),
 		EstimatedFreeDiskBytes:    iecBytesProp(m, EstimatedFreeDiskPropertyName, 0),
 		CustomResources:           customResources,
 		ContainerImage:            stringProp(m, containerImagePropertyName, ""),

--- a/server/util/platform/platform.go
+++ b/server/util/platform/platform.go
@@ -9,6 +9,7 @@ package platform
 import (
 	"context"
 	"encoding/base64"
+	"math"
 	"regexp"
 	"slices"
 	"strconv"
@@ -187,9 +188,13 @@ const (
 	// `resource_set` and in "resources:"-prefixed exec properties. Bazel
 	// measures "cpu" in cores and "memory" in MiB.
 	//
+	// Since these are interpreted as task size estimates, they cannot also be
+	// used as custom resource names; executors warn if they are registered as
+	// such.
+	//
 	// https://github.com/bazelbuild/bazel/blob/d2c57c67d49e051a5e7b2feb457c00b4ca531267/src/main/java/com/google/devtools/build/lib/actions/ResourceSet.java#L45-L46
-	bazelCPUResourceName    = "cpu"
-	bazelMemoryResourceName = "memory"
+	BazelCPUResourceName    = "cpu"
+	BazelMemoryResourceName = "memory"
 
 // If you add a container type, also add it to KnownContainerTypes
 )
@@ -499,23 +504,30 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 	var customResources []*scpb.CustomResource
 	var bazelMilliCPU, bazelMemoryBytes int64
 	for k, v := range m {
-		if after, ok := strings.CutPrefix(k, customResourcePrefix); ok {
-			name := after
-			value, err := strconv.ParseFloat(v, 32)
+		if name, ok := strings.CutPrefix(k, customResourcePrefix); ok {
+			value, err := strconv.ParseFloat(v, 64)
 			if err != nil {
-				return nil, status.InvalidArgumentErrorf("parse execution property %q: value is not a valid float32", k)
+				return nil, status.InvalidArgumentErrorf("parse execution property %q: value is not a valid float", k)
+			}
+			if math.IsNaN(value) {
+				continue
 			}
 			switch name {
-			case bazelCPUResourceName:
-				bazelMilliCPU = int64(value * 1000)
+			case BazelCPUResourceName:
+				if value > 0 {
+					bazelMilliCPU = int64(math.Round(value * 1000))
+				}
 				continue
-			case bazelMemoryResourceName:
-				bazelMemoryBytes = int64(value * 1024 * 1024)
+			case BazelMemoryResourceName:
+				if value > 0 {
+					bazelMemoryBytes = int64(math.Round(value * 1024 * 1024))
+				}
 				continue
 			}
 			customResources = append(customResources, &scpb.CustomResource{
-				Name:  name,
-				Value: float32(value),
+				Name: name,
+				// Clamp rather than letting the conversion produce ±Inf.
+				Value: float32(min(max(value, -math.MaxFloat32), math.MaxFloat32)),
 			})
 		}
 	}

--- a/server/util/platform/platform_test.go
+++ b/server/util/platform/platform_test.go
@@ -302,6 +302,24 @@ func TestParse_BazelResourceProperties(t *testing.T) {
 	}}, p.CustomResources, protocmp.Transform()))
 }
 
+func TestParse_BazelResourceProperties_UnusableValuesIgnored(t *testing.T) {
+	props := []*repb.Platform_Property{
+		{Name: "resources:cpu", Value: "-1"},
+		{Name: "resources:memory", Value: "0"},
+		{Name: "resources:gpu", Value: "NaN"},
+	}
+	task := &repb.ExecutionTask{Command: &repb.Command{Platform: &repb.Platform{Properties: props}}}
+	p, err := ParseProperties(task)
+	require.NoError(t, err)
+
+	// Values that can't produce a usable estimate are treated as unset rather
+	// than yielding a negative, zero or NaN task size, and a NaN custom
+	// resource is dropped instead of being sent to the scheduler.
+	assert.Equal(t, int64(0), p.EstimatedMilliCPU)
+	assert.Equal(t, int64(0), p.EstimatedMemoryBytes)
+	assert.Empty(t, p.CustomResources)
+}
+
 func TestParse_BazelResourceProperties_ExplicitEstimatesWin(t *testing.T) {
 	props := []*repb.Platform_Property{
 		{Name: "resources:cpu", Value: "4"},

--- a/server/util/platform/platform_test.go
+++ b/server/util/platform/platform_test.go
@@ -284,6 +284,49 @@ func TestParse_CustomResources_Invalid(t *testing.T) {
 	require.True(t, status.IsInvalidArgumentError(err), "expected InvalidArgument, got %s", gstatus.Code(err))
 }
 
+func TestParse_BazelResourceProperties(t *testing.T) {
+	props := []*repb.Platform_Property{
+		{Name: "resources:cpu", Value: "2.5"},
+		{Name: "resources:memory", Value: "512"},
+		{Name: "resources:gpu", Value: "1"},
+	}
+	task := &repb.ExecutionTask{Command: &repb.Command{Platform: &repb.Platform{Properties: props}}}
+	p, err := ParseProperties(task)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(2500), p.EstimatedMilliCPU)
+	assert.Equal(t, int64(512*1024*1024), p.EstimatedMemoryBytes)
+	// Resource names Bazel doesn't define stay custom resources.
+	require.Empty(t, cmp.Diff([]*scpb.CustomResource{{
+		Name: "gpu", Value: 1,
+	}}, p.CustomResources, protocmp.Transform()))
+}
+
+func TestParse_BazelResourceProperties_ExplicitEstimatesWin(t *testing.T) {
+	props := []*repb.Platform_Property{
+		{Name: "resources:cpu", Value: "4"},
+		{Name: "resources:memory", Value: "512"},
+		{Name: "EstimatedCPU", Value: "1"},
+		{Name: "EstimatedMemory", Value: "1GB"},
+	}
+	task := &repb.ExecutionTask{Command: &repb.Command{Platform: &repb.Platform{Properties: props}}}
+	p, err := ParseProperties(task)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1000), p.EstimatedMilliCPU)
+	assert.Equal(t, int64(1024*1024*1024), p.EstimatedMemoryBytes)
+	assert.Empty(t, p.CustomResources)
+}
+
+func TestParse_BazelResourceProperties_InvalidValue(t *testing.T) {
+	props := []*repb.Platform_Property{
+		{Name: "resources:cpu", Value: "blah"},
+	}
+	task := &repb.ExecutionTask{Command: &repb.Command{Platform: &repb.Platform{Properties: props}}}
+	_, err := ParseProperties(task)
+	require.True(t, status.IsInvalidArgumentError(err), "expected InvalidArgument, got %s", gstatus.Code(err))
+}
+
 func TestParse_OverrideSnapshotKey(t *testing.T) {
 	key := &fcpb.SnapshotKey{
 		SnapshotId:        "snapshot-id",


### PR DESCRIPTION
`exec_properties` on a target or `platform` can be used to convey both custom and default (CPU/memory) resource bounds for local and remote execution. Previously, we would treat `resources:cpu:1` as a request for a custom resource `cpu` that users had to register explicitly, now we consider it a hint for the expected CPU share of the the task.

In the future, Bazel may (optionally) turn any `resource_set` supplied on an action into `resources:` exec properties, at which point local resource bounds will automatically turn into remote resource estimates.