### PR TITLE
action_cache_server: read chunked trees

### DIFF
--- a/server/remote_cache/action_cache_server/BUILD
+++ b/server/remote_cache/action_cache_server/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//server/metrics",
         "//server/real_environment",
         "//server/remote_cache/chunking",
+        "//server/remote_cache/content_addressable_storage_server",
         "//server/remote_cache/digest",
         "//server/util/authutil",
         "//server/util/bazel_request",

--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/chunking"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/content_addressable_storage_server"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_request"
@@ -129,8 +130,9 @@ func ValidateActionResult(ctx context.Context, cache interfaces.Cache, remoteIns
 	for _, d := range r.OutputDirectories {
 		dc := d
 		g.Go(func() error {
-			rn := digest.NewResourceName(dc.GetTreeDigest(), remoteInstanceName, rspb.CacheType_CAS, digestFunction).ToProto()
-			blob, err := cache.Get(gCtx, rn)
+			treeDigest := dc.GetTreeDigest()
+			rn := digest.NewCASResourceName(treeDigest, remoteInstanceName, digestFunction)
+			blob, err := content_addressable_storage_server.GetBlob(gCtx, cache, rn, chunkingEnabled, efp)
 			if err != nil {
 				return err
 			}

--- a/server/remote_cache/action_cache_server/action_cache_server_test.go
+++ b/server/remote_cache/action_cache_server/action_cache_server_test.go
@@ -744,12 +744,9 @@ func TestValidateActionResult_ChunkedOutputDirectoryTree(t *testing.T) {
 			{Path: "output", TreeDigest: treeDigest},
 		},
 	}
-	// The validator currently checks only for the whole Tree blob, even when
-	// chunking is enabled, so it reports this complete chunked Tree as missing.
-	// A follow-up fix should flip this expectation to require.NoError.
-	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar)
-	require.Error(t, err)
-	assert.True(t, status.IsNotFoundError(err))
+	// With chunking enabled, the manifest and chunks make the Tree logically
+	// available, so the ActionResult should validate.
+	require.NoError(t, action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar))
 
 	// With chunking disabled, validation should require the whole Tree blob and
 	// report a cache miss.

--- a/server/remote_cache/action_cache_server/action_cache_server_test.go
+++ b/server/remote_cache/action_cache_server/action_cache_server_test.go
@@ -693,6 +693,71 @@ func TestValidateActionResult_ChunkedOutputFile(t *testing.T) {
 	assert.True(t, status.IsNotFoundError(err))
 }
 
+func TestValidateActionResult_ChunkedOutputDirectoryTree(t *testing.T) {
+	// Force chunking on all blobs so this small synthetic Tree exercises chunk
+	// reconstruction.
+	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 1)
+
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(t, err)
+	cache := te.GetCache()
+
+	// Store the output file referenced by the output-directory Tree.
+	outputRN, outputData := testdigest.RandomCASResourceBuf(t, 128)
+	require.NoError(t, cache.Set(ctx, outputRN, outputData))
+	tree := &repb.Tree{
+		Root: &repb.Directory{
+			Files: []*repb.FileNode{
+				{Name: "output.bin", Digest: outputRN.GetDigest()},
+			},
+		},
+	}
+	treeData, err := proto.Marshal(tree)
+	require.NoError(t, err)
+	treeDigest, err := digest.Compute(bytes.NewReader(treeData), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	// Store the Tree as two CAS chunks plus a manifest, intentionally omitting
+	// the whole Tree blob from CAS.
+	split := len(treeData) / 2
+	chunkData := [][]byte{treeData[:split], treeData[split:]}
+	chunkRNs := make([]*rspb.ResourceName, 0, len(chunkData))
+	for _, data := range chunkData {
+		d, err := digest.Compute(bytes.NewReader(data), repb.DigestFunction_SHA256)
+		require.NoError(t, err)
+		rn := digest.NewCASResourceName(d, "", repb.DigestFunction_SHA256).ToProto()
+		require.NoError(t, cache.Set(ctx, rn, data))
+		chunkRNs = append(chunkRNs, rn)
+	}
+	cm := &chunking.Manifest{
+		BlobDigest:     treeDigest,
+		ChunkDigests:   []*repb.Digest{chunkRNs[0].GetDigest(), chunkRNs[1].GetDigest()},
+		InstanceName:   "",
+		DigestFunction: repb.DigestFunction_SHA256,
+	}
+	require.NoError(t, cm.Store(ctx, cache))
+
+	ar := &repb.ActionResult{
+		OutputDirectories: []*repb.OutputDirectory{
+			{Path: "output", TreeDigest: treeDigest},
+		},
+	}
+	// The validator currently checks only for the whole Tree blob, even when
+	// chunking is enabled, so it reports this complete chunked Tree as missing.
+	// A follow-up fix should flip this expectation to require.NoError.
+	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar)
+	require.Error(t, err)
+	assert.True(t, status.IsNotFoundError(err))
+
+	// With chunking disabled, validation should require the whole Tree blob and
+	// report a cache miss.
+	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, false, te.GetExperimentFlagProvider(), ar)
+	require.Error(t, err)
+	assert.True(t, status.IsNotFoundError(err))
+}
+
 func TestValidateActionResult_ManyChunkedOutputFiles(t *testing.T) {
 	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 1024)
 

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -1354,6 +1354,61 @@ func (s *ContentAddressableStorageServer) readChunkedBlob(ctx context.Context, b
 	return buf, nil
 }
 
+// GetBlob reads a CAS blob, falling back to its chunked representation when
+// chunking is enabled and the blob is eligible for fallback.
+func GetBlob(ctx context.Context, cache interfaces.Cache, rn *digest.CASResourceName, chunkingEnabled bool, efp interfaces.ExperimentFlagProvider) ([]byte, error) {
+	// A digest does not identify which storage representation was used, so try
+	// the canonical CAS resource before looking for a chunk manifest.
+	blob, err := cache.Get(ctx, rn.ToProto())
+	if err == nil {
+		return blob, nil
+	}
+	blobDigest := rn.GetDigest()
+	if !status.IsNotFoundError(err) ||
+		!chunkingEnabled ||
+		blobDigest.GetSizeBytes() <= chunking.MinChunkedReadFallbackSizeBytes(ctx, efp) ||
+		chunking.ShouldDiscardLegacyChunkedBlob(ctx, efp, blobDigest.GetSizeBytes()) {
+		return nil, err
+	}
+	manifest, err := chunking.LoadManifest(ctx, cache, blobDigest, rn.GetInstanceName(), rn.GetDigestFunction())
+	if err != nil {
+		return nil, err
+	}
+	rns := manifest.ChunkResourceNames()
+	for _, chunkRN := range rns {
+		chunkRN.Compressor = rn.GetCompressor()
+	}
+	chunkData, err := cache.GetMulti(ctx, rns)
+	if err != nil {
+		return nil, err
+	}
+	remainingSize := blobDigest.GetSizeBytes()
+	if remainingSize < 0 {
+		return nil, status.NotFoundErrorf("invalid size for blob %s", blobDigest.GetHash())
+	}
+	for _, d := range manifest.ChunkDigests {
+		data, ok := chunkData[d]
+		if !ok {
+			return nil, status.NotFoundErrorf("chunk %s missing for blob %s", d.GetHash(), blobDigest.GetHash())
+		}
+		chunkSize := d.GetSizeBytes()
+		if chunkSize < 0 || chunkSize > remainingSize ||
+			(rn.GetCompressor() == repb.Compressor_IDENTITY && int64(len(data)) != chunkSize) {
+			return nil, status.NotFoundErrorf("invalid chunk %s for blob %s", d.GetHash(), blobDigest.GetHash())
+		}
+		remainingSize -= chunkSize
+	}
+	if remainingSize != 0 {
+		return nil, status.NotFoundErrorf("chunk sizes do not match blob %s", blobDigest.GetHash())
+	}
+	var buf []byte
+	for _, d := range manifest.ChunkDigests {
+		data := chunkData[d]
+		buf = append(buf, data...)
+	}
+	return buf, nil
+}
+
 // SplitBlob is used to get the digests of the chunks that make up a blob. Clients can then see if
 // any chunks are available locally to reduce download from the remote CAS.
 func (s *ContentAddressableStorageServer) SplitBlob(ctx context.Context, req *repb.SplitBlobRequest) (*repb.SplitBlobResponse, error) {

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
@@ -92,6 +92,19 @@ func (e *evilCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName
 	return rsp, err
 }
 
+type getErrorCache struct {
+	interfaces.Cache
+	cacheType rspb.CacheType
+	err       error
+}
+
+func (c *getErrorCache) Get(ctx context.Context, r *rspb.ResourceName) ([]byte, error) {
+	if r.GetCacheType() == c.cacheType {
+		return nil, c.err
+	}
+	return c.Cache.Get(ctx, r)
+}
+
 type casCompressionCache struct {
 	interfaces.Cache
 }
@@ -1457,6 +1470,138 @@ func TestFindMissingBlobsDiscardsLegacyChunkedBlobForAvgChunkSizeOverride(t *tes
 	require.NoError(t, err)
 	require.Len(t, rsp.MissingBlobDigests, 1)
 	require.Equal(t, blobDigest.GetHash(), rsp.MissingBlobDigests[0].GetHash())
+}
+
+func TestGetBlob(t *testing.T) {
+	flags.Set(t, "cache.avg_chunk_size_bytes", 512*1024)
+	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 1)
+
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(t, err)
+	cache := te.GetCache()
+
+	wholeBlob := []byte("whole blob")
+	wholeDigest, err := digest.Compute(bytes.NewReader(wholeBlob), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+	wholeRN := digest.NewCASResourceName(wholeDigest, "", repb.DigestFunction_SHA256)
+	require.NoError(t, cache.Set(ctx, wholeRN.ToProto(), wholeBlob))
+
+	// The canonical blob is returned without attempting to read a manifest,
+	// even when chunking is enabled.
+	manifestErrorCache := &getErrorCache{
+		Cache:     cache,
+		cacheType: rspb.CacheType_AC,
+		err:       status.InternalError("unexpected manifest read"),
+	}
+	got, err := content_addressable_storage_server.GetBlob(ctx, manifestErrorCache, wholeRN, true, te.GetExperimentFlagProvider())
+	require.NoError(t, err)
+	require.Equal(t, wholeBlob, got)
+
+	// Errors other than NotFound are returned without attempting chunked
+	// fallback.
+	cacheErr := status.InternalError("cache read failed")
+	_, err = content_addressable_storage_server.GetBlob(ctx, &getErrorCache{
+		Cache:     cache,
+		cacheType: rspb.CacheType_CAS,
+		err:       cacheErr,
+	}, wholeRN, true, te.GetExperimentFlagProvider())
+	require.ErrorIs(t, err, cacheErr)
+
+	chunk1RN, chunk1 := testdigest.RandomCASResourceBuf(t, 128)
+	chunk2RN, chunk2 := testdigest.RandomCASResourceBuf(t, 128)
+	chunkedBlob := append(append([]byte{}, chunk1...), chunk2...)
+	chunkedDigest, err := digest.Compute(bytes.NewReader(chunkedBlob), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+	require.NoError(t, cache.Set(ctx, chunk1RN, chunk1))
+	require.NoError(t, cache.Set(ctx, chunk2RN, chunk2))
+	manifest := &chunking.Manifest{
+		BlobDigest:     chunkedDigest,
+		ChunkDigests:   []*repb.Digest{chunk1RN.GetDigest(), chunk2RN.GetDigest()},
+		InstanceName:   "",
+		DigestFunction: repb.DigestFunction_SHA256,
+	}
+	require.NoError(t, manifest.Store(ctx, cache))
+	chunkedRN := digest.NewCASResourceName(chunkedDigest, "", repb.DigestFunction_SHA256)
+
+	got, err = content_addressable_storage_server.GetBlob(ctx, cache, chunkedRN, true, te.GetExperimentFlagProvider())
+	require.NoError(t, err)
+	require.Equal(t, chunkedBlob, got)
+
+	// The requested compressor is propagated to each chunk read.
+	compressedRN := digest.NewCASResourceName(chunkedDigest, "", repb.DigestFunction_SHA256)
+	compressedRN.SetCompressor(repb.Compressor_ZSTD)
+	got, err = content_addressable_storage_server.GetBlob(ctx, &casCompressionCache{Cache: cache}, compressedRN, true, te.GetExperimentFlagProvider())
+	require.NoError(t, err)
+	require.Equal(t, chunkedBlob, zstdDecompress(t, got))
+
+	// Disabling chunking prevents manifest fallback.
+	_, err = content_addressable_storage_server.GetBlob(ctx, cache, chunkedRN, false, te.GetExperimentFlagProvider())
+	require.Error(t, err)
+	require.True(t, status.IsNotFoundError(err))
+
+	// The fallback size threshold is non-inclusive.
+	thresholdDigest, err := digest.Compute(bytes.NewReader([]byte("x")), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+	thresholdRN := digest.NewCASResourceName(thresholdDigest, "", repb.DigestFunction_SHA256)
+	_, err = content_addressable_storage_server.GetBlob(ctx, manifestErrorCache, thresholdRN, true, te.GetExperimentFlagProvider())
+	require.Error(t, err)
+	require.True(t, status.IsNotFoundError(err))
+
+	// Missing chunks return NotFound rather than a partial blob.
+	missingBlob := []byte("blob with a missing chunk")
+	missingBlobDigest, err := digest.Compute(bytes.NewReader(missingBlob), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+	missingChunkDigest, err := digest.Compute(bytes.NewReader(missingBlob[:len(missingBlob)/2]), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+	require.NoError(t, (&chunking.Manifest{
+		BlobDigest:     missingBlobDigest,
+		ChunkDigests:   []*repb.Digest{missingChunkDigest},
+		InstanceName:   "",
+		DigestFunction: repb.DigestFunction_SHA256,
+	}).StoreWithoutVerification(ctx, cache))
+	missingRN := digest.NewCASResourceName(missingBlobDigest, "", repb.DigestFunction_SHA256)
+	_, err = content_addressable_storage_server.GetBlob(ctx, cache, missingRN, true, te.GetExperimentFlagProvider())
+	require.Error(t, err)
+	require.True(t, status.IsNotFoundError(err))
+
+	// An untrusted parent size cannot be used as an allocation hint before the
+	// manifest is validated.
+	hugeRN := digest.NewCASResourceName(&repb.Digest{
+		Hash:      strings.Repeat("b", 64),
+		SizeBytes: 1 << 62,
+	}, "", repb.DigestFunction_SHA256)
+	require.NoError(t, (&chunking.Manifest{
+		BlobDigest:     hugeRN.GetDigest(),
+		ChunkDigests:   []*repb.Digest{missingChunkDigest},
+		InstanceName:   "",
+		DigestFunction: repb.DigestFunction_SHA256,
+	}).StoreWithoutVerification(ctx, cache))
+	_, err = content_addressable_storage_server.GetBlob(ctx, cache, hugeRN, true, te.GetExperimentFlagProvider())
+	require.Error(t, err)
+	require.True(t, status.IsNotFoundError(err))
+
+	// Legacy blobs in the chunk-size migration range skip manifest fallback.
+	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		"cache.avg_chunk_size_override": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "one_mb",
+			Variants: map[string]any{
+				"one_mb": 1 * 1024 * 1024,
+			},
+		},
+	})
+	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
+	fp, err := experiments.NewFlagProvider(t.Name())
+	require.NoError(t, err)
+	legacyRN := digest.NewCASResourceName(&repb.Digest{
+		Hash:      strings.Repeat("a", 64),
+		SizeBytes: 3 * 1024 * 1024,
+	}, "", repb.DigestFunction_SHA256)
+	_, err = content_addressable_storage_server.GetBlob(ctx, manifestErrorCache, legacyRN, true, fp)
+	require.Error(t, err)
+	require.True(t, status.IsNotFoundError(err))
 }
 
 func TestBatchReadBlobsWithChunkedBlob(t *testing.T) {


### PR DESCRIPTION
Action cache validation rejects cached results when an output-directory
Tree exists only as a chunk manifest plus CAS chunks. This incorrectly
turns otherwise valid cache hits into misses. Fix this because cache-hit
validation should not depend on the blob's physical representation.

The first commit captures the current `NotFound` result in a green
characterization test. The second commit adds a CAS-level `GetBlob` read
that tries the canonical blob first and falls back to validated chunk
reconstruction when chunking is enabled and eligible. Action Cache
validation uses this function. The CAS batch-read fallback remains
unchanged because it has already performed a batched parent lookup.

The helper validates manifest chunk presence and sizes before assembly,
so a corrupt or untrusted parent digest cannot drive an oversized
allocation. `OutputDirectory.tree_digest` identifies an encoded `Tree`
proto rather than the root `Directory` proto required by the CAS
`GetTree` RPC.
