### PR TITLE
Fix action cache validation for chunked output trees

### DIFF
--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -1,6 +1,7 @@
 package action_cache_server
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -121,6 +122,13 @@ func readOutputTree(ctx context.Context, cache interfaces.Cache, instanceName st
 		blob, err = chunking.ReadBlob(ctx, cache, treeDigest, instanceName, digestFunction, repb.Compressor_IDENTITY)
 		if err != nil {
 			return nil, err
+		}
+		computedDigest, err := digest.Compute(bytes.NewReader(blob), digestFunction)
+		if err != nil {
+			return nil, err
+		}
+		if !digest.Equal(computedDigest, treeDigest) {
+			return nil, status.DataLossErrorf("reconstructed output Tree digest %s does not match expected %s", digest.String(computedDigest), digest.String(treeDigest))
 		}
 	}
 	tree := &repb.Tree{}

--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -110,6 +110,26 @@ func checkFilesExist(ctx context.Context, cache interfaces.Cache, instanceName s
 	return eg.Wait()
 }
 
+func readOutputTree(ctx context.Context, cache interfaces.Cache, instanceName string, digestFunction repb.DigestFunction_Value, chunkingEnabled bool, efp interfaces.ExperimentFlagProvider, treeDigest *repb.Digest) (*repb.Tree, error) {
+	rn := digest.NewResourceName(treeDigest, instanceName, rspb.CacheType_CAS, digestFunction).ToProto()
+	blob, err := cache.Get(ctx, rn)
+	if err != nil {
+		minFallbackSizeBytes := chunking.MinChunkedReadFallbackSizeBytes(ctx, efp)
+		if !status.IsNotFoundError(err) || !chunkingEnabled || treeDigest.GetSizeBytes() <= minFallbackSizeBytes || chunking.ShouldDiscardLegacyChunkedBlob(ctx, efp, treeDigest.GetSizeBytes()) {
+			return nil, err
+		}
+		blob, err = chunking.ReadBlob(ctx, cache, treeDigest, instanceName, digestFunction, repb.Compressor_IDENTITY)
+		if err != nil {
+			return nil, err
+		}
+	}
+	tree := &repb.Tree{}
+	if err := proto.Unmarshal(blob, tree); err != nil {
+		return nil, err
+	}
+	return tree, nil
+}
+
 func ValidateActionResult(ctx context.Context, cache interfaces.Cache, remoteInstanceName string, digestFunction repb.DigestFunction_Value, chunkingEnabled bool, efp interfaces.ExperimentFlagProvider, r *repb.ActionResult) error {
 	outputFileDigests := make([]*rspb.ResourceName, 0, len(r.OutputFiles))
 	mu := &sync.Mutex{}
@@ -129,13 +149,8 @@ func ValidateActionResult(ctx context.Context, cache interfaces.Cache, remoteIns
 	for _, d := range r.OutputDirectories {
 		dc := d
 		g.Go(func() error {
-			rn := digest.NewResourceName(dc.GetTreeDigest(), remoteInstanceName, rspb.CacheType_CAS, digestFunction).ToProto()
-			blob, err := cache.Get(gCtx, rn)
+			tree, err := readOutputTree(gCtx, cache, remoteInstanceName, digestFunction, chunkingEnabled, efp, dc.GetTreeDigest())
 			if err != nil {
-				return err
-			}
-			tree := &repb.Tree{}
-			if err := proto.Unmarshal(blob, tree); err != nil {
 				return err
 			}
 			for _, f := range tree.GetRoot().GetFiles() {

--- a/server/remote_cache/action_cache_server/action_cache_server_test.go
+++ b/server/remote_cache/action_cache_server/action_cache_server_test.go
@@ -693,6 +693,64 @@ func TestValidateActionResult_ChunkedOutputFile(t *testing.T) {
 	assert.True(t, status.IsNotFoundError(err))
 }
 
+func TestValidateActionResult_ChunkedOutputDirectoryTree(t *testing.T) {
+	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 1)
+
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(t, err)
+	cache := te.GetCache()
+
+	outputRN, outputData := testdigest.RandomCASResourceBuf(t, 128)
+	require.NoError(t, cache.Set(ctx, outputRN, outputData))
+	tree := &repb.Tree{
+		Root: &repb.Directory{
+			Files: []*repb.FileNode{
+				{Name: "output.bin", Digest: outputRN.GetDigest()},
+			},
+		},
+	}
+	treeData, err := proto.Marshal(tree)
+	require.NoError(t, err)
+	treeDigest, err := digest.Compute(bytes.NewReader(treeData), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	split := len(treeData) / 2
+	chunkData := [][]byte{treeData[:split], treeData[split:]}
+	chunkRNs := make([]*rspb.ResourceName, 0, len(chunkData))
+	for _, data := range chunkData {
+		d, err := digest.Compute(bytes.NewReader(data), repb.DigestFunction_SHA256)
+		require.NoError(t, err)
+		rn := digest.NewCASResourceName(d, "", repb.DigestFunction_SHA256).ToProto()
+		require.NoError(t, cache.Set(ctx, rn, data))
+		chunkRNs = append(chunkRNs, rn)
+	}
+	cm := &chunking.Manifest{
+		BlobDigest:     treeDigest,
+		ChunkDigests:   []*repb.Digest{chunkRNs[0].GetDigest(), chunkRNs[1].GetDigest()},
+		InstanceName:   "",
+		DigestFunction: repb.DigestFunction_SHA256,
+	}
+	require.NoError(t, cm.Store(ctx, cache))
+
+	ar := &repb.ActionResult{
+		OutputDirectories: []*repb.OutputDirectory{
+			{Path: "output", TreeDigest: treeDigest},
+		},
+	}
+	require.NoError(t, action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar))
+
+	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, false, te.GetExperimentFlagProvider(), ar)
+	require.Error(t, err)
+	assert.True(t, status.IsNotFoundError(err))
+
+	require.NoError(t, cache.Delete(ctx, chunkRNs[1]))
+	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar)
+	require.Error(t, err)
+	assert.True(t, status.IsNotFoundError(err))
+}
+
 func TestValidateActionResult_ManyChunkedOutputFiles(t *testing.T) {
 	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 1024)
 

--- a/server/remote_cache/action_cache_server/action_cache_server_test.go
+++ b/server/remote_cache/action_cache_server/action_cache_server_test.go
@@ -745,6 +745,21 @@ func TestValidateActionResult_ChunkedOutputDirectoryTree(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, status.IsNotFoundError(err))
 
+	tree.Root.Files[0].Name = "xutput.bin"
+	corruptTreeData, err := proto.Marshal(tree)
+	require.NoError(t, err)
+	require.Len(t, corruptTreeData, len(treeData))
+	corruptChunkData := [][]byte{corruptTreeData[:split], corruptTreeData[split:]}
+	for i, data := range corruptChunkData {
+		require.NoError(t, cache.Set(ctx, chunkRNs[i], data))
+	}
+	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar)
+	require.Error(t, err)
+	require.True(t, status.IsDataLossError(err), "expected DataLoss, got %s", err)
+
+	for i, data := range chunkData {
+		require.NoError(t, cache.Set(ctx, chunkRNs[i], data))
+	}
 	require.NoError(t, cache.Delete(ctx, chunkRNs[1]))
 	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar)
 	require.Error(t, err)

--- a/server/remote_cache/chunking/chunking.go
+++ b/server/remote_cache/chunking/chunking.go
@@ -451,6 +451,33 @@ func LoadManifest(ctx context.Context, cache interfaces.Cache, blobDigest *repb.
 	return manifest, nil
 }
 
+// ReadBlob reconstructs a chunked blob from its manifest and chunks.
+func ReadBlob(ctx context.Context, cache interfaces.Cache, blobDigest *repb.Digest, instanceName string, digestFunction repb.DigestFunction_Value, compressor repb.Compressor_Value) ([]byte, error) {
+	manifest, err := LoadManifest(ctx, cache, blobDigest, instanceName, digestFunction)
+	if err != nil {
+		return nil, err
+	}
+	rns := make([]*rspb.ResourceName, 0, len(manifest.ChunkDigests))
+	for _, d := range manifest.ChunkDigests {
+		rn := digest.NewCASResourceName(d, manifest.InstanceName, manifest.DigestFunction)
+		rn.SetCompressor(compressor)
+		rns = append(rns, rn.ToProto())
+	}
+	chunkData, err := cache.GetMulti(ctx, rns)
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, 0, blobDigest.GetSizeBytes())
+	for _, d := range manifest.ChunkDigests {
+		data, ok := chunkData[d]
+		if !ok {
+			return nil, status.NotFoundErrorf("chunk %s missing for blob %s", d.GetHash(), blobDigest.GetHash())
+		}
+		buf = append(buf, data...)
+	}
+	return buf, nil
+}
+
 func loadManifestFrom(ctx context.Context, cache interfaces.Cache, blobDigest *repb.Digest, instanceName string, digestFunction repb.DigestFunction_Value, acRNProto *rspb.ResourceName) (*Manifest, error) {
 	arBytes, err := cache.Get(ctx, acRNProto)
 	if err != nil {

--- a/server/remote_cache/chunking/chunking.go
+++ b/server/remote_cache/chunking/chunking.go
@@ -451,29 +451,45 @@ func LoadManifest(ctx context.Context, cache interfaces.Cache, blobDigest *repb.
 	return manifest, nil
 }
 
-// ReadBlob reconstructs a chunked blob from its manifest and chunks.
+// ReadBlob reconstructs a chunked blob in bounded batches. It validates the
+// manifest's declared sizes and, for identity reads, the reconstructed size.
 func ReadBlob(ctx context.Context, cache interfaces.Cache, blobDigest *repb.Digest, instanceName string, digestFunction repb.DigestFunction_Value, compressor repb.Compressor_Value) ([]byte, error) {
 	manifest, err := LoadManifest(ctx, cache, blobDigest, instanceName, digestFunction)
 	if err != nil {
 		return nil, err
 	}
-	rns := make([]*rspb.ResourceName, 0, len(manifest.ChunkDigests))
-	for _, d := range manifest.ChunkDigests {
-		rn := digest.NewCASResourceName(d, manifest.InstanceName, manifest.DigestFunction)
-		rn.SetCompressor(compressor)
-		rns = append(rns, rn.ToProto())
-	}
-	chunkData, err := cache.GetMulti(ctx, rns)
-	if err != nil {
+	if err := manifest.checkChunkSizes(); err != nil {
 		return nil, err
 	}
-	buf := make([]byte, 0, blobDigest.GetSizeBytes())
-	for _, d := range manifest.ChunkDigests {
-		data, ok := chunkData[d]
-		if !ok {
-			return nil, status.NotFoundErrorf("chunk %s missing for blob %s", d.GetHash(), blobDigest.GetHash())
+
+	// Avoid trusting the blob's declared size for an unbounded allocation. The
+	// previous BatchReadBlobs caller already capped reads below this value, so
+	// this preserves its allocation behavior while keeping larger callers safe.
+	initialCapacity := min(blobDigest.GetSizeBytes(), MaxSupportedChunkSizeBytes())
+	buf := make([]byte, 0, initialCapacity)
+	const batchSize = 20
+	rns := make([]*rspb.ResourceName, 0, batchSize)
+	for chunkDigests := range slices.Chunk(manifest.ChunkDigests, batchSize) {
+		for _, d := range chunkDigests {
+			rn := digest.NewCASResourceName(d, manifest.InstanceName, manifest.DigestFunction)
+			rn.SetCompressor(compressor)
+			rns = append(rns, rn.ToProto())
 		}
-		buf = append(buf, data...)
+		chunkData, err := cache.GetMulti(ctx, rns)
+		if err != nil {
+			return nil, err
+		}
+		for _, d := range chunkDigests {
+			data, ok := chunkData[d]
+			if !ok {
+				return nil, status.NotFoundErrorf("chunk %s missing for blob %s", d.GetHash(), blobDigest.GetHash())
+			}
+			buf = append(buf, data...)
+		}
+		rns = rns[:0]
+	}
+	if compressor == repb.Compressor_IDENTITY && int64(len(buf)) != blobDigest.GetSizeBytes() {
+		return nil, status.DataLossErrorf("reconstructed blob %s has size %d, expected %d", blobDigest.GetHash(), len(buf), blobDigest.GetSizeBytes())
 	}
 	return buf, nil
 }

--- a/server/remote_cache/chunking/chunking_test.go
+++ b/server/remote_cache/chunking/chunking_test.go
@@ -26,6 +26,16 @@ import (
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
+type getMultiBatchRecordingCache struct {
+	interfaces.Cache
+	batchSizes []int
+}
+
+func (c *getMultiBatchRecordingCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
+	c.batchSizes = append(c.batchSizes, len(resources))
+	return c.Cache.GetMulti(ctx, resources)
+}
+
 func TestChunker_ReassemblesOriginalData(t *testing.T) {
 	ctx := context.Background()
 
@@ -136,6 +146,42 @@ func TestReadFallbackThresholdClampsToMaxChunkSize(t *testing.T) {
 	ctx := context.Background()
 	efp := booleanFlagProvider{}
 	require.Equal(t, chunking.MaxChunkSizeBytes(ctx, efp), chunking.MinChunkedReadFallbackSizeBytes(ctx, efp))
+}
+
+func TestReadBlob_RejectsForgedManifestSizes(t *testing.T) {
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(t, err)
+	cache := te.GetCache()
+
+	chunkRN, chunkData := testdigest.RandomCASResourceBuf(t, 128)
+	require.NoError(t, cache.Set(ctx, chunkRN, chunkData))
+	const chunkCount = 21
+	forgedChunkDigest := &repb.Digest{
+		Hash:      chunkRN.GetDigest().GetHash(),
+		SizeBytes: 1024 * 1024,
+	}
+	forgedBlobDigest := &repb.Digest{
+		Hash:      chunkRN.GetDigest().GetHash(),
+		SizeBytes: chunkCount * forgedChunkDigest.GetSizeBytes(),
+	}
+	chunkDigests := make([]*repb.Digest, chunkCount)
+	for i := range chunkDigests {
+		chunkDigests[i] = forgedChunkDigest
+	}
+	manifest := &chunking.Manifest{
+		BlobDigest:     forgedBlobDigest,
+		ChunkDigests:   chunkDigests,
+		DigestFunction: repb.DigestFunction_SHA256,
+	}
+	require.NoError(t, manifest.StoreWithoutVerification(ctx, cache))
+
+	recordingCache := &getMultiBatchRecordingCache{Cache: cache}
+	_, err = chunking.ReadBlob(ctx, recordingCache, forgedBlobDigest, "", repb.DigestFunction_SHA256, repb.Compressor_IDENTITY)
+	require.Error(t, err)
+	require.True(t, status.IsDataLossError(err), "expected DataLoss, got %s", err)
+	require.Equal(t, []int{20, 1}, recordingCache.batchSizes)
 }
 
 func TestChunker_DeterministicChunking(t *testing.T) {

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -1327,31 +1327,11 @@ func (s *ContentAddressableStorageServer) readChunkedBlob(ctx context.Context, b
 	if blobDigest.GetSizeBytes() > rpcutil.GRPCMaxSizeBytes {
 		return nil, status.NotFoundErrorf("blob %s not found", blobDigest.GetHash())
 	}
-	manifest, err := chunking.LoadManifest(ctx, s.cache, blobDigest, instanceName, digestFunction)
-	if err != nil {
-		return nil, err
+	compressor := repb.Compressor_IDENTITY
+	if readZstd {
+		compressor = repb.Compressor_ZSTD
 	}
-	rns := make([]*rspb.ResourceName, 0, len(manifest.ChunkDigests))
-	for _, d := range manifest.ChunkDigests {
-		rn := digest.NewCASResourceName(d, manifest.InstanceName, manifest.DigestFunction)
-		if readZstd {
-			rn.SetCompressor(repb.Compressor_ZSTD)
-		}
-		rns = append(rns, rn.ToProto())
-	}
-	chunkData, err := s.cache.GetMulti(ctx, rns)
-	if err != nil {
-		return nil, err
-	}
-	buf := make([]byte, 0, blobDigest.GetSizeBytes())
-	for _, d := range manifest.ChunkDigests {
-		data, ok := chunkData[d]
-		if !ok {
-			return nil, status.NotFoundErrorf("chunk %s missing for blob %s", d.GetHash(), blobDigest.GetHash())
-		}
-		buf = append(buf, data...)
-	}
-	return buf, nil
+	return chunking.ReadBlob(ctx, s.cache, blobDigest, instanceName, digestFunction, compressor)
 }
 
 // SplitBlob is used to get the digests of the chunks that make up a blob. Clients can then see if


### PR DESCRIPTION
> **AI disclosure:** This pull request and its code changes were generated by OpenAI Codex.

## Summary

- reconstruct chunked output-directory Tree protos during ActionResult validation
- share the chunk reconstruction helper with the CAS server
- add regression coverage for valid chunked Trees and missing chunks

## Problem

Output-directory Tree protos may be stored as a chunk manifest plus CAS chunks. Action cache validation currently reads these Trees directly from the backing cache, bypassing chunk reconstruction. When the whole blob is absent, validation treats an otherwise available Tree as missing and returns an action cache miss.

## Example

Suppose an action produces an output directory named `dist/` whose serialized Tree proto is 3 MiB:

1. With output chunking enabled, BuildBuddy stores the Tree as a chunk manifest plus CAS chunks rather than as one whole CAS blob.
2. The logical CAS APIs can reconstruct and serve the Tree, but ActionResult validation performs a direct backing-cache lookup for the whole Tree blob.
3. That lookup returns `NOT_FOUND`, so the cached ActionResult is rejected.
4. A later build with the exact same action key executes the action again instead of receiving an action cache hit.

After this change, validation falls back to reconstructing the Tree from its manifest and chunks, then continues validating the files referenced by the Tree. If the manifest or any chunk is actually missing, validation still returns a cache miss.

## Testing

- `//server/remote_cache/action_cache_server:action_cache_server_test`
- `//server/remote_cache/content_addressable_storage_server:content_addressable_storage_server_test`
- `//server/remote_cache/chunking:chunking_test`