### PR TITLE
Fix pebble_cache.readBufSize

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2036,8 +2036,12 @@ func (p *PebbleCache) readBufSize(r *rspb.ResourceName, md *sgpb.FileMetadata, r
 	}
 	// WriteTo allows copying without a second read to get EOF. Without that
 	// bytes.Buffer.ReadFrom will allocate an extra bytes.MinRead unless we
-	// oversize it.
-	if _, ok := reader.(io.WriterTo); !ok {
+	// oversize it. *os.File advertises WriterTo (for sendfile support), but
+	// writing to a bytes.Buffer it falls back to bytes.Buffer.ReadFrom, which
+	// also needs the extra room.
+	_, isFile := reader.(*os.File)
+	_, isWriterTo := reader.(io.WriterTo)
+	if isFile || !isWriterTo {
 		bufSize += bytes.MinRead
 	}
 	return bufSize


### PR DESCRIPTION
os.File implements io.WriterTo, but only when writing using `sendfile`. Take this into consideration to better size buffers. This reduces allocations for file blobs by 50%.

Pulling this out of https://github.com/buildbuddy-io/buildbuddy/pull/12964 to simplify that PR.

```
                                      │     base     │                buf                 │
                                      │    sec/op    │   sec/op     vs base               │
GetSingle/LocalPebble10/AC-24            3.021µ ± 3%   3.046µ ± 4%        ~ (p=0.620 n=7)
GetSingle/LocalPebble10/CAS-24           2.265µ ± 1%   2.235µ ± 4%        ~ (p=0.596 n=7)
GetSingle/LocalPebble100/AC-24           3.157µ ± 2%   3.271µ ± 4%   +3.61% (p=0.007 n=7)
GetSingle/LocalPebble100/CAS-24          2.337µ ± 3%   2.381µ ± 5%        ~ (p=0.221 n=7)
GetSingle/LocalPebble1000/AC-24          3.381µ ± 5%   3.397µ ± 3%        ~ (p=0.710 n=7)
GetSingle/LocalPebble1000/CAS-24         2.588µ ± 4%   2.549µ ± 1%        ~ (p=0.272 n=7)
GetSingle/LocalPebble10000/AC-24        10.734µ ± 9%   9.524µ ± 1%  -11.27% (p=0.001 n=7)
GetSingle/LocalPebble10000/CAS-24        9.380µ ± 2%   8.520µ ± 2%   -9.17% (p=0.001 n=7)
GetMulti/LocalPebble100/batch1-24        2.532µ ± 3%   2.515µ ± 2%        ~ (p=0.273 n=7)
GetMulti/LocalPebble100/batch2-24        3.777µ ± 1%   3.712µ ± 2%   -1.72% (p=0.003 n=7)
GetMulti/LocalPebble100/batch3-24        5.010µ ± 1%   4.941µ ± 2%   -1.38% (p=0.007 n=7)
GetMulti/LocalPebble100/batch5-24        12.68µ ± 4%   12.37µ ± 5%        ~ (p=0.456 n=7)
GetMulti/LocalPebble100/batch10-24       18.74µ ± 4%   19.01µ ± 5%        ~ (p=0.383 n=7)
GetMulti/LocalPebble100/batch25-24       33.38µ ± 7%   33.07µ ± 2%        ~ (p=0.209 n=7)
GetMulti/LocalPebble100/batch50-24       57.91µ ± 9%   58.97µ ± 3%        ~ (p=0.097 n=7)
GetMulti/LocalPebble100/batch100-24      92.59µ ± 5%   94.68µ ± 4%        ~ (p=0.172 n=7)
GetMulti/LocalPebble100/batch500-24      313.5µ ± 7%   332.5µ ± 9%        ~ (p=0.097 n=7)
GetMulti/LocalPebble10000/batch1-24      9.404µ ± 2%   8.704µ ± 2%   -7.44% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch2-24      19.09µ ± 3%   17.21µ ± 4%   -9.85% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch3-24      24.72µ ± 8%   22.94µ ± 6%   -7.19% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch5-24      34.89µ ± 3%   31.00µ ± 4%  -11.12% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch10-24     52.06µ ± 3%   47.80µ ± 4%   -8.18% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch25-24     85.12µ ± 2%   78.96µ ± 2%   -7.24% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch50-24     126.8µ ± 6%   115.4µ ± 2%   -8.95% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch100-24    206.1µ ± 3%   185.1µ ± 2%  -10.15% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch500-24    820.0µ ± 4%   758.1µ ± 2%   -7.55% (p=0.001 n=7)
geomean                                  17.97µ        17.33µ        -3.58%

                                      │      base      │                  buf                  │
                                      │      B/s       │      B/s        vs base               │
GetSingle/LocalPebble10/AC-24            3.157Mi ±  3%    3.128Mi ±  5%        ~ (p=0.639 n=7)
GetSingle/LocalPebble10/CAS-24           4.215Mi ±  1%    4.263Mi ±  4%        ~ (p=0.600 n=7)
GetSingle/LocalPebble100/AC-24           30.21Mi ±  2%    29.15Mi ±  4%   -3.50% (p=0.007 n=7)
GetSingle/LocalPebble100/CAS-24          40.81Mi ±  3%    40.05Mi ±  4%        ~ (p=0.209 n=7)
GetSingle/LocalPebble1000/AC-24          282.1Mi ±  5%    280.8Mi ±  3%        ~ (p=0.710 n=7)
GetSingle/LocalPebble1000/CAS-24         368.5Mi ±  4%    374.2Mi ±  1%        ~ (p=0.259 n=7)
GetSingle/LocalPebble10000/AC-24         888.5Mi ±  8%   1001.3Mi ±  1%  +12.70% (p=0.001 n=7)
GetSingle/LocalPebble10000/CAS-24       1016.8Mi ±  2%   1119.4Mi ±  2%  +10.09% (p=0.001 n=7)
GetMulti/LocalPebble100/batch1-24        37.66Mi ±  3%    37.92Mi ±  2%        ~ (p=0.318 n=7)
GetMulti/LocalPebble100/batch2-24        50.50Mi ±  1%    51.38Mi ±  2%   +1.76% (p=0.004 n=7)
GetMulti/LocalPebble100/batch3-24        57.12Mi ±  1%    57.91Mi ±  2%   +1.39% (p=0.007 n=7)
GetMulti/LocalPebble100/batch5-24        37.60Mi ±  4%    38.54Mi ±  5%        ~ (p=0.456 n=7)
GetMulti/LocalPebble100/batch10-24       50.89Mi ±  4%    50.16Mi ±  5%        ~ (p=0.383 n=7)
GetMulti/LocalPebble100/batch25-24       71.42Mi ±  6%    72.09Mi ±  2%        ~ (p=0.209 n=7)
GetMulti/LocalPebble100/batch50-24       82.34Mi ± 10%    80.86Mi ±  3%        ~ (p=0.097 n=7)
GetMulti/LocalPebble100/batch100-24      103.0Mi ±  5%    100.7Mi ±  4%        ~ (p=0.172 n=7)
GetMulti/LocalPebble100/batch500-24      152.1Mi ±  7%    143.4Mi ± 10%        ~ (p=0.097 n=7)
GetMulti/LocalPebble10000/batch1-24     1014.1Mi ±  2%   1095.7Mi ±  3%   +8.05% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch2-24      999.3Mi ±  3%   1108.5Mi ±  4%  +10.93% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch3-24      1.130Gi ±  7%    1.218Gi ±  6%   +7.74% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch5-24      1.335Gi ±  3%    1.502Gi ±  4%  +12.51% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch10-24     1.789Gi ±  3%    1.948Gi ±  4%   +8.90% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch25-24     2.735Gi ±  2%    2.949Gi ±  2%   +7.80% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch50-24     3.673Gi ±  6%    4.034Gi ±  2%   +9.83% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch100-24    4.520Gi ±  3%    5.030Gi ±  2%  +11.30% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch500-24    5.679Gi ±  4%    6.143Gi ±  2%   +8.17% (p=0.001 n=7)
geomean                                  229.7Mi          238.2Mi         +3.70%

                                      │     base      │                  buf                  │
                                      │     B/op      │     B/op      vs base                 │
GetSingle/LocalPebble10/AC-24            3.135Ki ± 0%   3.135Ki ± 0%        ~ (p=1.000 n=7)
GetSingle/LocalPebble10/CAS-24           1.853Ki ± 0%   1.853Ki ± 0%        ~ (p=1.000 n=7) ¹
GetSingle/LocalPebble100/AC-24           3.218Ki ± 0%   3.218Ki ± 0%        ~ (p=1.000 n=7)
GetSingle/LocalPebble100/CAS-24          1.935Ki ± 0%   1.935Ki ± 0%        ~ (p=1.000 n=7)
GetSingle/LocalPebble1000/AC-24          3.840Ki ± 0%   3.840Ki ± 0%        ~ (p=0.960 n=7)
GetSingle/LocalPebble1000/CAS-24         2.554Ki ± 1%   2.554Ki ± 1%        ~ (p=0.959 n=7)
GetSingle/LocalPebble10000/AC-24        13.226Ki ± 1%   7.453Ki ± 0%  -43.65% (p=0.001 n=7)
GetSingle/LocalPebble10000/CAS-24       11.929Ki ± 1%   6.172Ki ± 0%  -48.26% (p=0.001 n=7)
GetMulti/LocalPebble100/batch1-24        2.399Ki ± 3%   2.399Ki ± 3%        ~ (p=1.000 n=7)
GetMulti/LocalPebble100/batch2-24        3.674Ki ± 2%   3.674Ki ± 2%        ~ (p=0.984 n=7)
GetMulti/LocalPebble100/batch3-24        4.916Ki ± 1%   4.916Ki ± 1%        ~ (p=1.000 n=7)
GetMulti/LocalPebble100/batch5-24        7.651Ki ± 1%   7.649Ki ± 2%        ~ (p=0.901 n=7)
GetMulti/LocalPebble100/batch10-24       14.43Ki ± 1%   14.42Ki ± 1%        ~ (p=1.000 n=7)
GetMulti/LocalPebble100/batch25-24       34.27Ki ± 1%   34.28Ki ± 1%        ~ (p=0.901 n=7)
GetMulti/LocalPebble100/batch50-24       67.35Ki ± 0%   67.35Ki ± 0%        ~ (p=1.000 n=7)
GetMulti/LocalPebble100/batch100-24      134.2Ki ± 0%   134.2Ki ± 0%        ~ (p=0.902 n=7)
GetMulti/LocalPebble100/batch500-24      682.3Ki ± 0%   682.3Ki ± 0%        ~ (p=0.902 n=7)
GetMulti/LocalPebble10000/batch1-24     12.365Ki ± 6%   6.613Ki ± 0%  -46.52% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch2-24      23.60Ki ± 3%   12.34Ki ± 0%  -47.71% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch3-24      35.52Ki ± 6%   17.88Ki ± 0%  -49.65% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch5-24      57.50Ki ± 3%   28.97Ki ± 2%  -49.62% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch10-24    115.31Ki ± 4%   57.01Ki ± 0%  -50.56% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch25-24     285.1Ki ± 2%   140.4Ki ± 1%  -50.76% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch50-24     569.8Ki ± 1%   279.5Ki ± 0%  -50.95% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch100-24   1138.1Ki ± 1%   556.9Ki ± 0%  -51.07% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch500-24    5.566Mi ± 0%   2.732Mi ± 0%  -50.92% (p=0.001 n=7)
geomean                                  25.60Ki        19.23Ki       -24.86%
¹ all samples are equal

                                      │    base     │                 buf                 │
                                      │  allocs/op  │  allocs/op   vs base                │
GetSingle/LocalPebble10/AC-24            52.00 ± 0%    52.00 ± 0%       ~ (p=1.000 n=7) ¹
GetSingle/LocalPebble10/CAS-24           34.00 ± 0%    34.00 ± 0%       ~ (p=1.000 n=7) ¹
GetSingle/LocalPebble100/AC-24           52.00 ± 0%    52.00 ± 0%       ~ (p=1.000 n=7) ¹
GetSingle/LocalPebble100/CAS-24          34.00 ± 0%    34.00 ± 0%       ~ (p=1.000 n=7) ¹
GetSingle/LocalPebble1000/AC-24          52.00 ± 0%    52.00 ± 0%       ~ (p=1.000 n=7) ¹
GetSingle/LocalPebble1000/CAS-24         34.00 ± 0%    34.00 ± 0%       ~ (p=1.000 n=7) ¹
GetSingle/LocalPebble10000/AC-24         55.00 ± 0%    54.00 ± 0%  -1.82% (p=0.001 n=7)
GetSingle/LocalPebble10000/CAS-24        37.00 ± 0%    36.00 ± 0%  -2.70% (p=0.001 n=7)
GetMulti/LocalPebble100/batch1-24        38.00 ± 0%    38.00 ± 0%       ~ (p=1.000 n=7) ¹
GetMulti/LocalPebble100/batch2-24        60.00 ± 0%    60.00 ± 0%       ~ (p=1.000 n=7) ¹
GetMulti/LocalPebble100/batch3-24        82.00 ± 0%    82.00 ± 0%       ~ (p=1.000 n=7) ¹
GetMulti/LocalPebble100/batch5-24        131.0 ± 0%    131.0 ± 0%       ~ (p=1.000 n=7) ¹
GetMulti/LocalPebble100/batch10-24       244.0 ± 0%    244.0 ± 0%       ~ (p=1.000 n=7) ¹
GetMulti/LocalPebble100/batch25-24       576.0 ± 0%    576.0 ± 0%       ~ (p=1.000 n=7) ¹
GetMulti/LocalPebble100/batch50-24      1.128k ± 0%   1.128k ± 0%       ~ (p=1.000 n=7) ¹
GetMulti/LocalPebble100/batch100-24     2.231k ± 0%   2.231k ± 0%       ~ (p=1.000 n=7) ¹
GetMulti/LocalPebble100/batch500-24     11.03k ± 0%   11.03k ± 0%       ~ (p=1.000 n=7) ¹
GetMulti/LocalPebble10000/batch1-24      41.00 ± 0%    40.00 ± 0%  -2.44% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch2-24      71.00 ± 0%    69.00 ± 0%  -2.82% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch3-24      97.00 ± 0%    94.00 ± 0%  -3.09% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch5-24      149.0 ± 0%    144.0 ± 0%  -3.36% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch10-24     281.0 ± 0%    271.0 ± 0%  -3.56% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch25-24     656.0 ± 0%    631.0 ± 0%  -3.81% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch50-24    1.281k ± 0%   1.231k ± 0%  -3.90% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch100-24   2.532k ± 0%   2.432k ± 0%  -3.95% (p=0.001 n=7)
GetMulti/LocalPebble10000/batch500-24   12.54k ± 0%   12.04k ± 0%  -4.00% (p=0.001 n=7)
geomean                                  194.8         192.1       -1.38%
```