### PR TITLE
Add a group billing status

### DIFF
--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -190,6 +190,7 @@ type apiKeyGroup struct {
 	EnforceIPRules         bool
 	Impersonation          bool
 	Status                 int32
+	BillingStatus          int32
 }
 
 func (g *apiKeyGroup) GetAPIKeyID() string {
@@ -236,6 +237,10 @@ func (g *apiKeyGroup) GetGroupStatus() grpb.Group_GroupStatus {
 	return grpb.Group_GroupStatus(g.Status)
 }
 
+func (g *apiKeyGroup) GetBillingStatus() grpb.Group_BillingStatus {
+	return grpb.Group_BillingStatus(g.BillingStatus)
+}
+
 // apiKeyGroupRow contains a single row from a DB lookup for an API key.
 // The data contains columns from both the APIKey and Group tables.
 // toAPIKeyGroup converts the data to the more compact apiKeyGroup
@@ -250,6 +255,7 @@ type apiKeyGroupRow struct {
 	EnforceIPRules         bool
 	IsParent               bool
 	GroupStatus            int32 `gorm:"column:group_status"`
+	BillingStatus          int32 `gorm:"column:billing_status"`
 	// Role from direct group membership for user-owned keys.
 	DirectMembershipRole *uint32 `gorm:"column:direct_membership_role"`
 	// Role from indirect membership via user lists for user-owned keys.
@@ -268,6 +274,7 @@ func (r *apiKeyGroupRow) toAPIKeyGroup() *apiKeyGroup {
 		EnforceIPRules:         r.EnforceIPRules,
 		Impersonation:          r.Impersonation,
 		Status:                 r.GroupStatus,
+		BillingStatus:          r.BillingStatus,
 	}
 }
 
@@ -650,7 +657,8 @@ func (d *AuthDB) newAPIKeyLookupQuery(subDomain string) *query_builder.Query {
 			g.cache_encryption_enabled,
 			g.enforce_ip_rules,
 			g.is_parent,
-			g.status AS group_status
+			g.status AS group_status,
+			g.billing_status
 		FROM "APIKeys" AS ak
 		JOIN "Groups" AS g ON ak.group_id = g.group_id
 		LEFT JOIN "UserGroups" AS ug

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -248,7 +248,7 @@ func main() {
 	if err := quota.Register(realEnv); err != nil {
 		log.Fatalf("%v", err)
 	}
-	realEnv.SetGroupStatusChecker(groupstatus.New())
+	realEnv.SetGroupStatusChecker(groupstatus.New(realEnv))
 
 	if err := redis_client.RegisterRemoteExecutionRedisClient(realEnv); err != nil {
 		log.Fatalf("%v", err)

--- a/proto/grp.proto
+++ b/proto/grp.proto
@@ -125,6 +125,19 @@ message Group {
 
   // The status of the group.
   GroupStatus status = 21;
+
+  enum BillingStatus {
+    UNKNOWN_BILLING_STATUS = 0;
+
+    // The group is in good standing.
+    OK_BILLING_STATUS = 1;
+
+    // The group has used up its usage allowance for the current period.
+    USAGE_LIMIT_EXCEEDED_BILLING_STATUS = 2;
+  }
+
+  // The billing status of the group.
+  BillingStatus billing_status = 22;
 }
 
 message JoinGroupRequest {

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -371,6 +371,7 @@ func makeGroups(groupRoles []*tables.GroupRole) ([]*grpb.Group, error) {
 			ExternalUserManagement:            g.ExternalUserManagement,
 			AllowedUserApiKeyCapabilities:     allowedUserAPIKeyCapabilities,
 			Status:                            g.Status,
+			BillingStatus:                     g.BillingStatus,
 		})
 	}
 	return groups, nil

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -141,6 +141,7 @@ type UserInfo interface {
 	GetCacheEncryptionEnabled() bool
 	GetEnforceIPRules() bool
 	GetGroupStatus() grpb.Group_GroupStatus
+	GetBillingStatus() grpb.Group_BillingStatus
 	// IsCustomerSSO indicates whether the user logged in via a customer SSO integration (SAML/OIDC).
 	IsCustomerSSO() bool
 }
@@ -511,6 +512,7 @@ type APIKeyGroup interface {
 	GetEnforceIPRules() bool
 	IsImpersonating() bool
 	GetGroupStatus() grpb.Group_GroupStatus
+	GetBillingStatus() grpb.Group_BillingStatus
 }
 
 type AuthDB interface {
@@ -1514,7 +1516,7 @@ type DistributedLock interface {
 // GroupStatusChecker rejects API requests from groups whose status does not
 // allow them.
 type GroupStatusChecker interface {
-	CheckAllowed(ctx context.Context) error
+	CheckAllowed(ctx context.Context, method string) error
 }
 
 // QuotaManager manages quota.

--- a/server/rpc/interceptors/interceptors.go
+++ b/server/rpc/interceptors/interceptors.go
@@ -478,7 +478,7 @@ func logRequestStreamServerInterceptor() grpc.StreamServerInterceptor {
 func groupStatusUnaryServerInterceptor(env environment.Env) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		if gs := env.GetGroupStatusChecker(); gs != nil {
-			if err := gs.CheckAllowed(ctx); err != nil {
+			if err := gs.CheckAllowed(ctx, info.FullMethod); err != nil {
 				return nil, err
 			}
 		}
@@ -489,7 +489,7 @@ func groupStatusUnaryServerInterceptor(env environment.Env) grpc.UnaryServerInte
 func groupStatusStreamServerInterceptor(env environment.Env) grpc.StreamServerInterceptor {
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if gs := env.GetGroupStatusChecker(); gs != nil {
-			if err := gs.CheckAllowed(stream.Context()); err != nil {
+			if err := gs.CheckAllowed(stream.Context(), info.FullMethod); err != nil {
 				return err
 			}
 		}

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -274,6 +274,10 @@ type Group struct {
 	// The status of the group: free tier, enterprise, etc.
 	Status grpb.Group_GroupStatus `gorm:"not null;default:1"`
 
+	// The billing state of the group, such as having exceeded its usage
+	// allowance. Independent of Status.
+	BillingStatus grpb.Group_BillingStatus `gorm:"not null;default:1"`
+
 	// Information about the request that created this group. The user agent
 	// size must be at least useragent.MaxLength, otherwise MySQL defaults to
 	// varchar(255) and rejects longer values.

--- a/server/util/claims/claims.go
+++ b/server/util/claims/claims.go
@@ -157,6 +157,7 @@ type Claims struct {
 	CacheEncryptionEnabled bool                          `json:"cache_encryption_enabled,omitempty"`
 	EnforceIPRules         bool                          `json:"enforce_ip_rules,omitempty"`
 	GroupStatus            grpb.Group_GroupStatus        `json:"group_status,omitempty"`
+	BillingStatus          grpb.Group_BillingStatus      `json:"billing_status,omitempty"`
 	// TODO(vadim): remove this field
 	SAML        bool `json:"saml,omitempty"`
 	CustomerSSO bool `json:"customer_sso,omitempty"`
@@ -222,6 +223,10 @@ func (c *Claims) GetEnforceIPRules() bool {
 
 func (c *Claims) GetGroupStatus() grpb.Group_GroupStatus {
 	return grpb.Group_GroupStatus(c.GroupStatus)
+}
+
+func (c *Claims) GetBillingStatus() grpb.Group_BillingStatus {
+	return c.BillingStatus
 }
 
 func (c *Claims) IsSAML() bool {
@@ -329,6 +334,7 @@ func APIKeyGroupClaims(ctx context.Context, akg interfaces.APIKeyGroup) (*Claims
 		EnforceIPRules:             akg.GetEnforceIPRules(),
 		Impersonating:              akg.IsImpersonating(),
 		GroupStatus:                akg.GetGroupStatus(),
+		BillingStatus:              akg.GetBillingStatus(),
 	}, nil
 }
 
@@ -409,6 +415,7 @@ func userClaims(u *tables.User, effectiveGroup string) (*Claims, error) {
 	cacheEncryptionEnabled := false
 	enforceIPRules := false
 	groupStatus := grpb.Group_UNKNOWN_GROUP_STATUS
+	billingStatus := grpb.Group_UNKNOWN_BILLING_STATUS
 	var capabilities []cappb.Capability
 	for _, g := range u.Groups {
 		allowedGroups = append(allowedGroups, g.Group.GroupID)
@@ -421,6 +428,7 @@ func userClaims(u *tables.User, effectiveGroup string) (*Claims, error) {
 			cacheEncryptionEnabled = g.Group.CacheEncryptionEnabled
 			enforceIPRules = g.Group.EnforceIPRules
 			groupStatus = g.Group.Status
+			billingStatus = g.Group.BillingStatus
 			capabilities = g.Capabilities
 		}
 	}
@@ -433,6 +441,7 @@ func userClaims(u *tables.User, effectiveGroup string) (*Claims, error) {
 		CacheEncryptionEnabled: cacheEncryptionEnabled,
 		EnforceIPRules:         enforceIPRules,
 		GroupStatus:            groupStatus,
+		BillingStatus:          billingStatus,
 	}, nil
 }
 

--- a/server/util/claims/claims_test.go
+++ b/server/util/claims/claims_test.go
@@ -105,6 +105,7 @@ type fakeAPIKeyGroup struct {
 	enforceIPRules         bool
 	impersonation          bool
 	groupStatus            grpb.Group_GroupStatus
+	billingStatus          grpb.Group_BillingStatus
 }
 
 func (f *fakeAPIKeyGroup) GetCapabilities() int32 {
@@ -145,6 +146,10 @@ func (f *fakeAPIKeyGroup) IsImpersonating() bool {
 
 func (f *fakeAPIKeyGroup) GetGroupStatus() grpb.Group_GroupStatus {
 	return f.groupStatus
+}
+
+func (f *fakeAPIKeyGroup) GetBillingStatus() grpb.Group_BillingStatus {
+	return f.billingStatus
 }
 
 func TestAPIKeyGroupClaimsWithRequestContext(t *testing.T) {

--- a/server/util/groupstatus/BUILD
+++ b/server/util/groupstatus/BUILD
@@ -7,6 +7,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:group_go_proto",
+        "//proto:remote_asset_go_proto",
+        "//proto:remote_execution_go_proto",
+        "//server/environment",
         "//server/interfaces",
         "//server/util/claims",
         "//server/util/status",
@@ -18,9 +21,13 @@ go_test(
     srcs = ["groupstatus_test.go"],
     deps = [
         ":groupstatus",
+        "//enterprise/server/experiments",
         "//proto:group_go_proto",
         "//server/testutil/testauth",
+        "//server/testutil/testenv",
         "//server/util/claims",
+        "@com_github_open_feature_go_sdk//openfeature",
+        "@com_github_open_feature_go_sdk//openfeature/memprovider",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/util/groupstatus/groupstatus.go
+++ b/server/util/groupstatus/groupstatus.go
@@ -4,28 +4,52 @@ package groupstatus
 
 import (
 	"context"
+	"strings"
 
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	grpb "github.com/buildbuddy-io/buildbuddy/proto/group"
+	rapb "github.com/buildbuddy-io/buildbuddy/proto/remote_asset"
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+const (
+	// restrictFreeTierExceededFlag enables rejecting requests from free tier
+	// groups that have exceeded their usage limit.
+	restrictFreeTierExceededFlag = "groupstatus.restrict_free_tier_exceeded"
 )
 
 var (
-	errBlocked = status.UnavailableError("there was an issue with your request - please contact support at https://buildbuddy.io/contact")
+	errBlocked          = status.UnavailableError("there was an issue with your request - please contact support at https://buildbuddy.io/contact")
+	errFreeTierExceeded = status.FailedPreconditionError("free tier usage limit reached - add a payment method at https://app.buildbuddy.io/settings/ to continue")
+
+	// usageLimitedServices are unavailable to groups that have exceeded
+	// their usage limit.
+	usageLimitedServices = []string{
+		"/google.bytestream.ByteStream/",
+		"/" + repb.ContentAddressableStorage_ServiceDesc.ServiceName + "/",
+		"/" + repb.ActionCache_ServiceDesc.ServiceName + "/",
+		"/" + repb.Execution_ServiceDesc.ServiceName + "/",
+		"/" + rapb.Fetch_ServiceDesc.ServiceName + "/",
+		"/" + rapb.Push_ServiceDesc.ServiceName + "/",
+	}
 )
 
-type checker struct{}
+type checker struct {
+	env environment.Env
+}
 
-func New() interfaces.GroupStatusChecker {
-	return &checker{}
+func New(env environment.Env) interfaces.GroupStatusChecker {
+	return &checker{env: env}
 }
 
 // CheckAllowed returns an error if the authenticated group's status does not
-// allow it to make API requests. Requests from the web UI and impersonating
-// requests are always allowed.
-func (c *checker) CheckAllowed(ctx context.Context) error {
+// allow it to call the given RPC method. Requests from the web UI and
+// impersonating requests are always allowed.
+func (c *checker) CheckAllowed(ctx context.Context, method string) error {
 	cl, err := claims.ClaimsFromContext(ctx)
 	if err != nil {
 		return nil
@@ -36,5 +60,22 @@ func (c *checker) CheckAllowed(ctx context.Context) error {
 	if cl.GetGroupStatus() == grpb.Group_BLOCKED_GROUP_STATUS {
 		return errBlocked
 	}
+	if cl.GetGroupStatus() == grpb.Group_FREE_TIER_GROUP_STATUS && cl.GetBillingStatus() == grpb.Group_USAGE_LIMIT_EXCEEDED_BILLING_STATUS && isUsageLimited(method) && c.restrictFreeTierExceeded(ctx) {
+		return errFreeTierExceeded
+	}
 	return nil
+}
+
+func (c *checker) restrictFreeTierExceeded(ctx context.Context) bool {
+	fp := c.env.GetExperimentFlagProvider()
+	return fp != nil && fp.Boolean(ctx, restrictFreeTierExceededFlag, false)
+}
+
+func isUsageLimited(method string) bool {
+	for _, prefix := range usageLimitedServices {
+		if strings.HasPrefix(method, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/server/util/groupstatus/groupstatus_test.go
+++ b/server/util/groupstatus/groupstatus_test.go
@@ -4,29 +4,63 @@ import (
 	"context"
 	"testing"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/experiments"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/groupstatus"
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	"github.com/stretchr/testify/require"
 
 	grpb "github.com/buildbuddy-io/buildbuddy/proto/group"
 )
 
+const (
+	casRead = "/build.bazel.remote.execution.v2.ContentAddressableStorage/BatchReadBlobs"
+	execute = "/build.bazel.remote.execution.v2.Execution/Execute"
+	fetch   = "/build.bazel.remote.asset.v1.Fetch/FetchBlob"
+	bes     = "/google.devtools.build.v1.PublishBuildEvent/PublishBuildToolEventStream"
+	getUser = "/buildbuddy.service.BuildBuddyService/GetUser"
+)
+
 func TestCheckAllowed(t *testing.T) {
+	env := testenv.GetTestEnv(t)
 	ctx := context.Background()
-	checker := groupstatus.New()
+	checker := groupstatus.New(env)
+	blocked := claims.Claims{APIKeyID: "AK1", UserID: "US1", GroupID: "GR1", GroupStatus: grpb.Group_BLOCKED_GROUP_STATUS}
+	exceeded := claims.Claims{APIKeyID: "AK1", UserID: "US1", GroupID: "GR1", GroupStatus: grpb.Group_FREE_TIER_GROUP_STATUS, BillingStatus: grpb.Group_USAGE_LIMIT_EXCEEDED_BILLING_STATUS}
+
+	require.Error(t, checker.CheckAllowed(testauth.WithAuthenticatedUserInfo(ctx, &blocked), casRead))
+	require.NoError(t, checker.CheckAllowed(testauth.WithAuthenticatedUserInfo(ctx, &exceeded), casRead))
+
+	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		"groupstatus.restrict_free_tier_exceeded": {State: memprovider.Enabled, DefaultVariant: "on", Variants: map[string]any{"on": true}},
+	})))
+	fp, err := experiments.NewFlagProvider(t.Name())
+	require.NoError(t, err)
+	env.SetExperimentFlagProvider(fp)
+
 	for _, tc := range []struct {
 		name    string
 		claims  claims.Claims
+		method  string
 		allowed bool
 	}{
-		{name: "blocked", claims: claims.Claims{APIKeyID: "AK1", UserID: "US1", GroupID: "GR1", GroupStatus: grpb.Group_BLOCKED_GROUP_STATUS}, allowed: false},
-		{name: "free tier", claims: claims.Claims{APIKeyID: "AK1", UserID: "US1", GroupID: "GR1", GroupStatus: grpb.Group_FREE_TIER_GROUP_STATUS}, allowed: true},
-		{name: "blocked without API key", claims: claims.Claims{UserID: "US1", GroupID: "GR1", GroupStatus: grpb.Group_BLOCKED_GROUP_STATUS}, allowed: true},
-		{name: "blocked while impersonating", claims: claims.Claims{APIKeyID: "AK1", UserID: "US1", GroupID: "GR1", GroupStatus: grpb.Group_BLOCKED_GROUP_STATUS, Impersonating: true}, allowed: true},
+		{name: "blocked", claims: blocked, method: casRead, allowed: false},
+		{name: "blocked BES", claims: blocked, method: bes, allowed: false},
+		{name: "blocked without API key", claims: claims.Claims{UserID: "US1", GroupID: "GR1", GroupStatus: grpb.Group_BLOCKED_GROUP_STATUS}, method: casRead, allowed: true},
+		{name: "blocked while impersonating", claims: claims.Claims{APIKeyID: "AK1", UserID: "US1", GroupID: "GR1", GroupStatus: grpb.Group_BLOCKED_GROUP_STATUS, Impersonating: true}, method: casRead, allowed: true},
+		{name: "free tier", claims: claims.Claims{APIKeyID: "AK1", UserID: "US1", GroupID: "GR1", GroupStatus: grpb.Group_FREE_TIER_GROUP_STATUS}, method: casRead, allowed: true},
+		{name: "exceeded cache", claims: exceeded, method: casRead, allowed: false},
+		{name: "exceeded execution", claims: exceeded, method: execute, allowed: false},
+		{name: "exceeded remote asset", claims: exceeded, method: fetch, allowed: false},
+		{name: "exceeded BES", claims: exceeded, method: bes, allowed: true},
+		{name: "exceeded app RPC", claims: exceeded, method: getUser, allowed: true},
+		{name: "exceeded enterprise", claims: claims.Claims{APIKeyID: "AK1", UserID: "US1", GroupID: "GR1", GroupStatus: grpb.Group_ENTERPRISE_GROUP_STATUS, BillingStatus: grpb.Group_USAGE_LIMIT_EXCEEDED_BILLING_STATUS}, method: casRead, allowed: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := checker.CheckAllowed(testauth.WithAuthenticatedUserInfo(ctx, &tc.claims))
+			err := checker.CheckAllowed(testauth.WithAuthenticatedUserInfo(ctx, &tc.claims), tc.method)
 			if tc.allowed {
 				require.NoError(t, err)
 			} else {
@@ -34,5 +68,5 @@ func TestCheckAllowed(t *testing.T) {
 			}
 		})
 	}
-	require.NoError(t, checker.CheckAllowed(ctx))
+	require.NoError(t, checker.CheckAllowed(ctx, casRead))
 }


### PR DESCRIPTION
Adds a billing status field to groups, separate from group status. 

Group status is the tier, billing status is the current account state, and the two are independent so a group in any tier can be marked as having exceeded its usage limit. 

Free tier groups that have exceeded their usage limit can be rejected and told to add a payment method, behind the flag which is off by default.