### PR TITLE
groups: restrict org creation by API key

### DIFF
--- a/enterprise/server/buildbuddy_server/buildbuddy_server_test.go
+++ b/enterprise/server/buildbuddy_server/buildbuddy_server_test.go
@@ -116,6 +116,9 @@ func TestCreateGroup(t *testing.T) {
 	require.NoError(t, err)
 	adminKeyCtx := te.GetAuthenticator().AuthContextFromAPIKey(ctx, adminKey.Value)
 
+	// Enable all organization-creation restrictions. Enterprise parent orgs
+	// should always be able to create child orgs using an org API key.
+	configureCreateGroupExperiments(t, te, 1, true /*=propagateGroupBlocks*/)
 	server, err := buildbuddy_server.NewBuildBuddyServer(te, nil)
 	require.NoError(t, err)
 
@@ -154,6 +157,7 @@ func TestCreateGroup_Allowed(t *testing.T) {
 		ownedGroups     int
 		invitedGroups   int
 		orgAPIKey       bool
+		userAPIKey      bool
 		propagateBlocks bool
 		expectDenied    bool
 	}{
@@ -204,6 +208,63 @@ func TestCreateGroup_Allowed(t *testing.T) {
 			ownedGroups: 2,
 		},
 		{
+			name:            "enterprise_org_api_key_not_limited",
+			maxGroups:       2,
+			groupStatus:     grpb.Group_ENTERPRISE_GROUP_STATUS,
+			ownedGroups:     2,
+			orgAPIKey:       true,
+			propagateBlocks: true,
+		},
+		{
+			name:            "enterprise_trial_org_api_key_not_limited",
+			maxGroups:       2,
+			groupStatus:     grpb.Group_ENTERPRISE_TRIAL_GROUP_STATUS,
+			ownedGroups:     2,
+			orgAPIKey:       true,
+			propagateBlocks: true,
+		},
+		{
+			name:            "enterprise_user_api_key_not_limited",
+			maxGroups:       2,
+			groupStatus:     grpb.Group_ENTERPRISE_GROUP_STATUS,
+			ownedGroups:     2,
+			userAPIKey:      true,
+			propagateBlocks: true,
+		},
+		{
+			name:            "enterprise_trial_user_api_key_not_limited",
+			maxGroups:       2,
+			groupStatus:     grpb.Group_ENTERPRISE_TRIAL_GROUP_STATUS,
+			ownedGroups:     2,
+			userAPIKey:      true,
+			propagateBlocks: true,
+		},
+		{
+			name:            "unknown_status_org_api_key_denied",
+			maxGroups:       1,
+			groupStatus:     grpb.Group_UNKNOWN_GROUP_STATUS,
+			ownedGroups:     1,
+			orgAPIKey:       true,
+			propagateBlocks: true,
+			expectDenied:    true,
+		},
+		{
+			name:         "blocked_org_api_key_denied_when_group_limit_enabled",
+			maxGroups:    1,
+			groupStatus:  grpb.Group_BLOCKED_GROUP_STATUS,
+			ownedGroups:  1,
+			orgAPIKey:    true,
+			expectDenied: true,
+		},
+		{
+			name:            "blocked_org_api_key_denied_when_block_propagation_enabled",
+			groupStatus:     grpb.Group_BLOCKED_GROUP_STATUS,
+			ownedGroups:     1,
+			orgAPIKey:       true,
+			propagateBlocks: true,
+			expectDenied:    true,
+		},
+		{
 			name:         "non_enterprise_org_api_key_denied",
 			maxGroups:    5,
 			groupStatus:  grpb.Group_FREE_TIER_GROUP_STATUS,
@@ -211,8 +272,19 @@ func TestCreateGroup_Allowed(t *testing.T) {
 			orgAPIKey:    true,
 			expectDenied: true,
 		},
+		{
+			name:         "non_enterprise_user_api_key_denied",
+			maxGroups:    5,
+			groupStatus:  grpb.Group_FREE_TIER_GROUP_STATUS,
+			ownedGroups:  1,
+			userAPIKey:   true,
+			expectDenied: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.userAPIKey {
+				flags.Set(t, "app.user_owned_keys_enabled", true)
+			}
 			te := enterprise_testenv.New(t)
 			enterprise_testauth.Configure(t, te)
 			auth := te.GetAuthenticator()
@@ -226,6 +298,7 @@ func TestCreateGroup_Allowed(t *testing.T) {
 			userCtx := authUserCtx(ctx, te, t, "US1")
 			group := getGroup(t, userCtx, te).Group
 			group.URLIdentifier = "initial-group"
+			group.UserOwnedKeysEnabled = tc.userAPIKey
 			_, err = te.GetUserDB().UpdateGroup(userCtx, &group)
 			require.NoError(t, err)
 
@@ -296,6 +369,12 @@ func TestCreateGroup_Allowed(t *testing.T) {
 					false /*=visibleToDevelopers*/)
 				require.NoError(t, err)
 				requestCtx = te.GetAuthenticator().AuthContextFromAPIKey(ctx, adminKey.Value)
+			} else if tc.userAPIKey {
+				userKey, err := te.GetAuthDB().CreateUserAPIKey(
+					userCtx, group.GroupID, "US1", "user key",
+					nil /*=capabilities*/, 0 /*=expiresIn*/)
+				require.NoError(t, err)
+				requestCtx = te.GetAuthenticator().AuthContextFromAPIKey(ctx, userKey.Value)
 			}
 			rsp, err := server.CreateGroup(requestCtx, &grpb.CreateGroupRequest{
 				Name:          "My Org",
@@ -313,7 +392,9 @@ func TestCreateGroup_Allowed(t *testing.T) {
 			user, err = te.GetUserDB().GetUser(userCtx)
 			require.NoError(t, err)
 			expectedGroups := tc.ownedGroups + tc.invitedGroups
-			if !tc.expectDenied {
+			// Groups created using an org API key are not owned by or directly
+			// associated with the user that created the API key.
+			if !tc.expectDenied && !tc.orgAPIKey {
 				expectedGroups++
 			}
 			require.Len(t, user.Groups, expectedGroups)

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -588,7 +588,9 @@ func createGroupAllowed(ctx context.Context, userDB interfaces.UserDB, efp inter
 		return nil, nil
 	}
 
-	if u.GetUserID() == "" {
+	// User-owned API keys retain a user ID, so the API key ID is the reliable
+	// way to distinguish both user- and org-owned API keys from browser users.
+	if u.GetAPIKeyInfo().ID != "" {
 		return nil, status.PermissionDeniedError("Creating organizations is not supported through the API. Please continue in our UI.")
 	}
 

--- a/server/buildbuddy_server/buildbuddy_server_test.go
+++ b/server/buildbuddy_server/buildbuddy_server_test.go
@@ -197,6 +197,7 @@ func userClaims(userID, groupID string) *claims.Claims {
 // associated user but does carry the key group's status.
 func orgAPIKeyClaims(groupID string, groupStatus grpb.Group_GroupStatus) *claims.Claims {
 	c := testauth.User("" /*=userID*/, groupID)
+	c.APIKeyID = "AK1"
 	c.Capabilities = []cappb.Capability{cappb.Capability_ORG_ADMIN}
 	c.GroupStatus = groupStatus
 	return c


### PR DESCRIPTION
Free-tier users can bypass the organization-creation API restriction when
they authenticate with a user-owned API key. Unlike organization-owned API
keys, user-owned keys retain a user ID, so the existing `GetUserID() == ""`
check treats them like browser-authenticated users and applies the interactive
user rules instead of the API-key restriction.

Detect API authentication using `GetAPIKeyInfo().ID` so the existing
non-enterprise restriction applies to both API key types. Enterprise and
enterprise-trial groups remain exempt.

| Authentication | Group status | Before | After |
| --- | --- | --- | --- |
| Organization-owned API key | Enterprise or enterprise trial | Allowed | Allowed |
| Organization-owned API key | Free tier, unknown, or blocked | Denied | Denied |
| User-owned API key | Enterprise or enterprise trial | Allowed | Allowed |
| User-owned API key | Free tier, unknown, or blocked | Evaluated using the interactive user rules | Denied by the API-key restriction |
| Browser-authenticated user | Any | Evaluated using the interactive user rules | Unchanged |

The only behavior change is the fourth row: user-owned API keys classified as
non-enterprise can no longer bypass the API-key restriction. The regression
coverage authenticates real organization-owned and user-owned keys for
enterprise, enterprise-trial, free-tier, unknown, and blocked groups.

This PR does not change how group status is assigned or propagated. If an
enterprise customer is incorrectly represented in claims as `FREE_TIER`, the
API gate will treat that key as free tier and deny it. That classification
issue needs to be fixed separately.
