### PR TITLE
Compress peer-to-peer transfers in RemoteGetWithMetadata

### DIFF
--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -304,6 +304,71 @@ func TestReadWrite_Compression(t *testing.T) {
 	}
 }
 
+// compressorRecordingCache wraps a CompressionCache and records the
+// compressor of each GetWithMetadata request it serves.
+type compressorRecordingCache struct {
+	*testcompression.CompressionCache
+	mu          sync.Mutex
+	compressors []repb.Compressor_Value
+}
+
+func (c *compressorRecordingCache) GetWithMetadata(ctx context.Context, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	c.mu.Lock()
+	c.compressors = append(c.compressors, r.GetCompressor())
+	c.mu.Unlock()
+	return c.CompressionCache.GetWithMetadata(ctx, r)
+}
+
+// TestGetWithMetadata_Compression verifies that GetWithMetadata transfers
+// large blobs between peers zstd-compressed, like Reader and GetMulti do.
+func TestGetWithMetadata_Compression(t *testing.T) {
+	env, _, ctx := getEnvAuthAndCtx(t)
+	peer := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	config := Options{
+		ReplicationFactor:            1,
+		Nodes:                        []string{peer},
+		DisableLocalLookup:           true,
+		EnableLocalCompressionLookup: true,
+		ListenAddr:                   peer,
+	}
+	base := &compressorRecordingCache{CompressionCache: &testcompression.CompressionCache{Cache: env.GetCache()}}
+	dc := startNewDCache(t, env, config, base)
+	waitForReady(t, peer)
+
+	// Write an entry bigger than 100 bytes (the peer-to-peer compression
+	// threshold).
+	rn, buf := testdigest.RandomCASResourceBuf(t, 1000)
+	require.NoError(t, dc.Set(ctx, rn, buf))
+
+	// An IDENTITY read above the threshold should be fetched from the peer as
+	// ZSTD and decompressed locally, without mutating the caller's resource.
+	data, md, err := dc.GetWithMetadata(ctx, rn)
+	require.NoError(t, err)
+	require.Equal(t, buf, data)
+	require.NotNil(t, md)
+	require.Equal(t, repb.Compressor_IDENTITY, rn.GetCompressor())
+	require.Equal(t, []repb.Compressor_Value{repb.Compressor_ZSTD}, base.compressors)
+
+	// A ZSTD read is served as-is: compressed data, no transport rewrite
+	// needed.
+	zstdRN := rn.CloneVT()
+	zstdRN.Compressor = repb.Compressor_ZSTD
+	data, _, err = dc.GetWithMetadata(ctx, zstdRN)
+	require.NoError(t, err)
+	decompressed, err := compression.DecompressZstd(nil, data)
+	require.NoError(t, err)
+	require.Equal(t, buf, decompressed)
+	require.Equal(t, []repb.Compressor_Value{repb.Compressor_ZSTD, repb.Compressor_ZSTD}, base.compressors)
+
+	// An IDENTITY read at or below the threshold is fetched uncompressed.
+	smallRN, smallBuf := testdigest.RandomCASResourceBuf(t, 100)
+	require.NoError(t, dc.Set(ctx, smallRN, smallBuf))
+	data, _, err = dc.GetWithMetadata(ctx, smallRN)
+	require.NoError(t, err)
+	require.Equal(t, smallBuf, data)
+	require.Equal(t, []repb.Compressor_Value{repb.Compressor_ZSTD, repb.Compressor_ZSTD, repb.Compressor_IDENTITY}, base.compressors)
+}
+
 func TestContains(t *testing.T) {
 	env, _, ctx := getEnvAuthAndCtx(t)
 	singleCacheSizeBytes := int64(1000000)

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -64,11 +64,9 @@ const (
 	// the write stream that spawned it completes.
 	referenceVerificationTimeout = 1 * time.Minute
 
-	// maxDecompressBufSizeBytes caps the initial buffer allocated to hold a
-	// decompressed peer response. Digest sizes are client-supplied and, for
-	// AC resources, unrelated to the stored payload size, so don't allocate
-	// them up front; the buffer still grows as needed for legitimately larger
-	// payloads.
+	// maxDecompressBufSizeBytes caps the initial buffer allocated for a
+	// decompressed peer response, since digest sizes are client-supplied.
+	// The buffer grows as needed.
 	maxDecompressBufSizeBytes = 4 * 1024 * 1024
 )
 

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -63,6 +63,13 @@ const (
 	// How long an async write-reference verification may keep running after
 	// the write stream that spawned it completes.
 	referenceVerificationTimeout = 1 * time.Minute
+
+	// maxDecompressBufSizeBytes caps the initial buffer allocated to hold a
+	// decompressed peer response. Digest sizes are client-supplied and, for
+	// AC resources, unrelated to the stored payload size, so don't allocate
+	// them up front; the buffer still grows as needed for legitimately larger
+	// payloads.
+	maxDecompressBufSizeBytes = 4 * 1024 * 1024
 )
 
 var (
@@ -639,7 +646,7 @@ func (c *Proxy) RemoteGetWithMetadata(ctx context.Context, peer string, r *rspb.
 	}
 	data := rsp.GetData()
 	if decompress {
-		data, err = compression.DecompressZstd(make([]byte, r.GetDigest().GetSizeBytes()), data)
+		data, err = compression.DecompressZstd(make([]byte, 0, digest.SafeBufferSize(r, maxDecompressBufSizeBytes)), data)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -696,10 +703,10 @@ func (c *Proxy) RemoteDelete(ctx context.Context, peer string, r *rspb.ResourceN
 
 func (c *Proxy) RemoteGetMulti(ctx context.Context, peer string, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
 	req := &dcpb.GetMultiRequest{}
-	hashDigests := make(map[string]*repb.Digest, len(resources))
+	hashResources := make(map[string]*rspb.ResourceName, len(resources))
 	compressedHashes := make(set.Set[string], len(resources))
 	for _, r := range resources {
-		hashDigests[r.GetDigest().GetHash()] = r.GetDigest()
+		hashResources[r.GetDigest().GetHash()] = r
 		if c.shouldReadCompressed(r) {
 			r = r.CloneVT()
 			r.Compressor = repb.Compressor_ZSTD
@@ -717,13 +724,14 @@ func (c *Proxy) RemoteGetMulti(ctx context.Context, peer string, resources []*rs
 	}
 	resultMap := make(map[*repb.Digest][]byte, len(rsp.GetKeyValue()))
 	for _, keyValue := range rsp.GetKeyValue() {
-		d, ok := hashDigests[keyValue.GetKey().GetKey()]
+		rn, ok := hashResources[keyValue.GetKey().GetKey()]
 		if !ok {
 			continue
 		}
+		d := rn.GetDigest()
 		buf := keyValue.GetValue()
 		if compressedHashes.Contains(d.GetHash()) {
-			buf, err = compression.DecompressZstd(make([]byte, d.GetSizeBytes()), buf)
+			buf, err = compression.DecompressZstd(make([]byte, 0, digest.SafeBufferSize(rn, maxDecompressBufSizeBytes)), buf)
 			if err != nil {
 				return nil, err
 			}

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -626,12 +626,26 @@ func (c *Proxy) RemoteGetWithMetadata(ctx context.Context, peer string, r *rspb.
 	if err != nil {
 		return nil, nil, err
 	}
+	// Fetch compressed data over the wire and decompress it locally, like
+	// RemoteReader and RemoteGetMulti do.
+	decompress := c.shouldReadCompressed(r)
+	if decompress {
+		r = r.CloneVT()
+		r.Compressor = repb.Compressor_ZSTD
+	}
 	rsp, err := client.GetWithMetadata(ctx, &dcpb.GetWithMetadataRequest{Resource: r})
 	if err != nil {
 		return nil, nil, err
 	}
+	data := rsp.GetData()
+	if decompress {
+		data, err = compression.DecompressZstd(make([]byte, r.GetDigest().GetSizeBytes()), data)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
 	md := rsp.GetMetadata()
-	return rsp.GetData(), &interfaces.CacheMetadata{
+	return data, &interfaces.CacheMetadata{
 		StoredSizeBytes:    md.GetStoredSizeBytes(),
 		DigestSizeBytes:    md.GetDigestSizeBytes(),
 		LastAccessTimeUsec: md.GetLastAccessUsec(),

--- a/server/testutil/testcompression/testcompression.go
+++ b/server/testutil/testcompression/testcompression.go
@@ -32,6 +32,20 @@ func (c *CompressionCache) Get(ctx context.Context, r *rspb.ResourceName) ([]byt
 	return cachedDataWithCompression, nil
 }
 
+func (c *CompressionCache) GetWithMetadata(ctx context.Context, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	data, md, err := c.Cache.GetWithMetadata(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cachedDataWithCompression, err := dataWithCompression(r, data)
+	if err != nil {
+		return nil, nil, status.InternalErrorf("Could not get data for compression %v for %s: %s", r.GetCompressor(), r.GetDigest(), err)
+	}
+
+	return cachedDataWithCompression, md, nil
+}
+
 func (c *CompressionCache) Reader(ctx context.Context, rn *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
 	buf, err := c.Get(ctx, rn)
 	if err != nil {


### PR DESCRIPTION
Addresses https://github.com/buildbuddy-io/buildbuddy/pull/12964#discussion_r3761918478.

`RemoteReader` and `RemoteGetMulti` rewrite the request compressor to ZSTD before the RPC and decompress locally, so large blobs move between peers compressed. `RemoteGetWithMetadata` had no such rewrite, so every cross-node `GetWithMetadata` above 100 bytes moved full uncompressed bytes — and once #12964 routes `Get` through it, `Get` would lose peer-to-peer compression too. This applies the same `shouldReadCompressed` rewrite + local decompression there.

Also teaches `testcompression.CompressionCache` to serve `GetWithMetadata` with the requested compression, so the new test can exercise the transport path end to end. `TestGetWithMetadata_Compression` asserts (via a compressor-recording base cache) that an IDENTITY read above the 100-byte threshold reaches the peer as a ZSTD request and returns the original bytes, that explicit ZSTD reads pass through untouched, and that reads at/below the threshold stay IDENTITY. Verified the test fails without the client change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V95nFkZkteqJPnv315dLF5