### PR TITLE
Allow estimated task size to take precedence over test size if set

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -1003,7 +1003,7 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 	executionTask.QueuedTimestamp = timestamppb.Now()
 	defaultTaskSize := tasksize.Default(executionTask)
 	requestedTaskSize := tasksize.Requested(executionTask)
-	taskSize := tasksize.ApplyLimits(ctx, s.env.GetExperimentFlagProvider(), command, props, tasksize.Override(defaultTaskSize, requestedTaskSize))
+	taskSize := tasksize.ApplyLimitsWithRequestedSize(ctx, s.env.GetExperimentFlagProvider(), command, props, defaultTaskSize, requestedTaskSize)
 	measuredSize := s.taskSizer.Get(ctx, command, props)
 	var predictedSize *scpb.TaskSize
 	if measuredSize == nil {

--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -683,8 +683,19 @@ func Override(base, over *scpb.TaskSize) *scpb.TaskSize {
 	return res
 }
 
+// ApplyLimitsWithRequestedSize applies the requested size to size, then clamps
+// the result to within an allowed range. An explicit CPU request overrides the
+// test-size CPU minimum but remains subject to the global CPU minimum.
+func ApplyLimitsWithRequestedSize(ctx context.Context, efp interfaces.ExperimentFlagProvider, cmd *repb.Command, props *platform.Properties, size, requestedSize *scpb.TaskSize) *scpb.TaskSize {
+	return applyLimits(ctx, efp, cmd, props, Override(size, requestedSize), requestedSize)
+}
+
 // ApplyLimits clamps each value in size to within an allowed range.
 func ApplyLimits(ctx context.Context, efp interfaces.ExperimentFlagProvider, cmd *repb.Command, props *platform.Properties, size *scpb.TaskSize) *scpb.TaskSize {
+	return applyLimits(ctx, efp, cmd, props, size, nil)
+}
+
+func applyLimits(ctx context.Context, efp interfaces.ExperimentFlagProvider, cmd *repb.Command, props *platform.Properties, size, requestedSize *scpb.TaskSize) *scpb.TaskSize {
 	if size == nil {
 		return nil
 	}
@@ -698,7 +709,7 @@ func ApplyLimits(ctx context.Context, efp interfaces.ExperimentFlagProvider, cmd
 	if s, ok := testSize(cmd); ok {
 		testSizeMemoryBytes, testSizeMilliCPU := estimateFromTestSize(s)
 		minMemoryBytes = testSizeMemoryBytes
-		if props == nil || props.EstimatedMilliCPU <= 0 {
+		if requestedSize.GetEstimatedMilliCpu() <= 0 {
 			minMilliCPU = testSizeMilliCPU
 		}
 	}

--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -684,8 +684,9 @@ func Override(base, over *scpb.TaskSize) *scpb.TaskSize {
 }
 
 // ApplyLimitsWithRequestedSize applies the requested size to size, then clamps
-// the result to within an allowed range. An explicit CPU request overrides the
-// test-size CPU minimum but remains subject to the global CPU minimum.
+// the result to within an allowed range. Explicit CPU and memory requests
+// override the corresponding test-size minimums but remain subject to the
+// global minimums.
 func ApplyLimitsWithRequestedSize(ctx context.Context, efp interfaces.ExperimentFlagProvider, cmd *repb.Command, props *platform.Properties, size, requestedSize *scpb.TaskSize) *scpb.TaskSize {
 	return applyLimits(ctx, efp, cmd, props, Override(size, requestedSize), requestedSize)
 }
@@ -704,13 +705,15 @@ func applyLimits(ctx context.Context, efp interfaces.ExperimentFlagProvider, cmd
 	minMemoryBytes := MinimumMemoryBytes
 	minMilliCPU := MinimumMilliCPU
 	// Test actions have higher minimums, determined by the test size ("small",
-	// "medium", etc.). Explicit CPU requests override the test-size CPU
-	// minimum, but are still subject to the global safety minimum.
+	// "medium", etc.). Explicit resource requests override the corresponding
+	// test-size minimum but are still subject to the global safety minimum.
 	if s, ok := testSize(cmd); ok {
-		testSizeMemoryBytes, testSizeMilliCPU := estimateFromTestSize(s)
-		minMemoryBytes = testSizeMemoryBytes
-		if requestedSize.GetEstimatedMilliCpu() <= 0 {
-			minMilliCPU = testSizeMilliCPU
+		minMemoryBytes, minMilliCPU = estimateFromTestSize(s)
+		if requestedSize.GetEstimatedMemoryBytes() > 0 {
+			minMemoryBytes = MinimumMemoryBytes
+		}
+		if requestedSize.GetEstimatedMilliCpu() > 0 {
+			minMilliCPU = MinimumMilliCPU
 		}
 	}
 

--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -693,9 +693,14 @@ func ApplyLimits(ctx context.Context, efp interfaces.ExperimentFlagProvider, cmd
 	minMemoryBytes := MinimumMemoryBytes
 	minMilliCPU := MinimumMilliCPU
 	// Test actions have higher minimums, determined by the test size ("small",
-	// "medium", etc.)
+	// "medium", etc.). Explicit CPU requests override the test-size CPU
+	// minimum, but are still subject to the global safety minimum.
 	if s, ok := testSize(cmd); ok {
-		minMemoryBytes, minMilliCPU = estimateFromTestSize(s)
+		testSizeMemoryBytes, testSizeMilliCPU := estimateFromTestSize(s)
+		minMemoryBytes = testSizeMemoryBytes
+		if props == nil || props.EstimatedMilliCPU <= 0 {
+			minMilliCPU = testSizeMilliCPU
+		}
 	}
 
 	if clone.EstimatedMilliCpu < minMilliCPU {

--- a/enterprise/server/tasksize/tasksize_test.go
+++ b/enterprise/server/tasksize/tasksize_test.go
@@ -255,6 +255,49 @@ func TestApplyLimits_LargeTest(t *testing.T) {
 	assert.Equal(t, tasksize.MaxEstimatedFreeDisk, sz.EstimatedFreeDiskBytes)
 }
 
+func TestApplyLimits_TestSizeWithExplicitCPU(t *testing.T) {
+	for _, testCase := range []struct {
+		name             string
+		estimatedCPU     string
+		expectedMilliCPU int64
+	}{
+		{name: "test size default", expectedMilliCPU: 1000},
+		{name: "half CPU", estimatedCPU: "0.5", expectedMilliCPU: 500},
+		{name: "three quarters CPU", estimatedCPU: "0.75", expectedMilliCPU: 750},
+		{name: "below global minimum", estimatedCPU: "0.1", expectedMilliCPU: tasksize.MinimumMilliCPU},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			task := &repb.ExecutionTask{
+				Command: &repb.Command{
+					EnvironmentVariables: []*repb.Command_EnvironmentVariable{
+						{Name: "TEST_SIZE", Value: "large"},
+					},
+				},
+			}
+			if testCase.estimatedCPU != "" {
+				task.Command.Platform = &repb.Platform{
+					Properties: []*repb.Platform_Property{
+						{Name: "EstimatedCPU", Value: testCase.estimatedCPU},
+					},
+				}
+			}
+
+			props, err := platform.ParseProperties(task)
+			require.NoError(t, err)
+			sz := tasksize.ApplyLimits(
+				context.Background(),
+				nil,
+				task.GetCommand(),
+				props,
+				tasksize.Override(tasksize.Default(task), tasksize.Requested(task)),
+			)
+
+			assert.Equal(t, testCase.expectedMilliCPU, sz.EstimatedMilliCpu)
+			assert.Equal(t, int64(300_000_000), sz.EstimatedMemoryBytes)
+		})
+	}
+}
+
 func TestApplyLimits_MaxDiskLimitDisabled(t *testing.T) {
 	testProvider := openfeatureTesting.NewTestProvider()
 	testProvider.UsingFlags(t, map[string]memprovider.InMemoryFlag{

--- a/enterprise/server/tasksize/tasksize_test.go
+++ b/enterprise/server/tasksize/tasksize_test.go
@@ -255,16 +255,19 @@ func TestApplyLimits_LargeTest(t *testing.T) {
 	assert.Equal(t, tasksize.MaxEstimatedFreeDisk, sz.EstimatedFreeDiskBytes)
 }
 
-func TestApplyLimits_TestSizeWithExplicitCPU(t *testing.T) {
+func TestApplyLimits_TestSizeWithExplicitCPURequest(t *testing.T) {
 	for _, testCase := range []struct {
-		name             string
-		estimatedCPU     string
-		expectedMilliCPU int64
+		name                string
+		propertyName        string
+		propertyValue       string
+		expectedMilliCPU    int64
+		expectedMemoryBytes int64
 	}{
-		{name: "test size default", expectedMilliCPU: 1000},
-		{name: "half CPU", estimatedCPU: "0.5", expectedMilliCPU: 500},
-		{name: "three quarters CPU", estimatedCPU: "0.75", expectedMilliCPU: 750},
-		{name: "below global minimum", estimatedCPU: "0.1", expectedMilliCPU: tasksize.MinimumMilliCPU},
+		{name: "test size default", expectedMilliCPU: 1000, expectedMemoryBytes: 300_000_000},
+		{name: "half CPU", propertyName: "EstimatedCPU", propertyValue: "0.5", expectedMilliCPU: 500, expectedMemoryBytes: 300_000_000},
+		{name: "three quarters CPU", propertyName: "EstimatedCPU", propertyValue: "0.75", expectedMilliCPU: 750, expectedMemoryBytes: 300_000_000},
+		{name: "half compute unit", propertyName: "EstimatedComputeUnits", propertyValue: "0.5", expectedMilliCPU: 500, expectedMemoryBytes: 1_250_000_000},
+		{name: "below global minimum", propertyName: "EstimatedCPU", propertyValue: "0.1", expectedMilliCPU: tasksize.MinimumMilliCPU, expectedMemoryBytes: 300_000_000},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			task := &repb.ExecutionTask{
@@ -274,26 +277,27 @@ func TestApplyLimits_TestSizeWithExplicitCPU(t *testing.T) {
 					},
 				},
 			}
-			if testCase.estimatedCPU != "" {
+			if testCase.propertyName != "" {
 				task.Command.Platform = &repb.Platform{
 					Properties: []*repb.Platform_Property{
-						{Name: "EstimatedCPU", Value: testCase.estimatedCPU},
+						{Name: testCase.propertyName, Value: testCase.propertyValue},
 					},
 				}
 			}
 
 			props, err := platform.ParseProperties(task)
 			require.NoError(t, err)
-			sz := tasksize.ApplyLimits(
+			sz := tasksize.ApplyLimitsWithRequestedSize(
 				context.Background(),
 				nil,
 				task.GetCommand(),
 				props,
-				tasksize.Override(tasksize.Default(task), tasksize.Requested(task)),
+				tasksize.Default(task),
+				tasksize.Requested(task),
 			)
 
 			assert.Equal(t, testCase.expectedMilliCPU, sz.EstimatedMilliCpu)
-			assert.Equal(t, int64(300_000_000), sz.EstimatedMemoryBytes)
+			assert.Equal(t, testCase.expectedMemoryBytes, sz.EstimatedMemoryBytes)
 		})
 	}
 }
@@ -476,6 +480,42 @@ func TestSizer_RespectsMinimumSize(t *testing.T) {
 	ts = sizer.Get(ctx, cmd, props)
 	assert.Equal(t, int64(1000), ts.GetEstimatedMilliCpu())
 	assert.Equal(t, int64(800*1e6), ts.GetEstimatedMemoryBytes())
+}
+
+func TestSizer_Get_TestSizeMinimumUnaffectedByExplicitCPU(t *testing.T) {
+	flags.Set(t, "remote_execution.use_measured_task_sizes", true)
+
+	env := testenv.GetTestEnv(t)
+	rdb := testredis.Start(t).Client()
+	env.SetRemoteExecutionRedisClient(rdb)
+	auth := testauth.NewTestAuthenticator(t, testauth.TestUsers())
+	env.SetAuthenticator(auth)
+	sizer, err := tasksize.NewSizer(env)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	cmd := &repb.Command{
+		Arguments: []string{"test.sh"},
+		EnvironmentVariables: []*repb.Command_EnvironmentVariable{
+			{Name: "TEST_SIZE", Value: "large"},
+		},
+	}
+	execStart := time.Now()
+	md := &repb.ExecutedActionMetadata{
+		UsageStats: &repb.UsageStats{
+			CpuNanos:        1,
+			PeakMemoryBytes: 1,
+		},
+		ExecutionStartTimestamp:     timestamppb.New(execStart),
+		ExecutionCompletedTimestamp: timestamppb.New(execStart.Add(1 * time.Second)),
+	}
+	require.NoError(t, sizer.Update(ctx, cmd, &platform.Properties{}, md))
+
+	// An explicit CPU request affects the requested task size, but must not
+	// lower the test-size floor applied independently to a measured size.
+	ts := sizer.Get(ctx, cmd, &platform.Properties{EstimatedMilliCPU: 4000})
+	assert.Equal(t, int64(1000), ts.GetEstimatedMilliCpu())
+	assert.Equal(t, int64(300*1e6), ts.GetEstimatedMemoryBytes())
 }
 
 func TestSizer_P90CPUExperiment(t *testing.T) {

--- a/enterprise/server/tasksize/tasksize_test.go
+++ b/enterprise/server/tasksize/tasksize_test.go
@@ -255,7 +255,7 @@ func TestApplyLimits_LargeTest(t *testing.T) {
 	assert.Equal(t, tasksize.MaxEstimatedFreeDisk, sz.EstimatedFreeDiskBytes)
 }
 
-func TestApplyLimits_TestSizeWithExplicitCPURequest(t *testing.T) {
+func TestApplyLimits_TestSizeWithExplicitResourceRequest(t *testing.T) {
 	for _, testCase := range []struct {
 		name                string
 		propertyName        string
@@ -268,6 +268,8 @@ func TestApplyLimits_TestSizeWithExplicitCPURequest(t *testing.T) {
 		{name: "three quarters CPU", propertyName: "EstimatedCPU", propertyValue: "0.75", expectedMilliCPU: 750, expectedMemoryBytes: 300_000_000},
 		{name: "half compute unit", propertyName: "EstimatedComputeUnits", propertyValue: "0.5", expectedMilliCPU: 500, expectedMemoryBytes: 1_250_000_000},
 		{name: "below global minimum", propertyName: "EstimatedCPU", propertyValue: "0.1", expectedMilliCPU: tasksize.MinimumMilliCPU, expectedMemoryBytes: 300_000_000},
+		{name: "memory below test-size minimum", propertyName: "EstimatedMemory", propertyValue: "10000000", expectedMilliCPU: 1000, expectedMemoryBytes: 10_000_000},
+		{name: "memory below global minimum", propertyName: "EstimatedMemory", propertyValue: "100", expectedMilliCPU: 1000, expectedMemoryBytes: tasksize.MinimumMemoryBytes},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			task := &repb.ExecutionTask{


### PR DESCRIPTION
Allow explicit user-requested CPU values to override the test-size default, while retaining the global safety minimum.