### PR TITLE
Remove a few allocations by switching from sort.Slice to slices.Sort

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -2,13 +2,13 @@ package distributed
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -847,8 +847,8 @@ func (c *Cache) readPeers(r *rspb.ResourceName) *peerset.PeerSet {
 			return 2
 		}
 	}
-	sort.Slice(primaryPeers, func(i, j int) bool {
-		return sortVal(primaryPeers[i]) < sortVal(primaryPeers[j])
+	slices.SortFunc(primaryPeers, func(a, b string) int {
+		return cmp.Compare(sortVal(a), sortVal(b))
 	})
 	ps := peerset.New(primaryPeers, secondaryPeers)
 	ps.BlockBackfills = blockBackfills

--- a/enterprise/server/test/performance/cache/cache_test.go
+++ b/enterprise/server/test/performance/cache/cache_test.go
@@ -301,9 +301,7 @@ func benchmarkRead(ctx context.Context, c interfaces.Cache, digestSizeBytes int6
 		if err != nil {
 			b.Fatal(err)
 		}
-		if n != digestSizeBytes {
-			b.Fatalf("Wanted %v bytes, got %v", digestSizeBytes, n)
-		}
+		require.Equal(b, len(dbuf.buf), int(n))
 	}
 }
 
@@ -504,7 +502,7 @@ func BenchmarkParallel(b *testing.B) {
 							require.NoError(b, err)
 							n, err := w.Write(dbuf.buf)
 							require.NoError(b, err)
-							require.Equal(b, size, int64(n))
+							require.Equal(b, len(dbuf.buf), n)
 							require.NoError(b, w.Commit())
 							require.NoError(b, w.Close())
 						}
@@ -514,7 +512,7 @@ func BenchmarkParallel(b *testing.B) {
 						require.NoError(b, err)
 						n, err := io.Copy(io.Discard, r)
 						require.NoError(b, err)
-						require.Equal(b, size, n)
+						require.Equal(b, len(dbuf.buf), int(n))
 						require.NoError(b, r.Close())
 
 						// Get the digest from the cache.

--- a/enterprise/server/test/performance/cache/cache_test.go
+++ b/enterprise/server/test/performance/cache/cache_test.go
@@ -284,18 +284,15 @@ func benchmarkRead(ctx context.Context, c interfaces.Cache, digestSizeBytes int6
 	b.ReportAllocs()
 	b.SetBytes(digestSizeBytes)
 
-	// Using a bytes.Buffer here because it is used in the distributed.Cache.Get
-	// path, which calls Cache.Reader, and this results in Read calls of various
-	// sizes.
-	readBuf := bytes.NewBuffer(make([]byte, 1))
-	i := 1
-	for b.Loop() {
+	for i := 1; b.Loop(); i++ {
 		dbuf := digestBufs[i%len(digestBufs)]
-		i++
 		r, err := c.Reader(ctx, dbuf.d, 0, 0)
 		if err != nil {
 			b.Fatal(err)
 		}
+		// Using an undersized bytes.Buffer here because this results in Read
+		// calls of various sizes.
+		readBuf := bytes.NewBuffer(make([]byte, 1))
 		n, err := readBuf.ReadFrom(r)
 		r.Close()
 		if err != nil {


### PR DESCRIPTION
sort.Slice has to allocate a Swapper.

Also fix the benchmarks I broke in https://github.com/buildbuddy-io/buildbuddy/pull/12832, so I can use them for this PR.

Only alloc count benchmark results since the rest are unchanged
```
                                              │  /tmp/base   │              /tmp/after               │
                                              │  allocs/op   │  allocs/op    vs base                 │
Set/DistPebble10/AC-24                           516.0 ±  0%    516.0 ±  0%        ~ (p=1.000 n=7)
Set/DistPebble10/CAS-24                          433.0 ±  0%    433.0 ±  0%        ~ (p=1.000 n=7) ¹
Set/DistPebble100/AC-24                          515.0 ±  0%    515.0 ±  0%        ~ (p=1.000 n=7) ¹
Set/DistPebble100/CAS-24                         433.0 ±  0%    433.0 ±  0%        ~ (p=1.000 n=7)
Set/DistPebble1000/AC-24                         515.0 ±  0%    515.0 ±  0%        ~ (p=1.000 n=7) ¹
Set/DistPebble1000/CAS-24                        433.0 ±  0%    433.0 ±  0%        ~ (p=1.000 n=7) ¹
Set/DistPebble10000/AC-24                        544.0 ±  0%    544.0 ±  0%        ~ (p=1.000 n=7) ¹
Set/DistPebble10000/CAS-24                       428.0 ±  0%    428.0 ±  0%        ~ (p=1.000 n=7) ¹
Set/DistPebble1000000/AC-24                      547.0 ±  0%    547.0 ±  0%        ~ (p=1.000 n=7) ¹
Set/DistPebble1000000/CAS-24                     430.0 ±  0%    430.0 ±  0%        ~ (p=1.000 n=7)
Set/LookasideDistPebble10/AC-24                  516.0 ±  0%    516.0 ±  0%        ~ (p=1.000 n=7)
Set/LookasideDistPebble10/CAS-24                 433.0 ±  0%    433.0 ±  0%        ~ (p=1.000 n=7) ¹
Set/LookasideDistPebble100/AC-24                 515.0 ±  0%    515.0 ±  0%        ~ (p=1.000 n=7)
Set/LookasideDistPebble100/CAS-24                433.0 ±  0%    433.0 ±  0%        ~ (p=1.000 n=7) ¹
Set/LookasideDistPebble1000/AC-24                515.0 ±  0%    515.0 ±  0%        ~ (p=1.000 n=7) ¹
Set/LookasideDistPebble1000/CAS-24               433.0 ±  0%    433.0 ±  0%        ~ (p=1.000 n=7) ¹
Set/LookasideDistPebble10000/AC-24               544.0 ±  0%    544.0 ±  0%        ~ (p=1.000 n=7)
Set/LookasideDistPebble10000/CAS-24              428.0 ±  0%    428.0 ±  0%        ~ (p=1.000 n=7) ¹
Set/LookasideDistPebble1000000/AC-24             547.0 ±  0%    547.0 ±  0%        ~ (p=1.000 n=7) ¹
Set/LookasideDistPebble1000000/CAS-24            430.0 ±  0%    430.0 ±  0%        ~ (p=1.000 n=7)
Read/DistPebble10-24                             463.0 ±  0%    462.0 ±  0%   -0.22% (p=0.004 n=7)
Read/DistPebble100-24                            463.0 ±  0%    462.0 ±  0%   -0.22% (p=0.001 n=7)
Read/DistPebble1000-24                           465.0 ±  0%    464.0 ±  0%   -0.22% (p=0.001 n=7)
Read/DistPebble10000-24                          462.0 ±  0%    461.0 ±  0%   -0.22% (p=0.004 n=7)
Read/LookasideDistPebble10-24                    9.000 ±  0%    8.000 ±  0%  -11.11% (p=0.001 n=7)
Read/LookasideDistPebble100-24                  10.000 ±  0%    9.000 ±  0%  -10.00% (p=0.001 n=7)
Read/LookasideDistPebble1000-24                  12.00 ±  0%    11.00 ±  0%   -8.33% (p=0.001 n=7)
Read/LookasideDistPebble10000-24                 475.0 ±  0%    474.0 ±  0%   -0.21% (p=0.001 n=7)
GetSingle/DistPebble10/AC-24                     408.0 ±  0%    407.0 ±  0%   -0.25% (p=0.001 n=7)
GetSingle/DistPebble10/CAS-24                    390.0 ±  0%    389.0 ±  0%   -0.26% (p=0.001 n=7)
GetSingle/DistPebble100/AC-24                    408.0 ±  0%    407.0 ±  0%   -0.25% (p=0.001 n=7)
GetSingle/DistPebble100/CAS-24                   390.0 ±  0%    389.0 ±  0%   -0.26% (p=0.001 n=7)
GetSingle/DistPebble1000/AC-24                   408.0 ±  0%    407.0 ±  0%   -0.25% (p=0.001 n=7)
GetSingle/DistPebble1000/CAS-24                  390.0 ±  0%    389.0 ±  0%   -0.26% (p=0.001 n=7)
GetSingle/DistPebble10000/AC-24                  405.0 ±  0%    404.0 ±  0%   -0.25% (p=0.001 n=7)
GetSingle/DistPebble10000/CAS-24                 387.0 ±  0%    386.0 ±  0%   -0.26% (p=0.001 n=7)
GetSingle/LookasideDistPebble10/AC-24            408.0 ±  0%    407.0 ±  0%   -0.25% (p=0.001 n=7)
GetSingle/LookasideDistPebble10/CAS-24           3.000 ±  0%    3.000 ±  0%        ~ (p=1.000 n=7) ¹
GetSingle/LookasideDistPebble100/AC-24           408.0 ±  0%    407.0 ±  0%   -0.25% (p=0.001 n=7)
GetSingle/LookasideDistPebble100/CAS-24          4.000 ±  0%    4.000 ±  0%        ~ (p=1.000 n=7) ¹
GetSingle/LookasideDistPebble1000/AC-24          408.0 ±  0%    407.0 ±  0%   -0.25% (p=0.001 n=7)
GetSingle/LookasideDistPebble1000/CAS-24         4.000 ±  0%    4.000 ±  0%        ~ (p=1.000 n=7) ¹
GetSingle/LookasideDistPebble10000/AC-24         405.0 ±  0%    404.0 ±  0%   -0.25% (p=0.001 n=7)
GetSingle/LookasideDistPebble10000/CAS-24        394.0 ±  0%    393.0 ±  0%   -0.25% (p=0.001 n=7)
GetMulti/DistPebble100/batch1-24                 421.0 ±  0%    420.0 ±  0%   -0.24% (p=0.001 n=7)
GetMulti/DistPebble100/batch2-24                 462.0 ±  0%    460.0 ±  0%   -0.43% (p=0.001 n=7)
GetMulti/DistPebble100/batch3-24                 503.0 ±  0%    500.0 ±  0%   -0.60% (p=0.001 n=7)
GetMulti/DistPebble100/batch5-24                 588.0 ±  0%    583.0 ±  0%   -0.85% (p=0.001 n=7)
GetMulti/DistPebble100/batch10-24                788.0 ±  0%    778.0 ±  0%   -1.27% (p=0.001 n=7)
GetMulti/DistPebble100/batch25-24               1.332k ±  0%   1.307k ±  0%   -1.88% (p=0.001 n=7)
GetMulti/DistPebble100/batch50-24               2.241k ±  0%   2.191k ±  0%   -2.23% (p=0.001 n=7)
GetMulti/DistPebble100/batch100-24              4.052k ±  1%   3.951k ±  1%   -2.49% (p=0.001 n=7)
GetMulti/DistPebble100/batch500-24              18.48k ±  0%   17.98k ±  0%   -2.70% (p=0.001 n=7)
GetMulti/DistPebble10000/batch1-24               418.0 ±  0%    417.0 ±  0%   -0.24% (p=0.001 n=7)
GetMulti/DistPebble10000/batch2-24               468.0 ±  0%    466.0 ±  0%   -0.43% (p=0.001 n=7)
GetMulti/DistPebble10000/batch3-24               512.0 ±  0%    509.0 ±  0%   -0.59% (p=0.001 n=7)
GetMulti/DistPebble10000/batch5-24               600.0 ±  1%    595.0 ±  1%   -0.83% (p=0.001 n=7)
GetMulti/DistPebble10000/batch10-24              820.0 ±  0%    810.0 ±  0%   -1.22% (p=0.001 n=7)
GetMulti/DistPebble10000/batch25-24             1.392k ±  0%   1.367k ±  0%   -1.80% (p=0.001 n=7)
GetMulti/DistPebble10000/batch50-24             2.350k ±  0%   2.300k ±  0%   -2.13% (p=0.001 n=7)
GetMulti/DistPebble10000/batch100-24            4.260k ±  0%   4.160k ±  0%   -2.35% (p=0.001 n=7)
GetMulti/DistPebble10000/batch500-24            19.52k ±  0%   19.02k ±  0%   -2.56% (p=0.001 n=7)
GetMulti/LookasideDistPebble100/batch1-24        25.00 ±  0%    24.00 ±  0%   -4.00% (p=0.001 n=7)
GetMulti/LookasideDistPebble100/batch2-24        35.00 ±  0%    33.00 ±  0%   -5.71% (p=0.001 n=7)
GetMulti/LookasideDistPebble100/batch3-24        45.00 ±  0%    42.00 ±  0%   -6.67% (p=0.001 n=7)
GetMulti/LookasideDistPebble100/batch5-24        65.00 ±  0%    60.00 ±  0%   -7.69% (p=0.001 n=7)
GetMulti/LookasideDistPebble100/batch10-24       123.0 ±  0%    113.0 ±  0%   -8.13% (p=0.001 n=7)
GetMulti/LookasideDistPebble100/batch25-24       263.0 ±  0%    238.0 ±  0%   -9.51% (p=0.001 n=7)
GetMulti/LookasideDistPebble100/batch50-24       493.0 ±  0%    443.0 ±  0%  -10.14% (p=0.001 n=7)
GetMulti/LookasideDistPebble100/batch100-24      948.0 ±  0%    848.0 ±  0%  -10.55% (p=0.001 n=7)
GetMulti/LookasideDistPebble100/batch500-24     4.569k ±  0%   4.068k ±  0%  -10.97% (p=0.001 n=7)
GetMulti/LookasideDistPebble10000/batch1-24      25.00 ±  0%    24.00 ±  0%   -4.00% (p=0.001 n=7)
GetMulti/LookasideDistPebble10000/batch2-24      35.00 ±  0%    33.00 ±  0%   -5.71% (p=0.001 n=7)
GetMulti/LookasideDistPebble10000/batch3-24      45.00 ±  0%    42.00 ±  0%   -6.67% (p=0.001 n=7)
GetMulti/LookasideDistPebble10000/batch5-24      65.00 ±  0%    60.00 ±  0%   -7.69% (p=0.001 n=7)
GetMulti/LookasideDistPebble10000/batch10-24     123.0 ±  0%    113.0 ±  0%   -8.13% (p=0.001 n=7)
GetMulti/LookasideDistPebble10000/batch25-24     263.0 ±  0%    238.0 ±  0%   -9.51% (p=0.001 n=7)
GetMulti/LookasideDistPebble10000/batch50-24    1.654k ±  1%   1.605k ±  1%   -2.96% (p=0.001 n=7)
GetMulti/LookasideDistPebble10000/batch100-24   3.917k ±  0%   3.817k ±  0%   -2.55% (p=0.001 n=7)
GetMulti/LookasideDistPebble10000/batch500-24   22.00k ±  0%   21.50k ±  0%   -2.26% (p=0.001 n=7)
FindMissing/DistPebble10-24                     1.390k ± 20%   1.330k ± 19%        ~ (p=0.318 n=7)
FindMissing/DistPebble100-24                    2.001k ±  0%   1.901k ±  0%   -5.00% (p=0.001 n=7)
FindMissing/DistPebble1000-24                   2.001k ±  0%   1.901k ±  0%   -5.00% (p=0.001 n=7)
FindMissing/DistPebble10000-24                  2.001k ±  0%   1.901k ±  0%   -5.00% (p=0.001 n=7)
FindMissing/LookasideDistPebble10-24            1.688k ±  7%   1.618k ±  7%        ~ (p=0.097 n=7)
FindMissing/LookasideDistPebble100-24           2.301k ±  0%   2.201k ±  0%   -4.35% (p=0.001 n=7)
FindMissing/LookasideDistPebble1000-24          2.301k ±  0%   2.201k ±  0%   -4.35% (p=0.001 n=7)
FindMissing/LookasideDistPebble10000-24         2.301k ±  0%   2.201k ±  0%   -4.35% (p=0.001 n=7)
Parallel/DistPebble20000/AC-24                  1.872k ±  0%   1.869k ±  0%   -0.16% (p=0.001 n=7)
Parallel/LookasideDistPebble20000/AC-24         1.872k ±  0%   1.869k ±  0%   -0.16% (p=0.001 n=7)
Parallel/DistPebble20000/CAS-24                 1.693k ±  0%   1.690k ±  0%   -0.18% (p=0.001 n=7)
Parallel/LookasideDistPebble20000/CAS-24        1.702k ±  0%   1.699k ±  1%   -0.18% (p=0.005 n=7)
geomean                                          440.9          430.1         -2.43%
```