### PR TITLE
[cli] Expand bbrc related options in the parser

### DIFF
--- a/cli/arg/BUILD
+++ b/cli/arg/BUILD
@@ -8,6 +8,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/arg",
     deps = [
         "//cli/parser",
+        "//cli/parser/bbrc",
         "//cli/parser/parsed",
     ],
 )

--- a/cli/arg/arg.go
+++ b/cli/arg/arg.go
@@ -8,26 +8,38 @@ import (
 	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/parser"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/bbrc"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/parsed"
 )
 
 type BazelArgs struct {
-	// forwarded are the Bazel args that are eventually passed to Bazelisk.
-	// bb might add to these, but --config and --bazelrc flags are not expanded.
-	// These should look fairly similarly to the user-supplied args, but with some additional bb-specific args.
-	forwarded *parsed.OrderedArgs
+	// unresolved are the Bazel args without any rc files (bazelrc or bbrc) or config flags
+	// (--config or --bb_config) expanded.
+	//
+	// Any bbrc-related options should be removed before being passed to Bazelisk, because
+	// Bazelisk does not support them.
+	//
+	// Any bazelrc-related options are not expanded, because Bazelisk will handle expansion.
+	unresolved *parsed.OrderedArgs
 
-	// resolved are the Bazel args that are used internally within the bb parser.
-	// --config and --bazelrc flags are expanded, so the parser has a complete view of the args.
+	// resolved are the Bazel args that are used internally within the bb parser to understand the complete set of args.
+	// All bazelrc files, --config flags, bbrc files, and --bb_config flags are expanded.
 	resolved *parsed.OrderedArgs
 
 	// noResolve indicates that resolved args (i.e. --config and --bazelrc flags expanded) should not be computed.
 	noResolve bool
 }
 
-// Forwarded returns the forwarded args as a canonicalized []string.
+// Forwarded returns the args that should be passed to Bazelisk as a canonicalized []string.
 func (a *BazelArgs) Forwarded() []string {
-	return a.forwarded.Canonicalized().Format()
+	// Clone to avoid mutation of a.unresolved.
+	args := cloneOrderedArgs(a.unresolved)
+	// Remove bbrc-related options that should not be passed to Bazelisk.
+	// bbrc files should not contain Bazel options, so they do not need to be expanded before
+	// being removed.
+	args.RemoveStartupOptions(bbrc.FileFlagName, bbrc.IgnoreAllRCFilesFlagName)
+	args.RemoveCommandOptions(bbrc.ConfigFlagName)
+	return args.Canonicalized().Format()
 }
 
 // Resolved returns the resolved args as a canonicalized []string.
@@ -53,7 +65,7 @@ func NewBazelArgsNoResolve(args []string) (*BazelArgs, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &BazelArgs{forwarded: parsed, noResolve: true}, nil
+	return &BazelArgs{unresolved: parsed, noResolve: true}, nil
 }
 
 func cloneOrderedArgs(args *parsed.OrderedArgs) *parsed.OrderedArgs {
@@ -63,11 +75,11 @@ func cloneOrderedArgs(args *parsed.OrderedArgs) *parsed.OrderedArgs {
 // Set updates the BazelArgs struct with a new slice of bazel args.
 // It also recomputes the resolved args.
 func (a *BazelArgs) Set(args []string) error {
-	forwarded, err := parser.ParseArgs(args)
+	parsedArgs, err := parser.ParseArgs(args)
 	if err != nil {
 		return err
 	}
-	a.forwarded = forwarded
+	a.unresolved = parsedArgs
 	if a.noResolve {
 		return nil
 	}
@@ -76,11 +88,11 @@ func (a *BazelArgs) Set(args []string) error {
 
 // Append adds a new bazel arg.
 func (a *BazelArgs) Append(arg string) error {
-	newFwd, err := parser.ParseArgs(Append(a.forwarded.Format(), arg))
+	newFwd, err := parser.ParseArgs(Append(a.unresolved.Format(), arg))
 	if err != nil {
 		return err
 	}
-	a.forwarded = newFwd
+	a.unresolved = newFwd
 	if a.noResolve {
 		return nil
 	}
@@ -103,7 +115,7 @@ func (a *BazelArgs) AppendStartupOption(name, value string) error {
 	if err != nil {
 		return err
 	}
-	if err := a.forwarded.Append(opt); err != nil {
+	if err := a.unresolved.Append(opt); err != nil {
 		return err
 	}
 	if a.noResolve {
@@ -121,11 +133,11 @@ func (a *BazelArgs) AppendStartupOption(name, value string) error {
 // If the same flag is specified multiple times, Bazel will use the last value. This is useful for adding flags that should
 // be overridden by later flags.
 func (a *BazelArgs) Prepend(arg string) error {
-	newFwd, err := parser.ParseArgs(prepend(a.forwarded.Format(), arg))
+	newFwd, err := parser.ParseArgs(prepend(a.unresolved.Format(), arg))
 	if err != nil {
 		return err
 	}
-	a.forwarded = newFwd
+	a.unresolved = newFwd
 	if a.noResolve {
 		return nil
 	}
@@ -156,9 +168,13 @@ func prepend(args []string, arg string) []string {
 
 // requiresResolve returns true if the arg can change rc/config expansion.
 func requiresResolve(arg string) bool {
-	flagName, _ := SplitOptionValue(arg)
-	flagName = strings.TrimPrefix(flagName, "--")
-	return flagName == "config" || flagName == "bazelrc"
+	name := flagName(arg)
+	return name == bbrc.ConfigFlagName || name == bbrc.FileFlagName || name == bbrc.IgnoreAllRCFilesFlagName || name == "config" || name == "bazelrc"
+}
+
+func flagName(arg string) string {
+	name, _ := SplitOptionValue(arg)
+	return strings.TrimPrefix(name, "--")
 }
 
 // Get returns the value of a flag.
@@ -171,7 +187,8 @@ func (a *BazelArgs) Has(flagName string) bool {
 	return a.Get(flagName) != ""
 }
 
-// resolve re-evaluates the forwarded args and expands all flags into the resolved field.
+// resolve re-evaluates the forwarded args and expands BB and Bazel rc files
+// into the resolved field.
 //
 // resolve is expensive because it re-parses all rc files and expands configs. It is only necessary
 // when requiresResolve returns true for a flag.
@@ -181,7 +198,7 @@ func (a *BazelArgs) resolve() error {
 	}
 
 	// Clone to avoid mutation of a.forwarded by ResolveArgs.
-	clone := cloneOrderedArgs(a.forwarded)
+	clone := cloneOrderedArgs(a.unresolved)
 	resolved, err := parser.ResolveArgs(clone)
 	if err != nil {
 		return err
@@ -204,46 +221,43 @@ func (a *BazelArgs) GetAllFlagsWithName(flagName string) []string {
 
 // StripBBFlag removes a CLI-only string flag from the args (so it is
 // not passed to Bazelisk) and returns its value.
-// TODO(#7389): If we support setting CLI flags via config, make sure we support reading them correctly
-// from the resolved args.
 func (a *BazelArgs) StripBBFlag(flagName string) (string, error) {
-	// GetCLICommandOptionVal removes the flag from a.forwarded in place.
-	flagVal, err := parser.GetCLICommandOptionVal(a.forwarded, flagName)
+	if a.noResolve {
+		return parser.GetCLICommandOptionVal(a.unresolved, flagName)
+	}
+	// GetCLICommandOptionVal removes the flag from the args in place,
+	// so we need to remove it from the unresolved args as well.
+	flagVal, err := parser.GetCLICommandOptionVal(a.resolved, flagName)
 	if err != nil {
 		return "", err
 	}
-	if a.noResolve {
-		return flagVal, nil
-	}
-	a.resolved.RemoveCommandOptions(flagName)
+	a.unresolved.RemoveCommandOptions(flagName)
 	return flagVal, nil
 }
 
 // StripBBBoolFlag removes a CLI-only bool flag from the forwarded args (so it
 // is not passed to Bazelisk) and returns whether it was set.
-// TODO(#7389): If we support setting CLI flags via config, make sure we support reading them correctly
-// from the resolved args.
 func (a *BazelArgs) StripBBBoolFlag(flagName string) (bool, error) {
-	// IsCLICommandOptionSet removes the flag from a.forwarded in place.
-	set, err := parser.IsCLICommandOptionSet(a.forwarded, flagName)
+	if a.noResolve {
+		return parser.IsCLICommandOptionSet(a.unresolved, flagName)
+	}
+	// IsCLICommandOptionSet removes the flag from the args in place,
+	// so we need to remove it from the unresolved args as well.
+	set, err := parser.IsCLICommandOptionSet(a.resolved, flagName)
 	if err != nil {
 		return false, err
 	}
-	if a.noResolve {
-		return set, nil
-	}
-	a.resolved.RemoveCommandOptions(flagName)
+	a.unresolved.RemoveCommandOptions(flagName)
 	return set, nil
 }
 
 // StripBBStartupOptions removes CLI-only startup options and returns the removed options.
-// TODO(#7389): If we support setting CLI flags via config, make sure we support reading them correctly.
 func (a *BazelArgs) StripBBStartupOptions(optionNames ...string) []*parsed.IndexedOption {
-	forwardedRemoved := a.forwarded.RemoveStartupOptions(optionNames...)
 	if a.noResolve {
-		return forwardedRemoved
+		return a.unresolved.RemoveStartupOptions(optionNames...)
 	}
 	removed := a.resolved.RemoveStartupOptions(optionNames...)
+	a.unresolved.RemoveStartupOptions(optionNames...)
 	return removed
 }
 
@@ -251,7 +265,7 @@ func (a *BazelArgs) StripBBStartupOptions(optionNames ...string) []*parsed.Index
 // given key, reading from the resolved args.
 func (a *BazelArgs) GetRemoteHeaderVal(key string) string {
 	if a.noResolve {
-		return parser.GetRemoteHeaderVal(a.forwarded, key)
+		return parser.GetRemoteHeaderVal(a.unresolved, key)
 	}
 	return parser.GetRemoteHeaderVal(a.resolved, key)
 }
@@ -259,14 +273,14 @@ func (a *BazelArgs) GetRemoteHeaderVal(key string) string {
 // Pop removes a flag and returns its value.
 // NOTE: Pop does not remove boolean flags.
 func (a *BazelArgs) Pop(flagName string) (string, error) {
-	value, newFwdSlice := Pop(a.forwarded.Format(), flagName)
+	value, newFwdSlice := Pop(a.unresolved.Format(), flagName)
 
 	if value != "" {
 		newFwd, err := parser.ParseArgs(newFwdSlice)
 		if err != nil {
 			return "", err
 		}
-		a.forwarded = newFwd
+		a.unresolved = newFwd
 		if a.noResolve {
 			return value, nil
 		}

--- a/cli/arg/arg.go
+++ b/cli/arg/arg.go
@@ -42,6 +42,15 @@ func (a *BazelArgs) Forwarded() []string {
 	return args.Canonicalized().Format()
 }
 
+// Unresolved returns the arguments before rc files and config flags are
+// expanded. Unlike Forwarded, it retains BB rc-file options so that they can
+// be re-parsed if needed.
+func (a *BazelArgs) Unresolved() []string {
+	// Clone to avoid mutation of a.unresolved.
+	args := cloneOrderedArgs(a.unresolved)
+	return args.Canonicalized().Format()
+}
+
 // Resolved returns the resolved args as a canonicalized []string.
 func (a *BazelArgs) Resolved() []string {
 	if a.noResolve {

--- a/cli/arg/arg.go
+++ b/cli/arg/arg.go
@@ -37,8 +37,7 @@ func (a *BazelArgs) Forwarded() []string {
 	// Remove bbrc-related options that should not be passed to Bazelisk.
 	// bbrc files should not contain Bazel options, so they do not need to be expanded before
 	// being removed.
-	args.RemoveStartupOptions(bbrc.FileFlagName, bbrc.IgnoreAllRCFilesFlagName)
-	args.RemoveCommandOptions(bbrc.ConfigFlagName)
+	bbrc.RemoveOptions(args)
 	return args.Canonicalized().Format()
 }
 

--- a/cli/arg/arg_test.go
+++ b/cli/arg/arg_test.go
@@ -541,3 +541,36 @@ run:ci --on_stream_run_logs_failure=warn
 	require.Contains(t, args.Resolved(), "--on_stream_run_logs_failure=warn")
 	require.Contains(t, args.Resolved(), "--build_metadata=LATE")
 }
+
+func TestUnresolved_RetainsBBRCArgs(t *testing.T) {
+	setupWorkspace(t, "")
+	ws, err := workspace.Path()
+	require.NoError(t, err)
+	customBBRC := filepath.Join(ws, "custom.bbrc")
+	require.NoError(t, os.WriteFile(customBBRC, []byte("run:ci --stream_run_logs\n"), 0644))
+
+	args, err := NewBazelArgs([]string{
+		"--bbrc=" + customBBRC,
+		"run",
+		"--bb_config=ci",
+		"//:target",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{
+		"--bbrc=" + customBBRC,
+		"run",
+		"--bb_config=ci",
+		"//:target",
+	}, args.Unresolved())
+	require.Equal(t, []string{"run", "//:target"}, args.Forwarded())
+
+	args, err = NewBazelArgs([]string{"--ignore_all_bb_rc_files", "run", "//:target"})
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"--ignore_all_bb_rc_files",
+		"run",
+		"//:target",
+	}, args.Unresolved())
+	require.Equal(t, []string{"run", "//:target"}, args.Forwarded())
+}

--- a/cli/arg/arg_test.go
+++ b/cli/arg/arg_test.go
@@ -499,7 +499,45 @@ func TestGetCommand(t *testing.T) {
 
 func setupWorkspace(t *testing.T, bazelrc string) {
 	ws := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
 	require.NoError(t, os.WriteFile(filepath.Join(ws, "WORKSPACE"), nil, 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(ws, ".bazelrc"), []byte(bazelrc), 0644))
 	workspace.SetForTest(t, ws)
+}
+
+func TestForwarded_DoesNotForwardBBRCArgs(t *testing.T) {
+	setupWorkspace(t, "run:late --build_metadata=LATE")
+	ws, err := workspace.Path()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(ws, ".bbrc"), []byte(`
+run --stream_run_logs
+run:ci --on_stream_run_logs_failure=warn
+`), 0644))
+
+	args, err := NewBazelArgs([]string{"run", "--bb_config=ci", "--build_metadata=CLI", "//:target"})
+	require.NoError(t, err)
+	// The resolved args should contain the bbrc-related options, but the forwarded args should not.
+	require.Equal(t, []string{
+		"run",
+		"--build_metadata=CLI",
+		"//:target",
+	}, args.Forwarded())
+	require.Contains(t, args.Resolved(), "--stream_run_logs")
+	require.Contains(t, args.Resolved(), "--on_stream_run_logs_failure=warn")
+
+	// Append a new config flag. The corresponding metadata flag should be in the resolved args, but not the forwarded args.
+	require.NoError(t, args.Append("--config=late"))
+	require.Equal(t, []string{"CLI"}, GetMulti(args.Forwarded(), "build_metadata"))
+	require.Equal(t, []string{"CLI", "LATE"}, GetMulti(args.Resolved(), "build_metadata"))
+
+	require.Equal(t, []string{
+		"run",
+		"--build_metadata=CLI",
+		"--config=late",
+		"//:target",
+	}, args.Forwarded())
+	// The bb flags should still be in the resolved args.
+	require.Contains(t, args.Resolved(), "--stream_run_logs")
+	require.Contains(t, args.Resolved(), "--on_stream_run_logs_failure=warn")
+	require.Contains(t, args.Resolved(), "--build_metadata=LATE")
 }

--- a/cli/cmd/bb/BUILD
+++ b/cli/cmd/bb/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//cli/metadata",
         "//cli/parser",
         "//cli/parser/arguments",
+        "//cli/parser/bbrc",
         "//cli/parser/options",
         "//cli/parser/parsed",
         "//cli/picker",

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -289,7 +289,9 @@ func runHelp(args *parsed.OrderedArgs) (int, error) {
 // EXPLICIT_COMMAND_LINE metadata to the bazel invocation.
 func handleBazelCommand(start time.Time, bazelArgs *arg.BazelArgs, execArgs []string, originalArgs []string) (exitCode int, err error) {
 	// Maybe run interactively (watching for changes to files).
-	if exitCode, err := watcher.Watch(append([]string{os.Args[0]}, arg.JoinExecutableArgs(bazelArgs.Forwarded(), execArgs)...)); exitCode >= 0 || err != nil {
+	// The watcher starts another bb process, so retain the complete set of original arguments.
+	// They'll be reparsed by the new process.
+	if exitCode, err := watcher.Watch(append([]string{os.Args[0]}, arg.JoinExecutableArgs(bazelArgs.Unresolved(), execArgs)...)); exitCode >= 0 || err != nil {
 		return exitCode, err
 	}
 

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -15,6 +15,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/metadata"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/arguments"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/bbrc"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/options"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/parsed"
 	"github.com/buildbuddy-io/buildbuddy/cli/picker"
@@ -154,6 +155,9 @@ func run() (exitCode int, err error) {
 		Configure(helpArgs.RemoveStartupOptions(logoptdef.Verbose.Name(), watchoptdef.Watch.Name(), watchoptdef.WatcherFlags.Name()))
 		StartupDebug(start)
 		helpArgs.RemoveCommandOptions(streamoptdef.StreamRunLogs.Name(), streamoptdef.OnStreamRunLogsFailure.Name())
+		// Help does not use .bbrc settings, and Bazel does not understand the
+		// flags that control them.
+		bbrc.RemoveOptions(helpArgs)
 		return runHelp(helpArgs)
 	}
 
@@ -274,10 +278,6 @@ func runHelp(args *parsed.OrderedArgs) (int, error) {
 			toPrepend,
 			args.Args[len(startupOpts)+1:],
 		)
-	}
-	args, err = helpParser.ResolveArgs(args)
-	if err != nil {
-		return -1, err
 	}
 	return help.HandleHelp(args)
 }

--- a/cli/flaghistory/flaghistory_test.go
+++ b/cli/flaghistory/flaghistory_test.go
@@ -21,6 +21,10 @@ func init() {
 func setup(t *testing.T) {
 	// Flag history is written to this dir.
 	t.Setenv("BUILDBUDDY_CACHE_DIR", t.TempDir())
+	// Keep user bbrc settings from affecting resolved args.
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 }
 
 func TestMain(m *testing.M) {

--- a/cli/login/login_test.go
+++ b/cli/login/login_test.go
@@ -67,6 +67,10 @@ func TestAPIKeyDiscovery(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
+			homeDir := t.TempDir()
+			t.Setenv("HOME", homeDir)
+			t.Setenv("USERPROFILE", homeDir)
+
 			repoRoot, _ := testgit.MakeTempRepo(t, map[string]string{
 				"README.md": "# test repo",
 			})

--- a/cli/metadata/metadata_test.go
+++ b/cli/metadata/metadata_test.go
@@ -17,6 +17,10 @@ func init() {
 }
 
 func TestAppendBuildMetadata(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+
 	ws, commitSHA := testgit.MakeTempRepo(t, map[string]string{"WORKSPACE": ""})
 	testgit.ConfigureRemoteOrigin(t, ws, "https://user:secret@example.com/org/repo.git")
 	workspace.SetForTest(t, ws)

--- a/cli/parser/BUILD
+++ b/cli/parser/BUILD
@@ -40,6 +40,7 @@ go_test(
     deps = [
         "//cli/cli_command",
         "//cli/log",
+        "//cli/parser/arguments",
         "//cli/parser/bbrc",
         "//cli/parser/options",
         "//cli/parser/test_data",

--- a/cli/parser/bbrc/bbrc.go
+++ b/cli/parser/bbrc/bbrc.go
@@ -62,3 +62,9 @@ func ExpandConfigs(
 ) (*parsed.OrderedArgs, error) {
 	return args.ExpandConfigsWithPolicy(namedConfigs, defaultConfig, NewConfigExpansionPolicy())
 }
+
+// RemoveOptions removes all options related to .bbrc files.
+func RemoveOptions(args *parsed.OrderedArgs) {
+	args.RemoveStartupOptions(FileFlagName, IgnoreAllRCFilesFlagName)
+	args.RemoveCommandOptions(ConfigFlagName)
+}

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"maps"
 	"os"
+	"os/user"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -865,7 +866,7 @@ func (p *Parser) expandBazelRC(parsedArgs *parsed.OrderedArgs, ws string) (*pars
 }
 
 func (p *Parser) expandBBRC(args *parsed.OrderedArgs, workspaceDir string) (*parsed.OrderedArgs, error) {
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := userHomeDir()
 	if err != nil {
 		log.Debugf("Could not determine home dir for .bbrc: %s", err)
 	}
@@ -878,6 +879,18 @@ func (p *Parser) expandBBRC(args *parsed.OrderedArgs, workspaceDir string) (*par
 		return nil, fmt.Errorf("failed to parse .bbrc file: %s", err)
 	}
 	return bbrc.ExpandConfigs(args, namedConfigs, defaultConfig)
+}
+
+func userHomeDir() (string, error) {
+	homeDir, homeDirErr := os.UserHomeDir()
+	if homeDirErr == nil && homeDir != "" {
+		return homeDir, nil
+	}
+	u, currentUserErr := user.Current()
+	if currentUserErr == nil && u != nil && u.HomeDir != "" {
+		return u.HomeDir, nil
+	}
+	return "", fmt.Errorf("os.UserHomeDir: %v; user.Current: %v", homeDirErr, currentUserErr)
 }
 
 func bbrcFilePaths(workspaceDir, homeDir string) []string {

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -989,8 +989,7 @@ func (p *Parser) parseBBRCConfig(phase string, tokens []string) ([]arguments.Arg
 		if !ok {
 			continue
 		}
-		switch option.AsOption().PluginID() {
-		case options.UnknownBuiltinPluginID, options.StarlarkBuiltinPluginID:
+		if id := option.AsOption().PluginID(); id == options.UnknownBuiltinPluginID || id == options.StarlarkBuiltinPluginID {
 			return nil, fmt.Errorf("option %q is not a bb CLI flag", option.AsOption().Name())
 		}
 	}

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -807,10 +807,7 @@ func runBazelHelpWithCache() (*bfpb.FlagCollection, error) {
 	return flags, err
 }
 
-// ResolveArgs removes all rc-file options from the args, appends an
-// `ignore_all_rc_files` option to the startup options, parses those rc-files
-// into Configs using the default parser, and expands all config options using
-// those configs, and returns the result.
+// ResolveArgs applies BB and Bazel rc-file settings to the parsed arguments.
 func ResolveArgs(parsedArgs *parsed.OrderedArgs) (*parsed.OrderedArgs, error) {
 	ws, err := workspace.Path()
 	if err != nil {
@@ -827,11 +824,7 @@ func resolveArgs(parsedArgs *parsed.OrderedArgs, ws string) (*parsed.OrderedArgs
 	return p.resolveArgs(parsedArgs, ws)
 }
 
-// ResolveArgs removes all rc-file options from the args, appends an
-// `ignore_all_rc_files` option to the startup options, parses those rc-files
-// into Configs, and expands all config options (as well as any
-// `enable_platform_specific_config` option, if one exists) using
-// those configs, and returns the result.
+// ResolveArgs applies BB and Bazel rc-file settings to the parsed arguments.
 func (p *Parser) ResolveArgs(parsedArgs *parsed.OrderedArgs) (*parsed.OrderedArgs, error) {
 	ws, err := workspace.Path()
 	if err != nil {
@@ -840,8 +833,30 @@ func (p *Parser) ResolveArgs(parsedArgs *parsed.OrderedArgs) (*parsed.OrderedArg
 	return p.resolveArgs(parsedArgs, ws)
 }
 
+// ResolveBBArgs expands bbrc settings.
+func (p *Parser) ResolveBBArgs(parsedArgs *parsed.OrderedArgs) (*parsed.OrderedArgs, error) {
+	ws, err := workspace.Path()
+	if err != nil {
+		log.Debugf("Could not determine workspace dir: %s", err)
+	}
+	return p.expandBBRC(parsedArgs, ws)
+}
+
 func (p *Parser) resolveArgs(parsedArgs *parsed.OrderedArgs, ws string) (*parsed.OrderedArgs, error) {
-	// TODO(Maggie): Add bbrc config expansion here
+	// When expanding bbrc, use the bb-specific parser because bbrc files
+	// should not contain Bazel options.
+	bbParser, err := GetBBParserForCommand(parsedArgs.GetCommand())
+	if err != nil {
+		return nil, err
+	}
+	parsedArgs, err = bbParser.expandBBRC(parsedArgs, ws)
+	if err != nil {
+		return nil, err
+	}
+	return p.expandBazelRC(parsedArgs, ws)
+}
+
+func (p *Parser) expandBazelRC(parsedArgs *parsed.OrderedArgs, ws string) (*parsed.OrderedArgs, error) {
 	configs, defaultConfig, err := p.consumeAndParseRCFiles(parsedArgs, ws)
 	if err != nil {
 		return nil, err
@@ -849,7 +864,11 @@ func (p *Parser) resolveArgs(parsedArgs *parsed.OrderedArgs, ws string) (*parsed
 	return bazelrc.ExpandConfigs(parsedArgs, configs, defaultConfig)
 }
 
-func (p *Parser) expandBBRC(args *parsed.OrderedArgs, workspaceDir, homeDir string) (*parsed.OrderedArgs, error) {
+func (p *Parser) expandBBRC(args *parsed.OrderedArgs, workspaceDir string) (*parsed.OrderedArgs, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Debugf("Could not determine home dir for .bbrc: %s", err)
+	}
 	filePaths, err := consumeBBRCFileOptions(args, workspaceDir, homeDir)
 	if err != nil {
 		return nil, err
@@ -927,8 +946,28 @@ func (p *Parser) ParseBBRCFiles(workspaceDir string, filePaths ...string) (map[s
 			_, isBBCommand := cli_command.CommandsByName[phase]
 			return bazelrc.IsPhase(phase) || isBBCommand
 		},
-		ParsePhase: p.ParseConfig,
+		ParsePhase: p.parseBBRCConfig,
 	}, filePaths...)
+}
+
+func (p *Parser) parseBBRCConfig(phase string, tokens []string) ([]arguments.Argument, error) {
+	args, err := p.ParseConfig(phase, tokens)
+	if err != nil {
+		return nil, err
+	}
+	// Validate that all options in the config are CLI flags.
+	// Bazel options are not allowed in bbrc files.
+	for _, classified := range parsed.Classify(args) {
+		option, ok := classified.(parsed.ClassifiedOption)
+		if !ok {
+			continue
+		}
+		switch option.AsOption().PluginID() {
+		case options.UnknownBuiltinPluginID, options.StarlarkBuiltinPluginID:
+			return nil, fmt.Errorf("option %q is not a bb CLI flag", option.AsOption().Name())
+		}
+	}
+	return args, nil
 }
 
 // ParseRCFilesWithPolicy parses rc files and returns a map of the named configs as well as the default (unnamed)

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -946,7 +946,21 @@ func (p *Parser) ParseBBRCFiles(workspaceDir string, filePaths ...string) (map[s
 			_, isBBCommand := cli_command.CommandsByName[phase]
 			return bazelrc.IsPhase(phase) || isBBCommand
 		},
-		ParsePhase: p.parseBBRCConfig,
+		ParsePhase: func(phase string, tokens []string) ([]arguments.Argument, error) {
+			sectionParser := p
+			// BB commands declare their flags in command-specific Go flag sets.
+			// Parse each such section with its command's parser so an unrelated
+			// section does not fail just because the current command's parser does
+			// not know those flags.
+			if command := cli_command.GetCommand(phase); command != nil && command.Flags != nil {
+				var err error
+				sectionParser, err = GetBBParserForCommand(command.Name)
+				if err != nil {
+					return nil, err
+				}
+			}
+			return sectionParser.parseBBRCConfig(phase, tokens)
+		},
 	}, filePaths...)
 }
 

--- a/cli/parser/parser_test.go
+++ b/cli/parser/parser_test.go
@@ -308,6 +308,90 @@ func TestConsumeBBRCFileOptions_IgnoreAllLastValueWins(t *testing.T) {
 	}, paths)
 }
 
+func TestResolveArgs_ExpandsBBRCBeforeBazelRC(t *testing.T) {
+	workspaceDir := testfs.MakeTempDir(t)
+	homeDir := testfs.MakeTempDir(t)
+	explicitBBRC := filepath.Join(testfs.MakeTempDir(t), "explicit.bbrc")
+	t.Setenv("HOME", homeDir)
+	testfs.WriteAllFileContents(t, workspaceDir, map[string]string{
+		".bbrc": `
+run --stream_run_logs
+run:ci --on_stream_run_logs_failure=warn
+`,
+		".bazelrc": `
+run:bazel --build_metadata=BAZEL
+`,
+	})
+	testfs.WriteAllFileContents(t, homeDir, map[string]string{
+		".bbrc": `
+run --nostream_run_logs
+run:ci --on_stream_run_logs_failure=ignore
+`,
+	})
+	require.NoError(t, os.WriteFile(explicitBBRC, []byte(`
+run:ci --on_stream_run_logs_failure=fail
+`), 0644))
+
+	p, err := GetParser()
+	require.NoError(t, err)
+	args, err := p.ParseArgs([]string{
+		"--bbrc=" + explicitBBRC,
+		"run",
+		"//:target",
+		"--bb_config=ci",
+		"--config=bazel",
+	})
+	require.NoError(t, err)
+	args, err = p.resolveArgs(args, workspaceDir)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"--ignore_all_rc_files",
+		"run",
+		"--stream_run_logs",
+		"--nostream_run_logs",
+		"//:target",
+		"--on_stream_run_logs_failure=warn",
+		"--on_stream_run_logs_failure=ignore",
+		"--on_stream_run_logs_failure=fail",
+		"--build_metadata=BAZEL",
+	}, args.Format())
+}
+
+func TestResolveArgs_BBRCRejectsBazelFlags(t *testing.T) {
+	workspaceDir := testfs.MakeTempDir(t)
+	t.Setenv("HOME", testfs.MakeTempDir(t))
+	testfs.WriteAllFileContents(t, workspaceDir, map[string]string{
+		".bbrc": "run --build_metadata=NOT_ALLOWED",
+	})
+
+	p, err := GetParser()
+	require.NoError(t, err)
+	args, err := p.ParseArgs([]string{"run", "//:target"})
+	require.NoError(t, err)
+	_, err = p.resolveArgs(args, workspaceDir)
+	require.ErrorContains(t, err, "build_metadata")
+}
+
+func TestResolveArgs_IgnoreAllBBRCFiles(t *testing.T) {
+	workspaceDir := testfs.MakeTempDir(t)
+	homeDir := testfs.MakeTempDir(t)
+	t.Setenv("HOME", homeDir)
+	testfs.WriteAllFileContents(t, workspaceDir, map[string]string{
+		".bbrc": "run --stream_run_logs",
+	})
+	testfs.WriteAllFileContents(t, homeDir, map[string]string{
+		".bbrc": "run --nostream_run_logs",
+	})
+
+	p, err := GetParser()
+	require.NoError(t, err)
+	args, err := p.ParseArgs([]string{"--ignore_all_bb_rc_files", "run", "//:target"})
+	require.NoError(t, err)
+	args, err = p.resolveArgs(args, workspaceDir)
+	require.NoError(t, err)
+	require.Equal(t, []string{"--ignore_all_rc_files", "run", "//:target"}, args.Format())
+}
+
 func TestParseBBRCFiles_MultipleConfigs(t *testing.T) {
 	ws := testfs.MakeTempDir(t)
 	testfs.WriteAllFileContents(t, ws, map[string]string{

--- a/cli/parser/parser_test.go
+++ b/cli/parser/parser_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"bytes"
+	"flag"
 	stdlog "log"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/cli/cli_command"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/arguments"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/bbrc"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/options"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/test_data"
@@ -144,6 +146,36 @@ build:nested --nested_flag
 		"--explain_flag",
 		"invocation-id",
 	}, expandedExplainArgs.Format())
+}
+
+func TestParseBBRCFiles_MultipleCommands(t *testing.T) {
+	remoteFlags := flag.NewFlagSet("remote", flag.ContinueOnError)
+	remoteFlags.String("container_image", "", "")
+
+	previousCommandsByName := cli_command.CommandsByName
+	cli_command.CommandsByName = map[string]*cli_command.Command{
+		"remote": {Name: "remote", Flags: remoteFlags},
+	}
+	t.Cleanup(func() {
+		cli_command.CommandsByName = previousCommandsByName
+	})
+
+	ws := testfs.MakeTempDir(t)
+	testfs.WriteAllFileContents(t, ws, map[string]string{
+		".bbrc": `
+run --stream_run_logs
+remote --container_image=docker://example
+`,
+	})
+
+	// Simulate parsing a Bazel run invocation. The unrelated remote section
+	// should still be parseable and not cause a parsing error.
+	p, err := GetBBParserForCommand("run")
+	require.NoError(t, err)
+	_, defaultConfig, err := p.ParseBBRCFiles(ws, filepath.Join(ws, ".bbrc"))
+	require.NoError(t, err)
+	require.Equal(t, []string{"--stream_run_logs"}, arguments.FormatAll(defaultConfig.ByPhase["run"]))
+	require.Equal(t, []string{"--container_image=docker://example"}, arguments.FormatAll(defaultConfig.ByPhase["remote"]))
 }
 
 func TestParseBBRCFiles_CircularConfigReference(t *testing.T) {

--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -629,7 +629,9 @@ func (p *Plugin) commandEnv() []string {
 // Plugins can read Bazel args from the FORWARDED_BAZEL_ARGS_FILE environment
 // variable. Plugins can write that file to modify the args (most commonly just
 // appending to the file), which will then be fed to the next plugin in the
-// pipeline, or passed to Bazel if this is the last plugin.
+// pipeline, or passed to Bazel if this is the last plugin. BB rc-file options
+// are retained in this file so that reparsing plugin changes does not change
+// the active .bbrc configuration; the CLI removes them before invoking Bazel.
 //
 // Plugins can also read the resolved args (i.e. all --config flags expanded) from the
 // file at RESOLVED_BAZEL_ARGS_FILE, but changes to that file are ignored.
@@ -640,7 +642,7 @@ func (p *Plugin) commandEnv() []string {
 //
 // See cli/example_plugins/ping-remote/pre_bazel.sh for an example.
 func (p *Plugin) PreBazel(bazelArgs *arg.BazelArgs, execArgs []string) (*arg.BazelArgs, []string, error) {
-	initialForwardedArgs := bazelArgs.Forwarded()
+	initialForwardedArgs := bazelArgs.Unresolved()
 	initialResolvedArgs := bazelArgs.Resolved()
 
 	// Write legacy resolved bazel args to $1 so existing plugins keep working.

--- a/cli/plugin/plugin_test.go
+++ b/cli/plugin/plugin_test.go
@@ -339,6 +339,34 @@ func TestPreBazel_AddConfig(t *testing.T) {
 	require.Equal(t, []string{"--ignore_all_rc_files", "test", "--test_output=all", "//initial"}, args.Resolved())
 }
 
+func TestPreBazel_PreservesBBRC(t *testing.T) {
+	ws, _ := setup(t)
+	testfs.WriteAllFileContents(t, ws, map[string]string{
+		".bbrc":                       `run:ci --stream_run_logs`,
+		"plugins/config/pre_bazel.sh": `echo '--build_metadata=PLUGIN' >> "$FORWARDED_BAZEL_ARGS_FILE"`,
+	})
+	p := testPlugin(t, ws, "./plugins/config")
+	args, err := arg.NewBazelArgs([]string{"run", "--bb_config=ci", "//initial"})
+	require.NoError(t, err)
+
+	args, execArgs, err := p.PreBazel(args, nil)
+	require.NoError(t, err)
+	require.Empty(t, execArgs)
+
+	// The plugin's Bazel flag is applied without losing the named BB config.
+	require.Contains(t, args.Unresolved(), "--bb_config=ci")
+	require.NotContains(t, args.Forwarded(), "--bb_config=ci")
+	require.NotContains(t, args.Resolved(), "--bb_config=ci")
+
+	require.NotContains(t, args.Unresolved(), "--stream_run_logs")
+	require.NotContains(t, args.Forwarded(), "--stream_run_logs")
+	require.Contains(t, args.Resolved(), "--stream_run_logs")
+
+	require.Contains(t, args.Unresolved(), "--build_metadata=PLUGIN")
+	require.Contains(t, args.Forwarded(), "--build_metadata=PLUGIN")
+	require.Contains(t, args.Resolved(), "--build_metadata=PLUGIN")
+}
+
 // TestPipelineWriter_HandlesFinalLine guards against a regression in which
 // the plugin output handler dropped the last line of plugin output due to a
 // race between draining the pty and closing the pipe. The plugin here only

--- a/cli/sidecar/sidecar.go
+++ b/cli/sidecar/sidecar.go
@@ -243,7 +243,7 @@ func ConfigureSidecar(args *arg.BazelArgs) (*Instance, error) {
 		return nil, nil
 	}
 
-	originalArgs := args.Forwarded()
+	originalArgs := args.Unresolved()
 
 	log.Debugf("Configuring sidecar")
 

--- a/cli/test/integration/cli/cli_test.go
+++ b/cli/test/integration/cli/cli_test.go
@@ -119,6 +119,41 @@ func TestBazelHelp(t *testing.T) {
 	require.Contains(t, output, `BAZEL_STARTUP_OPTIONS="`)
 }
 
+func TestBazelHelp_IgnoresBBRC(t *testing.T) {
+	ws := testcli.NewWorkspace(t)
+	testfs.WriteAllFileContents(t, ws, map[string]string{
+		// This would fail if help attempted to parse the workspace .bbrc.
+		".bbrc": `startup --not_a_bb_flag`,
+	})
+
+	// Explicit bbrc options should also not be forwarded to Bazel.
+	// to Bazel.
+	cmd := testcli.Command(t, ws,
+		"--bbrc="+ws+"/missing.bbrc",
+		"help",
+		"--bb_config=missing",
+		"build",
+	)
+	b, err := testcli.CombinedOutput(cmd)
+	output := string(b)
+	require.NoErrorf(t, err, "output: %s", output)
+	require.Contains(t, output, "Usage:")
+}
+
+func TestBazelHelp_UsesBazelrc(t *testing.T) {
+	ws := testcli.NewWorkspace(t)
+	testfs.WriteAllFileContents(t, ws, map[string]string{
+		".bazelrc": `help --announce_rc`,
+	})
+
+	cmd := testcli.Command(t, ws, "help", "build")
+	b, err := testcli.CombinedOutput(cmd)
+	output := string(b)
+	require.NoErrorf(t, err, "output: %s", output)
+	require.Contains(t, output, "Reading rc options for 'help'")
+	require.Contains(t, output, "--announce_rc")
+}
+
 func TestHelpWithoutHomeEnv(t *testing.T) {
 	ws := testcli.NewWorkspace(t)
 	cmd := testcli.Command(t, ws, "--help")

--- a/cli/test/integration/cli/cli_test.go
+++ b/cli/test/integration/cli/cli_test.go
@@ -127,7 +127,6 @@ func TestBazelHelp_IgnoresBBRC(t *testing.T) {
 	})
 
 	// Explicit bbrc options should also not be forwarded to Bazel.
-	// to Bazel.
 	cmd := testcli.Command(t, ws,
 		"--bbrc="+ws+"/missing.bbrc",
 		"help",
@@ -306,9 +305,17 @@ func TestBBRC_Watcher(t *testing.T) {
 	writeFakeBazel(t, ws)
 	customBBRC := ws + "/custom.bbrc"
 	testfs.WriteAllFileContents(t, ws, map[string]string{
-		"custom.bbrc": `run:ci --stream_run_logs --on_stream_run_logs_failure=warn`,
+		"custom.bbrc": `
+startup --watch
+run:ci --stream_run_logs --on_stream_run_logs_failure=warn
+`,
 		"fake-godemon.sh": `#!/usr/bin/env bash
 set -euo pipefail
+if [[ "${FAKE_GODEMON_ACTIVE:-}" == "1" ]]; then
+  echo "nested watcher invocation" >&2
+  exit 1
+fi
+export FAKE_GODEMON_ACTIVE=1
 # Skip Godemon's --watch and --lockfile arguments, then execute bb once.
 shift 4
 printf 'WATCHER_CHILD_ARGS:%s\n' "$*"
@@ -318,7 +325,6 @@ exec "$@"
 	testfs.MakeExecutable(t, ws, "fake-godemon.sh")
 
 	cmd := testcli.Command(t, ws,
-		"--watch",
 		"--bbrc="+customBBRC,
 		"run",
 		"--bb_config=ci",

--- a/cli/test/integration/cli/cli_test.go
+++ b/cli/test/integration/cli/cli_test.go
@@ -266,6 +266,137 @@ sh_binary(name = "echo", srcs = ["echo.sh"])`,
 	require.NotContains(t, output, log.WarningPrefix)
 }
 
+func TestBBRC_Watcher(t *testing.T) {
+	ws := testcli.NewWorkspace(t)
+	writeFakeBazel(t, ws)
+	customBBRC := ws + "/custom.bbrc"
+	testfs.WriteAllFileContents(t, ws, map[string]string{
+		"custom.bbrc": `run:ci --stream_run_logs --on_stream_run_logs_failure=warn`,
+		"fake-godemon.sh": `#!/usr/bin/env bash
+set -euo pipefail
+# Skip Godemon's --watch and --lockfile arguments, then execute bb once.
+shift 4
+printf 'WATCHER_CHILD_ARGS:%s\n' "$*"
+exec "$@"
+`,
+	})
+	testfs.MakeExecutable(t, ws, "fake-godemon.sh")
+
+	cmd := testcli.Command(t, ws,
+		"--watch",
+		"--bbrc="+customBBRC,
+		"run",
+		"--bb_config=ci",
+		":target",
+	)
+	cmd.Env = append(os.Environ(),
+		"GODEMON_BINARY_PATH="+ws+"/fake-godemon.sh",
+		"BB_DISABLE_SIDECAR=1",
+	)
+	b, err := testcli.CombinedOutput(cmd)
+	output := strings.ReplaceAll(string(b), "\r\n", "\n")
+	require.NoErrorf(t, err, "output: %s", output)
+
+	// Even when the watcher restarts the bb process, the BBRC flags should be preserved.
+	require.Contains(t, output, "WATCHER_CHILD_ARGS:")
+	require.Contains(t, output, "--bbrc="+customBBRC)
+	require.Contains(t, output, "--bb_config=ci")
+	// This log is only printed when the stream_run_logs flag is correctly set.
+	require.Contains(t, output, "streaming run logs is only supported")
+	// The Bazel wrapper should have been successfully invoked.
+	require.Contains(t, output, "FAKE_BAZEL_ARGS:")
+}
+
+func TestBBRC_Plugin(t *testing.T) {
+	ws := testcli.NewWorkspace(t)
+	writeFakeBazel(t, ws)
+	testfs.WriteAllFileContents(t, ws, map[string]string{
+		".bbrc": `run:ci --stream_run_logs --on_stream_run_logs_failure=warn`,
+		"buildbuddy.yaml": `plugins:
+  - path: testplugin
+`,
+		"testplugin/pre_bazel.sh": `#!/usr/bin/env bash
+set -euo pipefail
+echo '--build_metadata=FROM_PLUGIN' >> "$FORWARDED_BAZEL_ARGS_FILE"
+`,
+	})
+	testfs.MakeExecutable(t, ws, "testplugin/pre_bazel.sh")
+
+	cmd := testcli.Command(t, ws, "run", "--bb_config=ci", ":target")
+	cmd.Env = append(os.Environ(), "BB_DISABLE_SIDECAR=1")
+	b, err := testcli.CombinedOutput(cmd)
+	output := strings.ReplaceAll(string(b), "\r\n", "\n")
+	require.NoErrorf(t, err, "output: %s", output)
+
+	// Run-log streaming came from the named BB config, so this warning proves
+	// the config was still active after the plugin arguments were reparsed.
+	require.Contains(t, output, "streaming run logs is only supported")
+	require.Contains(t, output, "--build_metadata=FROM_PLUGIN")
+}
+
+func TestBBRC_SidecarRollback(t *testing.T) {
+	ws := testcli.NewWorkspace(t)
+	writeFakeBazel(t, ws)
+	testfs.WriteAllFileContents(t, ws, map[string]string{
+		".bbrc": `run:ci --stream_run_logs --on_stream_run_logs_failure=warn`,
+	})
+
+	cmd := testcli.Command(t, ws,
+		"run",
+		"--bb_config=ci",
+		"--remote_cache=grpc://127.0.0.1:1",
+		":target",
+	)
+	// An unmatched quote makes sidecar argument parsing fail immediately. The
+	// CLI then restores its original arguments and continues without a sidecar.
+	cmd.Env = append(os.Environ(), "BB_SIDECAR_ARGS='")
+	b, err := testcli.CombinedOutput(cmd)
+	output := strings.ReplaceAll(string(b), "\r\n", "\n")
+	require.NoErrorf(t, err, "output: %s", output)
+
+	require.Contains(t, output, "Sidecar could not be initialized")
+	// This setting came from --bb_config=ci. Seeing it after the sidecar
+	// rollback proves that restoring the arguments retained the config choice.
+	require.Contains(t, output, "streaming run logs is only supported")
+	require.Contains(t, output, "FAKE_BAZEL_ARGS:")
+}
+
+// writeFakeBazel installs a workspace Bazel wrapper that completes `run`
+// commands without starting Bazel. It also rejects BB-only arguments, since
+// those must be consumed by the CLI before it invokes Bazelisk.
+func writeFakeBazel(t *testing.T, ws string) {
+	testfs.WriteAllFileContents(t, ws, map[string]string{
+		"tools/bazel": `#!/usr/bin/env bash
+set -euo pipefail
+# The CLI queries Bazel's option definitions before parsing the command. Let
+# the hermetic test Bazel answer that query, and intercept the final run only.
+for arg in "$@"; do
+  if [[ "$arg" == "help" ]]; then
+    exec "$BAZEL_REAL" "$@"
+  fi
+done
+script_path=""
+for arg in "$@"; do
+  case "$arg" in
+    --bbrc*|--bb_config*|--ignore_all_bb_rc_files*|--stream_run_logs*|--on_stream_run_logs_failure*)
+      echo "BB-only argument leaked to Bazel: $arg" >&2
+      exit 1
+      ;;
+    --script_path=*)
+      script_path="${arg#--script_path=}"
+      ;;
+  esac
+done
+printf 'FAKE_BAZEL_ARGS:%s\n' "$*"
+if [[ -n "$script_path" ]]; then
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$script_path"
+  chmod +x "$script_path"
+fi
+`,
+	})
+	testfs.MakeExecutable(t, ws, "tools/bazel")
+}
+
 func TestBazelBuildWithBuildBuddyServices(t *testing.T) {
 	ws := testcli.NewWorkspace(t)
 	testgit.ConfigureRemoteOrigin(t, ws, "https://secretUser:secretToken@github.com/test-org/test-repo")

--- a/cli/watcher/watcher.go
+++ b/cli/watcher/watcher.go
@@ -10,6 +10,8 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/workspace"
 )
 
+const lockfilePathEnvVar = "BB_WATCHER_LOCKFILE_PATH"
+
 var (
 	settings = struct {
 		watch        bool
@@ -26,6 +28,12 @@ func Configure(watch bool, watcherFlags []string) {
 // CLI as a subprocess on changes to source files.
 func Watch(args []string) (exitCode int, err error) {
 	if !settings.watch {
+		return -1, nil
+	}
+	// Godemon's child inherits the lockfile path from the original bb process.
+	// Do not recursively start another watcher if the child re-enables --watch
+	// (can happen on accident through a rc file, for example).
+	if os.Getenv(lockfilePathEnvVar) != "" {
 		return -1, nil
 	}
 	// Notes on FS watcher solutions:
@@ -75,7 +83,7 @@ func initLockfile() (string, error) {
 	if err := os.Remove(f.Name()); err != nil {
 		return "", err
 	}
-	os.Setenv("BB_WATCHER_LOCKFILE_PATH", f.Name())
+	os.Setenv(lockfilePathEnvVar, f.Name())
 	return f.Name(), nil
 }
 
@@ -83,7 +91,7 @@ func initLockfile() (string, error) {
 // is called. Any FS events received while paused will be buffered, then flushed
 // when unpaused.
 func Pause() {
-	lockfilePath := os.Getenv("BB_WATCHER_LOCKFILE_PATH")
+	lockfilePath := os.Getenv(lockfilePathEnvVar)
 	if lockfilePath == "" {
 		// We're not running in watch mode.
 		return
@@ -100,7 +108,7 @@ func Pause() {
 // triggered immediately if any events were buffered while the watcher was
 // paused.
 func Unpause() {
-	lockfilePath := os.Getenv("BB_WATCHER_LOCKFILE_PATH")
+	lockfilePath := os.Getenv(lockfilePathEnvVar)
 	if lockfilePath == "" {
 		// We're not running in watch mode.
 		return

--- a/go.mod
+++ b/go.mod
@@ -254,7 +254,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
 	github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df // indirect
-	github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-2 // indirect
+	github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -861,8 +861,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df h1:GSoSVRLoBaFpOOds6QyY1L8AX7uoY+Ln3BHc22W40X0=
 github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df/go.mod h1:hiVxq5OP2bUGBRNS3Z/bt/reCLFNbdcST6gISi1fiOM=
-github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-2 h1:lSINS7DK4xjm0Z4CBd7onO63uIe6WUsEZ/0voExa+JY=
-github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-2/go.mod h1:B76PjnaM2KyUG8ypV/ePHHDmGbyUNZ2PCEdEQIJISQM=
+github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-3 h1:Mq3iQ30V39RGCErrbnhHFOAcnxpWTIrk35Pc9guNfOY=
+github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-3/go.mod h1:B76PjnaM2KyUG8ypV/ePHHDmGbyUNZ2PCEdEQIJISQM=
 github.com/bazelbuild/bazel-gazelle v0.52.2 h1:QtesXLd3vugaaZW7+spf6K1kUcnWACWmrEds/S9aeao=
 github.com/bazelbuild/bazel-gazelle v0.52.2/go.mod h1:AeYjUGaxXcMZ51CYHBT1YK3Qxb2yrJl77A8g7GF6d+g=
 github.com/bazelbuild/bazelisk v1.25.1-0.20250219134847-cdb99bfb1b7d h1:ewduqIuhzpKB6Uw887ecLrnC9abSQHqofklqlfJgs3k=


### PR DESCRIPTION
After this PR, bbrc related options will be parsed for Bazel commands.
Ex:
``` .bbrc
run --stream_run_logs
```

A future PR in the stack will parse bbrc options for bb CLI commands (like bb remote)