### PR TITLE
Add `ReferenceCache.CreateReference()`

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2234,6 +2234,49 @@ func (p *PebbleCache) ReadReference(ctx context.Context, r *rspb.ResourceName) (
 	return &refpb.Reference{Metadata: md}, nil
 }
 
+func (p *PebbleCache) CreateReference(ctx context.Context, r *rspb.ResourceName, reader io.Reader) (*refpb.Reference, error) {
+	if p.gcsBlobstore == nil {
+		return nil, status.FailedPreconditionError("pebble cache is not backed by shared storage; cannot create references")
+	}
+	if !p.storesInGCS(r.GetDigest().GetSizeBytes()) {
+		return nil, status.NotFoundErrorf("resource %s is too small for shared storage", r.GetDigest().GetHash())
+	}
+
+	r, shouldCompress := p.autoZstdResource(r)
+	encryption, err := p.activeEncryption(ctx)
+	if err != nil {
+		return nil, err
+	}
+	fileRecord, err := p.makeFileRecord(p.userGroupID(ctx), encryption, r)
+	if err != nil {
+		return nil, err
+	}
+	bw, err := p.fileStorer.BlobWriter(ctx, fileRecord)
+	if err != nil {
+		return nil, err
+	}
+
+	// Commit only captures the blob's metadata instead of registering it in
+	// this cache.
+	var md *sgpb.FileMetadata
+	wc, err := p.wrapWriter(ctx, fileRecord, bw, shouldCompress, nil, func(m *sgpb.FileMetadata) error {
+		md = m
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer wc.Close()
+
+	if _, err := io.Copy(wc, reader); err != nil {
+		return nil, err
+	}
+	if err := wc.Commit(); err != nil {
+		return nil, err
+	}
+	return &refpb.Reference{Metadata: md}, nil
+}
+
 func validateReference(ref *refpb.Reference) error {
 	sm := ref.GetMetadata().GetStorageMetadata()
 	if sm.GetGcsMetadata().GetBlobName() == "" {
@@ -2590,18 +2633,7 @@ func (p *PebbleCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfa
 			attribute.String("digest_hash", r.GetDigest().GetHash()),
 			attribute.Int64("digest_size", r.GetDigest().GetSizeBytes()))
 	}
-	// If data is not already compressed, return a writer that will compress it before writing
-	// Only compress data over a given size for more optimal compression ratios
-	shouldCompress := r.GetCompressor() == repb.Compressor_IDENTITY && r.GetDigest().GetSizeBytes() >= p.minBytesAutoZstdCompression
-	if shouldCompress {
-		r = &rspb.ResourceName{
-			Digest:         r.GetDigest(),
-			DigestFunction: r.GetDigestFunction(),
-			InstanceName:   r.GetInstanceName(),
-			Compressor:     repb.Compressor_ZSTD,
-			CacheType:      r.GetCacheType(),
-		}
-	}
+	r, shouldCompress := p.autoZstdResource(r)
 
 	encryption, err := p.activeEncryption(ctx)
 	if err != nil {
@@ -2619,17 +2651,31 @@ func (p *PebbleCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfa
 	return p.newWrappedWriter(ctx, fileRecord, key, shouldCompress)
 }
 
-// newWrappedWriter returns an interfaces.CommittedWriteCloser that on Write
-// will:
-// (1) compress the data if shouldCompress is true; and then
-// (2) encrypt the data if encryption is enabled
-// (3) write the data using input wcm's Write method.
-// On Commit, it will write the metadata for fileRecord.
+func (p *PebbleCache) autoZstdResource(r *rspb.ResourceName) (*rspb.ResourceName, bool) {
+	if r.GetCompressor() != repb.Compressor_IDENTITY || r.GetDigest().GetSizeBytes() < p.minBytesAutoZstdCompression {
+		return r, false
+	}
+	return &rspb.ResourceName{
+		Digest:         r.GetDigest(),
+		DigestFunction: r.GetDigestFunction(),
+		InstanceName:   r.GetInstanceName(),
+		Compressor:     repb.Compressor_ZSTD,
+		CacheType:      r.GetCacheType(),
+	}, true
+}
+
+func (p *PebbleCache) storesInGCS(sizeBytes int64) bool {
+	return sizeBytes >= p.maxInlineFileSizeBytes && sizeBytes >= p.minGCSFileSizeBytes
+}
+
+// newWrappedWriter returns an interfaces.CommittedWriteCloser that writes
+// data to the storage tier appropriate for fileRecord and, on Commit, writes
+// the metadata for fileRecord.
 func (p *PebbleCache) newWrappedWriter(ctx context.Context, fileRecord *sgpb.FileRecord, key filestore.PebbleKey, shouldCompress bool) (interfaces.CommittedWriteCloser, error) {
 	var wcm interfaces.MetadataWriteCloser
 	if fileRecord.GetDigest().GetSizeBytes() < p.maxInlineFileSizeBytes {
 		wcm = p.fileStorer.InlineWriter(ctx, fileRecord.GetDigest().GetSizeBytes())
-	} else if fileRecord.GetDigest().GetSizeBytes() >= p.minGCSFileSizeBytes {
+	} else if p.storesInGCS(fileRecord.GetDigest().GetSizeBytes()) {
 		bw, err := p.fileStorer.BlobWriter(ctx, fileRecord)
 		if err != nil {
 			return nil, err
@@ -2648,10 +2694,21 @@ func (p *PebbleCache) newWrappedWriter(ctx context.Context, fileRecord *sgpb.Fil
 	if err != nil {
 		return nil, err
 	}
+	return p.wrapWriter(ctx, fileRecord, wcm, shouldCompress, db.Close, func(md *sgpb.FileMetadata) error {
+		return p.writeMetadata(ctx, db, key, md)
+	})
+}
 
+// wrapWriter wraps wcm in the storage-independent layers of the write path:
+// a commit hook that assembles the written blob's metadata and hands it to
+// commitFn, encryption (if enabled), and compression (if shouldCompress).
+// closeFn, if non-nil, is called when the returned writer is closed.
+func (p *PebbleCache) wrapWriter(ctx context.Context, fileRecord *sgpb.FileRecord, wcm interfaces.MetadataWriteCloser, shouldCompress bool, closeFn func() error, commitFn func(md *sgpb.FileMetadata) error) (interfaces.CommittedWriteCloser, error) {
 	var encryptionMetadata *sgpb.EncryptionMetadata
 	cwc := ioutil.NewCustomCommitWriteCloser(wcm)
-	cwc.SetCloseFn(db.Close)
+	if closeFn != nil {
+		cwc.SetCloseFn(closeFn)
+	}
 	cwc.SetCommitFn(func(bytesWritten int64) error {
 		now := p.clock.Now().UnixMicro()
 		md := &sgpb.FileMetadata{
@@ -2663,11 +2720,11 @@ func (p *PebbleCache) newWrappedWriter(ctx context.Context, fileRecord *sgpb.Fil
 			LastModifyUsec:     now,
 		}
 		if bytesWritten == 0 {
-			log.Infof("Rejecting zero-length write. Key %q, md: %+v", key, md)
+			log.Infof("Rejecting zero-length write. md: %+v", md)
 			return status.UnavailableError("zero-length writes are not allowed")
 		}
 
-		return p.writeMetadata(ctx, db, key, md)
+		return commitFn(md)
 	})
 
 	wc := interfaces.CommittedWriteCloser(cwc)

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -3011,6 +3011,70 @@ func TestReadReference(t *testing.T) {
 	require.True(t, status.IsNotFoundError(err), "expected NotFound, got %v", err)
 }
 
+func TestCreateReference(t *testing.T) {
+	te := testenv.GetTestEnv(t)
+	te.SetAuthenticator(testauth.NewTestAuthenticator(t, emptyUserMap))
+	clock := clockwork.NewFakeClock()
+	ctx := getAnonContext(t, te)
+
+	var minGCSFileSize int64 = 100
+	var gcsTTLDays int64 = 1
+
+	mockGCS := mockgcs.New(clock)
+	require.NoError(t, mockGCS.SetBucketCustomTimeTTL(ctx, gcsTTLDays))
+	fileStorer := filestore.New(filestore.WithGCSBlobstore(mockGCS, "app-name"), filestore.WithClock(clock))
+	options := &pebble_cache.Options{
+		RootDirectory:          testfs.MakeTempDir(t),
+		MaxSizeBytes:           int64(1_000_000), // 1MB
+		Clock:                  clock,
+		FileStorer:             fileStorer,
+		GCSBlobstore:           mockGCS,
+		MaxInlineFileSizeBytes: 10,
+		MinGCSFileSizeBytes:    &minGCSFileSize,
+		GCSTTLDays:             &gcsTTLDays,
+	}
+	pc, err := pebble_cache.NewPebbleCache(te, options)
+	require.NoError(t, err)
+	require.NoError(t, pc.Start())
+	defer pc.Stop()
+
+	// Blobs at or above minGCSFileSize are staged in GCS and referenceable.
+	gcsRN, gcsBuf := testdigest.RandomCASResourceBuf(t, 100)
+	ref, err := pc.CreateReference(ctx, gcsRN, bytes.NewReader(gcsBuf))
+	require.NoError(t, err)
+	require.NotEmpty(t, ref.GetMetadata().GetStorageMetadata().GetGcsMetadata().GetBlobName())
+	require.Equal(t, gcsRN.GetDigest().GetHash(), ref.GetMetadata().GetFileRecord().GetDigest().GetHash())
+
+	// The blob is only staged, not written to the cache.
+	_, err = pc.Get(ctx, gcsRN)
+	require.True(t, status.IsNotFoundError(err), "expected NotFound, got %v", err)
+	_, err = pc.ReadReference(ctx, gcsRN)
+	require.True(t, status.IsNotFoundError(err), "expected NotFound, got %v", err)
+
+	// The reference dereferences back to the written bytes.
+	rc, err := pc.Dereference(ctx, ref, gcsRN, 0, 0)
+	require.NoError(t, err)
+	defer rc.Close()
+	got, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Equal(t, gcsBuf, got)
+
+	// A cache that stores the reference takes ownership of the staged blob,
+	// and the blob becomes readable from it.
+	require.NoError(t, pc.WriteReference(ctx, ref, gcsRN, false /*=mustClone*/))
+	got, err = pc.Get(ctx, gcsRN)
+	require.NoError(t, err)
+	require.Equal(t, gcsBuf, got)
+
+	// Blobs below minGCSFileSize cannot be referenced, and nothing is
+	// written anywhere for them.
+	diskRN, diskBuf := testdigest.RandomCASResourceBuf(t, 50)
+	_, err = pc.CreateReference(ctx, diskRN, bytes.NewReader(diskBuf))
+	require.True(t, status.IsNotFoundError(err), "expected NotFound, got %v", err)
+	_, err = pc.Get(ctx, diskRN)
+	require.True(t, status.IsNotFoundError(err), "expected NotFound, got %v", err)
+}
+
 func TestGCSBlobStorageOverwriteObjects(t *testing.T) {
 	te := testenv.GetTestEnv(t)
 	te.SetAuthenticator(testauth.NewTestAuthenticator(t, emptyUserMap))

--- a/enterprise/server/util/distributed_client/distributed_client_test.go
+++ b/enterprise/server/util/distributed_client/distributed_client_test.go
@@ -1427,6 +1427,10 @@ func (c *fakeReferenceCache) ReadReference(ctx context.Context, r *rspb.Resource
 	return nil, status.UnimplementedError("not implemented")
 }
 
+func (c *fakeReferenceCache) CreateReference(ctx context.Context, r *rspb.ResourceName, reader io.Reader) (*refpb.Reference, error) {
+	return nil, status.UnimplementedError("not implemented")
+}
+
 func (c *fakeReferenceCache) SupportsCompressor(compressor repb.Compressor_Value) bool {
 	return compressor == repb.Compressor_IDENTITY || compressor == repb.Compressor_ZSTD
 }
@@ -1616,6 +1620,10 @@ func (c *serverReferenceCache) ReadReference(ctx context.Context, r *rspb.Resour
 		return ref, nil
 	}
 	return nil, status.NotFoundError("no reference available")
+}
+
+func (c *serverReferenceCache) CreateReference(ctx context.Context, r *rspb.ResourceName, reader io.Reader) (*refpb.Reference, error) {
+	return nil, status.UnimplementedError("not implemented")
 }
 
 // Dereference serves the configured blob bytes, standing in for shared

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -330,6 +330,15 @@ type StoppableCache interface {
 type ReferenceCache interface {
 	Cache
 
+	// Creates a reference to the resource named by r from the bytes read from
+	// reader by writing them to shared storage, without writing r as an entry
+	// in this cache (so that the created reference can be claimed by another
+	// cache). The returned reference can be dereferenced with Dereference() or
+	// stored with WriteReference() by an identically-configured ReferenceCache;
+	// no cache owns the staged blob until a cache stores the reference, and at
+	// most one may do so without cloning.
+	CreateReference(ctx context.Context, r *rspb.ResourceName, reader io.Reader) (*refpb.Reference, error)
+
 	// Reads the provided resource from the cache and returns a reference to it.
 	// The provided reference can be dereferenced into an io.ReadCloser using
 	// Dereference(). This function returns a NotFound error if the requested


### PR DESCRIPTION
This PR adds a new function to the `ReferenceCache`: `CreateReference()` which creates a `refpb.Reference` out of incoming written bytes if possible. This is implemented and used in Pebble Cache for its GCS write path and will be used down the line to:
1. Convert written bytes into references for sending to peers on the live-write path and
2. Teeing written bytes to GCS to create a reference which can be used on the verify-write path. In this case, the reference will come on the last message of the write stream sent to the peer performing the verification, to avoid too much work playing with gRPC streams.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7911