### PR TITLE
Record DistributedCachePeerLookups in GetWithMetadata and GetMulti, and backfill in GetWithMetadata

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -1130,6 +1130,8 @@ func (c *Cache) copyFile(ctx context.Context, rn *rspb.ResourceName, source stri
 	//	  we shouldn't either, since the blob might never be read from this node.
 	// 2) A Get/Read call, which would have already written to those caches if
 	//    appropriate.
+	// 3) A GetWithMetadata call, which doesn't write to those caches, so as
+	//    with FindMissing/Contains, we shouldn't either.
 	r, err := c.distributedProxy.RemoteReader(ctx, source, rn, 0, 0)
 	if err != nil {
 		return err

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -1261,13 +1261,21 @@ func (c *Cache) Metadata(ctx context.Context, r *rspb.ResourceName) (*interfaces
 }
 
 func (c *Cache) GetWithMetadata(ctx context.Context, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	return c.getWithMetadata(ctx, r, "GetWithMetadata" /*=metricsLabel*/)
+}
+
+func (c *Cache) getWithMetadata(ctx context.Context, r *rspb.ResourceName, metricsLabel string) ([]byte, *interfaces.CacheMetadata, error) {
 	d := r.GetDigest()
 	ps := c.readPeers(r)
 
+	lookups := 0
 	for peer := ps.GetNextPeer(); peer != ""; peer = ps.GetNextPeer() {
+		lookups++
 		data, md, err := c.remoteGetWithMetadata(ctx, peer, r)
 		if err == nil {
+			c.backfillPeers(ctx, c.getBackfillOrders(r, ps))
 			c.log.CtxDebugf(ctx, "GetWithMetadata(%q) found on peer %q", d, peer)
+			metrics.DistributedCachePeerLookups.WithLabelValues(metricsLabel, metrics.HitStatusLabel).Observe(float64(lookups))
 			return data, md, nil
 		}
 		if status.IsNotFoundError(err) {
@@ -1280,6 +1288,7 @@ func (c *Cache) GetWithMetadata(ctx context.Context, r *rspb.ResourceName) ([]by
 		ps.MarkPeerAsFailed(peer)
 	}
 
+	metrics.DistributedCachePeerLookups.WithLabelValues(metricsLabel, metrics.MissStatusLabel).Observe(float64(lookups))
 	c.log.CtxDebugf(ctx, "Exhausted all peers attempting to GetWithMetadata %q. Peerset: %+v", d.GetHash(), ps)
 	return nil, nil, status.NotFoundErrorf("Exhausted all peers attempting to GetWithMetadata %q.", d.GetHash())
 }
@@ -1504,6 +1513,11 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 		}
 	}
 
+	hitMetric := metrics.DistributedCachePeerLookups.WithLabelValues(
+		"GetMulti",
+		metrics.HitStatusLabel,
+	)
+	lookups := 0
 	for {
 		// Each iteration through this outer loop sends a "batch" of requests in
 		// parallel, until all digests have been found or we have exhausted all
@@ -1529,6 +1543,7 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 			// we're out of peers and should exit, returning what we have.
 			break
 		}
+		lookups++
 		eg, gCtx := errgroup.WithContext(ctx)
 		for peer, resources := range peerRequests {
 			peer := peer
@@ -1547,6 +1562,7 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 				}
 				for d, data := range peerRsp {
 					gotMap[d.GetHash()] = data
+					hitMetric.Observe(float64(lookups))
 				}
 				return nil
 			})
@@ -1578,10 +1594,25 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 	c.backfillPeers(ctx, backfills)
 
 	rsp := make(map[*repb.Digest][]byte, len(resources))
+	misses := 0
 	for _, r := range resources {
 		d := r.GetDigest()
 		if buf, ok := gotMap[d.GetHash()]; ok {
 			rsp[d] = buf
+		} else {
+			misses++
+		}
+	}
+
+	// For every resource we didn't find, record an observation indicating how
+	// many lookups we did.
+	if misses > 0 {
+		missMetric := metrics.DistributedCachePeerLookups.WithLabelValues(
+			"GetMulti",
+			metrics.MissStatusLabel,
+		)
+		for range misses {
+			missMetric.Observe(float64(lookups))
 		}
 	}
 	return rsp, nil

--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -187,6 +187,106 @@ func TestBasicReadWrite(t *testing.T) {
 	}, peerLookupMetrics)
 }
 
+func TestGetPeerLookupMetrics(t *testing.T) {
+	env, _, ctx := getEnvAuthAndCtx(t)
+	metrics.DistributedCachePeerLookups.Reset()
+	singleCacheSizeBytes := int64(1000000)
+	peer1 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	peer2 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	peer3 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	baseConfig := Options{
+		ReplicationFactor:  3,
+		Nodes:              []string{peer1, peer2, peer3},
+		DisableLocalLookup: true,
+	}
+
+	// Setup a distributed cache, 3 nodes, R = 3.
+	memoryCache1 := newMemoryCache(t, singleCacheSizeBytes)
+	config1 := baseConfig
+	config1.ListenAddr = peer1
+	dc1 := startNewDCache(t, env, config1, memoryCache1)
+
+	memoryCache2 := newMemoryCache(t, singleCacheSizeBytes)
+	config2 := baseConfig
+	config2.ListenAddr = peer2
+	dc2 := startNewDCache(t, env, config2, memoryCache2)
+
+	memoryCache3 := newMemoryCache(t, singleCacheSizeBytes)
+	config3 := baseConfig
+	config3.ListenAddr = peer3
+	dc3 := startNewDCache(t, env, config3, memoryCache3)
+
+	waitForReady(t, config1.ListenAddr)
+	waitForReady(t, config2.ListenAddr)
+	waitForReady(t, config3.ListenAddr)
+
+	distributedCaches := []interfaces.Cache{dc1, dc2, dc3}
+
+	for i := 0; i < 10; i++ {
+		// Do a write, then Get and GetWithMetadata it back through each node.
+		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
+		require.NoError(t, distributedCaches[i%3].Set(ctx, rn, buf))
+		for _, distributedCache := range distributedCaches {
+			data, err := distributedCache.Get(ctx, rn)
+			require.NoError(t, err)
+			require.Equal(t, buf, data)
+
+			data, md, err := distributedCache.GetWithMetadata(ctx, rn)
+			require.NoError(t, err)
+			require.Equal(t, buf, data)
+			require.NotNil(t, md)
+		}
+
+		// Get and GetWithMetadata a digest that was never written.
+		missingRN, _ := testdigest.RandomCASResourceBuf(t, 100)
+		for _, distributedCache := range distributedCaches {
+			_, err := distributedCache.Get(ctx, missingRN)
+			require.True(t, status.IsNotFoundError(err))
+
+			_, _, err = distributedCache.GetWithMetadata(ctx, missingRN)
+			require.True(t, status.IsNotFoundError(err))
+		}
+	}
+
+	peerLookupMetrics := testmetrics.HistogramVecValues(t, metrics.DistributedCachePeerLookups)
+	assert.Equal(t, []testmetrics.HistogramValues{
+		{
+			Labels: map[string]string{
+				"op":                       "Get",
+				metrics.CacheHitMissStatus: metrics.HitStatusLabel,
+			},
+			// For each of the 10 objects, we did a Get on all 3 distributed
+			// caches, which should have done only 1 lookup each (every peer
+			// has a replica).
+			Buckets: map[float64]uint64{1: 30},
+		},
+		{
+			Labels: map[string]string{
+				"op":                       "GetWithMetadata",
+				metrics.CacheHitMissStatus: metrics.HitStatusLabel,
+			},
+			Buckets: map[float64]uint64{1: 30},
+		},
+		{
+			Labels: map[string]string{
+				"op":                       "Get",
+				metrics.CacheHitMissStatus: metrics.MissStatusLabel,
+			},
+			// Each missing digest requires exhausting all 3 peers
+			// (replication factor), on each of the 3 distributed caches, for
+			// each of the 10 missing objects.
+			Buckets: map[float64]uint64{3: 30},
+		},
+		{
+			Labels: map[string]string{
+				"op":                       "GetWithMetadata",
+				metrics.CacheHitMissStatus: metrics.MissStatusLabel,
+			},
+			Buckets: map[float64]uint64{3: 30},
+		},
+	}, peerLookupMetrics)
+}
+
 func TestReadPeers_FewerNodesThanReplicationFactor(t *testing.T) {
 	env, _, _ := getEnvAuthAndCtx(t)
 	peer1 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
@@ -854,6 +954,78 @@ func TestBackfillContinuesWhenOnePeerFails(t *testing.T) {
 	require.False(t, exists, "blob should not have been written to the failing peer")
 }
 
+// TestBackfillViaGet verifies that Get and GetWithMetadata backfill
+// more-preferred peers that were missing the digest, like Reader does.
+func TestBackfillViaGet(t *testing.T) {
+	env, _, ctx := getEnvAuthAndCtx(t)
+	singleCacheSizeBytes := int64(1000000)
+	peer1 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	peer2 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	peer3 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	baseConfig := Options{
+		ReplicationFactor:    3,
+		Nodes:                []string{peer1, peer2, peer3},
+		DisableLocalLookup:   true,
+		RPCHeartbeatInterval: 100 * time.Millisecond,
+	}
+
+	// Setup a distributed cache, 3 nodes, R = 3.
+	memoryCache1 := newMemoryCache(t, singleCacheSizeBytes)
+	config1 := baseConfig
+	config1.ListenAddr = peer1
+	dc1 := startNewDCache(t, env, config1, memoryCache1)
+
+	memoryCache2 := newMemoryCache(t, singleCacheSizeBytes)
+	config2 := baseConfig
+	config2.ListenAddr = peer2
+	_ = startNewDCache(t, env, config2, memoryCache2)
+
+	memoryCache3 := newMemoryCache(t, singleCacheSizeBytes)
+	config3 := baseConfig
+	config3.ListenAddr = peer3
+	_ = startNewDCache(t, env, config3, memoryCache3)
+
+	waitForReady(t, peer1)
+	waitForReady(t, peer2)
+	waitForReady(t, peer3)
+
+	baseCaches := map[string]interfaces.Cache{
+		peer1: memoryCache1,
+		peer2: memoryCache2,
+		peer3: memoryCache3,
+	}
+
+	rn, buf := testdigest.RandomCASResourceBuf(t, 100)
+	require.NoError(t, dc1.Set(ctx, rn, buf))
+
+	// Delete the digest from the most-preferred peer so the read hits a
+	// less-preferred replica, making the most-preferred peer a backfill
+	// target.
+	preferredPeer := dc1.readPeers(rn).GetNextPeer()
+	require.NoError(t, baseCaches[preferredPeer].Delete(ctx, rn))
+
+	// backfillPeers blocks until copies finish, so the assertions below are
+	// deterministic.
+	data, err := dc1.Get(ctx, rn)
+	require.NoError(t, err)
+	require.Equal(t, buf, data)
+
+	exists, err := baseCaches[preferredPeer].Contains(ctx, rn)
+	require.NoError(t, err)
+	require.True(t, exists, "Get did not backfill the most-preferred peer")
+
+	// Same again via GetWithMetadata.
+	require.NoError(t, baseCaches[preferredPeer].Delete(ctx, rn))
+
+	data, _, err = dc1.GetWithMetadata(ctx, rn)
+	require.NoError(t, err)
+	require.Equal(t, buf, data)
+
+	exists, err = baseCaches[preferredPeer].Contains(ctx, rn)
+	require.NoError(t, err)
+	require.True(t, exists, "GetWithMetadata did not backfill the most-preferred peer")
+}
+
 func TestCopyFileDoesNotMutateResourceNameCompressor(t *testing.T) {
 	env, _, ctx := getEnvAuthAndCtx(t)
 	singleCacheSizeBytes := int64(1000000)
@@ -1107,6 +1279,7 @@ func TestFindMissing(t *testing.T) {
 
 func TestGetMulti(t *testing.T) {
 	env, _, ctx := getEnvAuthAndCtx(t)
+	metrics.DistributedCachePeerLookups.Reset()
 	singleCacheSizeBytes := int64(1000000)
 	peer1 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
 	peer2 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
@@ -1165,8 +1338,16 @@ func TestGetMulti(t *testing.T) {
 		}
 	}
 
+	// Generate some more digests, but don't write them to the cache.
+	resourcesNotWritten := make([]*rspb.ResourceName, 0)
+	for i := 0; i < 70; i++ {
+		rn, _ := testdigest.RandomCASResourceBuf(t, 100)
+		resourcesNotWritten = append(resourcesNotWritten, rn)
+	}
+	allResources := append(resourcesWritten, resourcesNotWritten...)
+
 	for _, distributedCache := range distributedCaches {
-		gotMap, err := distributedCache.GetMulti(ctx, resourcesWritten)
+		gotMap, err := distributedCache.GetMulti(ctx, allResources)
 		assert.Nil(t, err)
 		for _, r := range resourcesWritten {
 			d := r.GetDigest()
@@ -1174,7 +1355,35 @@ func TestGetMulti(t *testing.T) {
 			assert.True(t, ok)
 			assert.Equal(t, d.GetSizeBytes(), int64(len(buf)))
 		}
+		for _, r := range resourcesNotWritten {
+			_, ok := gotMap[r.GetDigest()]
+			assert.False(t, ok)
+		}
 	}
+
+	peerLookupMetrics := testmetrics.HistogramVecValues(t, metrics.DistributedCachePeerLookups)
+	assert.Equal(t, []testmetrics.HistogramValues{
+		{
+			Labels: map[string]string{
+				"op":                       "GetMulti",
+				metrics.CacheHitMissStatus: metrics.HitStatusLabel,
+			},
+			// Each hit only requires 1 peer lookup, and we did 3 GetMulti
+			// calls (loop count above) * 100 hits for each call (number of
+			// digests written).
+			Buckets: map[float64]uint64{1: 300},
+		},
+		{
+			Labels: map[string]string{
+				"op":                       "GetMulti",
+				metrics.CacheHitMissStatus: metrics.MissStatusLabel,
+			},
+			// Each miss should result in 3 peer lookups (replication factor),
+			// and we did 3 GetMulti calls (loop count above) * 70 misses each
+			// (number of digests not written).
+			Buckets: map[float64]uint64{3: 210},
+		},
+	}, peerLookupMetrics)
 }
 
 func TestHintedHandoff(t *testing.T) {


### PR DESCRIPTION
Extracted from #12964.

`GetWithMetadata` didn't backfill more-preferred peers on a hit, or record the `DistributedCachePeerLookups` metric, the way `Get` and `Reader` do. `GetMulti` also didn't record that metric, the way `FindMissing` does.

- `GetWithMetadata` now backfills on a hit and records the metric with `op="GetWithMetadata"` (one observation per request, with the number of peers consulted). The metrics label is threaded through an internal `getWithMetadata` helper so #12964 can route `Get` through it with its own label.
- `GetMulti` now records the metric with `op="GetMulti"`, following the `FindMissing` pattern: one observation per digest, counting batch rounds.

Tests: `TestGetPeerLookupMetrics` covers hit/miss observations for `Get` and `GetWithMetadata`; `TestBackfillViaGet` verifies both `Get` and `GetWithMetadata` repopulate a more-preferred replica; `TestGetMulti` now also asserts hit/miss observations (100 written + 70 unwritten digests across 3 nodes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V95nFkZkteqJPnv315dLF5