### PR TITLE
Remove app.propagate_group_blocks experiment flag

### DIFF
--- a/enterprise/server/buildbuddy_server/buildbuddy_server_test.go
+++ b/enterprise/server/buildbuddy_server/buildbuddy_server_test.go
@@ -35,22 +35,16 @@ import (
 )
 
 const (
-	maxGroupsPerUserExperiment     = "app.max_groups_per_user"
-	propagateGroupBlocksExperiment = "app.propagate_group_blocks"
+	maxGroupsPerUserExperiment = "app.max_groups_per_user"
 )
 
-func configureCreateGroupExperiments(t *testing.T, env *testenv.TestEnv, maxGroups int64, propagateGroupBlocks bool) {
+func configureCreateGroupExperiments(t *testing.T, env *testenv.TestEnv, maxGroups int64) {
 	provider := openfeatureTesting.NewTestProvider()
 	provider.UsingFlags(t, map[string]memprovider.InMemoryFlag{
 		maxGroupsPerUserExperiment: {
 			State:          memprovider.Enabled,
 			DefaultVariant: "configured",
 			Variants:       map[string]any{"configured": int(maxGroups)},
-		},
-		propagateGroupBlocksExperiment: {
-			State:          memprovider.Enabled,
-			DefaultVariant: "configured",
-			Variants:       map[string]any{"configured": propagateGroupBlocks},
 		},
 	})
 	require.NoError(t, openfeature.SetProviderAndWait(provider))
@@ -148,14 +142,13 @@ func TestCreateGroup(t *testing.T) {
 
 func TestCreateGroup_Allowed(t *testing.T) {
 	for _, tc := range []struct {
-		name            string
-		maxGroups       int
-		groupStatus     grpb.Group_GroupStatus
-		ownedGroups     int
-		invitedGroups   int
-		orgAPIKey       bool
-		propagateBlocks bool
-		expectDenied    bool
+		name          string
+		maxGroups     int
+		groupStatus   grpb.Group_GroupStatus
+		ownedGroups   int
+		invitedGroups int
+		orgAPIKey     bool
+		expectDenied  bool
 	}{
 		{
 			name:        "limit_disabled",
@@ -184,12 +177,11 @@ func TestCreateGroup_Allowed(t *testing.T) {
 			expectDenied: true,
 		},
 		{
-			name:            "blocked_user_below_limit",
-			maxGroups:       2,
-			groupStatus:     grpb.Group_BLOCKED_GROUP_STATUS,
-			ownedGroups:     1,
-			propagateBlocks: true,
-			expectDenied:    true,
+			name:         "blocked_user_below_limit",
+			maxGroups:    2,
+			groupStatus:  grpb.Group_BLOCKED_GROUP_STATUS,
+			ownedGroups:  1,
+			expectDenied: true,
 		},
 		{
 			name:        "enterprise_user_not_limited",
@@ -283,7 +275,7 @@ func TestCreateGroup_Allowed(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, user.Groups, tc.ownedGroups+tc.invitedGroups)
 
-			configureCreateGroupExperiments(t, te, int64(tc.maxGroups), tc.propagateBlocks)
+			configureCreateGroupExperiments(t, te, int64(tc.maxGroups))
 			server, err := buildbuddy_server.NewBuildBuddyServer(te, nil)
 			require.NoError(t, err)
 

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -101,9 +101,6 @@ var (
 )
 
 const (
-	// When enabled, propagates "blocked" status across users/groups.
-	propagateGroupBlocksExperiment = "app.propagate_group_blocks"
-
 	maxGroupsPerUserExperiment = "app.max_groups_per_user"
 )
 
@@ -582,11 +579,7 @@ func createGroupAllowed(ctx context.Context, userDB interfaces.UserDB, efp inter
 	if isEnterprise || efp == nil {
 		return nil, nil
 	}
-	propagateGroupBlocks := efp.Boolean(ctx, propagateGroupBlocksExperiment, false /*=default*/)
 	maxGroupsPerUser := efp.Int64(ctx, maxGroupsPerUserExperiment, 0)
-	if !propagateGroupBlocks && maxGroupsPerUser == 0 {
-		return nil, nil
-	}
 
 	if u.GetUserID() == "" {
 		return nil, status.PermissionDeniedError("Creating organizations is not supported through the API. Please continue in our UI.")
@@ -607,7 +600,7 @@ func createGroupAllowed(ctx context.Context, userDB interfaces.UserDB, efp inter
 			ownedNonEnterpriseGroupCount++
 		}
 	}
-	if propagateGroupBlocks && allOwnedGroupsBlocked {
+	if allOwnedGroupsBlocked {
 		return nil, status.PermissionDeniedError("Error creating organization. Please contact support@buildbuddy.io.")
 	}
 

--- a/server/buildbuddy_server/buildbuddy_server_test.go
+++ b/server/buildbuddy_server/buildbuddy_server_test.go
@@ -204,17 +204,15 @@ func orgAPIKeyClaims(groupID string, groupStatus grpb.Group_GroupStatus) *claims
 
 func TestCreateGroup_PropagateGroupBlocks(t *testing.T) {
 	for _, tc := range []struct {
-		name              string
-		experimentEnabled bool
-		claims            *claims.Claims
+		name   string
+		claims *claims.Claims
 		// user is what the fake UserDB returns; nil means the DB has no such user.
 		user         *tables.User
 		expectDenied bool
 	}{
 		{
-			name:              "user_all_groups_blocked_denied",
-			experimentEnabled: true,
-			claims:            userClaims(user1, group1),
+			name:   "user_all_groups_blocked_denied",
+			claims: userClaims(user1, group1),
 			user: &tables.User{UserID: user1, Groups: []*tables.GroupRole{
 				groupRole(group1, grpb.Group_BLOCKED_GROUP_STATUS),
 				groupRole(group2, grpb.Group_BLOCKED_GROUP_STATUS),
@@ -222,9 +220,8 @@ func TestCreateGroup_PropagateGroupBlocks(t *testing.T) {
 			expectDenied: true,
 		},
 		{
-			name:              "user_one_group_not_blocked_allowed",
-			experimentEnabled: true,
-			claims:            userClaims(user1, group1),
+			name:   "user_one_group_not_blocked_allowed",
+			claims: userClaims(user1, group1),
 			user: &tables.User{UserID: user1, Groups: []*tables.GroupRole{
 				groupRole(group1, grpb.Group_BLOCKED_GROUP_STATUS),
 				groupRole(group2, grpb.Group_FREE_TIER_GROUP_STATUS),
@@ -232,9 +229,8 @@ func TestCreateGroup_PropagateGroupBlocks(t *testing.T) {
 			expectDenied: false,
 		},
 		{
-			name:              "user_owned_group_blocked_and_invited_group_unblocked_denied",
-			experimentEnabled: true,
-			claims:            userClaims(user1, group1),
+			name:   "user_owned_group_blocked_and_invited_group_unblocked_denied",
+			claims: userClaims(user1, group1),
 			user: &tables.User{UserID: user1, Groups: []*tables.GroupRole{
 				groupRole(group1, grpb.Group_BLOCKED_GROUP_STATUS),
 				groupRoleOwnedBy(group2, user2, grpb.Group_FREE_TIER_GROUP_STATUS),
@@ -242,47 +238,28 @@ func TestCreateGroup_PropagateGroupBlocks(t *testing.T) {
 			expectDenied: true,
 		},
 		{
-			name:              "user_only_invited_to_blocked_group_allowed",
-			experimentEnabled: true,
-			claims:            userClaims(user1, group1),
+			name:   "user_only_invited_to_blocked_group_allowed",
+			claims: userClaims(user1, group1),
 			user: &tables.User{UserID: user1, Groups: []*tables.GroupRole{
 				groupRoleOwnedBy(group1, user2, grpb.Group_BLOCKED_GROUP_STATUS),
 			}},
 			expectDenied: false,
 		},
 		{
-			name:              "user_with_no_groups_allowed",
-			experimentEnabled: true,
-			claims:            userClaims(user1, group1),
-			user:              &tables.User{UserID: user1},
-			expectDenied:      false,
-		},
-		{
-			name:              "org_api_key_blocked_group_denied",
-			experimentEnabled: true,
-			claims:            orgAPIKeyClaims(group1, grpb.Group_BLOCKED_GROUP_STATUS),
-			expectDenied:      true,
-		},
-		{
-			name:              "org_api_key_unblocked_group_allowed",
-			experimentEnabled: true,
-			claims:            orgAPIKeyClaims(group1, grpb.Group_ENTERPRISE_GROUP_STATUS),
-			expectDenied:      false,
-		},
-		{
-			name:              "experiment_disabled_user_all_groups_blocked_allowed",
-			experimentEnabled: false,
-			claims:            userClaims(user1, group1),
-			user: &tables.User{UserID: user1, Groups: []*tables.GroupRole{
-				groupRole(group1, grpb.Group_BLOCKED_GROUP_STATUS),
-			}},
+			name:         "user_with_no_groups_allowed",
+			claims:       userClaims(user1, group1),
+			user:         &tables.User{UserID: user1},
 			expectDenied: false,
 		},
 		{
-			name:              "experiment_disabled_org_api_key_blocked_group_allowed",
-			experimentEnabled: false,
-			claims:            orgAPIKeyClaims(group1, grpb.Group_BLOCKED_GROUP_STATUS),
-			expectDenied:      false,
+			name:         "org_api_key_blocked_group_denied",
+			claims:       orgAPIKeyClaims(group1, grpb.Group_BLOCKED_GROUP_STATUS),
+			expectDenied: true,
+		},
+		{
+			name:         "org_api_key_unblocked_group_allowed",
+			claims:       orgAPIKeyClaims(group1, grpb.Group_ENTERPRISE_GROUP_STATUS),
+			expectDenied: false,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -290,9 +267,7 @@ func TestCreateGroup_PropagateGroupBlocks(t *testing.T) {
 			te.SetAuthenticator(testauth.NewTestAuthenticator(t, nil))
 			udb := &fakeUserDB{user: tc.user}
 			te.SetUserDB(udb)
-			te.SetExperimentFlagProvider(&fakeExperimentFlagProvider{
-				booleanFlags: map[string]bool{"app.propagate_group_blocks": tc.experimentEnabled},
-			})
+			te.SetExperimentFlagProvider(&fakeExperimentFlagProvider{})
 			server, err := buildbuddy_server.NewBuildBuddyServer(te, nil)
 			require.NoError(t, err)
 


### PR DESCRIPTION
## Summary

The `app.propagate_group_blocks` experiment is enabled everywhere, so this change stops consulting the flag and treats it as always true. Blocked-group propagation now always applies in `createGroupAllowed`.

## Changes

- **`server/buildbuddy_server/buildbuddy_server.go`**: Removed the `propagateGroupBlocksExperiment` const and its `efp.Boolean(...)` lookup. Dropped the now-dead early return (its `!propagateGroupBlocks && maxGroupsPerUser == 0` guard could never trigger with the flag on) and simplified the block check to `if allOwnedGroupsBlocked`.
- **`server/buildbuddy_server/buildbuddy_server_test.go`**: Removed the `experimentEnabled` field, the two `experiment_disabled_*` cases (that behavior no longer exists), and stopped setting the boolean flag.
- **`enterprise/server/buildbuddy_server/buildbuddy_server_test.go`**: Removed the `propagateGroupBlocksExperiment` const, dropped the `propagateGroupBlocks` param from `configureCreateGroupExperiments`, and removed the `propagateBlocks` test field.

## Testing

- `bazel test //server/buildbuddy_server:buildbuddy_server_test //enterprise/server/buildbuddy_server:buildbuddy_server_test` — both pass.