### PR TITLE
Add a metric for common DNS resolvers

### DIFF
--- a/enterprise/dns/server/server.go
+++ b/enterprise/dns/server/server.go
@@ -157,8 +157,9 @@ func (h *Handler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	}
 	defer func() {
 		metrics.DNSServerRequestCount.With(prometheus.Labels{
-			metrics.DNSRecordTypeLabel:   recordType,
-			metrics.DNSResponseCodeLabel: rcodeLabel(m.Rcode),
+			metrics.DNSRecordTypeLabel:       recordType,
+			metrics.DNSResponseCodeLabel:     rcodeLabel(m.Rcode),
+			metrics.DNSResolverProviderLabel: resolverProvider(w.RemoteAddr()),
 		}).Inc()
 		metrics.DNSServerHandlerDurationUsec.With(prometheus.Labels{
 			metrics.DNSRecordTypeLabel: recordType,
@@ -559,6 +560,39 @@ func rcodeLabel(rcode int) string {
 		return s
 	}
 	return "OTHER"
+}
+
+// resolverProvider classifies the recursive resolver that sent a query from
+// the transport peer's ASN organization. In particular, this deliberately does
+// not use EDNS Client Subnet: ECS identifies the end client on whose behalf a
+// resolver is querying, not the resolver itself. The returned set is fixed to
+// keep the Prometheus label cardinality bounded.
+func resolverProvider(remote net.Addr) string {
+	ip := addrFromNetAddr(remote)
+	if !ip.IsValid() {
+		return "unknown"
+	}
+	asn, err := maxmind.LookupASN(ip)
+	if err != nil {
+		log.Debugf("ASN lookup for DNS resolver %s failed: %s", ip, err)
+		return "unknown"
+	}
+	if asn.Number == 0 {
+		return "unknown"
+	}
+	organization := strings.ToLower(asn.Organization)
+	switch {
+	case strings.Contains(organization, "cloudflare"):
+		return "cloudflare"
+	case strings.Contains(organization, "google"):
+		return "google"
+	case strings.Contains(organization, "amazon"):
+		return "aws"
+	case strings.Contains(organization, "microsoft"):
+		return "azure"
+	default:
+		return "other"
+	}
 }
 
 func filterByType(records []dns.RR, qType uint16) []dns.RR {

--- a/enterprise/dns/server/server_test.go
+++ b/enterprise/dns/server/server_test.go
@@ -176,6 +176,17 @@ func TestRequestMetricResolverProvider(t *testing.T) {
 			assert.Equal(t, float64(1), got)
 		})
 	}
+
+	// Resolver-provider classification must use the transport peer, not ECS.
+	// Here Google is the advertised end-client network, while Cloudflare is the
+	// recursive resolver that actually sent the query.
+	serve(t, h, withECS(t, newQuery("cache.buildbuddy.io.", dns.TypeA), "8.8.8.8"), "1.1.1.1")
+	got := testutil.ToFloat64(metrics.DNSServerRequestCount.With(prometheus.Labels{
+		metrics.DNSRecordTypeLabel:       "A",
+		metrics.DNSResponseCodeLabel:     "NOERROR",
+		metrics.DNSResolverProviderLabel: "cloudflare",
+	}))
+	assert.Equal(t, float64(2), got)
 }
 
 // queryFromIP issues a query carrying an EDNS Client Subnet option advertising

--- a/enterprise/dns/server/server_test.go
+++ b/enterprise/dns/server/server_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/dns/server"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/experiments"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/util/maxmind"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -24,6 +25,8 @@ import (
 	"github.com/miekg/dns"
 	flagd "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg"
 	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 // zone is a small stand-in for the real buildbuddy.io zone, exercising exact
@@ -144,6 +147,35 @@ func serve(t *testing.T, h dns.Handler, req *dns.Msg, remoteIP string) *dns.Msg 
 func query(t *testing.T, h dns.Handler, name string, qType uint16) *dns.Msg {
 	t.Helper()
 	return serve(t, h, newQuery(name, qType), "")
+}
+
+func TestRequestMetricResolverProvider(t *testing.T) {
+	metrics.DNSServerRequestCount.Reset()
+	t.Cleanup(metrics.DNSServerRequestCount.Reset)
+	h := newTestHandler(t)
+
+	for _, tc := range []struct {
+		name     string
+		remoteIP string
+		provider string
+	}{
+		{name: "cloudflare", remoteIP: "1.1.1.1", provider: "cloudflare"},
+		{name: "google", remoteIP: "8.8.8.8", provider: "google"},
+		{name: "aws", remoteIP: "3.5.140.1", provider: "aws"},
+		{name: "azure", remoteIP: "20.0.0.1", provider: "azure"},
+		{name: "other", remoteIP: "9.9.9.9", provider: "other"},
+		{name: "unknown", provider: "unknown"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			serve(t, h, newQuery("cache.buildbuddy.io.", dns.TypeA), tc.remoteIP)
+			got := testutil.ToFloat64(metrics.DNSServerRequestCount.With(prometheus.Labels{
+				metrics.DNSRecordTypeLabel:       "A",
+				metrics.DNSResponseCodeLabel:     "NOERROR",
+				metrics.DNSResolverProviderLabel: tc.provider,
+			}))
+			assert.Equal(t, float64(1), got)
+		})
+	}
 }
 
 // queryFromIP issues a query carrying an EDNS Client Subnet option advertising

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -445,6 +445,10 @@ const (
 	// The DNS response code, such as "NOERROR", "NXDOMAIN", or "FORMERR".
 	DNSResponseCodeLabel = "rcode"
 
+	// The provider operating the recursive resolver that sent the query, inferred
+	// from the transport peer's ASN. Values are bounded by the DNS server.
+	DNSResolverProviderLabel = "resolver_provider"
+
 	// The apex of a served DNS zone, such as "buildbuddy.io.". Zones come from
 	// operator-controlled zone files, so cardinality is bounded. Named
 	// "dns_zone" because ZoneLabel ("zone") is the availability zone of a node.
@@ -4605,10 +4609,11 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "dns",
 		Name:      "server_request_count",
-		Help:      "The total number of DNS queries handled, by record type and response code.",
+		Help:      "The total number of DNS queries handled, by record type, response code, and recursive resolver provider.",
 	}, []string{
 		DNSRecordTypeLabel,
 		DNSResponseCodeLabel,
+		DNSResolverProviderLabel,
 	})
 
 	// #### Examples
@@ -4616,6 +4621,9 @@ var (
 	// ```promql
 	// # DNS queries per second by record type
 	// sum by (record_type) (rate(buildbuddy_dns_server_request_count[5m]))
+	//
+	// # DNS queries per second by recursive resolver provider
+	// sum by (resolver_provider) (rate(buildbuddy_dns_server_request_count[5m]))
 	//
 	// # NXDOMAIN rate
 	// sum(rate(buildbuddy_dns_server_request_count{rcode="NXDOMAIN"}[5m]))

--- a/tools/metrics/grafana/generated/nameserver/nameserver.go
+++ b/tools/metrics/grafana/generated/nameserver/nameserver.go
@@ -91,10 +91,17 @@ func qpsByRcodePanel() *timeseries.PanelBuilder {
 		WithTarget(q(rateBy("rcode"), "{{rcode}}"))
 }
 
+func qpsByResolverProviderPanel() *timeseries.PanelBuilder {
+	return dash.StackedTimeseries("Queries/sec by Recursive Resolver Provider", dash.UnitOps).
+		Description("DNS query rate by the provider operating the recursive resolver, inferred from the transport peer's ASN. Cloudflare, Google, AWS, and Azure are identified explicitly; all remaining public ASNs are grouped as other.").
+		GridPos(grid(8, 24, 0, 15)).
+		WithTarget(q(rateBy("resolver_provider"), "{{resolver_provider}}"))
+}
+
 func latencyPanel() *timeseries.PanelBuilder {
 	return dash.Timeseries("Handler Latency Percentiles", dash.UnitMicroseconds).
 		Description("Query handler latency percentiles.").
-		GridPos(grid(8, 12, 0, 15)).
+		GridPos(grid(8, 12, 0, 24)).
 		WithTarget(q(latencyQuantile("0.5"), "p50").RefId("A")).
 		WithTarget(q(latencyQuantile("0.9"), "p90").RefId("B")).
 		WithTarget(q(latencyQuantile("0.99"), "p99").RefId("C"))
@@ -103,7 +110,7 @@ func latencyPanel() *timeseries.PanelBuilder {
 func durationHeatmapPanel() *heatmap.PanelBuilder {
 	return dash.Heatmap("Handler Duration", dash.UnitMicroseconds).
 		Description("Distribution of query handler durations.").
-		GridPos(grid(8, 12, 12, 15)).
+		GridPos(grid(8, 12, 12, 24)).
 		WithTarget(dash.PromHeatmapQuery(`sum by (le) (rate(` + dur + `_bucket{` + filter + `}[` + window + `]))`).Interval(window).RefId("A"))
 }
 
@@ -112,7 +119,7 @@ func durationHeatmapPanel() *heatmap.PanelBuilder {
 func zoneSerialsStat() *stat.PanelBuilder {
 	return dash.Stat("Zones Served", dash.UnitNone).
 		Description("SOA serial of each zone currently served (max across replicas). A zone missing here is not being served at all.").
-		GridPos(grid(8, 12, 0, 24)).
+		GridPos(grid(8, 12, 0, 33)).
 		WithTarget(q(`max by (dns_zone) (`+serial+`{`+filter+`})`, "{{dns_zone}}"))
 }
 
@@ -122,7 +129,7 @@ func zoneSerialsStat() *stat.PanelBuilder {
 func zoneSerialByReplicaPanel() *timeseries.PanelBuilder {
 	return dash.Timeseries("Zone Serial by Replica", dash.UnitNone).
 		Description("SOA serial of each served zone, per replica. Divergence between replicas of the same zone means a stale or failed zone reload.").
-		GridPos(grid(8, 12, 12, 24)).
+		GridPos(grid(8, 12, 12, 33)).
 		WithTarget(q(`max by (dns_zone, instance) (`+serial+`{`+filter+`})`, "{{dns_zone}} {{instance}}"))
 }
 
@@ -163,10 +170,12 @@ func build() (dashboard.Dashboard, error) {
 		WithRow(rowAt("Traffic", 5)).
 		WithPanel(qpsByTypePanel()).
 		WithPanel(qpsByRcodePanel()).
-		WithRow(rowAt("Latency", 14)).
+		WithRow(rowAt("Recursive Resolvers", 14)).
+		WithPanel(qpsByResolverProviderPanel()).
+		WithRow(rowAt("Latency", 23)).
 		WithPanel(latencyPanel()).
 		WithPanel(durationHeatmapPanel()).
-		WithRow(rowAt("Zones", 23)).
+		WithRow(rowAt("Zones", 32)).
 		WithPanel(zoneSerialsStat()).
 		WithPanel(zoneSerialByReplicaPanel()).
 		Build()

--- a/tools/metrics/grafana/generated/nameserver/nameserver.go
+++ b/tools/metrics/grafana/generated/nameserver/nameserver.go
@@ -95,7 +95,7 @@ func qpsByResolverProviderPanel() *timeseries.PanelBuilder {
 	return dash.StackedTimeseries("Queries/sec by Recursive Resolver Provider", dash.UnitOps).
 		Description("DNS query rate by the provider operating the recursive resolver, inferred from the transport peer's ASN. Cloudflare, Google, AWS, and Azure are identified explicitly; all remaining public ASNs are grouped as other.").
 		GridPos(grid(8, 24, 0, 15)).
-		WithTarget(q(rateBy("resolver_provider"), "{{resolver_provider}}"))
+		WithTarget(q(`sum by (resolver_provider) (rate(`+reqs+`{resolver_provider=~".+", `+filter+`}[`+window+`]))`, "{{resolver_provider}}"))
 }
 
 func latencyPanel() *timeseries.PanelBuilder {


### PR DESCRIPTION
To ensure we know where most of our requests are coming from.