### PR TITLE
Check group status in the RPC capabilities filter

### DIFF
--- a/server/capabilities_filter/BUILD
+++ b/server/capabilities_filter/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//proto:buildbuddy_service_go_proto",
         "//proto:capability_go_proto",
+        "//proto:group_go_proto",
         "//proto/api/v1:api_v1_go_proto",
         "//server/environment",
         "//server/util/capabilities",
@@ -25,6 +26,7 @@ go_test(
         "//proto:buildbuddy_service_go_proto",
         "//proto:capability_go_proto",
         "//proto:context_go_proto",
+        "//proto:group_go_proto",
         "//proto/api/v1:api_v1_go_proto",
         "//server/testutil/testauth",
         "//server/testutil/testenv",

--- a/server/capabilities_filter/capabilities_filter.go
+++ b/server/capabilities_filter/capabilities_filter.go
@@ -13,6 +13,7 @@ import (
 	apipb "github.com/buildbuddy-io/buildbuddy/proto/api/v1"
 	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
 	cappb "github.com/buildbuddy-io/buildbuddy/proto/capability"
+	grpb "github.com/buildbuddy-io/buildbuddy/proto/group"
 )
 
 var (
@@ -306,6 +307,9 @@ func AuthorizeRPC(ctx context.Context, env environment.Env, rpcName string) erro
 	u, err := env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err == nil {
 		groupID = u.GetGroupID()
+		if u.GetGroupStatus() == grpb.Group_BLOCKED_GROUP_STATUS && !u.IsImpersonating() && rpcName != buildBuddyServicePrefix+"GetUser" {
+			return status.PermissionDeniedError("permission denied")
+		}
 	}
 
 	if !slices.Contains(AllowedRPCs(ctx, env, groupID), rpcName) {

--- a/server/capabilities_filter/capabilities_filter_test.go
+++ b/server/capabilities_filter/capabilities_filter_test.go
@@ -16,6 +16,7 @@ import (
 	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
 	cappb "github.com/buildbuddy-io/buildbuddy/proto/capability"
 	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
+	grpb "github.com/buildbuddy-io/buildbuddy/proto/group"
 )
 
 var (
@@ -258,6 +259,39 @@ func TestAllowedRPCs(t *testing.T) {
 			} else {
 				assert.Error(t, authErr)
 				assert.NotContains(t, allowedRPCs, test.RPC)
+			}
+		})
+	}
+}
+
+func TestAuthorizeRPC_GroupStatus(t *testing.T) {
+	for _, test := range []struct {
+		Name          string
+		RPC           string
+		Status        grpb.Group_GroupStatus
+		Impersonating bool
+		Allowed       bool
+	}{
+		{Name: "Blocked_GetUser_Allowed", RPC: buildBuddyServicePrefix + "GetUser", Status: grpb.Group_BLOCKED_GROUP_STATUS, Allowed: true},
+		{Name: "Blocked_GetInvocation_NotAllowed", RPC: buildBuddyServicePrefix + "GetInvocation", Status: grpb.Group_BLOCKED_GROUP_STATUS, Allowed: false},
+		{Name: "Blocked_SearchInvocation_NotAllowed", RPC: buildBuddyServicePrefix + "SearchInvocation", Status: grpb.Group_BLOCKED_GROUP_STATUS, Allowed: false},
+		{Name: "Blocked_Impersonating_Allowed", RPC: buildBuddyServicePrefix + "SearchInvocation", Status: grpb.Group_BLOCKED_GROUP_STATUS, Impersonating: true, Allowed: true},
+		{Name: "FreeTier_SearchInvocation_Allowed", RPC: buildBuddyServicePrefix + "SearchInvocation", Status: grpb.Group_FREE_TIER_GROUP_STATUS, Allowed: true},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			env := testenv.GetTestEnv(t)
+			users := testauth.TestUsers("US1", "GR1")
+			env.SetAuthenticator(testauth.NewTestAuthenticator(t, users))
+			u := users["US1"].(*testauth.TestUser)
+			u.GroupStatus = test.Status
+			u.Impersonating = test.Impersonating
+			ctx := testauth.WithAuthenticatedUserInfo(context.Background(), u)
+
+			err := capabilities_filter.AuthorizeRPC(ctx, env, test.RPC)
+			if test.Allowed {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
The existing group status check only runs in the gRPC interceptors, so it only applies to API key requests. The web app calls RPCs over HTTP at `/rpc/`, which does not go through those interceptors. 

This adds the check to the capabilities filter, which every RPC goes through on both the HTTP and gRPC paths. GetUser is left open so the app can still load and users can switch organizations or log out. Impersonation is not affected.

This will prevent blocked users from accessing the UI