### PR TITLE
Patch Gazelle to fix existing build file detection on Windows

### DIFF
--- a/buildpatches/bazel_dep/gazelle_2405.patch
+++ b/buildpatches/bazel_dep/gazelle_2405.patch
@@ -1,0 +1,16 @@
+diff --git a/internal/go_repository.bzl b/internal/go_repository.bzl
+index d21bd47..918754a 100644
+--- a/internal/go_repository.bzl
++++ b/internal/go_repository.bzl
+@@ -302,7 +302,10 @@ def _go_repository_impl(ctx):
+     existing_build_file = ""
+     for name in build_file_names:
+         path = ctx.path(name)
+-        if path.exists and not env_execute(ctx, ["test", "-f", path]).return_code:
++
++        # The is_dir check matters on case-insensitive file systems, where e.g.
++        # a `build` directory is found when looking up `BUILD`.
++        if path.exists and not path.is_dir:
+             existing_build_file = name
+             break
+ 

--- a/deps/bazel_dep.MODULE.bazel
+++ b/deps/bazel_dep.MODULE.bazel
@@ -9,6 +9,7 @@ single_version_override(
         "//buildpatches/bazel_dep:gazelle.patch",
         # TODO: Remove after upgrading to the next Gazelle release.
         "//buildpatches/bazel_dep:gazelle_2383.patch",
+        "//buildpatches/bazel_dep:gazelle_2405.patch",
     ],
     version = "0.52.2",
 )


### PR DESCRIPTION
go_repository's default build_file_generation = "auto" is meant to skip Gazelle for modules that already ship build files, but it detects them by shelling out to `test -f`, and Windows has no `test` binary. ctx.execute reports the missing executable as a non-zero return code rather than failing, so the probe fails silently and Gazelle regenerates build files on Windows only.

That breaks io_kythe.patch on Windows without GNU coreutils installed.

Patch in  the upstream fix (https://github.com/bazel-contrib/bazel-gazelle/pull/2405), which uses `path.is_dir` instead.

