### PR TITLE
Fix chunked output tree validation

### DIFF
--- a/server/remote_cache/action_cache_server/BUILD
+++ b/server/remote_cache/action_cache_server/BUILD
@@ -24,10 +24,12 @@ go_library(
         "//server/util/log",
         "//server/util/prefix",
         "//server/util/proto",
+        "//server/util/rpcutil",
         "//server/util/status",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_protobuf//types/known/anypb",
         "@org_golang_x_sync//errgroup",
+        "@org_golang_x_sync//semaphore",
     ],
 )
 
@@ -57,6 +59,7 @@ go_test(
         "//server/util/claims",
         "//server/util/prefix",
         "//server/util/proto",
+        "//server/util/rpcutil",
         "//server/util/status",
         "//server/util/testing/flags",
         "@com_github_google_go_cmp//cmp",

--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 
@@ -23,9 +24,11 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
+	"github.com/buildbuddy-io/buildbuddy/server/util/rpcutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	cappb "github.com/buildbuddy-io/buildbuddy/proto/capability"
@@ -42,6 +45,10 @@ var (
 // checkFilesExist performs in parallel. Each lookup issues independent cache
 // reads, so the work is I/O-bound.
 const chunkCheckConcurrency = 8
+
+// Set high enough to avoid affecting normal requests while still preventing
+// abusive fan-out.
+const chunkedTreeReadConcurrency = 32
 
 type ActionCacheServer struct {
 	env   environment.Env
@@ -111,19 +118,30 @@ func checkFilesExist(ctx context.Context, cache interfaces.Cache, instanceName s
 	return eg.Wait()
 }
 
-func readOutputTree(ctx context.Context, cache interfaces.Cache, instanceName string, digestFunction repb.DigestFunction_Value, chunkingEnabled bool, efp interfaces.ExperimentFlagProvider, treeDigest *repb.Digest) (*repb.Tree, error) {
+func readOutputTree(ctx context.Context, cache interfaces.Cache, instanceName string, digestFunction repb.DigestFunction_Value, chunkingEnabled bool, efp interfaces.ExperimentFlagProvider, chunkedReadLimiter *semaphore.Weighted, treeDigest *repb.Digest) (*repb.Tree, error) {
 	rn := digest.NewResourceName(treeDigest, instanceName, rspb.CacheType_CAS, digestFunction).ToProto()
 	blob, err := cache.Get(ctx, rn)
 	if err != nil {
+		isNotFound := status.IsNotFoundError(err) || os.IsNotExist(err)
+		treeSizeBytes := treeDigest.GetSizeBytes()
 		minFallbackSizeBytes := chunking.MinChunkedReadFallbackSizeBytes(ctx, efp)
-		if !status.IsNotFoundError(err) || !chunkingEnabled || treeDigest.GetSizeBytes() <= minFallbackSizeBytes || chunking.ShouldDiscardLegacyChunkedBlob(ctx, efp, treeDigest.GetSizeBytes()) {
+		if !isNotFound ||
+			!chunkingEnabled ||
+			treeSizeBytes <= minFallbackSizeBytes ||
+			treeSizeBytes > rpcutil.GRPCMaxSizeBytes ||
+			chunking.ShouldDiscardLegacyChunkedBlob(ctx, efp, treeSizeBytes) {
 			return nil, err
 		}
-		blob, err = chunking.GetBlob(ctx, cache, treeDigest, instanceName, digestFunction, repb.Compressor_IDENTITY)
+		// Avoid unbounded fan-out across chunked Tree reconstructions.
+		if err := chunkedReadLimiter.Acquire(ctx, 1); err != nil {
+			return nil, err
+		}
+		defer chunkedReadLimiter.Release(1)
+		blob, err = chunking.GetBlob(ctx, cache, treeDigest, instanceName, rn.GetDigestFunction(), repb.Compressor_IDENTITY)
 		if err != nil {
 			return nil, err
 		}
-		computedDigest, err := digest.Compute(bytes.NewReader(blob), digestFunction)
+		computedDigest, err := digest.Compute(bytes.NewReader(blob), rn.GetDigestFunction())
 		if err != nil {
 			return nil, err
 		}
@@ -154,10 +172,11 @@ func ValidateActionResult(ctx context.Context, cache interfaces.Cache, remoteIns
 	}
 
 	g, gCtx := errgroup.WithContext(ctx)
+	chunkedTreeReadLimiter := semaphore.NewWeighted(chunkedTreeReadConcurrency)
 	for _, d := range r.OutputDirectories {
 		dc := d
 		g.Go(func() error {
-			tree, err := readOutputTree(gCtx, cache, remoteInstanceName, digestFunction, chunkingEnabled, efp, dc.GetTreeDigest())
+			tree, err := readOutputTree(gCtx, cache, remoteInstanceName, digestFunction, chunkingEnabled, efp, chunkedTreeReadLimiter, dc.GetTreeDigest())
 			if err != nil {
 				return err
 			}

--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -1,6 +1,7 @@
 package action_cache_server
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -121,6 +122,13 @@ func readOutputTree(ctx context.Context, cache interfaces.Cache, instanceName st
 		blob, err = chunking.ReadBlob(ctx, cache, treeDigest, instanceName, digestFunction, repb.Compressor_IDENTITY)
 		if err != nil {
 			return nil, err
+		}
+		computedDigest, err := digest.Compute(bytes.NewReader(blob), digestFunction)
+		if err != nil {
+			return nil, err
+		}
+		if !digest.Equal(computedDigest, treeDigest) {
+			return nil, status.DataLossErrorf("reconstructed output Tree digest %s does not match expected %s", digest.String(computedDigest), digest.String(treeDigest))
 		}
 	}
 	tree := &repb.Tree{}

--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -110,6 +110,26 @@ func checkFilesExist(ctx context.Context, cache interfaces.Cache, instanceName s
 	return eg.Wait()
 }
 
+func readOutputTree(ctx context.Context, cache interfaces.Cache, instanceName string, digestFunction repb.DigestFunction_Value, chunkingEnabled bool, efp interfaces.ExperimentFlagProvider, treeDigest *repb.Digest) (*repb.Tree, error) {
+	rn := digest.NewResourceName(treeDigest, instanceName, rspb.CacheType_CAS, digestFunction).ToProto()
+	blob, err := cache.Get(ctx, rn)
+	if err != nil {
+		minFallbackSizeBytes := chunking.MinChunkedReadFallbackSizeBytes(ctx, efp)
+		if !status.IsNotFoundError(err) || !chunkingEnabled || treeDigest.GetSizeBytes() <= minFallbackSizeBytes || chunking.ShouldDiscardLegacyChunkedBlob(ctx, efp, treeDigest.GetSizeBytes()) {
+			return nil, err
+		}
+		blob, err = chunking.ReadBlob(ctx, cache, treeDigest, instanceName, digestFunction, repb.Compressor_IDENTITY)
+		if err != nil {
+			return nil, err
+		}
+	}
+	tree := &repb.Tree{}
+	if err := proto.Unmarshal(blob, tree); err != nil {
+		return nil, err
+	}
+	return tree, nil
+}
+
 func ValidateActionResult(ctx context.Context, cache interfaces.Cache, remoteInstanceName string, digestFunction repb.DigestFunction_Value, chunkingEnabled bool, efp interfaces.ExperimentFlagProvider, r *repb.ActionResult) error {
 	outputFileDigests := make([]*rspb.ResourceName, 0, len(r.OutputFiles))
 	mu := &sync.Mutex{}
@@ -129,13 +149,8 @@ func ValidateActionResult(ctx context.Context, cache interfaces.Cache, remoteIns
 	for _, d := range r.OutputDirectories {
 		dc := d
 		g.Go(func() error {
-			rn := digest.NewResourceName(dc.GetTreeDigest(), remoteInstanceName, rspb.CacheType_CAS, digestFunction).ToProto()
-			blob, err := cache.Get(gCtx, rn)
+			tree, err := readOutputTree(gCtx, cache, remoteInstanceName, digestFunction, chunkingEnabled, efp, dc.GetTreeDigest())
 			if err != nil {
-				return err
-			}
-			tree := &repb.Tree{}
-			if err := proto.Unmarshal(blob, tree); err != nil {
 				return err
 			}
 			for _, f := range tree.GetRoot().GetFiles() {

--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -119,7 +119,7 @@ func readOutputTree(ctx context.Context, cache interfaces.Cache, instanceName st
 		if !status.IsNotFoundError(err) || !chunkingEnabled || treeDigest.GetSizeBytes() <= minFallbackSizeBytes || chunking.ShouldDiscardLegacyChunkedBlob(ctx, efp, treeDigest.GetSizeBytes()) {
 			return nil, err
 		}
-		blob, err = chunking.ReadBlob(ctx, cache, treeDigest, instanceName, digestFunction, repb.Compressor_IDENTITY)
+		blob, err = chunking.GetBlob(ctx, cache, treeDigest, instanceName, digestFunction, repb.Compressor_IDENTITY)
 		if err != nil {
 			return nil, err
 		}

--- a/server/remote_cache/action_cache_server/action_cache_server_test.go
+++ b/server/remote_cache/action_cache_server/action_cache_server_test.go
@@ -693,6 +693,64 @@ func TestValidateActionResult_ChunkedOutputFile(t *testing.T) {
 	assert.True(t, status.IsNotFoundError(err))
 }
 
+func TestValidateActionResult_ChunkedOutputDirectoryTree(t *testing.T) {
+	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 1)
+
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(t, err)
+	cache := te.GetCache()
+
+	outputRN, outputData := testdigest.RandomCASResourceBuf(t, 128)
+	require.NoError(t, cache.Set(ctx, outputRN, outputData))
+	tree := &repb.Tree{
+		Root: &repb.Directory{
+			Files: []*repb.FileNode{
+				{Name: "output.bin", Digest: outputRN.GetDigest()},
+			},
+		},
+	}
+	treeData, err := proto.Marshal(tree)
+	require.NoError(t, err)
+	treeDigest, err := digest.Compute(bytes.NewReader(treeData), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	split := len(treeData) / 2
+	chunkData := [][]byte{treeData[:split], treeData[split:]}
+	chunkRNs := make([]*rspb.ResourceName, 0, len(chunkData))
+	for _, data := range chunkData {
+		d, err := digest.Compute(bytes.NewReader(data), repb.DigestFunction_SHA256)
+		require.NoError(t, err)
+		rn := digest.NewCASResourceName(d, "", repb.DigestFunction_SHA256).ToProto()
+		require.NoError(t, cache.Set(ctx, rn, data))
+		chunkRNs = append(chunkRNs, rn)
+	}
+	cm := &chunking.Manifest{
+		BlobDigest:     treeDigest,
+		ChunkDigests:   []*repb.Digest{chunkRNs[0].GetDigest(), chunkRNs[1].GetDigest()},
+		InstanceName:   "",
+		DigestFunction: repb.DigestFunction_SHA256,
+	}
+	require.NoError(t, cm.Store(ctx, cache))
+
+	ar := &repb.ActionResult{
+		OutputDirectories: []*repb.OutputDirectory{
+			{Path: "output", TreeDigest: treeDigest},
+		},
+	}
+	require.NoError(t, action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar))
+
+	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, false, te.GetExperimentFlagProvider(), ar)
+	require.Error(t, err)
+	assert.True(t, status.IsNotFoundError(err))
+
+	require.NoError(t, cache.Delete(ctx, chunkRNs[1]))
+	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar)
+	require.Error(t, err)
+	assert.True(t, status.IsNotFoundError(err))
+}
+
 func TestValidateActionResult_ManyChunkedOutputFiles(t *testing.T) {
 	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 1024)
 

--- a/server/remote_cache/action_cache_server/action_cache_server_test.go
+++ b/server/remote_cache/action_cache_server/action_cache_server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -26,6 +27,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
+	"github.com/buildbuddy-io/buildbuddy/server/util/rpcutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/google/go-cmp/cmp"
@@ -45,6 +47,42 @@ import (
 	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 	gcodes "google.golang.org/grpc/codes"
 )
+
+type getErrorCache struct {
+	interfaces.Cache
+	match func(*rspb.ResourceName) bool
+	err   error
+}
+
+func (c *getErrorCache) Get(ctx context.Context, r *rspb.ResourceName) ([]byte, error) {
+	if c.match(r) {
+		return nil, c.err
+	}
+	return c.Cache.Get(ctx, r)
+}
+
+func storeChunkedBlob(t testing.TB, ctx context.Context, cache interfaces.Cache, data []byte, digestFunction repb.DigestFunction_Value) (*repb.Digest, []*rspb.ResourceName) {
+	t.Helper()
+	blobDigest, err := digest.Compute(bytes.NewReader(data), digestFunction)
+	require.NoError(t, err)
+
+	split := len(data) / 2
+	chunkData := [][]byte{data[:split], data[split:]}
+	chunkRNs := make([]*rspb.ResourceName, 0, len(chunkData))
+	for _, data := range chunkData {
+		d, err := digest.Compute(bytes.NewReader(data), digestFunction)
+		require.NoError(t, err)
+		rn := digest.NewCASResourceName(d, "", digestFunction).ToProto()
+		require.NoError(t, cache.Set(ctx, rn, data))
+		chunkRNs = append(chunkRNs, rn)
+	}
+	require.NoError(t, (&chunking.Manifest{
+		BlobDigest:     blobDigest,
+		ChunkDigests:   []*repb.Digest{chunkRNs[0].GetDigest(), chunkRNs[1].GetDigest()},
+		DigestFunction: digestFunction,
+	}).Store(ctx, cache))
+	return blobDigest, chunkRNs
+}
 
 func TestInlineSingleFile(t *testing.T) {
 	resetMetrics()
@@ -713,26 +751,9 @@ func TestValidateActionResult_ChunkedOutputDirectoryTree(t *testing.T) {
 	}
 	treeData, err := proto.Marshal(tree)
 	require.NoError(t, err)
-	treeDigest, err := digest.Compute(bytes.NewReader(treeData), repb.DigestFunction_SHA256)
-	require.NoError(t, err)
-
 	split := len(treeData) / 2
 	chunkData := [][]byte{treeData[:split], treeData[split:]}
-	chunkRNs := make([]*rspb.ResourceName, 0, len(chunkData))
-	for _, data := range chunkData {
-		d, err := digest.Compute(bytes.NewReader(data), repb.DigestFunction_SHA256)
-		require.NoError(t, err)
-		rn := digest.NewCASResourceName(d, "", repb.DigestFunction_SHA256).ToProto()
-		require.NoError(t, cache.Set(ctx, rn, data))
-		chunkRNs = append(chunkRNs, rn)
-	}
-	cm := &chunking.Manifest{
-		BlobDigest:     treeDigest,
-		ChunkDigests:   []*repb.Digest{chunkRNs[0].GetDigest(), chunkRNs[1].GetDigest()},
-		InstanceName:   "",
-		DigestFunction: repb.DigestFunction_SHA256,
-	}
-	require.NoError(t, cm.Store(ctx, cache))
+	treeDigest, chunkRNs := storeChunkedBlob(t, ctx, cache, treeData, repb.DigestFunction_SHA256)
 
 	ar := &repb.ActionResult{
 		OutputDirectories: []*repb.OutputDirectory{
@@ -740,6 +761,13 @@ func TestValidateActionResult_ChunkedOutputDirectoryTree(t *testing.T) {
 		},
 	}
 	require.NoError(t, action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar))
+	require.NoError(t, action_cache_server.ValidateActionResult(ctx, &getErrorCache{
+		Cache: cache,
+		match: func(r *rspb.ResourceName) bool {
+			return r.GetCacheType() == rspb.CacheType_CAS && digest.Equal(r.GetDigest(), treeDigest)
+		},
+		err: os.ErrNotExist,
+	}, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar))
 
 	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, false, te.GetExperimentFlagProvider(), ar)
 	require.Error(t, err)
@@ -761,6 +789,47 @@ func TestValidateActionResult_ChunkedOutputDirectoryTree(t *testing.T) {
 		require.NoError(t, cache.Set(ctx, chunkRNs[i], data))
 	}
 	require.NoError(t, cache.Delete(ctx, chunkRNs[1]))
+	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar)
+	require.Error(t, err)
+	assert.True(t, status.IsNotFoundError(err))
+}
+
+func TestValidateActionResult_ChunkedOutputDirectoryTreeInfersDigestFunction(t *testing.T) {
+	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 1)
+
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(t, err)
+	cache := te.GetCache()
+
+	treeData, err := proto.Marshal(&repb.Tree{Root: &repb.Directory{}})
+	require.NoError(t, err)
+	treeDigest, _ := storeChunkedBlob(t, ctx, cache, treeData, repb.DigestFunction_SHA1)
+	ar := &repb.ActionResult{OutputDirectories: []*repb.OutputDirectory{{TreeDigest: treeDigest}}}
+
+	require.NoError(t, action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_UNKNOWN, true, te.GetExperimentFlagProvider(), ar))
+}
+
+func TestValidateActionResult_DoesNotReconstructOversizedOutputDirectoryTree(t *testing.T) {
+	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 1)
+
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(t, err)
+	cache := &getErrorCache{
+		Cache: te.GetCache(),
+		match: func(r *rspb.ResourceName) bool {
+			return r.GetCacheType() == rspb.CacheType_AC
+		},
+		err: status.InternalError("unexpected manifest read"),
+	}
+	ar := &repb.ActionResult{OutputDirectories: []*repb.OutputDirectory{{TreeDigest: &repb.Digest{
+		Hash:      strings.Repeat("a", 64),
+		SizeBytes: rpcutil.GRPCMaxSizeBytes + 1,
+	}}}}
+
 	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar)
 	require.Error(t, err)
 	assert.True(t, status.IsNotFoundError(err))

--- a/server/remote_cache/action_cache_server/action_cache_server_test.go
+++ b/server/remote_cache/action_cache_server/action_cache_server_test.go
@@ -745,6 +745,21 @@ func TestValidateActionResult_ChunkedOutputDirectoryTree(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, status.IsNotFoundError(err))
 
+	tree.Root.Files[0].Name = "xutput.bin"
+	corruptTreeData, err := proto.Marshal(tree)
+	require.NoError(t, err)
+	require.Len(t, corruptTreeData, len(treeData))
+	corruptChunkData := [][]byte{corruptTreeData[:split], corruptTreeData[split:]}
+	for i, data := range corruptChunkData {
+		require.NoError(t, cache.Set(ctx, chunkRNs[i], data))
+	}
+	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar)
+	require.Error(t, err)
+	require.True(t, status.IsDataLossError(err), "expected DataLoss, got %s", err)
+
+	for i, data := range chunkData {
+		require.NoError(t, cache.Set(ctx, chunkRNs[i], data))
+	}
 	require.NoError(t, cache.Delete(ctx, chunkRNs[1]))
 	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar)
 	require.Error(t, err)

--- a/server/remote_cache/chunking/chunking.go
+++ b/server/remote_cache/chunking/chunking.go
@@ -451,6 +451,33 @@ func LoadManifest(ctx context.Context, cache interfaces.Cache, blobDigest *repb.
 	return manifest, nil
 }
 
+// ReadBlob reconstructs a chunked blob from its manifest and chunks.
+func ReadBlob(ctx context.Context, cache interfaces.Cache, blobDigest *repb.Digest, instanceName string, digestFunction repb.DigestFunction_Value, compressor repb.Compressor_Value) ([]byte, error) {
+	manifest, err := LoadManifest(ctx, cache, blobDigest, instanceName, digestFunction)
+	if err != nil {
+		return nil, err
+	}
+	rns := make([]*rspb.ResourceName, 0, len(manifest.ChunkDigests))
+	for _, d := range manifest.ChunkDigests {
+		rn := digest.NewCASResourceName(d, manifest.InstanceName, manifest.DigestFunction)
+		rn.SetCompressor(compressor)
+		rns = append(rns, rn.ToProto())
+	}
+	chunkData, err := cache.GetMulti(ctx, rns)
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, 0, blobDigest.GetSizeBytes())
+	for _, d := range manifest.ChunkDigests {
+		data, ok := chunkData[d]
+		if !ok {
+			return nil, status.NotFoundErrorf("chunk %s missing for blob %s", d.GetHash(), blobDigest.GetHash())
+		}
+		buf = append(buf, data...)
+	}
+	return buf, nil
+}
+
 func loadManifestFrom(ctx context.Context, cache interfaces.Cache, blobDigest *repb.Digest, instanceName string, digestFunction repb.DigestFunction_Value, acRNProto *rspb.ResourceName) (*Manifest, error) {
 	arBytes, err := cache.Get(ctx, acRNProto)
 	if err != nil {

--- a/server/remote_cache/chunking/chunking.go
+++ b/server/remote_cache/chunking/chunking.go
@@ -437,7 +437,9 @@ func (cm *Manifest) store(ctx context.Context, cache interfaces.Cache) error {
 	return nil
 }
 
-// LoadManifest retrieves a chunked manifest from the cache. It does NOT validate existence of the chunks.
+// LoadManifest retrieves a chunked manifest from the cache. It returns an error
+// if the blob does not have a chunked representation and does not validate the
+// existence of the chunks.
 func LoadManifest(ctx context.Context, cache interfaces.Cache, blobDigest *repb.Digest, instanceName string, digestFunction repb.DigestFunction_Value) (*Manifest, error) {
 	rn, err := acResourceName(blobDigest, instanceName, digestFunction)
 	if err != nil {
@@ -453,7 +455,8 @@ func LoadManifest(ctx context.Context, cache interfaces.Cache, blobDigest *repb.
 
 // GetBlob reconstructs a blob from its chunked representation in bounded
 // batches. It validates the manifest's declared sizes and, for identity reads,
-// the reconstructed size.
+// the reconstructed size. It returns an error if the blob does not have a
+// chunked representation.
 func GetBlob(ctx context.Context, cache interfaces.Cache, blobDigest *repb.Digest, instanceName string, digestFunction repb.DigestFunction_Value, compressor repb.Compressor_Value) ([]byte, error) {
 	manifest, err := LoadManifest(ctx, cache, blobDigest, instanceName, digestFunction)
 	if err != nil {
@@ -469,8 +472,8 @@ func GetBlob(ctx context.Context, cache interfaces.Cache, blobDigest *repb.Diges
 	initialCapacity := min(blobDigest.GetSizeBytes(), MaxSupportedChunkSizeBytes())
 	buf := make([]byte, 0, initialCapacity)
 	const batchSize = 20
-	rns := make([]*rspb.ResourceName, 0, batchSize)
 	for chunkDigests := range slices.Chunk(manifest.ChunkDigests, batchSize) {
+		rns := make([]*rspb.ResourceName, 0, len(chunkDigests))
 		for _, d := range chunkDigests {
 			rn := digest.NewCASResourceName(d, manifest.InstanceName, manifest.DigestFunction)
 			rn.SetCompressor(compressor)
@@ -487,7 +490,6 @@ func GetBlob(ctx context.Context, cache interfaces.Cache, blobDigest *repb.Diges
 			}
 			buf = append(buf, data...)
 		}
-		rns = rns[:0]
 	}
 	if compressor == repb.Compressor_IDENTITY && int64(len(buf)) != blobDigest.GetSizeBytes() {
 		return nil, status.DataLossErrorf("reconstructed blob %s has size %d, expected %d", blobDigest.GetHash(), len(buf), blobDigest.GetSizeBytes())

--- a/server/remote_cache/chunking/chunking.go
+++ b/server/remote_cache/chunking/chunking.go
@@ -451,29 +451,45 @@ func LoadManifest(ctx context.Context, cache interfaces.Cache, blobDigest *repb.
 	return manifest, nil
 }
 
-// ReadBlob reconstructs a chunked blob from its manifest and chunks.
+// ReadBlob reconstructs a chunked blob in bounded batches. It validates the
+// manifest's declared sizes and, for identity reads, the reconstructed size.
 func ReadBlob(ctx context.Context, cache interfaces.Cache, blobDigest *repb.Digest, instanceName string, digestFunction repb.DigestFunction_Value, compressor repb.Compressor_Value) ([]byte, error) {
 	manifest, err := LoadManifest(ctx, cache, blobDigest, instanceName, digestFunction)
 	if err != nil {
 		return nil, err
 	}
-	rns := make([]*rspb.ResourceName, 0, len(manifest.ChunkDigests))
-	for _, d := range manifest.ChunkDigests {
-		rn := digest.NewCASResourceName(d, manifest.InstanceName, manifest.DigestFunction)
-		rn.SetCompressor(compressor)
-		rns = append(rns, rn.ToProto())
-	}
-	chunkData, err := cache.GetMulti(ctx, rns)
-	if err != nil {
+	if err := manifest.checkChunkSizes(); err != nil {
 		return nil, err
 	}
-	buf := make([]byte, 0, blobDigest.GetSizeBytes())
-	for _, d := range manifest.ChunkDigests {
-		data, ok := chunkData[d]
-		if !ok {
-			return nil, status.NotFoundErrorf("chunk %s missing for blob %s", d.GetHash(), blobDigest.GetHash())
+
+	// Avoid trusting the blob's declared size for an unbounded allocation. The
+	// previous BatchReadBlobs caller already capped reads below this value, so
+	// this preserves its allocation behavior while keeping larger callers safe.
+	initialCapacity := min(blobDigest.GetSizeBytes(), MaxSupportedChunkSizeBytes())
+	buf := make([]byte, 0, initialCapacity)
+	const batchSize = 20
+	rns := make([]*rspb.ResourceName, 0, batchSize)
+	for chunkDigests := range slices.Chunk(manifest.ChunkDigests, batchSize) {
+		for _, d := range chunkDigests {
+			rn := digest.NewCASResourceName(d, manifest.InstanceName, manifest.DigestFunction)
+			rn.SetCompressor(compressor)
+			rns = append(rns, rn.ToProto())
 		}
-		buf = append(buf, data...)
+		chunkData, err := cache.GetMulti(ctx, rns)
+		if err != nil {
+			return nil, err
+		}
+		for _, d := range chunkDigests {
+			data, ok := chunkData[d]
+			if !ok {
+				return nil, status.NotFoundErrorf("chunk %s missing for blob %s", d.GetHash(), blobDigest.GetHash())
+			}
+			buf = append(buf, data...)
+		}
+		rns = rns[:0]
+	}
+	if compressor == repb.Compressor_IDENTITY && int64(len(buf)) != blobDigest.GetSizeBytes() {
+		return nil, status.DataLossErrorf("reconstructed blob %s has size %d, expected %d", blobDigest.GetHash(), len(buf), blobDigest.GetSizeBytes())
 	}
 	return buf, nil
 }

--- a/server/remote_cache/chunking/chunking.go
+++ b/server/remote_cache/chunking/chunking.go
@@ -451,9 +451,10 @@ func LoadManifest(ctx context.Context, cache interfaces.Cache, blobDigest *repb.
 	return manifest, nil
 }
 
-// ReadBlob reconstructs a chunked blob in bounded batches. It validates the
-// manifest's declared sizes and, for identity reads, the reconstructed size.
-func ReadBlob(ctx context.Context, cache interfaces.Cache, blobDigest *repb.Digest, instanceName string, digestFunction repb.DigestFunction_Value, compressor repb.Compressor_Value) ([]byte, error) {
+// GetBlob reconstructs a blob from its chunked representation in bounded
+// batches. It validates the manifest's declared sizes and, for identity reads,
+// the reconstructed size.
+func GetBlob(ctx context.Context, cache interfaces.Cache, blobDigest *repb.Digest, instanceName string, digestFunction repb.DigestFunction_Value, compressor repb.Compressor_Value) ([]byte, error) {
 	manifest, err := LoadManifest(ctx, cache, blobDigest, instanceName, digestFunction)
 	if err != nil {
 		return nil, err

--- a/server/remote_cache/chunking/chunking_test.go
+++ b/server/remote_cache/chunking/chunking_test.go
@@ -148,7 +148,7 @@ func TestReadFallbackThresholdClampsToMaxChunkSize(t *testing.T) {
 	require.Equal(t, chunking.MaxChunkSizeBytes(ctx, efp), chunking.MinChunkedReadFallbackSizeBytes(ctx, efp))
 }
 
-func TestReadBlob_RejectsForgedManifestSizes(t *testing.T) {
+func TestGetBlobRejectsForgedManifestSizes(t *testing.T) {
 	ctx := context.Background()
 	te := testenv.GetTestEnv(t)
 	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
@@ -178,7 +178,7 @@ func TestReadBlob_RejectsForgedManifestSizes(t *testing.T) {
 	require.NoError(t, manifest.StoreWithoutVerification(ctx, cache))
 
 	recordingCache := &getMultiBatchRecordingCache{Cache: cache}
-	_, err = chunking.ReadBlob(ctx, recordingCache, forgedBlobDigest, "", repb.DigestFunction_SHA256, repb.Compressor_IDENTITY)
+	_, err = chunking.GetBlob(ctx, recordingCache, forgedBlobDigest, "", repb.DigestFunction_SHA256, repb.Compressor_IDENTITY)
 	require.Error(t, err)
 	require.True(t, status.IsDataLossError(err), "expected DataLoss, got %s", err)
 	require.Equal(t, []int{20, 1}, recordingCache.batchSizes)

--- a/server/remote_cache/chunking/chunking_test.go
+++ b/server/remote_cache/chunking/chunking_test.go
@@ -29,10 +29,12 @@ import (
 type getMultiBatchRecordingCache struct {
 	interfaces.Cache
 	batchSizes []int
+	batches    [][]*rspb.ResourceName
 }
 
 func (c *getMultiBatchRecordingCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
 	c.batchSizes = append(c.batchSizes, len(resources))
+	c.batches = append(c.batches, resources)
 	return c.Cache.GetMulti(ctx, resources)
 }
 
@@ -155,21 +157,28 @@ func TestGetBlobRejectsForgedManifestSizes(t *testing.T) {
 	require.NoError(t, err)
 	cache := te.GetCache()
 
-	chunkRN, chunkData := testdigest.RandomCASResourceBuf(t, 128)
-	require.NoError(t, cache.Set(ctx, chunkRN, chunkData))
+	firstChunkRN, firstChunkData := testdigest.RandomCASResourceBuf(t, 128)
+	require.NoError(t, cache.Set(ctx, firstChunkRN, firstChunkData))
+	lastChunkRN, lastChunkData := testdigest.RandomCASResourceBuf(t, 128)
+	require.NoError(t, cache.Set(ctx, lastChunkRN, lastChunkData))
 	const chunkCount = 21
-	forgedChunkDigest := &repb.Digest{
-		Hash:      chunkRN.GetDigest().GetHash(),
+	firstForgedChunkDigest := &repb.Digest{
+		Hash:      firstChunkRN.GetDigest().GetHash(),
 		SizeBytes: 1024 * 1024,
 	}
+	lastForgedChunkDigest := &repb.Digest{
+		Hash:      lastChunkRN.GetDigest().GetHash(),
+		SizeBytes: firstForgedChunkDigest.GetSizeBytes(),
+	}
 	forgedBlobDigest := &repb.Digest{
-		Hash:      chunkRN.GetDigest().GetHash(),
-		SizeBytes: chunkCount * forgedChunkDigest.GetSizeBytes(),
+		Hash:      firstChunkRN.GetDigest().GetHash(),
+		SizeBytes: chunkCount * firstForgedChunkDigest.GetSizeBytes(),
 	}
 	chunkDigests := make([]*repb.Digest, chunkCount)
-	for i := range chunkDigests {
-		chunkDigests[i] = forgedChunkDigest
+	for i := 0; i < chunkCount-1; i++ {
+		chunkDigests[i] = firstForgedChunkDigest
 	}
+	chunkDigests[chunkCount-1] = lastForgedChunkDigest
 	manifest := &chunking.Manifest{
 		BlobDigest:     forgedBlobDigest,
 		ChunkDigests:   chunkDigests,
@@ -182,6 +191,8 @@ func TestGetBlobRejectsForgedManifestSizes(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, status.IsDataLossError(err), "expected DataLoss, got %s", err)
 	require.Equal(t, []int{20, 1}, recordingCache.batchSizes)
+	require.Equal(t, firstChunkRN.GetDigest().GetHash(), recordingCache.batches[0][0].GetDigest().GetHash())
+	require.Equal(t, lastChunkRN.GetDigest().GetHash(), recordingCache.batches[1][0].GetDigest().GetHash())
 }
 
 func TestChunker_DeterministicChunking(t *testing.T) {

--- a/server/remote_cache/chunking/chunking_test.go
+++ b/server/remote_cache/chunking/chunking_test.go
@@ -26,6 +26,16 @@ import (
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
+type getMultiBatchRecordingCache struct {
+	interfaces.Cache
+	batchSizes []int
+}
+
+func (c *getMultiBatchRecordingCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
+	c.batchSizes = append(c.batchSizes, len(resources))
+	return c.Cache.GetMulti(ctx, resources)
+}
+
 func TestChunker_ReassemblesOriginalData(t *testing.T) {
 	ctx := context.Background()
 
@@ -136,6 +146,42 @@ func TestReadFallbackThresholdClampsToMaxChunkSize(t *testing.T) {
 	ctx := context.Background()
 	efp := booleanFlagProvider{}
 	require.Equal(t, chunking.MaxChunkSizeBytes(ctx, efp), chunking.MinChunkedReadFallbackSizeBytes(ctx, efp))
+}
+
+func TestReadBlob_RejectsForgedManifestSizes(t *testing.T) {
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(t, err)
+	cache := te.GetCache()
+
+	chunkRN, chunkData := testdigest.RandomCASResourceBuf(t, 128)
+	require.NoError(t, cache.Set(ctx, chunkRN, chunkData))
+	const chunkCount = 21
+	forgedChunkDigest := &repb.Digest{
+		Hash:      chunkRN.GetDigest().GetHash(),
+		SizeBytes: 1024 * 1024,
+	}
+	forgedBlobDigest := &repb.Digest{
+		Hash:      chunkRN.GetDigest().GetHash(),
+		SizeBytes: chunkCount * forgedChunkDigest.GetSizeBytes(),
+	}
+	chunkDigests := make([]*repb.Digest, chunkCount)
+	for i := range chunkDigests {
+		chunkDigests[i] = forgedChunkDigest
+	}
+	manifest := &chunking.Manifest{
+		BlobDigest:     forgedBlobDigest,
+		ChunkDigests:   chunkDigests,
+		DigestFunction: repb.DigestFunction_SHA256,
+	}
+	require.NoError(t, manifest.StoreWithoutVerification(ctx, cache))
+
+	recordingCache := &getMultiBatchRecordingCache{Cache: cache}
+	_, err = chunking.ReadBlob(ctx, recordingCache, forgedBlobDigest, "", repb.DigestFunction_SHA256, repb.Compressor_IDENTITY)
+	require.Error(t, err)
+	require.True(t, status.IsDataLossError(err), "expected DataLoss, got %s", err)
+	require.Equal(t, []int{20, 1}, recordingCache.batchSizes)
 }
 
 func TestChunker_DeterministicChunking(t *testing.T) {

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -1327,31 +1327,11 @@ func (s *ContentAddressableStorageServer) readChunkedBlob(ctx context.Context, b
 	if blobDigest.GetSizeBytes() > rpcutil.GRPCMaxSizeBytes {
 		return nil, status.NotFoundErrorf("blob %s not found", blobDigest.GetHash())
 	}
-	manifest, err := chunking.LoadManifest(ctx, s.cache, blobDigest, instanceName, digestFunction)
-	if err != nil {
-		return nil, err
+	compressor := repb.Compressor_IDENTITY
+	if readZstd {
+		compressor = repb.Compressor_ZSTD
 	}
-	rns := make([]*rspb.ResourceName, 0, len(manifest.ChunkDigests))
-	for _, d := range manifest.ChunkDigests {
-		rn := digest.NewCASResourceName(d, manifest.InstanceName, manifest.DigestFunction)
-		if readZstd {
-			rn.SetCompressor(repb.Compressor_ZSTD)
-		}
-		rns = append(rns, rn.ToProto())
-	}
-	chunkData, err := s.cache.GetMulti(ctx, rns)
-	if err != nil {
-		return nil, err
-	}
-	buf := make([]byte, 0, blobDigest.GetSizeBytes())
-	for _, d := range manifest.ChunkDigests {
-		data, ok := chunkData[d]
-		if !ok {
-			return nil, status.NotFoundErrorf("chunk %s missing for blob %s", d.GetHash(), blobDigest.GetHash())
-		}
-		buf = append(buf, data...)
-	}
-	return buf, nil
+	return chunking.ReadBlob(ctx, s.cache, blobDigest, instanceName, digestFunction, compressor)
 }
 
 // SplitBlob is used to get the digests of the chunks that make up a blob. Clients can then see if

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -1331,7 +1331,7 @@ func (s *ContentAddressableStorageServer) readChunkedBlob(ctx context.Context, b
 	if readZstd {
 		compressor = repb.Compressor_ZSTD
 	}
-	return chunking.ReadBlob(ctx, s.cache, blobDigest, instanceName, digestFunction, compressor)
+	return chunking.GetBlob(ctx, s.cache, blobDigest, instanceName, digestFunction, compressor)
 }
 
 // SplitBlob is used to get the digests of the chunks that make up a blob. Clients can then see if


### PR DESCRIPTION
Output-directory Tree protos may be stored as a chunk manifest plus CAS chunks. Action cache validation currently reads these Trees directly from the backing cache, bypassing chunk reconstruction. When the whole blob is absent, validation treats an otherwise available Tree as missing and returns an action cache miss.

After this change, validation falls back to reconstructing the Tree from its manifest and chunks, then continues validating the files referenced by the Tree. If the manifest or any chunk is actually missing, validation still returns a cache miss.

Copied over from https://github.com/buildbuddy-io/buildbuddy/pull/13048, thanks @hendrikhofstadt! The only change is I renamed `ReadBlob` to `GetBlob` to illustrate we're reading the whole thing into memory, similar to `cache.Get`