### PR TITLE
Fix `Parser.canonicalizeArgs`

### DIFF
--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -669,7 +669,7 @@ func (p *Parser) canonicalizeArgs(args []string) ([]string, error) {
 			return args, nil
 		}
 	}
-	parsedArgs, err := ParseArgs(args)
+	parsedArgs, err := p.ParseArgs(args)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Switch to using the specific parser's `ParseArgs` function instead of the general `ParseArgs` function, which uses the default parser.
