### PR TITLE
Record dial vm exec duration in clickhouse

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2369,16 +2369,13 @@ func (c *FirecrackerContainer) sendExecRequestToGuest(ctx context.Context, conn 
 		cancelCgroupPoll()
 		res.UsageStats = combineHostAndGuestStats(hostCgroupStats.TaskStats(), res.UsageStats)
 		c.fillNetStats(ctx, res.UsageStats)
-		if res.VMMetrics == nil {
-			res.VMMetrics = &espb.VMMetrics{}
-		} else if c.createFromSnapshot {
+		if c.createFromSnapshot && res.VMMetrics != nil {
 			// The guest reports boot timings for the original boot, so
 			// they're not meaningful when starting from a snapshot.
 			res.VMMetrics.DockerdWaitDurationUsec = 0
 			res.VMMetrics.VmDnsWaitDurationUsec = 0
 			res.VMMetrics.VmExecInitDurationUsec = 0
 		}
-		res.VMMetrics.VmExecDialDurationUsec = c.vmExec.dialDuration.Microseconds()
 		return res, true
 	case err := <-healthCheckErrCh:
 		cancelCgroupPoll()
@@ -2396,11 +2393,6 @@ func (c *FirecrackerContainer) sendExecRequestToGuest(ctx context.Context, conn 
 		res := commandutil.ErrorResult(status.UnavailableErrorf("%s: %s", errMsg, err))
 		res.UsageStats = usage
 		c.fillNetStats(ctx, res.UsageStats)
-		// The dial succeeded even though the VM crashed mid-execution, so
-		// still report the host-measured dial duration.
-		res.VMMetrics = &espb.VMMetrics{
-			VmExecDialDurationUsec: c.vmExec.dialDuration.Microseconds(),
-		}
 		return res, false
 	}
 }
@@ -2533,6 +2525,10 @@ func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdi
 	defer func() {
 		ctx, cancel = background.ExtendContextForFinalization(ctx, finalizationTimeout)
 		defer cancel()
+		if result.VMMetrics == nil {
+			result.VMMetrics = &espb.VMMetrics{}
+		}
+		result.VMMetrics.VmExecDialDurationUsec = c.vmExec.dialDuration.Microseconds()
 
 		// Attach VM metadata to the result
 		result.VMMetadata = c.getVMMetadata()
@@ -2611,7 +2607,8 @@ func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdi
 
 	conn, err := c.vmExecConn(ctx)
 	if err != nil {
-		return commandutil.ErrorResult(status.InternalErrorf("Firecracker exec failed: failed to dial VM exec port: %s", err))
+		result.Error = status.InternalErrorf("Firecracker exec failed: failed to dial VM exec port: %s", err)
+		return result
 	}
 	// Emit metrics to track time spent preparing VM to execute a command
 	c.emitCOWAndUFFDMetrics(stage)

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -734,8 +734,9 @@ type FirecrackerContainer struct {
 	releaseCPUs func()
 
 	vmExec struct {
-		conn *grpc.ClientConn
-		err  error
+		conn         *grpc.ClientConn
+		err          error
+		dialDuration time.Duration
 	}
 
 	// latestGuestStats is the latest UsageStats sample streamed from vmexec.
@@ -2368,13 +2369,16 @@ func (c *FirecrackerContainer) sendExecRequestToGuest(ctx context.Context, conn 
 		cancelCgroupPoll()
 		res.UsageStats = combineHostAndGuestStats(hostCgroupStats.TaskStats(), res.UsageStats)
 		c.fillNetStats(ctx, res.UsageStats)
-		if c.createFromSnapshot && res.VMMetrics != nil {
-			// The guest reports boot timings for the original boot, so they're
-			// not meaningful when starting from a snapshot.
+		if res.VMMetrics == nil {
+			res.VMMetrics = &espb.VMMetrics{}
+		} else if c.createFromSnapshot {
+			// The guest reports boot timings for the original boot, so
+			// they're not meaningful when starting from a snapshot.
 			res.VMMetrics.DockerdWaitDurationUsec = 0
 			res.VMMetrics.VmDnsWaitDurationUsec = 0
 			res.VMMetrics.VmExecInitDurationUsec = 0
 		}
+		res.VMMetrics.VmExecDialDurationUsec = c.vmExec.dialDuration.Microseconds()
 		return res, true
 	case err := <-healthCheckErrCh:
 		cancelCgroupPoll()
@@ -2392,6 +2396,11 @@ func (c *FirecrackerContainer) sendExecRequestToGuest(ctx context.Context, conn 
 		res := commandutil.ErrorResult(status.UnavailableErrorf("%s: %s", errMsg, err))
 		res.UsageStats = usage
 		c.fillNetStats(ctx, res.UsageStats)
+		// The dial succeeded even though the VM crashed mid-execution, so
+		// still report the host-measured dial duration.
+		res.VMMetrics = &espb.VMMetrics{
+			VmExecDialDurationUsec: c.vmExec.dialDuration.Microseconds(),
+		}
 		return res, false
 	}
 }
@@ -2449,9 +2458,10 @@ func (c *FirecrackerContainer) dialVMExecServer(ctx context.Context) (*grpc.Clie
 
 	start := time.Now()
 	defer func() {
+		c.vmExec.dialDuration = time.Since(start)
 		metrics.FirecrackerExecDialDurationUsec.With(prometheus.Labels{
 			metrics.CreatedFromSnapshot: strconv.FormatBool(c.createFromSnapshot),
-		}).Observe(float64(time.Since(start).Microseconds()))
+		}).Observe(float64(c.vmExec.dialDuration.Microseconds()))
 	}()
 
 	ctx, cancel := context.WithTimeout(ctx, vSocketDialTimeout)

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2370,8 +2370,8 @@ func (c *FirecrackerContainer) sendExecRequestToGuest(ctx context.Context, conn 
 		res.UsageStats = combineHostAndGuestStats(hostCgroupStats.TaskStats(), res.UsageStats)
 		c.fillNetStats(ctx, res.UsageStats)
 		if c.createFromSnapshot && res.VMMetrics != nil {
-			// The guest reports boot timings for the original boot, so
-			// they're not meaningful when starting from a snapshot.
+			// The guest reports boot timings for the original boot, so they're
+			// not meaningful when starting from a snapshot.
 			res.VMMetrics.DockerdWaitDurationUsec = 0
 			res.VMMetrics.VmDnsWaitDurationUsec = 0
 			res.VMMetrics.VmExecInitDurationUsec = 0

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -635,6 +635,7 @@ func TestFirecrackerSnapshotAndResume(t *testing.T) {
 		assert.Greater(t, res.VMMetrics.GetVmExecInitDurationUsec(), int64(0))
 		assert.Zero(t, res.VMMetrics.GetDockerdWaitDurationUsec())
 		assert.Zero(t, res.VMMetrics.GetVmDnsWaitDurationUsec())
+		assert.Greater(t, res.VMMetrics.GetVmExecDialDurationUsec(), int64(0))
 
 		// Try pause, unpause, exec several times.
 		var cpuMillisObservations []float64
@@ -657,6 +658,9 @@ func TestFirecrackerSnapshotAndResume(t *testing.T) {
 			// Tasks on a VM resumed from a snapshot did not pay the boot cost,
 			// so boot timings should be cleared.
 			assert.Zero(t, res.VMMetrics.GetVmExecInitDurationUsec())
+			// The vmexec connection is re-established for each task, so the
+			// dial duration should be reported even on resumed VMs.
+			assert.Greater(t, res.VMMetrics.GetVmExecDialDurationUsec(), int64(0))
 			assert.Equal(t, fmt.Sprintf("/workspace/count: %d\n/root/count: %d\n", countBefore+1, i), string(res.Stdout))
 			require.NotContains(t, string(res.AuxiliaryLogs["vm_log_tail.txt"]), "is not a multiple of sector size")
 			cpuMillisObservations = append(cpuMillisObservations, float64(res.UsageStats.GetCpuNanos())/1e6)

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -3927,6 +3927,8 @@ func TestFirecrackerHealthChecking(t *testing.T) {
 	res := c.Exec(ctx, cmd, nil /*=stdio*/)
 	require.True(t, status.IsUnavailableError(res.Error), "expected Unavailable err, got %s", res.Error)
 	require.GreaterOrEqual(t, res.UsageStats.GetPeakMemoryBytes(), int64(0))
+	// The dial duration should be recorded even though the exec failed.
+	require.Greater(t, res.VMMetrics.GetVmExecDialDurationUsec(), int64(0))
 }
 
 func TestFirecrackerStressIO(t *testing.T) {

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -491,6 +491,7 @@ func (s *ExecutionServer) updateExecution(ctx context.Context, executionID strin
 				executionProto.VmDockerdWaitDurationUsec = vmMetrics.GetDockerdWaitDurationUsec()
 				executionProto.VmDnsWaitDurationUsec = vmMetrics.GetVmDnsWaitDurationUsec()
 				executionProto.VmExecInitDurationUsec = vmMetrics.GetVmExecInitDurationUsec()
+				executionProto.VmExecDialDurationUsec = vmMetrics.GetVmExecDialDurationUsec()
 			}
 
 			if properties != nil {

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -1007,6 +1007,7 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 			DockerdWaitDurationUsec: 4001,
 			VmDnsWaitDurationUsec:   4002,
 			VmExecInitDurationUsec:  4003,
+			VmExecDialDurationUsec:  4004,
 		}
 	} else {
 		effectivePool := "test-pool"
@@ -1269,6 +1270,7 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 		expectedExecution.VmDockerdWaitDurationUsec = 4001
 		expectedExecution.VmDnsWaitDurationUsec = 4002
 		expectedExecution.VmExecInitDurationUsec = 4003
+		expectedExecution.VmExecDialDurationUsec = 4004
 	}
 	require.Empty(t, cmp.Diff(
 		expectedExecution,

--- a/proto/execution_stats.proto
+++ b/proto/execution_stats.proto
@@ -162,9 +162,9 @@ message ExecutionAuxiliaryMetadata {
   VMMetrics vm_metrics = 12;
 }
 
-// Metrics reported by the guest VM's vmexec server, including timings of
-// one-time initialization steps performed during VM boot, before the guest
-// could begin accepting commands.
+// Metrics associated with the guest VM which executed an action. Mostly
+// reported by the guest's vmexec server; some fields are measured by the
+// executor.
 message VMMetrics {
   // Time the guest spent waiting for dockerd to become ready. Zero if
   // dockerd initialization was not requested.
@@ -178,6 +178,13 @@ message VMMetrics {
   // was about to begin serving. Includes the waits above, but not earlier
   // guest init (kernel boot or init process setup).
   int64 vm_exec_init_duration_usec = 3;
+
+  // Time the executor spent dialing the guest's vmexec server, measured on
+  // the host. For executions that booted a fresh VM, this includes guest boot
+  // up to the point where the vmexec server was serving. Unlike the boot
+  // timings above, this is set for every execution, since the connection is
+  // re-established for each task.
+  int64 vm_exec_dial_duration_usec = 4;
 }
 
 // Stats about work done after the COMPLETED operation is streamed back to the

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -3153,4 +3153,10 @@ message StoredExecution {
   // above, but not earlier guest init such as kernel boot). Only set for
   // executions that booted a fresh firecracker VM.
   int64 vm_exec_init_duration_usec = 95;
+
+  // Time the executor spent dialing the guest VM's vmexec server. For
+  // executions that booted a fresh firecracker VM, this includes guest boot
+  // up to the point where the vmexec server was serving. Set for every
+  // firecracker execution.
+  int64 vm_exec_dial_duration_usec = 96;
 }

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -471,6 +471,7 @@ func ExecutionFromProto(in *repb.StoredExecution, inv *sipb.StoredInvocation) (*
 		VMDockerdWaitDurationUsec:          in.GetVmDockerdWaitDurationUsec(),
 		VMDnsWaitDurationUsec:              in.GetVmDnsWaitDurationUsec(),
 		VMExecInitDurationUsec:             in.GetVmExecInitDurationUsec(),
+		VMExecDialDurationUsec:             in.GetVmExecDialDurationUsec(),
 		BuildrootDiskUsageBytes:            in.GetBuildrootDiskUsageBytes(),
 	}
 

--- a/server/util/clickhouse/clickhouse_test.go
+++ b/server/util/clickhouse/clickhouse_test.go
@@ -98,11 +98,13 @@ func TestExecutionFromProto(t *testing.T) {
 				VmDockerdWaitDurationUsec: 4001,
 				VmDnsWaitDurationUsec:     4002,
 				VmExecInitDurationUsec:    4003,
+				VmExecDialDurationUsec:    4004,
 			},
 			want: &schema.Execution{
 				VMDockerdWaitDurationUsec: 4001,
 				VMDnsWaitDurationUsec:     4002,
 				VMExecInitDurationUsec:    4003,
+				VMExecDialDurationUsec:    4004,
 			},
 		},
 		{
@@ -143,6 +145,7 @@ func TestExecutionFromProto(t *testing.T) {
 			require.Equal(t, testCase.want.VMDockerdWaitDurationUsec, execution.VMDockerdWaitDurationUsec)
 			require.Equal(t, testCase.want.VMDnsWaitDurationUsec, execution.VMDnsWaitDurationUsec)
 			require.Equal(t, testCase.want.VMExecInitDurationUsec, execution.VMExecInitDurationUsec)
+			require.Equal(t, testCase.want.VMExecDialDurationUsec, execution.VMExecDialDurationUsec)
 			require.Equal(t, testCase.in.GetExecutionId(), reconstructExecutionID(t, execution))
 		})
 	}

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -303,6 +303,9 @@ type Execution struct {
 	VMDockerdWaitDurationUsec int64 `gorm:"codec:T64,ZSTD(1)"`
 	VMDnsWaitDurationUsec     int64 `gorm:"codec:T64,ZSTD(1)"`
 	VMExecInitDurationUsec    int64 `gorm:"codec:T64,ZSTD(1)"`
+	// Time the executor spent dialing the guest VM's vmexec server. Set for
+	// every firecracker execution, not just fresh boots.
+	VMExecDialDurationUsec int64 `gorm:"codec:T64,ZSTD(1)"`
 
 	// Disk usage of the task's workspace (buildroot), measured after the task
 	// finishes. Only populated when executor.workspace.measure_disk_usage is
@@ -427,6 +430,7 @@ func (e *Execution) AdditionalFields() []string {
 		"VMDockerdWaitDurationUsec",
 		"VMDnsWaitDurationUsec",
 		"VMExecInitDurationUsec",
+		"VMExecDialDurationUsec",
 		"BuildrootDiskUsageBytes",
 		"ExecutorHostname",
 		"Experiments",


### PR DESCRIPTION
Together with https://github.com/buildbuddy-io/buildbuddy/pull/13013, this will give us a more complete picture of how long it takes to connect to the vmexec server, and why it takes so long.