### PR TITLE
[FC] Remove unneeded image pull if chunked image is cached

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -690,6 +690,10 @@ type FirecrackerContainer struct {
 	// If set, the snapshot used to load the VM
 	snapshot *snaploader.Snapshot
 
+	// If set, the snapshot for the container image that can be used for the root filesystem.
+	containerfsSnapshot     *snaploader.Snapshot
+	containerfsSnapshotOnce sync.Once
+
 	// The current task assigned to the VM.
 	task *repb.ExecutionTask
 	// When the VM was initialized (i.e. created or unpaused) for the command
@@ -1479,14 +1483,41 @@ func (c *FirecrackerContainer) initScratchImage(ctx context.Context, path string
 	return nil
 }
 
+// cachedContainerfs returns the snapshot for the container image.
+func (c *FirecrackerContainer) cachedContainerfs(ctx context.Context) *snaploader.Snapshot {
+	if !snaputil.IsChunkedSnapshotSharingEnabled() {
+		return nil
+	}
+	c.containerfsSnapshotOnce.Do(func() {
+		instanceName := c.snapshotKeySet.GetBranchKey().GetInstanceName()
+		snap, err := snaploader.GetCachedContainerImage(ctx, c.loader, instanceName, c.containerImage, c.supportsRemoteSnapshots)
+		if err != nil {
+			if !status.IsNotFoundError(err) {
+				log.CtxWarningf(ctx, "Failed to look up cached containerfs for image %q: %s", c.containerImage, err)
+			}
+			return
+		}
+		c.containerfsSnapshot = snap
+	})
+	return c.containerfsSnapshot
+}
+
 // initRootfsStore creates the initial rootfs chunk layout in the chroot.
 func (c *FirecrackerContainer) initRootfsStore(ctx context.Context) error {
 	cowChunkDir := filepath.Join(c.getChroot(), rootFSName)
 	if err := os.MkdirAll(cowChunkDir, 0755); err != nil {
 		return status.UnavailableErrorf("failed to create rootfs chunk dir: %s", err)
 	}
-	containerExt4Path := filepath.Join(c.getChroot(), containerFSName)
-	cf, err := snaploader.UnpackContainerImage(c.vmCtx, c.loader, c.snapshotKeySet.GetBranchKey().GetInstanceName(), c.containerImage, containerExt4Path, cowChunkDir, cowChunkSizeBytes(), c.supportsRemoteSnapshots)
+	var cf *copy_on_write.COWStore
+	var err error
+	if snap := c.cachedContainerfs(ctx); snap != nil {
+		// If a chunked containerfs snapshot is in the cache, unpack it directly.
+		cf, err = snaploader.UnpackContainerImageSnapshot(c.vmCtx, c.loader, snap, cowChunkDir)
+	} else {
+		// If a chunked containerfs is not cached, we need to convert the ext4 image into chunks.
+		containerExt4Path := filepath.Join(c.getChroot(), containerFSName)
+		cf, err = snaploader.UnpackContainerImage(c.vmCtx, c.loader, c.snapshotKeySet.GetBranchKey().GetInstanceName(), c.containerImage, containerExt4Path, cowChunkDir, cowChunkSizeBytes(), c.supportsRemoteSnapshots)
+	}
 	if err != nil {
 		return status.WrapError(err, "unpack container image")
 	}
@@ -2188,12 +2219,18 @@ func (c *FirecrackerContainer) create(ctx context.Context) error {
 	// Hardlink the ext4 image to the chroot at containerFSPath, if we haven't
 	// already. Normally it will only exist if we got a cache miss and had to
 	// call PullImage; otherwise we expect to find it in cache.
-	if exists, err := disk.FileExists(ctx, containerFSPath); err != nil {
-		return status.UnavailableErrorf("check containerfs exists: %s", err)
-	} else if !exists {
-		err := ociconv.LinkCachedImage(ctx, c.env.GetFileCache(), c.executorConfig.CacheRoot, c.containerImage, containerFSPath)
-		if err != nil {
-			return status.UnavailableErrorf("link cached image: %s", err)
+	//
+	// If the chunked containerfs is already cached then the image was never
+	// pulled or converted, and the VM reads the rootfs chunks over VBD instead,
+	// so there is no EXT4 image to link.
+	if c.cachedContainerfs(ctx) == nil {
+		if exists, err := disk.FileExists(ctx, containerFSPath); err != nil {
+			return status.UnavailableErrorf("check containerfs exists: %s", err)
+		} else if !exists {
+			err := ociconv.LinkCachedImage(ctx, c.env.GetFileCache(), c.executorConfig.CacheRoot, c.containerImage, containerFSPath)
+			if err != nil {
+				return status.UnavailableErrorf("link cached image: %s", err)
+			}
 		}
 	}
 
@@ -2721,7 +2758,16 @@ func (c *FirecrackerContainer) IsImageCached(ctx context.Context) (bool, error) 
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	return ociconv.IsImageCached(ctx, c.env.GetFileCache(), c.executorConfig.CacheRoot, c.containerImage)
+	// Checking for the EXT4 image on local disk is cheap, so do it first.
+	cached, err := ociconv.IsImageCached(ctx, c.env.GetFileCache(), c.executorConfig.CacheRoot, c.containerImage)
+	if err != nil || cached {
+		return cached, err
+	}
+
+	// The image also doesn't need to be pulled if the chunked containerfs is
+	// cached, since then the VM reads rootfs chunks over VBD rather than
+	// reading the EXT4 image.
+	return c.cachedContainerfs(ctx) != nil, nil
 }
 
 // PullImage pulls the container image from the remote. It always
@@ -2750,6 +2796,16 @@ func (c *FirecrackerContainer) PullImage(ctx context.Context, creds oci.Credenti
 
 	if err := c.resolver.AuthenticateWithRegistry(ctx, c.containerImage, oci.RuntimePlatform(), creds); err != nil {
 		return status.WrapError(err, "authenticate with registry")
+	}
+
+	// If the chunked containerfs is already cached, the VM reads its rootfs
+	// chunks lazily over VBD, so we don't need to pull the image.
+	// Note that we still authenticate with the
+	// registry above, so skipping the pull doesn't grant access to an image the
+	// caller can't pull.
+	if c.cachedContainerfs(ctx) != nil {
+		log.CtxInfof(ctx, "Skipping pull of %q: chunked containerfs is already cached", c.containerImage)
+		return nil
 	}
 
 	containerFSPath := filepath.Join(c.getChroot(), containerFSName)

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -547,6 +547,102 @@ func TestFirecrackerPullImageIfNecessary_CachedImageRequiresReauth(t *testing.T)
 	)
 }
 
+func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
+	ctx := context.Background()
+	// Keep snapshot sharing local-only to simplify test setup.
+	flags.Set(t, "executor.enable_remote_snapshot_sharing", false)
+	flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.1/32"})
+
+	// Mock requests to the container registry.
+	var manifestRequests, blobRequests atomic.Int32
+	reg := testregistry.Run(t, testregistry.Opts{
+		HttpInterceptor: func(w http.ResponseWriter, r *http.Request) bool {
+			if strings.Contains(r.URL.Path, "/blobs/") {
+				blobRequests.Add(1)
+			} else if strings.Contains(r.URL.Path, "/manifests/") {
+				manifestRequests.Add(1)
+			}
+			return true
+		},
+	})
+	t.Cleanup(func() {
+		require.NoError(t, reg.Shutdown())
+	})
+
+	// The test registry listens on a random port, so this image ref is unique
+	// to this test run and is guaranteed not to be present in the executor
+	// image cache, which may be shared across runs.
+	imageRef, _ := reg.PushNamedImage(t, "firecracker-skip-redundant-pull:latest", nil)
+
+	// Reset the registry counters so they only reflect requests made by following code.
+	manifestRequests.Store(0)
+	blobRequests.Store(0)
+
+	env := getTestEnv(ctx, t, envOpts{})
+	opts := firecracker.ContainerOpts{
+		ContainerImage:         imageRef,
+		ActionWorkingDirectory: testfs.MakeTempDir(t),
+		VMConfiguration: &fcpb.VMConfiguration{
+			NumCpus:           1,
+			MemSizeMb:         minMemSizeMB,
+			NetworkMode:       fcpb.NetworkMode_NETWORK_MODE_OFF,
+			ScratchDiskSizeMb: 100,
+		},
+		ExecutorConfig: getExecutorConfig(t),
+	}
+	newContainer := func() *firecracker.FirecrackerContainer {
+		containerOpts := opts
+		containerOpts.ActionWorkingDirectory = testfs.MakeTempDir(t)
+		c, err := firecracker.NewContainer(ctx, env, &repb.ExecutionTask{}, containerOpts)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, c.Remove(context.Background()))
+		})
+		return c
+	}
+
+	// Sanity check: the image should not be cached yet.
+	coldContainer := newContainer()
+	cached, err := coldContainer.IsImageCached(ctx)
+	require.NoError(t, err)
+	require.False(t, cached)
+	require.Equal(t, int32(0), blobRequests.Load())
+
+	// Cache a chunked containerfs for the image, as a previous VM run would've.
+	loader, err := snaploader.New(env)
+	require.NoError(t, err)
+	const chunkSize = 512 * 1024
+	workDir := testfs.MakeTempDir(t)
+	// The chunk contents are arbitrary: no VM is booted here, so only the presence
+	// of the cache entry matters.
+	testfs.WriteRandomString(t, workDir, "containerfs.ext4", 4*chunkSize)
+	ext4Path := filepath.Join(workDir, "containerfs.ext4")
+	instanceName := coldContainer.SnapshotKeySet().GetBranchKey().GetInstanceName()
+	cow, err := snaploader.UnpackContainerImage(
+		ctx, loader, instanceName, imageRef, ext4Path,
+		testfs.MakeDirAll(t, workDir, "chunks"), chunkSize,
+		false /*=remoteEnabled*/)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cow.Close()
+	})
+
+	// A container for a subsequent task should now see the cached containerfs.
+	c := newContainer()
+	cached, err = c.IsImageCached(ctx)
+	require.NoError(t, err)
+	require.True(t, cached)
+
+	// Call PullImage, as a clean VM run would.
+	require.NoError(t, c.PullImage(ctx, oci.Credentials{}))
+
+	// Because the chunked containerfs is already cached, PullImage should not download the image layers
+	// from the registry.
+	require.Equal(t, int32(0), blobRequests.Load())
+	// The manifest should still have been fetched, in order to authenticate with the registry.
+	require.Greater(t, manifestRequests.Load(), int32(0))
+}
+
 func TestFirecrackerSnapshotAndResume(t *testing.T) {
 	// Test for both small and large memory sizes
 	for _, memorySize := range []int64{minMemSizeMB, 4000} {

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -1373,6 +1373,51 @@ func groupID(ctx context.Context, env environment.Env) (string, error) {
 	return gid, nil
 }
 
+// containerImageSnapshotKey returns the key under which the chunked
+// containerfs for the given container image is cached.
+//
+// TODO: use an Action for this key instead (to allow remote snapshot
+// sharing).
+func containerImageSnapshotKey(instanceName, imageRef string) *fcpb.SnapshotKeySet {
+	return &fcpb.SnapshotKeySet{BranchKey: &fcpb.SnapshotKey{
+		InstanceName:      instanceName,
+		ConfigurationHash: hashStrings("__UnpackContainerImage", imageRef),
+	}}
+}
+
+// GetCachedContainerImage returns the cached snapshot for the given
+// container image.
+func GetCachedContainerImage(ctx context.Context, l *FileCacheLoader, instanceName, imageRef string, remoteEnabled bool) (*Snapshot, error) {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+
+	snap, err := l.GetSnapshot(ctx, containerImageSnapshotKey(instanceName, imageRef), &GetSnapshotOptions{
+		SupportsRemoteManifest: remoteEnabled,
+		SupportsRemoteChunks:   remoteEnabled,
+		ReadPolicy:             platform.AlwaysReadNewestSnapshot,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return snap, nil
+}
+
+// UnpackContainerImageSnapshot returns a ChunkedFile from a container image snapshot.
+func UnpackContainerImageSnapshot(ctx context.Context, l *FileCacheLoader, snap *Snapshot, outDir string) (*copy_on_write.COWStore, error) {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+
+	unpacked, err := l.UnpackSnapshot(ctx, snap, outDir)
+	if err != nil {
+		return nil, err
+	}
+	cf := unpacked.ChunkedFiles[rootfsFileName]
+	if cf == nil {
+		return nil, status.InternalError("missing rootfs artifact in snapshot")
+	}
+	return cf, nil
+}
+
 // UnpackContainerImage returns a ChunkedFile representing the given container
 // image. The chunk dir is stored as a child directory of the given outDir.
 //
@@ -1382,31 +1427,12 @@ func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, instanceName,
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	// TODO: use an Action for this key instead (to allow remote snapshot
-	// sharing).
-	key := &fcpb.SnapshotKeySet{BranchKey: &fcpb.SnapshotKey{
-		InstanceName:      instanceName,
-		ConfigurationHash: hashStrings("__UnpackContainerImage", imageRef),
-	}}
-
-	snap, err := l.GetSnapshot(ctx, key, &GetSnapshotOptions{
-		SupportsRemoteManifest: remoteEnabled,
-		SupportsRemoteChunks:   remoteEnabled,
-		ReadPolicy:             platform.AlwaysReadNewestSnapshot,
-	})
+	snap, err := GetCachedContainerImage(ctx, l, instanceName, imageRef, remoteEnabled)
 	if err != nil && !(status.IsNotFoundError(err) || status.IsUnavailableError(err)) {
 		return nil, err
 	}
 	if snap != nil {
-		unpacked, err := l.UnpackSnapshot(ctx, snap, outDir)
-		if err != nil {
-			return nil, err
-		}
-		cf := unpacked.ChunkedFiles[rootfsFileName]
-		if cf == nil {
-			return nil, status.InternalError("missing rootfs artifact in snapshot")
-		}
-		return cf, nil
+		return UnpackContainerImageSnapshot(ctx, l, snap, outDir)
 	}
 	// containerfs is not available in cache; convert the EXT4 image to a
 	// ChunkedFile then add it to cache.
@@ -1423,6 +1449,7 @@ func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, instanceName,
 		CacheSnapshotLocally:  true,
 		WriteManifestLocally:  !remoteEnabled,
 	}
+	key := containerImageSnapshotKey(instanceName, imageRef)
 	if err := l.CacheSnapshot(ctx, key.GetBranchKey(), opts); err != nil {
 		return nil, status.WrapError(err, "cache containerfs snapshot")
 	}


### PR DESCRIPTION
Currently, for clean VMs (not started from a snapshot), we unconditionally pull the container image if it doesn't already exist locally. Later, when initializing the root filesystem, we try to lazily load the chunked image from the cache. If it's cached, the original image pull was wasted. This PR removes that pull