### PR TITLE
codex/vmexec connection backoff

### DIFF
--- a/enterprise/server/util/vsock/BUILD
+++ b/enterprise/server/util/vsock/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -18,11 +18,4 @@ go_library(
         "@org_golang_google_grpc//backoff",
         "@org_golang_x_sys//unix",
     ],
-)
-
-go_test(
-    name = "vsock_test",
-    srcs = ["vsock_test.go"],
-    embed = [":vsock"],
-    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/enterprise/server/util/vsock/BUILD
+++ b/enterprise/server/util/vsock/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -18,4 +18,11 @@ go_library(
         "@org_golang_google_grpc//backoff",
         "@org_golang_x_sys//unix",
     ],
+)
+
+go_test(
+    name = "vsock_test",
+    srcs = ["vsock_test.go"],
+    embed = [":vsock"],
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/enterprise/server/util/vsock/vsock.go
+++ b/enterprise/server/util/vsock/vsock.go
@@ -178,11 +178,11 @@ func SimpleGRPCDial(ctx context.Context, socketPath string, port uint32) (*grpc.
 	// These params are tuned for a fast-reconnect to the vmexec server
 	// running inside the VM.
 	backoffConfig := backoff.Config{
-               BaseDelay:  10 * time.Millisecond,
-               Multiplier: 1,
-               Jitter:     .2,
-               MaxDelay:   20 * time.Millisecond,
-        }
+		BaseDelay:  10 * time.Millisecond,
+		Multiplier: 1,
+		Jitter:     0.2,
+		MaxDelay:   10 * time.Millisecond,
+	}
 	connectParams := grpc.ConnectParams{
 		Backoff:           backoffConfig,
 		MinConnectTimeout: 10 * time.Second,

--- a/enterprise/server/util/vsock/vsock.go
+++ b/enterprise/server/util/vsock/vsock.go
@@ -133,6 +133,12 @@ func dialHostToGuest(ctx context.Context, socketPath string, port uint32) (net.C
 	if err != nil {
 		return nil, err
 	}
+	connected := false
+	defer func() {
+		if !connected {
+			_ = conn.Close()
+		}
+	}()
 
 	// https://github.com/firecracker-microvm/firecracker/blob/main/docs/vsock.md#host-initiated-connections
 	fcConnectString := fmt.Sprintf("CONNECT %d\n", port)
@@ -156,6 +162,7 @@ func dialHostToGuest(ctx context.Context, socketPath string, port uint32) (net.C
 		return nil, status.InternalErrorf("HostDial failed: didn't receive 'OK' after CONNECT, got %q", rsp)
 	}
 	conn.SetReadDeadline(time.Time{})
+	connected = true
 	return conn, nil
 }
 

--- a/enterprise/server/util/vsock/vsock.go
+++ b/enterprise/server/util/vsock/vsock.go
@@ -178,11 +178,11 @@ func SimpleGRPCDial(ctx context.Context, socketPath string, port uint32) (*grpc.
 	// These params are tuned for a fast-reconnect to the vmexec server
 	// running inside the VM.
 	backoffConfig := backoff.Config{
-		BaseDelay:  1 * time.Millisecond,
-		Multiplier: 1.6,
-		Jitter:     0.2,
-		MaxDelay:   10 * time.Second,
-	}
+               BaseDelay:  10 * time.Millisecond,
+               Multiplier: 1,
+               Jitter:     .2,
+               MaxDelay:   20 * time.Millisecond,
+        }
 	connectParams := grpc.ConnectParams{
 		Backoff:           backoffConfig,
 		MinConnectTimeout: 10 * time.Second,


### PR DESCRIPTION
Reconnect more aggressively to vmexec to reduce the average amount of time spent waiting for fc vms.

This improves connect latency:

```
  20-run results:

   Metric                 Original    Cleaned    Difference
  ━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━  ━━━━━━━━━  ━━━━━━━━━━━━
   vmexec connect mean     248.0ms    238.0ms       −10.0ms
  ─────────────────────  ──────────  ─────────  ────────────
   vmexec connect p50      242.6ms    237.8ms        −4.8ms
  ─────────────────────  ──────────  ─────────  ────────────
   vmexec connect p95      269.6ms    241.9ms       −27.7ms
  ─────────────────────  ──────────  ─────────  ────────────
   full run mean           570.2ms    549.1ms       −21.1ms
  ─────────────────────  ──────────  ─────────  ────────────
   full run p95            591.3ms    570.5ms       −20.8ms
   ```