### PR TITLE
Rename `ReferenceCache.GetReference()` to `ReferenceCache.ReadReference()`

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2173,7 +2173,7 @@ func (p *PebbleCache) GetMulti(ctx context.Context, resources []*rspb.ResourceNa
 	return foundMap, nil
 }
 
-func (p *PebbleCache) GetReference(ctx context.Context, r *rspb.ResourceName) (*refpb.Reference, error) {
+func (p *PebbleCache) ReadReference(ctx context.Context, r *rspb.ResourceName) (*refpb.Reference, error) {
 	ctx, spn := tracing.StartSpan(ctx)
 	defer spn.End()
 

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -2937,7 +2937,7 @@ func TestGCSBlobStorage(t *testing.T) {
 	}
 }
 
-func TestGetReference(t *testing.T) {
+func TestReadReference(t *testing.T) {
 	te := testenv.GetTestEnv(t)
 	te.SetAuthenticator(testauth.NewTestAuthenticator(t, emptyUserMap))
 	clock := clockwork.NewFakeClock()
@@ -2968,7 +2968,7 @@ func TestGetReference(t *testing.T) {
 	gcsRN, gcsBuf := testdigest.RandomCASResourceBuf(t, 100)
 	require.NoError(t, pc.Set(ctx, gcsRN, gcsBuf))
 
-	ref, err := pc.GetReference(ctx, gcsRN)
+	ref, err := pc.ReadReference(ctx, gcsRN)
 	require.NoError(t, err)
 	require.NotEmpty(t, ref.GetMetadata().GetStorageMetadata().GetGcsMetadata().GetBlobName())
 	require.Equal(t, gcsRN.GetDigest().GetHash(), ref.GetMetadata().GetFileRecord().GetDigest().GetHash())
@@ -2991,23 +2991,23 @@ func TestGetReference(t *testing.T) {
 	// they have no reference.
 	inlineRN, inlineBuf := testdigest.RandomCASResourceBuf(t, 1)
 	require.NoError(t, pc.Set(ctx, inlineRN, inlineBuf))
-	_, err = pc.GetReference(ctx, inlineRN)
+	_, err = pc.ReadReference(ctx, inlineRN)
 	require.True(t, status.IsNotFoundError(err), "expected NotFound, got %v", err)
 
 	diskRN, diskBuf := testdigest.RandomCASResourceBuf(t, 50)
 	require.NoError(t, pc.Set(ctx, diskRN, diskBuf))
-	_, err = pc.GetReference(ctx, diskRN)
+	_, err = pc.ReadReference(ctx, diskRN)
 	require.True(t, status.IsNotFoundError(err), "expected NotFound, got %v", err)
 
 	// Missing resources have no reference either.
 	missingRN, _ := testdigest.RandomCASResourceBuf(t, 100)
-	_, err = pc.GetReference(ctx, missingRN)
+	_, err = pc.ReadReference(ctx, missingRN)
 	require.True(t, status.IsNotFoundError(err), "expected NotFound, got %v", err)
 
 	// Once the backing object is past its GCS lifecycle TTL, stop handing out
 	// references to it.
 	clock.Advance(25 * time.Hour)
-	_, err = pc.GetReference(ctx, gcsRN)
+	_, err = pc.ReadReference(ctx, gcsRN)
 	require.True(t, status.IsNotFoundError(err), "expected NotFound, got %v", err)
 }
 
@@ -3782,7 +3782,7 @@ func TestDereference(t *testing.T) {
 
 		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
 		require.NoError(t, pc.Set(ctx, rn, buf))
-		ref, err := pc.GetReference(ctx, rn)
+		ref, err := pc.ReadReference(ctx, rn)
 		require.NoError(t, err)
 		require.Equal(t, repb.Compressor_IDENTITY, ref.GetMetadata().GetFileRecord().GetCompressor())
 
@@ -3810,7 +3810,7 @@ func TestDereference(t *testing.T) {
 
 		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
 		require.NoError(t, pc.Set(ctx, rn, buf))
-		ref, err := pc.GetReference(ctx, rn)
+		ref, err := pc.ReadReference(ctx, rn)
 		require.NoError(t, err)
 		require.Equal(t, repb.Compressor_ZSTD, ref.GetMetadata().GetFileRecord().GetCompressor())
 
@@ -3838,7 +3838,7 @@ func TestDereference(t *testing.T) {
 
 		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
 		require.NoError(t, pc.Set(ctx, rn, buf))
-		ref, err := pc.GetReference(ctx, rn)
+		ref, err := pc.ReadReference(ctx, rn)
 		require.NoError(t, err)
 		require.Equal(t, repb.Compressor_IDENTITY, ref.GetMetadata().GetFileRecord().GetCompressor())
 
@@ -3862,7 +3862,7 @@ func TestDereference(t *testing.T) {
 
 		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
 		require.NoError(t, pc.Set(ctx, rn, buf))
-		ref, err := pc.GetReference(ctx, rn)
+		ref, err := pc.ReadReference(ctx, rn)
 		require.NoError(t, err)
 
 		rnZstd := rn.CloneVT()
@@ -3892,7 +3892,7 @@ func TestDereference(t *testing.T) {
 
 		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
 		require.NoError(t, pc.Set(ctx, rn, buf))
-		ref, err := pc.GetReference(ctx, rn)
+		ref, err := pc.ReadReference(ctx, rn)
 		require.NoError(t, err)
 
 		// Delete the backing blob out from under the reference.
@@ -3926,7 +3926,7 @@ func TestDereference(t *testing.T) {
 
 		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
 		require.NoError(t, pc.Set(ctx, rn, buf))
-		ref, err := pc.GetReference(ctx, rn)
+		ref, err := pc.ReadReference(ctx, rn)
 		require.NoError(t, err)
 		// The reference must carry the encryption metadata needed to
 		// decrypt, and dereferencing must return the decrypted bytes.
@@ -3996,7 +3996,7 @@ func TestWriteReference(t *testing.T) {
 
 		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
 		require.NoError(t, src.Set(ctx, rn, buf))
-		ref, err := src.GetReference(ctx, rn)
+		ref, err := src.ReadReference(ctx, rn)
 		require.NoError(t, err)
 
 		require.NoError(t, dst.WriteReference(ctx, ref, rn, false /*=mustClone*/))
@@ -4005,7 +4005,7 @@ func TestWriteReference(t *testing.T) {
 		require.Equal(t, buf, got)
 
 		// The accepting cache points directly at the referenced blob.
-		dstRef, err := dst.GetReference(ctx, rn)
+		dstRef, err := dst.ReadReference(ctx, rn)
 		require.NoError(t, err)
 		require.Equal(t, blobName(ref), blobName(dstRef))
 	})
@@ -4018,7 +4018,7 @@ func TestWriteReference(t *testing.T) {
 
 		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
 		require.NoError(t, src.Set(ctx, rn, buf))
-		ref, err := src.GetReference(ctx, rn)
+		ref, err := src.ReadReference(ctx, rn)
 		require.NoError(t, err)
 
 		// Accept the reference when the blob has burned most of its 24h TTL.
@@ -4041,7 +4041,7 @@ func TestWriteReference(t *testing.T) {
 
 		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
 		require.NoError(t, src.Set(ctx, rn, buf))
-		ref, err := src.GetReference(ctx, rn)
+		ref, err := src.ReadReference(ctx, rn)
 		require.NoError(t, err)
 
 		require.NoError(t, dst.WriteReference(ctx, ref, rn, true /*=mustClone*/))
@@ -4051,7 +4051,7 @@ func TestWriteReference(t *testing.T) {
 
 		// The accepting cache stored its own copy of the blob; the source
 		// cache's blob is untouched.
-		dstRef, err := dst.GetReference(ctx, rn)
+		dstRef, err := dst.ReadReference(ctx, rn)
 		require.NoError(t, err)
 		require.NotEqual(t, blobName(ref), blobName(dstRef))
 		require.True(t, strings.HasPrefix(blobName(dstRef), "app-dst/"), "unexpected blob name %q", blobName(dstRef))
@@ -4068,7 +4068,7 @@ func TestWriteReference(t *testing.T) {
 
 		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
 		require.NoError(t, src.Set(ctx, rn, buf))
-		ref, err := src.GetReference(ctx, rn)
+		ref, err := src.ReadReference(ctx, rn)
 		require.NoError(t, err)
 		require.Equal(t, repb.Compressor_ZSTD, ref.GetMetadata().GetFileRecord().GetCompressor())
 
@@ -4088,7 +4088,7 @@ func TestWriteReference(t *testing.T) {
 
 		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
 		require.NoError(t, src.Set(ctx, rn, buf))
-		ref, err := src.GetReference(ctx, rn)
+		ref, err := src.ReadReference(ctx, rn)
 		require.NoError(t, err)
 
 		otherRN, _ := testdigest.RandomCASResourceBuf(t, 100)
@@ -4117,7 +4117,7 @@ func TestWriteReference(t *testing.T) {
 
 		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
 		require.NoError(t, src.Set(ctx, rn, buf))
-		ref, err := src.GetReference(ctx, rn)
+		ref, err := src.ReadReference(ctx, rn)
 		require.NoError(t, err)
 
 		// Once the referenced blob is past its GCS lifecycle TTL, it may be
@@ -4151,7 +4151,7 @@ func TestWriteReference(t *testing.T) {
 		anonCtx := getAnonContext(t, te)
 		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
 		require.NoError(t, src.Set(anonCtx, rn, buf))
-		ref, err := src.GetReference(anonCtx, rn)
+		ref, err := src.ReadReference(anonCtx, rn)
 		require.NoError(t, err)
 		require.Nil(t, ref.GetMetadata().GetEncryptionMetadata())
 

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -368,7 +368,7 @@ func (c *Proxy) Read(req *dcpb.ReadRequest, stream dcpb.DistributedCache_ReadSer
 	var ref *refpb.Reference
 	if refCache, ok := c.cache.(interfaces.ReferenceCache); ok {
 		if sendReference {
-			if r, err := refCache.GetReference(ctx, rn); err == nil {
+			if r, err := refCache.ReadReference(ctx, rn); err == nil {
 				ref = r
 			}
 		}

--- a/enterprise/server/util/distributed_client/distributed_client_test.go
+++ b/enterprise/server/util/distributed_client/distributed_client_test.go
@@ -1423,7 +1423,7 @@ type fakeReferenceCache struct {
 	lastLimit    int64
 }
 
-func (c *fakeReferenceCache) GetReference(ctx context.Context, r *rspb.ResourceName) (*refpb.Reference, error) {
+func (c *fakeReferenceCache) ReadReference(ctx context.Context, r *rspb.ResourceName) (*refpb.Reference, error) {
 	return nil, status.UnimplementedError("not implemented")
 }
 
@@ -1611,7 +1611,7 @@ type serverReferenceCache struct {
 	writeRefErr   error
 }
 
-func (c *serverReferenceCache) GetReference(ctx context.Context, r *rspb.ResourceName) (*refpb.Reference, error) {
+func (c *serverReferenceCache) ReadReference(ctx context.Context, r *rspb.ResourceName) (*refpb.Reference, error) {
 	if ref, ok := c.refs[r.GetDigest().GetHash()]; ok {
 		return ref, nil
 	}

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -336,12 +336,12 @@ type ReferenceCache interface {
 	// resource does not exist as a reference in the cache. In this case, the
 	// caller should try reading it directly from the Cache via Get(), Reader(),
 	// or similar.
-	GetReference(ctx context.Context, r *rspb.ResourceName) (*refpb.Reference, error)
+	ReadReference(ctx context.Context, r *rspb.ResourceName) (*refpb.Reference, error)
 
 	// Converts a refpb.Reference into an io.ReadCloser serving the resource
 	// named by r. The stored blob is decrypted and transcoded as needed so the
 	// returned bytes use r's compressor, with offset and limit interpreted in
-	// uncompressed bytes. The reference must come from GetReference() from an
+	// uncompressed bytes. The reference must come from ReadReference() from an
 	// identically-configured ReferenceCache, or dereferencing will fail.
 	Dereference(ctx context.Context, ref *refpb.Reference, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error)
 


### PR DESCRIPTION
I prefer this name.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7911