### PR TITLE
Create fewer goroutines in metacache.GetMulti

### DIFF
--- a/enterprise/server/backends/metacache/metacache.go
+++ b/enterprise/server/backends/metacache/metacache.go
@@ -129,6 +129,7 @@ func GetOptionsFromConfig(env environment.Env, cfg *cache_config.MetaCacheConfig
 		PartitionMappings:           cfg.PartitionMappings,
 		MaxInlineFileSizeBytes:      cfg.MaxInlineFileSizeBytes,
 		MinBytesAutoZstdCompression: cfg.MinBytesAutoZstdCompression,
+		MaxReadGoroutines:           cfg.MaxReadGoroutines,
 		MaxWriteGoroutines:          cfg.MaxWriteGoroutines,
 		GCSBucket:                   cfg.GCSConfig.Bucket,
 		GCSCredentials:              cfg.GCSConfig.Credentials,
@@ -722,7 +723,7 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 
 	// Add 1 goroutine per non-inline resource, since they can be slow. The
 	// inline blobs don't require any more I/O.
-	maxGoroutines := min(10, nonInlineCount)
+	maxGoroutines := min(c.opts.MaxReadGoroutines, nonInlineCount)
 	if maxGoroutines <= 1 {
 		// Don't start goroutines if we don't have to.
 		if err := handleBatch(); err != nil {

--- a/enterprise/server/backends/metacache/metacache.go
+++ b/enterprise/server/backends/metacache/metacache.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"io"
 	"os"
-	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/cache_config"
@@ -669,47 +669,73 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 		md       *sgpb.FileMetadata
 	}
 	hits := make([]resourceMetadata, 0, len(resources))
+	nonInlineCount := 0
 	for i, r := range resources {
-		if mds[i].GetFileRecord() == nil {
+		md := mds[i]
+		if md.GetFileRecord() == nil {
 			// Missing metadata, skip
 			continue
 		}
-		hits = append(hits, resourceMetadata{resource: r, md: mds[i]})
+		hits = append(hits, resourceMetadata{resource: r, md: md})
+		if md.GetStorageMetadata().GetInlineMetadata() == nil {
+			nonInlineCount++
+		}
 	}
 
+	var next atomic.Int64
 	var foundMu sync.Mutex
 	foundMap := make(map[*repb.Digest][]byte, len(hits))
-	eg, ctx := errgroup.WithContext(ctx)
-	numChunks := c.opts.MaxReadGoroutines
-	chunkSize := max(1, (len(hits)+numChunks-1)/numChunks)
-	for chunk := range slices.Chunk(hits, chunkSize) {
-		eg.Go(func() error {
-			for _, hit := range chunk {
-				r := hit.resource
-				rc, err := c.reader(ctx, hit.md, r, 0, 0, encryption)
-				if err != nil {
-					if status.IsNotFoundError(err) || os.IsNotExist(err) {
-						continue
-					}
-					return err
-				}
-				buf := bytes.NewBuffer(make([]byte, 0, c.readBufSize(r, hit.md, rc)))
-				_, copyErr := io.Copy(buf, rc)
-				closeErr := rc.Close()
-				if copyErr != nil {
-					log.Warningf("[%s] GetMulti encountered error when copying %s: %s", c.opts.Name, r.GetDigest().GetHash(), copyErr)
-					continue
-				}
-				if closeErr != nil {
-					log.Warningf("[%s] GetMulti cannot close reader when copying %s: %s", c.opts.Name, r.GetDigest().GetHash(), closeErr)
-					continue
-				}
-				foundMu.Lock()
-				foundMap[r.GetDigest()] = buf.Bytes()
-				foundMu.Unlock()
+	handleBatch := func() error {
+		for {
+			if err := ctx.Err(); err != nil {
+				return err
 			}
-			return nil
-		})
+			i := int(next.Add(1)) - 1
+			if i >= len(hits) {
+				return nil
+			}
+			hit := hits[i]
+			r := hit.resource
+			rc, err := c.reader(ctx, hit.md, r, 0, 0, encryption)
+			if err != nil {
+				if status.IsNotFoundError(err) || os.IsNotExist(err) {
+					continue
+				}
+				return err
+			}
+			buf := bytes.NewBuffer(make([]byte, 0, c.readBufSize(r, hit.md, rc)))
+			_, copyErr := io.Copy(buf, rc)
+			closeErr := rc.Close()
+			if copyErr != nil {
+				log.Warningf("[%s] GetMulti encountered error when copying %s: %s", c.opts.Name, r.GetDigest().GetHash(), copyErr)
+				continue
+			}
+			if closeErr != nil {
+				log.Warningf("[%s] GetMulti cannot close reader when copying %s: %s", c.opts.Name, r.GetDigest().GetHash(), closeErr)
+				continue
+			}
+			foundMu.Lock()
+			foundMap[r.GetDigest()] = buf.Bytes()
+			foundMu.Unlock()
+		}
+	}
+
+	// Add 1 goroutine per non-inline resource, since they can be slow. The
+	// inline blobs don't require any more I/O.
+	maxGoroutines := min(10, nonInlineCount)
+	if maxGoroutines <= 1 {
+		// Don't start goroutines if we don't have to.
+		if err := handleBatch(); err != nil {
+			return nil, err
+		}
+		return foundMap, nil
+	}
+
+	// Make sure to set the ctx used inside handleBatch (don't shadow it).
+	var eg *errgroup.Group
+	eg, ctx = errgroup.WithContext(ctx)
+	for range maxGoroutines {
+		eg.Go(handleBatch)
 	}
 	if err := eg.Wait(); err != nil {
 		return nil, err


### PR DESCRIPTION
This is like https://github.com/buildbuddy-io/buildbuddy/pull/12970, but for the metacache instead of the pebble cache.

One notable difference is that the metacache reads all inline records in a single RPC from the metadata service, so it doesn't need any additional goroutines for those.

```
                               │   metabase    │               metasc4               │
                               │    sec/op     │    sec/op     vs base               │
GetMulti/Meta100/batch1-24        44.83µ ±  3%   41.84µ ±  3%   -6.65% (p=0.001 n=7)
GetMulti/Meta100/batch2-24        48.13µ ±  5%   44.04µ ±  9%   -8.50% (p=0.004 n=7)
GetMulti/Meta100/batch3-24        49.17µ ±  3%   44.89µ ±  4%   -8.72% (p=0.001 n=7)
GetMulti/Meta100/batch5-24        52.71µ ±  9%   46.81µ ±  4%  -11.19% (p=0.001 n=7)
GetMulti/Meta100/batch10-24       60.78µ ±  8%   55.51µ ±  6%   -8.68% (p=0.001 n=7)
GetMulti/Meta100/batch25-24       87.42µ ± 16%   73.41µ ±  4%  -16.03% (p=0.004 n=7)
GetMulti/Meta100/batch50-24      126.00µ ±  4%   96.55µ ±  8%  -23.38% (p=0.001 n=7)
GetMulti/Meta100/batch100-24      210.1µ ±  4%   172.2µ ± 10%  -18.03% (p=0.001 n=7)
GetMulti/Meta100/batch500-24      833.8µ ±  6%   662.7µ ±  3%  -20.52% (p=0.001 n=7)
GetMulti/Meta10000/batch1-24      1.058m ±  0%   1.056m ±  0%        ~ (p=0.209 n=7)
GetMulti/Meta10000/batch2-24      1.082m ±  0%   1.083m ±  1%        ~ (p=0.259 n=7)
GetMulti/Meta10000/batch3-24      1.085m ±  1%   1.083m ±  0%        ~ (p=0.259 n=7)
GetMulti/Meta10000/batch5-24      1.105m ±  1%   1.106m ±  1%        ~ (p=0.318 n=7)
GetMulti/Meta10000/batch10-24     1.163m ±  1%   1.163m ±  0%        ~ (p=1.000 n=7)
GetMulti/Meta10000/batch25-24     3.207m ±  1%   3.155m ±  0%   -1.61% (p=0.001 n=7)
GetMulti/Meta10000/batch50-24     5.280m ±  1%   5.268m ±  1%        ~ (p=0.902 n=7)
GetMulti/Meta10000/batch100-24    10.33m ±  1%   10.30m ±  1%        ~ (p=0.383 n=7)
GetMulti/Meta10000/batch500-24    51.63m ±  1%   51.41m ±  1%   -0.43% (p=0.017 n=7)
geomean                           525.8µ         487.7µ         -7.25%

                               │   metabase    │                metasc4                │
                               │      B/s      │      B/s        vs base               │
GetMulti/Meta100/batch1-24       2.127Mi ±  3%    2.279Mi ±  3%   +7.17% (p=0.001 n=7)
GetMulti/Meta100/batch2-24       3.967Mi ±  5%    4.330Mi ±  8%   +9.13% (p=0.004 n=7)
GetMulti/Meta100/batch3-24       5.817Mi ±  3%    6.371Mi ±  4%   +9.51% (p=0.001 n=7)
GetMulti/Meta100/batch5-24       9.050Mi ± 10%   10.185Mi ±  4%  +12.54% (p=0.001 n=7)
GetMulti/Meta100/batch10-24      15.69Mi ±  7%    17.19Mi ±  6%   +9.54% (p=0.001 n=7)
GetMulti/Meta100/batch25-24      27.28Mi ± 19%    32.48Mi ±  4%  +19.09% (p=0.004 n=7)
GetMulti/Meta100/batch50-24      37.84Mi ±  5%    49.39Mi ±  8%  +30.52% (p=0.001 n=7)
GetMulti/Meta100/batch100-24     45.39Mi ±  4%    55.38Mi ± 11%  +22.00% (p=0.001 n=7)
GetMulti/Meta100/batch500-24     57.19Mi ±  7%    71.95Mi ±  3%  +25.80% (p=0.001 n=7)
GetMulti/Meta10000/batch1-24     9.022Mi ±  0%    9.031Mi ±  0%        ~ (p=0.302 n=7)
GetMulti/Meta10000/batch2-24     17.63Mi ±  0%    17.61Mi ±  1%        ~ (p=0.210 n=7)
GetMulti/Meta10000/batch3-24     26.37Mi ±  1%    26.42Mi ±  0%        ~ (p=0.302 n=7)
GetMulti/Meta10000/batch5-24     43.15Mi ±  1%    43.10Mi ±  1%        ~ (p=0.300 n=7)
GetMulti/Meta10000/batch10-24    82.03Mi ±  1%    81.99Mi ±  0%        ~ (p=0.979 n=7)
GetMulti/Meta10000/batch25-24    74.34Mi ±  1%    75.56Mi ±  0%   +1.64% (p=0.001 n=7)
GetMulti/Meta10000/batch50-24    90.30Mi ±  1%    90.51Mi ±  1%        ~ (p=0.929 n=7)
GetMulti/Meta10000/batch100-24   92.33Mi ±  1%    92.56Mi ±  1%        ~ (p=0.364 n=7)
GetMulti/Meta10000/batch500-24   92.35Mi ±  1%    92.74Mi ±  1%   +0.42% (p=0.017 n=7)
geomean                          25.12Mi          27.08Mi         +7.80%

                               │   metabase   │              metasc4               │
                               │     B/op     │     B/op      vs base              │
GetMulti/Meta100/batch1-24       29.56Ki ± 0%   29.41Ki ± 0%  -0.51% (p=0.001 n=7)
GetMulti/Meta100/batch2-24       31.71Ki ± 1%   31.43Ki ± 1%  -0.88% (p=0.001 n=7)
GetMulti/Meta100/batch3-24       34.22Ki ± 1%   33.85Ki ± 1%  -1.09% (p=0.001 n=7)
GetMulti/Meta100/batch5-24       38.85Ki ± 0%   38.28Ki ± 0%  -1.47% (p=0.001 n=7)
GetMulti/Meta100/batch10-24      46.73Ki ± 0%   45.63Ki ± 0%  -2.36% (p=0.001 n=7)
GetMulti/Meta100/batch25-24      69.54Ki ± 1%   68.48Ki ± 1%  -1.53% (p=0.001 n=7)
GetMulti/Meta100/batch50-24      111.2Ki ± 0%   109.9Ki ± 0%  -1.22% (p=0.001 n=7)
GetMulti/Meta100/batch100-24     196.1Ki ± 0%   194.4Ki ± 0%  -0.90% (p=0.001 n=7)
GetMulti/Meta100/batch500-24     896.0Ki ± 0%   885.0Ki ± 0%  -1.23% (p=0.001 n=7)
GetMulti/Meta10000/batch1-24     32.73Ki ± 3%   32.67Ki ± 3%       ~ (p=0.209 n=7)
GetMulti/Meta10000/batch2-24     38.39Ki ± 1%   38.34Ki ± 1%       ~ (p=0.805 n=7)
GetMulti/Meta10000/batch3-24     44.28Ki ± 1%   44.11Ki ± 1%       ~ (p=0.209 n=7)
GetMulti/Meta10000/batch5-24     53.06Ki ± 1%   52.63Ki ± 1%       ~ (p=0.318 n=7)
GetMulti/Meta10000/batch10-24    79.49Ki ± 1%   78.76Ki ± 1%  -0.92% (p=0.004 n=7)
GetMulti/Meta10000/batch25-24    150.8Ki ± 2%   150.0Ki ± 2%       ~ (p=0.383 n=7)
GetMulti/Meta10000/batch50-24    275.8Ki ± 1%   276.1Ki ± 1%       ~ (p=0.902 n=7)
GetMulti/Meta10000/batch100-24   524.4Ki ± 1%   521.8Ki ± 1%       ~ (p=0.128 n=7)
GetMulti/Meta10000/batch500-24   2.589Mi ± 1%   2.585Mi ± 2%       ~ (p=1.000 n=7)
geomean                          100.4Ki        99.58Ki       -0.82%

                               │  metabase   │              metasc4              │
                               │  allocs/op  │  allocs/op   vs base              │
GetMulti/Meta100/batch1-24        402.0 ± 0%    398.0 ± 0%  -1.00% (p=0.001 n=7)
GetMulti/Meta100/batch2-24        431.0 ± 0%    425.0 ± 0%  -1.39% (p=0.001 n=7)
GetMulti/Meta100/batch3-24        461.0 ± 0%    452.0 ± 0%  -1.95% (p=0.001 n=7)
GetMulti/Meta100/batch5-24        517.0 ± 0%    505.0 ± 0%  -2.32% (p=0.001 n=7)
GetMulti/Meta100/batch10-24       651.0 ± 0%    629.0 ± 0%  -3.38% (p=0.001 n=7)
GetMulti/Meta100/batch25-24      1.022k ± 0%   1.001k ± 0%  -2.05% (p=0.001 n=7)
GetMulti/Meta100/batch50-24      1.651k ± 0%   1.629k ± 0%  -1.33% (p=0.001 n=7)
GetMulti/Meta100/batch100-24     2.910k ± 0%   2.887k ± 0%  -0.79% (p=0.001 n=7)
GetMulti/Meta100/batch500-24     12.93k ± 0%   12.91k ± 0%  -0.19% (p=0.001 n=7)
GetMulti/Meta10000/batch1-24      406.0 ± 0%    402.0 ± 0%  -0.99% (p=0.001 n=7)
GetMulti/Meta10000/batch2-24      434.0 ± 0%    433.0 ± 0%  -0.23% (p=0.020 n=7)
GetMulti/Meta10000/batch3-24      464.0 ± 0%    461.0 ± 0%  -0.65% (p=0.001 n=7)
GetMulti/Meta10000/batch5-24      514.0 ± 0%    510.0 ± 0%  -0.78% (p=0.001 n=7)
GetMulti/Meta10000/batch10-24     654.0 ± 0%    645.0 ± 0%  -1.38% (p=0.001 n=7)
GetMulti/Meta10000/batch25-24    1.027k ± 0%   1.020k ± 0%  -0.68% (p=0.001 n=7)
GetMulti/Meta10000/batch50-24    1.659k ± 0%   1.650k ± 0%  -0.54% (p=0.001 n=7)
GetMulti/Meta10000/batch100-24   2.922k ± 0%   2.913k ± 0%  -0.31% (p=0.001 n=7)
GetMulti/Meta10000/batch500-24   13.02k ± 0%   13.01k ± 0%       ~ (p=0.070 n=7)
geomean                          1.064k        1.052k       -1.11%
```