### PR TITLE
Add a metric for how many pebble cache eviction samples have been generated

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -3086,6 +3086,7 @@ func (e *partitionEvictor) generateSamplesForEviction(quitChan chan struct{}) er
 		fileMetadata.ResetVT() // UnmarshalVT doesn't reset, unlike proto.Unmarshal.
 		err = fileMetadata.UnmarshalVT(iter.Value())
 		if err != nil {
+			metrics.PebbleCacheEvictionSamples.WithLabelValues(e.part.ID, e.cacheName, "invalid_proto").Inc()
 			log.Warningf("[%s] cannot generate sample for eviction, skipping: failed to read proto: %s", e.cacheName, err)
 			continue
 		}
@@ -3108,6 +3109,7 @@ func (e *partitionEvictor) maybeAddToSampleChan(iter pebble.Iterator, fileMetada
 	atime := time.UnixMicro(fileMetadata.GetLastAccessUsec())
 	age := e.clock.Since(atime)
 	if age < e.minEvictionAge {
+		metrics.PebbleCacheEvictionSamples.WithLabelValues(e.part.ID, e.cacheName, "age_too_small").Inc()
 		return
 	}
 	keyBytes := make([]byte, len(iter.Key()))
@@ -3124,8 +3126,10 @@ func (e *partitionEvictor) maybeAddToSampleChan(iter pebble.Iterator, fileMetada
 	timer.Reset(SamplerSleepDuration)
 	select {
 	case e.samples <- sample:
+		metrics.PebbleCacheEvictionSamples.WithLabelValues(e.part.ID, e.cacheName, "enqueued").Inc()
 	case <-quitChan:
 	case <-timer.Chan(): // e.samples is full.
+		metrics.PebbleCacheEvictionSamples.WithLabelValues(e.part.ID, e.cacheName, "queue_full").Inc()
 	}
 }
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -3567,6 +3567,17 @@ var (
 		CacheNameLabel,
 	})
 
+	PebbleCacheEvictionSamples = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "pebble_cache_eviction_samples",
+		Help:      "Number of samples produced, by status",
+	}, []string{
+		PartitionID,
+		CacheNameLabel,
+		StatusLabel,
+	})
+
 	PebbleCachePebbleCompactCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_cache",

--- a/tools/metrics/grafana/dashboards/cache-proxy.json
+++ b/tools/metrics/grafana/dashboards/cache-proxy.json
@@ -4415,6 +4415,196 @@
                   }
                 ]
               },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 1503
+          },
+          "id": 10741,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "repeat": "cache_name",
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "expr": "sum(buildbuddy_remote_cache_pebble_cache_eviction_samples_chan_size{region=\"${region}\", job=~\"cache-proxy.*\", cache_name=\"${cache_name}\"}[${window}]) by (partition_id)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Eviction sample queue length",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 1511
+          },
+          "id": 10742,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "repeat": "cache_name",
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(buildbuddy_remote_cache_pebble_cache_eviction_samples{region=\"${region}\", job=~\"cache-proxy.*\", cache_name=\"${cache_name}\"}[${window}])) by (partition_id, status)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Eviction samples by status (${cache_name})",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
               "unit": "µs"
             },
             "overrides": []

--- a/tools/metrics/grafana/generated/buildbuddy/buildbuddy.go
+++ b/tools/metrics/grafana/generated/buildbuddy/buildbuddy.go
@@ -441,11 +441,16 @@ func remoteCacheRow() *dashboard.RowBuilder {
 			Repeat("cache_name").
 			RepeatDirection(dashboard.PanelRepeatDirectionH).
 			WithTarget(dash.PromQuery(`histogram_quantile(${quantile}, sum(rate(buildbuddy_remote_cache_pebble_cache_eviction_resample_latency_usec_bucket{region="${region}", job="buildbuddy-app", cache_name="${cache_name}"}[${window}])) by (le, partition_id))`, ""))).
-		WithPanel(ts("Eviction sample queue length", dash.UnitShort).
+		WithPanel(ts("Eviction sample queue length (${cache_name})", dash.UnitShort).
 			Span(24).
 			Repeat("cache_name").
 			RepeatDirection(dashboard.PanelRepeatDirectionH).
 			WithTarget(dash.PromQuery(`sum(buildbuddy_remote_cache_pebble_cache_eviction_samples_chan_size{region="${region}", job="buildbuddy-app", cache_name="${cache_name}"}[${window}]) by (partition_id)`, ""))).
+		WithPanel(ts("Eviction samples by status (${cache_name})", dash.UnitOps).
+			Span(24).
+			Repeat("cache_name").
+			RepeatDirection(dashboard.PanelRepeatDirectionH).
+			WithTarget(dash.PromQuery(`sum(rate(buildbuddy_remote_cache_pebble_cache_eviction_samples{region="${region}", job="buildbuddy-app", cache_name="${cache_name}"}[${window}])) by (partition_id, status)`, ""))).
 		WithPanel(ts("Eviction evict latency (${cache_name})", dash.UnitMicroseconds).
 			Span(24).
 			Repeat("cache_name").


### PR DESCRIPTION
This should helps us debug slow eviction.