### PR TITLE
Tweak the backoff config for dialing vmexec

### DIFF
--- a/enterprise/server/util/vsock/vsock.go
+++ b/enterprise/server/util/vsock/vsock.go
@@ -180,8 +180,8 @@ func SimpleGRPCDial(ctx context.Context, socketPath string, port uint32) (*grpc.
 	backoffConfig := backoff.Config{
 		BaseDelay:  4 * time.Millisecond,
 		Multiplier: 1.15,
-		Jitter:     0.01,
-		MaxDelay:   500 * time.Millisecond,
+		Jitter:     0.10,
+		MaxDelay:   2 * time.Second,
 	}
 	connectParams := grpc.ConnectParams{
 		Backoff:           backoffConfig,

--- a/enterprise/server/util/vsock/vsock.go
+++ b/enterprise/server/util/vsock/vsock.go
@@ -138,9 +138,11 @@ func dialHostToGuest(ctx context.Context, socketPath string, port uint32) (net.C
 	fcConnectString := fmt.Sprintf("CONNECT %d\n", port)
 	n, err := conn.Write([]byte(fcConnectString))
 	if err != nil {
+		conn.Close()
 		return nil, err
 	}
 	if n != len(fcConnectString) {
+		conn.Close()
 		return nil, status.InternalErrorf("HostDial failed: wrote %d bytes, expected %d", n, len(fcConnectString))
 	}
 	// Firecracker should normally be listening on v.sock as soon as
@@ -150,9 +152,11 @@ func dialHostToGuest(ctx context.Context, socketPath string, port uint32) (net.C
 	conn.SetReadDeadline(time.Now().Add(1 * time.Second))
 	rsp, err := bufio.NewReaderSize(conn, 32).ReadString('\n')
 	if err != nil {
+		conn.Close()
 		return nil, err
 	}
 	if !strings.HasPrefix(rsp, "OK ") {
+		conn.Close()
 		return nil, status.InternalErrorf("HostDial failed: didn't receive 'OK' after CONNECT, got %q", rsp)
 	}
 	conn.SetReadDeadline(time.Time{})

--- a/enterprise/server/util/vsock/vsock.go
+++ b/enterprise/server/util/vsock/vsock.go
@@ -178,10 +178,10 @@ func SimpleGRPCDial(ctx context.Context, socketPath string, port uint32) (*grpc.
 	// These params are tuned for a fast-reconnect to the vmexec server
 	// running inside the VM.
 	backoffConfig := backoff.Config{
-		BaseDelay:  1 * time.Millisecond,
-		Multiplier: 1.6,
-		Jitter:     0.2,
-		MaxDelay:   10 * time.Second,
+		BaseDelay:  4 * time.Millisecond,
+		Multiplier: 1.15,
+		Jitter:     0.01,
+		MaxDelay:   500 * time.Millisecond,
 	}
 	connectParams := grpc.ConnectParams{
 		Backoff:           backoffConfig,


### PR DESCRIPTION
The current config starts off with too many attempts, and then slows down way too quickly. Starting with a higher initial delay, but with a lower multiplier, gives us only twice as many attempts in the first second, but the incremental delay around the 750ms mark is much smaller (75ms vs 280ms)

Math worked out in https://docs.google.com/spreadsheets/d/1qvYc4JiW2I5nxTC_8ctHjr5VyTuFkRqmWjC6D21BrM0/edit?gid=0#gid=0.

I also lowered the max delay and jitter. Since this is the only client to the vmexec server, there should be no reason to add jitter or have the delay grow very large.