### PR TITLE
clientidentity: support additional verification key for rotation

### DIFF
--- a/enterprise/server/clientidentity/clientidentity.go
+++ b/enterprise/server/clientidentity/clientidentity.go
@@ -204,17 +204,17 @@ func (s *Service) ValidateIncomingIdentity(ctx context.Context) (context.Context
 	var verifyErr error
 	for _, key := range s.verificationKeys {
 		c := &claims{}
-		if _, err := jwt.ParseWithClaims(headerValue, c, func(token *jwt.Token) (interface{}, error) {
+		_, err := jwt.ParseWithClaims(headerValue, c, func(token *jwt.Token) (interface{}, error) {
 			return key, nil
-		}); err != nil {
-			// A signature mismatch is expected for all but the key that signed
-			// the token, so prefer reporting any other failure (e.g. expiry).
-			if verifyErr == nil || !errors.Is(err, jwt.ErrTokenSignatureInvalid) {
-				verifyErr = err
-			}
-			continue
+		})
+		if err == nil {
+			return context.WithValue(ctx, validatedIdentityContextKey, &c.ClientIdentity), nil
 		}
-		return context.WithValue(ctx, validatedIdentityContextKey, &c.ClientIdentity), nil
+		// A signature mismatch is expected for all but the key that signed
+		// the token, so prefer reporting any other failure (e.g. expiry).
+		if verifyErr == nil || !errors.Is(err, jwt.ErrTokenSignatureInvalid) {
+			verifyErr = err
+		}
 	}
 	return ctx, status.PermissionDeniedErrorf("invalid identity header: %s", verifyErr)
 }

--- a/enterprise/server/clientidentity/clientidentity.go
+++ b/enterprise/server/clientidentity/clientidentity.go
@@ -2,6 +2,7 @@ package clientidentity
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -23,7 +24,8 @@ const (
 )
 
 var (
-	signingKey = flag.String("app.client_identity.key", "", "The key used to sign and verify identity JWTs.", flag.Secret)
+	signingKey                 = flag.String("app.client_identity.key", "", "The key used to sign and verify identity JWTs.", flag.Secret)
+	additionalVerificationKeys = flag.Slice("app.client_identity.additional_verification_keys", []string{}, "Additional keys accepted when verifying identity JWTs, tried after the signing key. Used to keep old and new keys trusted simultaneously during key rotation.", flag.Secret)
 	client     = flag.String("app.client_identity.client", "", "The client identifier to place in the identity header.")
 	origin     = flag.String("app.client_identity.origin", "", "The origin identifier to place in the identity header.")
 	expiration = flag.Duration("app.client_identity.expiration", DefaultExpiration, "The expiration time for the identity header.")
@@ -87,6 +89,9 @@ func (c *headerCache) Get(si *interfaces.ClientIdentity) (string, error) {
 
 type Service struct {
 	signingKey []byte
+	// verificationKeys holds the signing key followed by any additional
+	// verification keys; incoming JWTs are accepted if any key verifies them.
+	verificationKeys [][]byte
 
 	clock clockwork.Clock
 
@@ -97,9 +102,17 @@ func New(clock clockwork.Clock) (*Service, error) {
 	if *signingKey == "" {
 		return nil, status.InvalidArgumentError("ClientIdentityService requires a signing key")
 	}
+	verificationKeys := [][]byte{[]byte(*signingKey)}
+	for _, k := range *additionalVerificationKeys {
+		if k == "" {
+			continue
+		}
+		verificationKeys = append(verificationKeys, []byte(k))
+	}
 	s := &Service{
-		signingKey: []byte(*signingKey),
-		clock:      clock,
+		signingKey:       []byte(*signingKey),
+		verificationKeys: verificationKeys,
+		clock:            clock,
 	}
 	headerCache, err := newHeaderCache(clock, *expiration, func(si *interfaces.ClientIdentity) (string, error) {
 		return s.NewIdentityHeader(si, *expiration)
@@ -188,14 +201,22 @@ func (s *Service) ValidateIncomingIdentity(ctx context.Context) (context.Context
 		}
 	}
 	headerValue := vals[0]
-	c := &claims{}
-	if _, err := jwt.ParseWithClaims(headerValue, c, func(token *jwt.Token) (interface{}, error) {
-		return s.signingKey, nil
-	}); err != nil {
-		return ctx, status.PermissionDeniedErrorf("invalid identity header: %s", err)
+	var verifyErr error
+	for _, key := range s.verificationKeys {
+		c := &claims{}
+		if _, err := jwt.ParseWithClaims(headerValue, c, func(token *jwt.Token) (interface{}, error) {
+			return key, nil
+		}); err != nil {
+			// A signature mismatch is expected for all but the key that signed
+			// the token, so prefer reporting any other failure (e.g. expiry).
+			if verifyErr == nil || !errors.Is(err, jwt.ErrTokenSignatureInvalid) {
+				verifyErr = err
+			}
+			continue
+		}
+		return context.WithValue(ctx, validatedIdentityContextKey, &c.ClientIdentity), nil
 	}
-
-	return context.WithValue(ctx, validatedIdentityContextKey, &c.ClientIdentity), nil
+	return ctx, status.PermissionDeniedErrorf("invalid identity header: %s", verifyErr)
 }
 
 func (s *Service) IdentityFromContext(ctx context.Context) (*interfaces.ClientIdentity, error) {

--- a/enterprise/server/clientidentity/clientidentity.go
+++ b/enterprise/server/clientidentity/clientidentity.go
@@ -24,12 +24,12 @@ const (
 )
 
 var (
-	signingKey                 = flag.String("app.client_identity.key", "", "The key used to sign and verify identity JWTs.", flag.Secret)
-	additionalVerificationKeys = flag.Slice("app.client_identity.additional_verification_keys", []string{}, "Additional keys accepted when verifying identity JWTs, tried after the signing key. Used to keep old and new keys trusted simultaneously during key rotation.", flag.Secret)
-	client                     = flag.String("app.client_identity.client", "", "The client identifier to place in the identity header.")
-	origin                     = flag.String("app.client_identity.origin", "", "The origin identifier to place in the identity header.")
-	expiration                 = flag.Duration("app.client_identity.expiration", DefaultExpiration, "The expiration time for the identity header.")
-	required                   = flag.Bool("app.client_identity.required", false, "If set, a client identity is required.")
+	signingKey                = flag.String("app.client_identity.key", "", "The key used to sign and verify identity JWTs.", flag.Secret)
+	additionalVerificationKey = flag.String("app.client_identity.additional_verification_key", "", "An additional key accepted when verifying identity JWTs. Used to keep old and new keys trusted simultaneously during key rotation.", flag.Secret)
+	client                    = flag.String("app.client_identity.client", "", "The client identifier to place in the identity header.")
+	origin                    = flag.String("app.client_identity.origin", "", "The origin identifier to place in the identity header.")
+	expiration                = flag.Duration("app.client_identity.expiration", DefaultExpiration, "The expiration time for the identity header.")
+	required                  = flag.Bool("app.client_identity.required", false, "If set, a client identity is required.")
 )
 
 type cachedHeader struct {
@@ -89,8 +89,8 @@ func (c *headerCache) Get(si *interfaces.ClientIdentity) (string, error) {
 
 type Service struct {
 	signingKey []byte
-	// verificationKeys holds the signing key followed by any additional
-	// verification keys; incoming JWTs are accepted if any key verifies them.
+	// verificationKeys holds the signing key followed by the optional additional
+	// verification key; incoming JWTs are accepted if either key verifies them.
 	verificationKeys [][]byte
 
 	clock clockwork.Clock
@@ -103,11 +103,8 @@ func New(clock clockwork.Clock) (*Service, error) {
 		return nil, status.InvalidArgumentError("ClientIdentityService requires a signing key")
 	}
 	verificationKeys := [][]byte{[]byte(*signingKey)}
-	for _, k := range *additionalVerificationKeys {
-		if k == "" {
-			continue
-		}
-		verificationKeys = append(verificationKeys, []byte(k))
+	if *additionalVerificationKey != "" {
+		verificationKeys = append(verificationKeys, []byte(*additionalVerificationKey))
 	}
 	s := &Service{
 		signingKey:       []byte(*signingKey),
@@ -210,10 +207,10 @@ func (s *Service) ValidateIncomingIdentity(ctx context.Context) (context.Context
 		if err == nil {
 			return context.WithValue(ctx, validatedIdentityContextKey, &c.ClientIdentity), nil
 		}
-		// A signature mismatch is expected for all but the key that signed
-		// the token, so prefer reporting any other failure (e.g. expiry).
-		if verifyErr == nil || !errors.Is(err, jwt.ErrTokenSignatureInvalid) {
-			verifyErr = err
+		verifyErr = err
+		// Only a signature mismatch can be resolved by trying another key.
+		if !errors.Is(err, jwt.ErrTokenSignatureInvalid) {
+			break
 		}
 	}
 	return ctx, status.PermissionDeniedErrorf("invalid identity header: %s", verifyErr)

--- a/enterprise/server/clientidentity/clientidentity.go
+++ b/enterprise/server/clientidentity/clientidentity.go
@@ -26,10 +26,10 @@ const (
 var (
 	signingKey                 = flag.String("app.client_identity.key", "", "The key used to sign and verify identity JWTs.", flag.Secret)
 	additionalVerificationKeys = flag.Slice("app.client_identity.additional_verification_keys", []string{}, "Additional keys accepted when verifying identity JWTs, tried after the signing key. Used to keep old and new keys trusted simultaneously during key rotation.", flag.Secret)
-	client     = flag.String("app.client_identity.client", "", "The client identifier to place in the identity header.")
-	origin     = flag.String("app.client_identity.origin", "", "The origin identifier to place in the identity header.")
-	expiration = flag.Duration("app.client_identity.expiration", DefaultExpiration, "The expiration time for the identity header.")
-	required   = flag.Bool("app.client_identity.required", false, "If set, a client identity is required.")
+	client                     = flag.String("app.client_identity.client", "", "The client identifier to place in the identity header.")
+	origin                     = flag.String("app.client_identity.origin", "", "The origin identifier to place in the identity header.")
+	expiration                 = flag.Duration("app.client_identity.expiration", DefaultExpiration, "The expiration time for the identity header.")
+	required                   = flag.Bool("app.client_identity.required", false, "If set, a client identity is required.")
 )
 
 type cachedHeader struct {

--- a/enterprise/server/clientidentity/clientidentity_test.go
+++ b/enterprise/server/clientidentity/clientidentity_test.go
@@ -135,27 +135,26 @@ func TestRequired(t *testing.T) {
 	require.Error(t, err)
 }
 
-func newServiceWithKeys(t testing.TB, clock clockwork.Clock, signingKey string, additionalKeys ...string) *clientidentity.Service {
+func newServiceWithKeys(t testing.TB, clock clockwork.Clock, signingKey, additionalVerificationKey string) *clientidentity.Service {
 	flags.Set(t, "app.client_identity.key", signingKey)
-	flags.Set(t, "app.client_identity.additional_verification_keys", additionalKeys)
+	flags.Set(t, "app.client_identity.additional_verification_key", additionalVerificationKey)
 	si, err := clientidentity.New(clock)
 	require.NoError(t, err)
 	return si
 }
 
-func TestAdditionalVerificationKeys(t *testing.T) {
+func TestAdditionalVerificationKey(t *testing.T) {
 	clock := clockwork.NewFakeClock()
-	oldKey, err := random.RandomString(16)
-	require.NoError(t, err)
-	newKey, err := random.RandomString(16)
-	require.NoError(t, err)
+	// Commas are preserved in both key flags.
+	oldKey := "old,key"
+	newKey := "new,key"
 
-	oldSigner := newServiceWithKeys(t, clock, string(oldKey))
-	newSigner := newServiceWithKeys(t, clock, string(newKey))
+	oldSigner := newServiceWithKeys(t, clock, oldKey, "")
+	newSigner := newServiceWithKeys(t, clock, newKey, "")
 	// Rotation phase 1: still signing with the old key, new key trusted.
-	oldSignerTrustingNew := newServiceWithKeys(t, clock, string(oldKey), string(newKey))
+	oldSignerTrustingNew := newServiceWithKeys(t, clock, oldKey, newKey)
 	// Rotation phase 2: signing with the new key, old key still trusted.
-	newSignerTrustingOld := newServiceWithKeys(t, clock, string(newKey), string(oldKey))
+	newSignerTrustingOld := newServiceWithKeys(t, clock, newKey, oldKey)
 
 	identity := &interfaces.ClientIdentity{Origin: "internal", Client: "app"}
 	oldSignedHeader, err := oldSigner.NewIdentityHeader(identity, clientidentity.DefaultExpiration)
@@ -193,7 +192,7 @@ func TestAdditionalVerificationKeys(t *testing.T) {
 	}
 }
 
-func TestAdditionalVerificationKeys_RejectsUnknownKey(t *testing.T) {
+func TestAdditionalVerificationKey_RejectsUnknownKey(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	keys := make([]string, 3)
 	for i := range keys {
@@ -202,7 +201,7 @@ func TestAdditionalVerificationKeys_RejectsUnknownKey(t *testing.T) {
 		keys[i] = string(k)
 	}
 
-	unknownSigner := newServiceWithKeys(t, clock, keys[2])
+	unknownSigner := newServiceWithKeys(t, clock, keys[2], "")
 	header, err := unknownSigner.NewIdentityHeader(&interfaces.ClientIdentity{Origin: "internal", Client: "app"}, clientidentity.DefaultExpiration)
 	require.NoError(t, err)
 
@@ -213,7 +212,7 @@ func TestAdditionalVerificationKeys_RejectsUnknownKey(t *testing.T) {
 	require.True(t, status.IsPermissionDeniedError(err))
 }
 
-func TestAdditionalVerificationKeys_ExpiredTokenReportsExpiry(t *testing.T) {
+func TestAdditionalVerificationKey_ExpiredTokenReportsExpiry(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	jwt.TimeFunc = func() time.Time {
 		return clock.Now()
@@ -227,7 +226,7 @@ func TestAdditionalVerificationKeys_ExpiredTokenReportsExpiry(t *testing.T) {
 	newKey, err := random.RandomString(16)
 	require.NoError(t, err)
 
-	oldSigner := newServiceWithKeys(t, clock, string(oldKey))
+	oldSigner := newServiceWithKeys(t, clock, string(oldKey), "")
 	header, err := oldSigner.NewIdentityHeader(&interfaces.ClientIdentity{Origin: "internal", Client: "app"}, clientidentity.DefaultExpiration)
 	require.NoError(t, err)
 

--- a/enterprise/server/clientidentity/clientidentity_test.go
+++ b/enterprise/server/clientidentity/clientidentity_test.go
@@ -135,6 +135,114 @@ func TestRequired(t *testing.T) {
 	require.Error(t, err)
 }
 
+func newServiceWithKeys(t testing.TB, clock clockwork.Clock, signingKey string, additionalKeys ...string) *clientidentity.Service {
+	flags.Set(t, "app.client_identity.key", signingKey)
+	flags.Set(t, "app.client_identity.additional_verification_keys", additionalKeys)
+	si, err := clientidentity.New(clock)
+	require.NoError(t, err)
+	return si
+}
+
+func TestAdditionalVerificationKeys(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	oldKey, err := random.RandomString(16)
+	require.NoError(t, err)
+	newKey, err := random.RandomString(16)
+	require.NoError(t, err)
+
+	oldSigner := newServiceWithKeys(t, clock, string(oldKey))
+	newSigner := newServiceWithKeys(t, clock, string(newKey))
+	// Rotation phase 1: still signing with the old key, new key trusted.
+	oldSignerTrustingNew := newServiceWithKeys(t, clock, string(oldKey), string(newKey))
+	// Rotation phase 2: signing with the new key, old key still trusted.
+	newSignerTrustingOld := newServiceWithKeys(t, clock, string(newKey), string(oldKey))
+
+	identity := &interfaces.ClientIdentity{Origin: "internal", Client: "app"}
+	oldSignedHeader, err := oldSigner.NewIdentityHeader(identity, clientidentity.DefaultExpiration)
+	require.NoError(t, err)
+	newSignedHeader, err := newSigner.NewIdentityHeader(identity, clientidentity.DefaultExpiration)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name        string
+		verifier    *clientidentity.Service
+		header      string
+		expectValid bool
+	}{
+		{name: "phase1_accepts_old_signed", verifier: oldSignerTrustingNew, header: oldSignedHeader, expectValid: true},
+		{name: "phase1_accepts_new_signed", verifier: oldSignerTrustingNew, header: newSignedHeader, expectValid: true},
+		{name: "phase2_accepts_old_signed", verifier: newSignerTrustingOld, header: oldSignedHeader, expectValid: true},
+		{name: "phase2_accepts_new_signed", verifier: newSignerTrustingOld, header: newSignedHeader, expectValid: true},
+		{name: "old_only_rejects_new_signed", verifier: oldSigner, header: newSignedHeader, expectValid: false},
+		{name: "new_only_rejects_old_signed", verifier: newSigner, header: oldSignedHeader, expectValid: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs(authutil.ClientIdentityHeaderName, tc.header))
+			ctx, err := tc.verifier.ValidateIncomingIdentity(ctx)
+			if !tc.expectValid {
+				require.Error(t, err)
+				require.True(t, status.IsPermissionDeniedError(err))
+				return
+			}
+			require.NoError(t, err)
+			si, err := tc.verifier.IdentityFromContext(ctx)
+			require.NoError(t, err)
+			require.Equal(t, identity.Origin, si.Origin)
+			require.Equal(t, identity.Client, si.Client)
+		})
+	}
+}
+
+func TestAdditionalVerificationKeys_RejectsUnknownKey(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	keys := make([]string, 3)
+	for i := range keys {
+		k, err := random.RandomString(16)
+		require.NoError(t, err)
+		keys[i] = string(k)
+	}
+
+	unknownSigner := newServiceWithKeys(t, clock, keys[2])
+	header, err := unknownSigner.NewIdentityHeader(&interfaces.ClientIdentity{Origin: "internal", Client: "app"}, clientidentity.DefaultExpiration)
+	require.NoError(t, err)
+
+	verifier := newServiceWithKeys(t, clock, keys[0], keys[1])
+	ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs(authutil.ClientIdentityHeaderName, header))
+	_, err = verifier.ValidateIncomingIdentity(ctx)
+	require.Error(t, err)
+	require.True(t, status.IsPermissionDeniedError(err))
+}
+
+func TestAdditionalVerificationKeys_ExpiredTokenReportsExpiry(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	jwt.TimeFunc = func() time.Time {
+		return clock.Now()
+	}
+	t.Cleanup(func() {
+		jwt.TimeFunc = time.Now
+	})
+
+	oldKey, err := random.RandomString(16)
+	require.NoError(t, err)
+	newKey, err := random.RandomString(16)
+	require.NoError(t, err)
+
+	oldSigner := newServiceWithKeys(t, clock, string(oldKey))
+	header, err := oldSigner.NewIdentityHeader(&interfaces.ClientIdentity{Origin: "internal", Client: "app"}, clientidentity.DefaultExpiration)
+	require.NoError(t, err)
+
+	clock.Advance(clientidentity.DefaultExpiration + time.Second)
+
+	// The expired token was signed with a trusted (additional) key; the error
+	// should surface the expiry rather than a signature mismatch from the
+	// other keys that were tried.
+	verifier := newServiceWithKeys(t, clock, string(newKey), string(oldKey))
+	ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs(authutil.ClientIdentityHeaderName, header))
+	_, err = verifier.ValidateIncomingIdentity(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expired")
+}
+
 func TestClearIdentity(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	sis := newService(t, clock)


### PR DESCRIPTION
Add `--app.client_identity.additional_verification_keys` flag so servers can accept identity JWTs signed with old or new keys during a rotation. Signing still uses only `app.client_identity.key`; incoming tokens are verified against the signing key plus each additional key.