### PR TITLE
Set up basic pricing model for self-serve

### DIFF
--- a/enterprise/server/billing/pricing/BUILD
+++ b/enterprise/server/billing/pricing/BUILD
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "pricing",
+    srcs = ["pricing.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/billing/pricing",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//server/interfaces",
+        "//server/tables",
+        "//server/usage/sku",
+        "//server/util/db",
+    ],
+)
+
+go_test(
+    name = "pricing_test",
+    srcs = ["pricing_test.go"],
+    deps = [
+        ":pricing",
+        "//server/tables",
+        "//server/testutil/testenv",
+        "//server/usage/sku",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/server/billing/pricing/pricing.go
+++ b/enterprise/server/billing/pricing/pricing.go
@@ -1,0 +1,43 @@
+// Package pricing reads usage SKU prices from the BillingPrices table.
+package pricing
+
+import (
+	"context"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/tables"
+	"github.com/buildbuddy-io/buildbuddy/server/usage/sku"
+	"github.com/buildbuddy-io/buildbuddy/server/util/db"
+)
+
+// Price is the price of a SKU from EffectiveAt onward: PriceMicroDollars per
+// Quantity units of usage.
+type Price struct {
+	SKU               sku.SKU
+	EffectiveAt       time.Time
+	Quantity          int64
+	PriceMicroDollars int64
+}
+
+// PriceAt returns the price of a SKU in effect at the given time, or nil if
+// the SKU has no price.
+func PriceAt(ctx context.Context, dbh interfaces.DBHandle, s sku.SKU, at time.Time) (*Price, error) {
+	row := &tables.BillingPrice{}
+	err := dbh.NewQuery(ctx, "pricing_price_at").Raw(`
+		SELECT * FROM "BillingPrices"
+		WHERE sku = ? AND effective_at_usec <= ?
+		ORDER BY effective_at_usec DESC LIMIT 1`, s, at.UnixMicro()).Take(row)
+	if db.IsRecordNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &Price{
+		SKU:               row.SKU,
+		EffectiveAt:       time.UnixMicro(row.EffectiveAtUsec).UTC(),
+		Quantity:          row.Quantity,
+		PriceMicroDollars: row.PriceMicroDollars,
+	}, nil
+}

--- a/enterprise/server/billing/pricing/pricing_test.go
+++ b/enterprise/server/billing/pricing/pricing_test.go
@@ -1,0 +1,54 @@
+package pricing_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/billing/pricing"
+	"github.com/buildbuddy-io/buildbuddy/server/tables"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/usage/sku"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPriceAt(t *testing.T) {
+	te := testenv.GetTestEnv(t)
+	ctx := context.Background()
+	t0 := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(10 * 24 * time.Hour)
+	p1 := pricing.Price{SKU: sku.RemoteCacheCASHits, EffectiveAt: t0, Quantity: 1000, PriceMicroDollars: 1}
+	p2 := pricing.Price{SKU: sku.RemoteCacheCASHits, EffectiveAt: t1, Quantity: 1000, PriceMicroDollars: 2}
+	for id, p := range map[string]pricing.Price{"BP1": p1, "BP2": p2} {
+		require.NoError(t, te.GetDBHandle().NewQuery(ctx, "test_insert_price").Create(&tables.BillingPrice{
+			BillingPriceID:    id,
+			SKU:               p.SKU,
+			EffectiveAtUsec:   p.EffectiveAt.UnixMicro(),
+			Quantity:          p.Quantity,
+			PriceMicroDollars: p.PriceMicroDollars,
+		}))
+	}
+
+	for _, tc := range []struct {
+		name string
+		sku  sku.SKU
+		at   time.Time
+		want *pricing.Price
+	}{
+		{name: "before first price", sku: p1.SKU, at: t0.Add(-time.Hour), want: nil},
+		{name: "first price", sku: p1.SKU, at: t0, want: &p1},
+		{name: "between prices", sku: p1.SKU, at: t1.Add(-time.Hour), want: &p1},
+		{name: "latest price", sku: p1.SKU, at: t1.Add(time.Hour), want: &p2},
+		{name: "unpriced sku", sku: sku.BuildEventsBESCount, at: t1, want: nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := pricing.PriceAt(ctx, te.GetDBHandle(), tc.sku, tc.at)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+
+	require.Error(t, te.GetDBHandle().NewQuery(ctx, "test_insert_duplicate_price").Create(&tables.BillingPrice{
+		BillingPriceID: "BP3", SKU: p1.SKU, EffectiveAtUsec: t0.UnixMicro(), Quantity: 1, PriceMicroDollars: 1,
+	}))
+}

--- a/server/tables/BUILD
+++ b/server/tables/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//proto:group_go_proto",
         "//proto:usage_go_proto",
         "//proto:user_id_go_proto",
+        "//server/usage/sku",
         "//server/util/flag",
         "//server/util/log",
         "//server/util/random",

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/buildbuddy-io/buildbuddy/server/usage/sku"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
@@ -1035,6 +1036,22 @@ func (*IPRule) TableName() string {
 	return "IPRules"
 }
 
+// BillingPrice is the price of a usage SKU from EffectiveAtUsec onward. To
+// change a price, insert a new row with a later effective time.
+type BillingPrice struct {
+	Model
+	BillingPriceID string `gorm:"primaryKey"`
+
+	SKU               sku.SKU `gorm:"not null;uniqueIndex:billing_price_sku_effective_at_idx,priority:1"`
+	EffectiveAtUsec   int64   `gorm:"not null;uniqueIndex:billing_price_sku_effective_at_idx,priority:2"`
+	Quantity          int64   `gorm:"not null"`
+	PriceMicroDollars int64   `gorm:"not null"`
+}
+
+func (*BillingPrice) TableName() string {
+	return "BillingPrices"
+}
+
 type PostAutoMigrateLogic func() error
 
 // Manual migration called before auto-migration.
@@ -1521,6 +1538,7 @@ func RegisterTables() {
 	// Keep these sorted by two-letter prefix (and when adding new tables,
 	// use a unique prefix if possible):
 	registerTable("AK", &APIKey{})
+	registerTable("BP", &BillingPrice{})
 	registerTable("CA", &CacheEntry{})
 	registerTable("CL", &CacheLog{})
 	registerTable("EK", &EncryptionKey{})


### PR DESCRIPTION
This adds a basic data model for usage-based billing: a BillingPrices table keyed by usage SKU, and a pricing package that looks up the price of a SKU in effect at a given time. 

Prices are per SKU and apply to every usage-based customer. Customers needing custom billing are handled as enterprise. We can add GroupID to the table later, with a default, but this is out of scope to start. 

Each row is the price from an effective time onward, so a price change is an insert rather than an update and past periods stay reproducible. Billing computation, enforcement, and payment collection are separate follow-ups.