### PR TITLE
filecache: preserve cache across Windows restarts

### DIFF
--- a/.github/workflows/build-executor-win.yaml
+++ b/.github/workflows/build-executor-win.yaml
@@ -137,6 +137,7 @@ jobs:
                    --test_tag_filters=-performance `
                    @authArgs `
                    -- `
+                   //enterprise/server/remote_execution/filecache:filecache_test `
                    //enterprise/server/remote_execution/workspace:workspace_test `
                    //enterprise/server/util/procstats:procstats_test `
                    //server/util/fastcopy:fastcopy_test

--- a/enterprise/server/remote_execution/filecache/BUILD
+++ b/enterprise/server/remote_execution/filecache/BUILD
@@ -13,6 +13,7 @@ go_library(
         "filecache_darwin.go",
         "filecache_linux.go",
         "filecache_other.go",
+        "filecache_unix.go",
         "filecache_windows.go",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache",
@@ -49,7 +50,10 @@ go_library(
 go_test(
     name = "filecache_test",
     size = "small",
-    srcs = ["filecache_test.go"],
+    srcs = [
+        "filecache_test.go",
+        "filecache_windows_test.go",
+    ],
     deps = [
         ":filecache",
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -218,20 +218,6 @@ func (h *directoryHandle) moveToTrash() error {
 	return h.filecache.trash(h.path)
 }
 
-// syncDir fsyncs the directory at path to ensure any pending metadata changes
-// (e.g. file creation or deletion) are durable on disk.
-func syncDir(path string) error {
-	dir, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer dir.Close()
-	start := time.Now()
-	err = dir.Sync()
-	log.Infof("filecache: syncDir(%q) took %s (err: %v)", path, time.Since(start), err)
-	return err
-}
-
 // NewFileCache constructs an fileCache with maxSize that will cache files
 // in rootDir.
 // If deleteContent is true, the root dir will be deleted and recreated.
@@ -241,6 +227,7 @@ func NewFileCache(rootDir string, maxSizeBytes int64, deleteContent bool) (*file
 	if maxSizeBytes <= 0 {
 		return nil, errors.New("Must provide a positive size")
 	}
+	rootDir = filepath.Clean(rootDir)
 
 	if deleteContent {
 		log.CtxInfof(ctx, "Deleting cache directory %q", rootDir)
@@ -461,11 +448,11 @@ func validateFilecacheHash(hash string) error {
 const sep = string(filepath.Separator)
 
 func (c *fileCache) nodeFromPathAndSize(fullPath string, sizeBytes int64) (string, *repb.FileNode, error) {
-	if !strings.HasPrefix(fullPath, c.rootDir) {
+	subdirPath, ok := relativePathWithinRootDir(c.rootDir, fullPath)
+	if !ok {
 		return "", nil, status.FailedPreconditionErrorf("Path %q not in rootDir: %q", fullPath, c.rootDir)
 	}
 
-	subdirPath := strings.TrimPrefix(fullPath, c.rootDir)
 	keyPrefix, name := filepath.Split(subdirPath)
 	keyPrefix = strings.Trim(keyPrefix, sep)
 
@@ -486,6 +473,19 @@ func (c *fileCache) nodeFromPathAndSize(fullPath string, sizeBytes int64) (strin
 			Hash:      nameParts[0],
 			SizeBytes: sizeBytes,
 		}}, nil
+}
+
+func relativePathWithinRootDir(rootDir, fullPath string) (string, bool) {
+	rel, err := filepath.Rel(rootDir, fullPath)
+	if err != nil || !filepath.IsLocal(rel) {
+		return "", false
+	}
+	return rel, true
+}
+
+func samePath(a, b string) bool {
+	rel, err := filepath.Rel(a, b)
+	return err == nil && rel == "."
 }
 
 func (c *fileCache) scanDir() {
@@ -749,13 +749,14 @@ func (c *fileCache) addFileWithKeyPrefix(keyPrefix string, node *repb.FileNode, 
 		return err
 	}
 	fp := filecachePath(c.rootDir, k)
+	existingFileIsInPlace := samePath(fp, existingFilePath)
 
 	// Ensure the parent directory exists. (We can skip this if the source and
 	// dest are the same, which happens during the initial directory scan.)
 	// TODO(vanja) Consider doing this ahead of time, or just once per
 	// group. With includeSubdirPrefix=false, this could make the Add path
 	// 7% faster, but it's more complicated with includeSubdirPrefix=true.
-	if fp != existingFilePath {
+	if !existingFileIsInPlace {
 		start := time.Now()
 		if err := disk.EnsureDirectoryExists(filepath.Dir(fp)); err != nil {
 			return err
@@ -770,7 +771,7 @@ func (c *fileCache) addFileWithKeyPrefix(keyPrefix string, node *repb.FileNode, 
 	// (i.e. during the initial directory scan), and if it's already tracked in
 	// the LRU (i.e. another action added it concurrently with the scan), then
 	// short-circuit to avoid evicting the file.
-	if fp == existingFilePath {
+	if existingFileIsInPlace {
 		if c.l.Contains(k) {
 			return nil
 		}
@@ -788,7 +789,8 @@ func (c *fileCache) addFileWithKeyPrefix(keyPrefix string, node *repb.FileNode, 
 
 		// If the file being added is inside the filecache dir, and it
 		// is stored in an "old-style" location, then remove it.
-		if strings.HasPrefix(existingFilePath, c.rootDir) && filepath.Base(fp) == filepath.Base(existingFilePath) {
+		_, existingFileIsInCache := relativePathWithinRootDir(c.rootDir, existingFilePath)
+		if existingFileIsInCache && filepath.Base(fp) == filepath.Base(existingFilePath) {
 			if err := syscall.Unlink(existingFilePath); err != nil {
 				log.Errorf("Failed to unlink existing filecache path: %q: %s", existingFilePath, err)
 			}

--- a/enterprise/server/remote_execution/filecache/filecache_other.go
+++ b/enterprise/server/remote_execution/filecache/filecache_other.go
@@ -4,6 +4,10 @@ package filecache
 
 import "errors"
 
+func syncDir(path string) error {
+	return nil
+}
+
 func syncFilesystem(path string) error {
 	return nil
 }

--- a/enterprise/server/remote_execution/filecache/filecache_test.go
+++ b/enterprise/server/remote_execution/filecache/filecache_test.go
@@ -303,6 +303,7 @@ func TestFileCacheInvalidSharedDirectoryNamesAreIgnored(t *testing.T) {
 		sharedDirName           string
 		startupDir              string
 		unexpectedSharedDirName string
+		skipWindows             bool
 	}{
 		{
 			name:          "empty",
@@ -313,11 +314,17 @@ func TestFileCacheInvalidSharedDirectoryNamesAreIgnored(t *testing.T) {
 			name:          "dot",
 			sharedDirName: ".",
 			startupDir:    "_SHARED_.",
+			// Windows strips the trailing dot from this directory name, so the
+			// malformed startup fixture cannot be represented on disk.
+			skipWindows: true,
 		},
 		{
 			name:          "dotdot",
 			sharedDirName: "..",
 			startupDir:    "_SHARED_..",
+			// Windows strips the trailing dots from this directory name, so the
+			// malformed startup fixture cannot be represented on disk.
+			skipWindows: true,
 		},
 		{
 			name:          "anon",
@@ -349,6 +356,9 @@ func TestFileCacheInvalidSharedDirectoryNamesAreIgnored(t *testing.T) {
 
 	// Seed malformed shared-directory layouts on disk before startup scanning.
 	for _, test := range tests {
+		if test.skipWindows && runtime.GOOS == "windows" {
+			continue
+		}
 		node := nodeFromString("invalid-shared-"+test.name, false)
 		writeFileContent(
 			t,
@@ -366,6 +376,9 @@ func TestFileCacheInvalidSharedDirectoryNamesAreIgnored(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			if test.skipWindows && runtime.GOOS == "windows" {
+				t.Skip("malformed startup fixture cannot be represented on Windows")
+			}
 			node := nodeFromString("invalid-shared-"+test.name, false)
 			invalidSharedDirectoryCtx := fc.WithSharedDirectory(group1Ctx, test.sharedDirName)
 

--- a/enterprise/server/remote_execution/filecache/filecache_unix.go
+++ b/enterprise/server/remote_execution/filecache/filecache_unix.go
@@ -1,0 +1,24 @@
+//go:build linux || darwin
+
+package filecache
+
+import (
+	"os"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+)
+
+// syncDir fsyncs the directory at path to ensure any pending metadata changes
+// (e.g. file creation or deletion) are durable on disk.
+func syncDir(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	start := time.Now()
+	err = dir.Sync()
+	log.Debugf("filecache: syncDir(%q) took %s (err: %v)", path, time.Since(start), err)
+	return err
+}

--- a/enterprise/server/remote_execution/filecache/filecache_windows.go
+++ b/enterprise/server/remote_execution/filecache/filecache_windows.go
@@ -4,16 +4,25 @@ package filecache
 
 import (
 	"fmt"
-	"path/filepath"
 	"strconv"
+	"strings"
 
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
 )
 
+// Buffer lengths for the Windows volume path APIs are expressed in UTF-16
+// code units. See https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getvolumepathnamew.
+const volumePathBufferLength = windows.MAX_PATH + 1
+
+// Windows does not expose a supported equivalent of fsync for directories, so
+// flush the whole volume to make directory metadata changes durable.
+func syncDir(path string) error {
+	return syncFilesystem(path)
+}
+
 func syncFilesystem(path string) error {
-	vol := filepath.VolumeName(path)
-	volumePath, err := windows.UTF16PtrFromString(`\\.\` + vol)
+	volumePath, err := volumeDevicePath(path)
 	if err != nil {
 		return err
 	}
@@ -31,6 +40,25 @@ func syncFilesystem(path string) error {
 	}
 	defer windows.CloseHandle(handle)
 	return windows.FlushFileBuffers(handle)
+}
+
+// volumeDevicePath returns the volume GUID path for the volume containing
+// path. Resolving the containing volume is important when path is below a
+// volume mount point rather than directly below a drive letter.
+func volumeDevicePath(path string) (*uint16, error) {
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	var mountPoint [volumePathBufferLength]uint16
+	if err := windows.GetVolumePathName(pathPtr, &mountPoint[0], uint32(len(mountPoint))); err != nil {
+		return nil, fmt.Errorf("get volume path for %q: %w", path, err)
+	}
+	var volumeName [volumePathBufferLength]uint16
+	if err := windows.GetVolumeNameForVolumeMountPoint(&mountPoint[0], &volumeName[0], uint32(len(volumeName))); err != nil {
+		return nil, fmt.Errorf("get volume name for %q: %w", path, err)
+	}
+	return windows.UTF16PtrFromString(strings.TrimSuffix(windows.UTF16ToString(volumeName[:]), `\`))
 }
 
 // getBootID returns an identifier that is unique to the current boot session.

--- a/enterprise/server/remote_execution/filecache/filecache_windows_test.go
+++ b/enterprise/server/remote_execution/filecache/filecache_windows_test.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package filecache_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileCacheRestartScanWindows(t *testing.T) {
+	ctx := context.Background()
+	// Deliberately use slash separators so this remains a regression test even
+	// though MakeTempDir returns a canonical native Windows path.
+	cacheRoot := filepath.ToSlash(testfs.MakeTempDir(t))
+	workspace := testfs.MakeTempDir(t)
+	node := nodeFromString("restart-scan", true)
+	sourcePath := writeFileContent(t, workspace, "source", "restart-scan", true)
+
+	fc, err := filecache.NewFileCache(cacheRoot, 100_000, false)
+	require.NoError(t, err)
+	fc.WaitForDirectoryScanToComplete()
+	require.NoError(t, fc.AddFile(ctx, node, sourcePath))
+	require.NoError(t, fc.Close())
+
+	fc, err = filecache.NewFileCache(cacheRoot, 100_000, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, fc.Close()) })
+	fc.WaitForDirectoryScanToComplete()
+
+	linkedPath := filepath.Join(workspace, "linked")
+	require.True(t, fc.FastLinkFile(ctx, node, linkedPath), "startup scan should preserve the cached file")
+}

--- a/server/testutil/testfs/testfs.go
+++ b/server/testutil/testfs/testfs.go
@@ -56,6 +56,10 @@ func MakeTempDir(t testing.TB) string {
 	if err != nil {
 		assert.FailNow(t, "failed to create temp dir", err)
 	}
+	// TEST_TMPDIR may use slash-separated paths on Windows while os.MkdirTemp
+	// appends a native backslash-separated component. Return a canonical native
+	// path so callers do not accidentally exercise mixed-separator behavior.
+	tmpDir = filepath.Clean(tmpDir)
 	t.Cleanup(func() {
 		// Use mktempdir to get a new tempdir name to move our dir to before we
 		// remove it. This prevents a race condition where something else could
@@ -66,8 +70,9 @@ func MakeTempDir(t testing.TB) string {
 		if err != nil {
 			assert.FailNow(t, "failed to clean up temp dir", err)
 		}
+		newDir = filepath.Clean(newDir)
 		// Move the old directory into the new directory.
-		if err := os.Rename(tmpDir, path.Join(newDir, path.Base(tmpDir))); err != nil && !os.IsNotExist(err) {
+		if err := os.Rename(tmpDir, filepath.Join(newDir, filepath.Base(tmpDir))); err != nil && !os.IsNotExist(err) {
 			assert.FailNow(t, "failed to clean up temp dir", err)
 		}
 		// Remove the new directory containing the old directory.


### PR DESCRIPTION
After a Windows executor restart, the file cache can come back empty
even though its files are still on disk. The startup scanner may receive
a slash-separated cache root while WalkDir reports native-separator
paths. Direct string comparisons then misclassify in-place entries
as legacy files and unlink them.

Canonicalize the root and use filepath.Rel for containment and
Windows-aware equality. Add a mixed-separator restart regression,
while canonicalizing test temp directories so ordinary tests do not
accidentally depend on mixed separators.

Unclean-shutdown detection also needs durable boot-marker creation
and removal. Windows has no supported directory fsync, so resolve
the containing volume by GUID and call FlushFileBuffers at startup
and shutdown lifecycle boundaries. This also handles caches below
directory-mounted volumes. Keep per-execution batching out of scope
because these flushes are not on the cache-write path.

Keep the shared restart and durability tests enabled on Windows,
skipping only malformed trailing-dot fixtures that Windows cannot
represent. Run the full filecache test target in the Windows executor
workflow.
