### PR TITLE
filecache: run Windows test suite

### DIFF
--- a/.github/workflows/build-executor-win.yaml
+++ b/.github/workflows/build-executor-win.yaml
@@ -137,6 +137,7 @@ jobs:
                    --test_tag_filters=-performance `
                    @authArgs `
                    -- `
+                   //enterprise/server/remote_execution/filecache:filecache_test `
                    //enterprise/server/remote_execution/workspace:workspace_test `
                    //enterprise/server/util/procstats:procstats_test `
                    //server/util/fastcopy:fastcopy_test

--- a/enterprise/server/remote_execution/filecache/BUILD
+++ b/enterprise/server/remote_execution/filecache/BUILD
@@ -13,6 +13,7 @@ go_library(
         "filecache_darwin.go",
         "filecache_linux.go",
         "filecache_other.go",
+        "filecache_unix.go",
         "filecache_windows.go",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache",
@@ -49,7 +50,12 @@ go_library(
 go_test(
     name = "filecache_test",
     size = "small",
-    srcs = ["filecache_test.go"],
+    timeout = "moderate",
+    srcs = [
+        "filecache_nonwindows_test.go",
+        "filecache_test.go",
+        "filecache_windows_test.go",
+    ],
     deps = [
         ":filecache",
         "//proto:remote_execution_go_proto",
@@ -67,5 +73,10 @@ go_test(
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_sync//errgroup",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:windows": [
+            "@org_golang_x_sys//windows",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -218,20 +218,6 @@ func (h *directoryHandle) moveToTrash() error {
 	return h.filecache.trash(h.path)
 }
 
-// syncDir fsyncs the directory at path to ensure any pending metadata changes
-// (e.g. file creation or deletion) are durable on disk.
-func syncDir(path string) error {
-	dir, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer dir.Close()
-	start := time.Now()
-	err = dir.Sync()
-	log.Infof("filecache: syncDir(%q) took %s (err: %v)", path, time.Since(start), err)
-	return err
-}
-
 // NewFileCache constructs an fileCache with maxSize that will cache files
 // in rootDir.
 // If deleteContent is true, the root dir will be deleted and recreated.

--- a/enterprise/server/remote_execution/filecache/filecache_nonwindows_test.go
+++ b/enterprise/server/remote_execution/filecache/filecache_nonwindows_test.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package filecache_test
+
+import "testing"
+
+func canCreateSharedDirectoryStartupFixture(name string) bool {
+	return true
+}
+
+func requireFilecacheDurabilitySupport(t testing.TB, path string) {}
+
+func requireFilecacheRestartScanSupport(t testing.TB) {}

--- a/enterprise/server/remote_execution/filecache/filecache_other.go
+++ b/enterprise/server/remote_execution/filecache/filecache_other.go
@@ -4,6 +4,10 @@ package filecache
 
 import "errors"
 
+func syncDir(path string) error {
+	return nil
+}
+
 func syncFilesystem(path string) error {
 	return nil
 }

--- a/enterprise/server/remote_execution/filecache/filecache_test.go
+++ b/enterprise/server/remote_execution/filecache/filecache_test.go
@@ -112,6 +112,7 @@ func TestFilecache(t *testing.T) {
 }
 
 func TestFileCacheGroupIsolation(t *testing.T) {
+	requireFilecacheRestartScanSupport(t)
 	ctx := context.TODO()
 	fcDir := testfs.MakeTempDir(t)
 	baseDir := testfs.MakeTempDir(t)
@@ -247,6 +248,7 @@ func TestFileCacheSharedDirectoryAcrossGroups(t *testing.T) {
 }
 
 func TestFileCacheSharedDirectoryAcrossGroupsAfterRestart(t *testing.T) {
+	requireFilecacheRestartScanSupport(t)
 	ctx := context.Background()
 	fcDir := testfs.MakeTempDir(t)
 	baseDir := testfs.MakeTempDir(t)
@@ -349,6 +351,9 @@ func TestFileCacheInvalidSharedDirectoryNamesAreIgnored(t *testing.T) {
 
 	// Seed malformed shared-directory layouts on disk before startup scanning.
 	for _, test := range tests {
+		if !canCreateSharedDirectoryStartupFixture(test.sharedDirName) {
+			continue
+		}
 		node := nodeFromString("invalid-shared-"+test.name, false)
 		writeFileContent(
 			t,
@@ -545,6 +550,7 @@ func TestFileCacheEviction(t *testing.T) {
 }
 
 func TestFileCacheEvictionAfterStartupScan(t *testing.T) {
+	requireFilecacheRestartScanSupport(t)
 	ctx := context.Background()
 	// For now just assume the disk block size is 4096
 	const fsBlockSize = 4096
@@ -583,6 +589,7 @@ func TestFileCacheEvictionAfterStartupScan(t *testing.T) {
 }
 
 func TestScanWithConcurrentAdd(t *testing.T) {
+	requireFilecacheRestartScanSupport(t)
 	for trial := 0; trial < 100; trial++ {
 		ctx := context.Background()
 		filecacheRoot := testfs.MakeTempDir(t)
@@ -836,9 +843,11 @@ func TestFileCacheEvictionAfterSubdirPrefixing(t *testing.T) {
 }
 
 func TestFileCacheProcessCrash(t *testing.T) {
+	requireFilecacheRestartScanSupport(t)
 	flags.Set(t, "executor.delete_filecache_on_unclean_shutdown", true)
 	ctx := context.Background()
 	fcDir := testfs.MakeTempDir(t)
+	requireFilecacheDurabilitySupport(t, fcDir)
 	baseDir := testfs.MakeTempDir(t)
 
 	// Create a filecache and add a file.
@@ -870,6 +879,7 @@ func TestFileCacheRebootWithoutCleanShutdown(t *testing.T) {
 	flags.Set(t, "executor.delete_filecache_on_unclean_shutdown", true)
 	ctx := context.Background()
 	fcDir := testfs.MakeTempDir(t)
+	requireFilecacheDurabilitySupport(t, fcDir)
 	baseDir := testfs.MakeTempDir(t)
 
 	// Create a filecache and add a file.
@@ -901,9 +911,11 @@ func TestFileCacheRebootWithoutCleanShutdown(t *testing.T) {
 }
 
 func TestFileCacheCleanShutdown(t *testing.T) {
+	requireFilecacheRestartScanSupport(t)
 	flags.Set(t, "executor.delete_filecache_on_unclean_shutdown", true)
 	ctx := context.Background()
 	fcDir := testfs.MakeTempDir(t)
+	requireFilecacheDurabilitySupport(t, fcDir)
 	baseDir := testfs.MakeTempDir(t)
 
 	// Create a filecache, add a file, then shut down cleanly.
@@ -930,9 +942,11 @@ func TestFileCacheCleanShutdown(t *testing.T) {
 }
 
 func TestFileCacheBootIDFileRemovedWhenDetectionDisabled(t *testing.T) {
+	requireFilecacheRestartScanSupport(t)
 	flags.Set(t, "executor.delete_filecache_on_unclean_shutdown", true)
 	ctx := context.Background()
 	fcDir := testfs.MakeTempDir(t)
+	requireFilecacheDurabilitySupport(t, fcDir)
 	baseDir := testfs.MakeTempDir(t)
 
 	// With unclean shutdown detection enabled, create a filecache, add a
@@ -969,6 +983,7 @@ func TestFileCacheAddFileAfterClose(t *testing.T) {
 	flags.Set(t, "executor.delete_filecache_on_unclean_shutdown", true)
 	ctx := context.Background()
 	fcDir := testfs.MakeTempDir(t)
+	requireFilecacheDurabilitySupport(t, fcDir)
 	baseDir := testfs.MakeTempDir(t)
 
 	fc, err := filecache.NewFileCache(fcDir, 100000, false)
@@ -988,6 +1003,7 @@ func TestFileCacheFastLinkFileAfterClose(t *testing.T) {
 	flags.Set(t, "executor.delete_filecache_on_unclean_shutdown", true)
 	ctx := context.Background()
 	fcDir := testfs.MakeTempDir(t)
+	requireFilecacheDurabilitySupport(t, fcDir)
 	baseDir := testfs.MakeTempDir(t)
 
 	fc, err := filecache.NewFileCache(fcDir, 100000, false)
@@ -1010,6 +1026,7 @@ func TestFileCacheWriterCommitAfterClose(t *testing.T) {
 	flags.Set(t, "executor.delete_filecache_on_unclean_shutdown", true)
 	ctx := context.Background()
 	fcDir := testfs.MakeTempDir(t)
+	requireFilecacheDurabilitySupport(t, fcDir)
 	baseDir := testfs.MakeTempDir(t)
 
 	fc, err := filecache.NewFileCache(fcDir, 100000, false)
@@ -1038,6 +1055,7 @@ func TestFileCacheTrackExternalDirectoryAfterClose(t *testing.T) {
 	flags.Set(t, "executor.delete_filecache_on_unclean_shutdown", true)
 	ctx := context.Background()
 	fcDir := testfs.MakeTempDir(t)
+	requireFilecacheDurabilitySupport(t, fcDir)
 	fc, err := filecache.NewFileCache(fcDir, 100000, false)
 	require.NoError(t, err)
 	fc.WaitForDirectoryScanToComplete()
@@ -1464,6 +1482,7 @@ func TestFileCacheWriteAfterClose(t *testing.T) {
 	flags.Set(t, "executor.delete_filecache_on_unclean_shutdown", true)
 	ctx := context.Background()
 	fcDir := testfs.MakeTempDir(t)
+	requireFilecacheDurabilitySupport(t, fcDir)
 	outputDir := testfs.MakeTempDir(t)
 	fc, err := filecache.NewFileCache(fcDir, 100000, false)
 	require.NoError(t, err)

--- a/enterprise/server/remote_execution/filecache/filecache_unix.go
+++ b/enterprise/server/remote_execution/filecache/filecache_unix.go
@@ -1,0 +1,24 @@
+//go:build linux || darwin
+
+package filecache
+
+import (
+	"os"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+)
+
+// syncDir fsyncs the directory at path to ensure any pending metadata changes
+// (e.g. file creation or deletion) are durable on disk.
+func syncDir(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	start := time.Now()
+	err = dir.Sync()
+	log.Infof("filecache: syncDir(%q) took %s (err: %v)", path, time.Since(start), err)
+	return err
+}

--- a/enterprise/server/remote_execution/filecache/filecache_windows.go
+++ b/enterprise/server/remote_execution/filecache/filecache_windows.go
@@ -11,6 +11,12 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
+// Windows does not expose a supported equivalent of fsync for directories, so
+// flush the whole volume to make directory metadata changes durable.
+func syncDir(path string) error {
+	return syncFilesystem(path)
+}
+
 func syncFilesystem(path string) error {
 	vol := filepath.VolumeName(path)
 	volumePath, err := windows.UTF16PtrFromString(`\\.\` + vol)

--- a/enterprise/server/remote_execution/filecache/filecache_windows_test.go
+++ b/enterprise/server/remote_execution/filecache/filecache_windows_test.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+package filecache_test
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+func canCreateSharedDirectoryStartupFixture(name string) bool {
+	// Windows strips trailing dots from directory names, so these names cannot
+	// be represented as distinct malformed on-disk cache directories. The
+	// platform-neutral test still covers their API fallback behavior.
+	return name != "." && name != ".."
+}
+
+func requireFilecacheDurabilitySupport(t testing.TB, path string) {
+	t.Helper()
+	volumePath, err := windows.UTF16PtrFromString(`\\.\` + filepath.VolumeName(path))
+	require.NoError(t, err)
+	handle, err := windows.CreateFile(
+		volumePath,
+		windows.GENERIC_WRITE,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil,
+		windows.OPEN_EXISTING,
+		0,
+		0,
+	)
+	if errors.Is(err, windows.ERROR_ACCESS_DENIED) || errors.Is(err, windows.ERROR_PRIVILEGE_NOT_HELD) {
+		t.Skip("filecache power-loss durability tests require permission to flush the Windows volume")
+	}
+	require.NoError(t, err)
+	require.NoError(t, windows.CloseHandle(handle))
+}
+
+// requireFilecacheRestartScanSupport skips restart-scan tests until FileCache
+// normalizes WalkDir's native paths before combining them with slash-separated
+// relative cache paths. Otherwise, FastLinkFile looks up mixed-separator source
+// paths that do not exist.
+func requireFilecacheRestartScanSupport(t testing.TB) {
+	t.Helper()
+	t.Skip("Windows startup scans require native cache path normalization")
+}

--- a/server/testutil/testfs/testfs.go
+++ b/server/testutil/testfs/testfs.go
@@ -56,6 +56,10 @@ func MakeTempDir(t testing.TB) string {
 	if err != nil {
 		assert.FailNow(t, "failed to create temp dir", err)
 	}
+	// TEST_TMPDIR may use slash-separated paths on Windows while os.MkdirTemp
+	// appends a native backslash-separated component. Return a canonical native
+	// path so callers do not accidentally exercise mixed-separator behavior.
+	tmpDir = filepath.Clean(tmpDir)
 	t.Cleanup(func() {
 		// Use mktempdir to get a new tempdir name to move our dir to before we
 		// remove it. This prevents a race condition where something else could
@@ -66,8 +70,9 @@ func MakeTempDir(t testing.TB) string {
 		if err != nil {
 			assert.FailNow(t, "failed to clean up temp dir", err)
 		}
+		newDir = filepath.Clean(newDir)
 		// Move the old directory into the new directory.
-		if err := os.Rename(tmpDir, path.Join(newDir, path.Base(tmpDir))); err != nil && !os.IsNotExist(err) {
+		if err := os.Rename(tmpDir, filepath.Join(newDir, filepath.Base(tmpDir))); err != nil && !os.IsNotExist(err) {
 			assert.FailNow(t, "failed to clean up temp dir", err)
 		}
 		// Remove the new directory containing the old directory.


### PR DESCRIPTION
Windows CI cannot require the complete file-cache target because Bazel
can provide a slash-separated `TEST_TMPDIR` that `os.MkdirTemp` combines
with a native path component. Power-loss cases also fail on ordinary
developer accounts because Windows restricts whole-volume flushes to
administrators.

Keep directory fsync on Unix and use volume flushes on Windows. Return
canonical native paths from `MakeTempDir`, skip unrepresentable
trailing-dot fixtures, and probe volume-flush permission before the
durability-only cases. Elevated CI still exercises those cases while
non-admin local runs skip them explicitly.

Run the complete target in the required Windows executor test batch. The
restart-scan cases remain skipped on Windows with the exact mixed-separator
reason; the focused follow-up normalizes cache paths and re-enables them.

The restart-scan follow-up is
[#13028](https://github.com/buildbuddy-io/buildbuddy/pull/13028).
