### PR TITLE
Fix handling of invalid digests in metacache.FindMissing

### DIFF
--- a/enterprise/server/backends/metacache/metacache.go
+++ b/enterprise/server/backends/metacache/metacache.go
@@ -543,23 +543,38 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*rspb.ResourceName)
 	}
 	groupID := c.userGroupID(ctx)
 	req := &mdpb.FindRequest{
-		FileRecords: make([]*sgpb.FileRecord, len(resources)),
+		FileRecords: make([]*sgpb.FileRecord, 0, len(resources)),
 	}
+	// Resources with invalid digests are reported as missing rather than
+	// failing the whole batch. They are excluded from the Find request.
+	var missing []*repb.Digest
+	// requestedResources aliases resources until the first invalid digest,
+	// then diverges to a copy holding only the valid ones, so it stays
+	// index-aligned with req.FileRecords (and the FindResponses).
+	requestedResources := resources
 	for i, r := range resources {
 		fileRecord, err := c.makeFileRecord(groupID, encryption, r)
 		if err != nil {
-			return nil, err
+			missing = append(missing, r.GetDigest())
+			if len(requestedResources) == len(resources) {
+				// First invalid digest: all prior resources were valid,
+				// so seed the copy with them.
+				requestedResources = append(make([]*rspb.ResourceName, 0, len(resources)-1), resources[:i]...)
+			}
+			continue
 		}
-		req.FileRecords[i] = fileRecord
+		if len(requestedResources) != len(resources) {
+			requestedResources = append(requestedResources, r)
+		}
+		req.FileRecords = append(req.FileRecords, fileRecord)
 	}
 	rsp, err := c.opts.MetadataClient.Find(ctx, req)
 	if err != nil {
 		return nil, err
 	}
-	missing := make([]*repb.Digest, 0)
 	for i, findRsp := range rsp.GetFindResponses() {
 		if !findRsp.GetPresent() {
-			missing = append(missing, resources[i].GetDigest())
+			missing = append(missing, requestedResources[i].GetDigest())
 		}
 	}
 	return missing, nil

--- a/enterprise/server/backends/metacache/metacache.go
+++ b/enterprise/server/backends/metacache/metacache.go
@@ -568,11 +568,20 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*rspb.ResourceName)
 		}
 		req.FileRecords = append(req.FileRecords, fileRecord)
 	}
+	if len(req.GetFileRecords()) == 0 {
+		return missing, nil // no valid digests to check
+	}
 	rsp, err := c.opts.MetadataClient.Find(ctx, req)
 	if err != nil {
 		return nil, err
 	}
-	for i, findRsp := range rsp.GetFindResponses() {
+	responses := rsp.GetFindResponses()
+	if len(responses) != len(requestedResources) {
+		// Aligned 1:1 is the server contract; a mismatch is a server bug.
+		log.CtxErrorf(ctx, "[%s] FindMissing metadata length %d != request length %d", c.opts.Name, len(responses), len(requestedResources))
+		return nil, status.InternalErrorf("metadata response length %d does not match request length %d", len(responses), len(requestedResources))
+	}
+	for i, findRsp := range responses {
 		if !findRsp.GetPresent() {
 			missing = append(missing, requestedResources[i].GetDigest())
 		}

--- a/enterprise/server/backends/metacache/metacache_test.go
+++ b/enterprise/server/backends/metacache/metacache_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/kms"
@@ -194,6 +195,73 @@ func TestFindMissing(t *testing.T) {
 			require.Empty(t, missing)
 		})
 	}
+}
+
+// Invalid digests can't be looked up, so FindMissing must report them as
+// missing (like pebble_cache does) rather than failing the whole batch.
+func TestFindMissingWithInvalidDigests(t *testing.T) {
+	te := testenv.GetTestEnv(t)
+	te.SetAuthenticator(testauth.NewTestAuthenticator(t, emptyUserMap))
+	ctx := getAnonContext(t, te)
+	clock := clockwork.NewFakeClock()
+
+	options := metacache.Options{
+		Name: "TestFindMissingWithInvalidDigests",
+
+		MaxInlineFileSizeBytes:      1000,
+		MinBytesAutoZstdCompression: 100,
+
+		GCSTTLDays: 1,
+	}
+	bc := runMetacache(t, te, clock, options)
+
+	present, buf := testdigest.RandomCASResourceBuf(t, 100)
+	require.NoError(t, bc.Set(ctx, present, buf))
+	absent, _ := testdigest.RandomCASResourceBuf(t, 100)
+
+	badHashLength := &rspb.ResourceName{
+		Digest:         &repb.Digest{Hash: "invalid-hash", SizeBytes: 100},
+		CacheType:      rspb.CacheType_CAS,
+		DigestFunction: repb.DigestFunction_SHA256,
+	}
+	notHex := &rspb.ResourceName{
+		Digest: &repb.Digest{
+			Hash:      "ZZZZc44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			SizeBytes: 100,
+		},
+		CacheType:      rspb.CacheType_CAS,
+		DigestFunction: repb.DigestFunction_SHA256,
+	}
+	negativeSize := &rspb.ResourceName{
+		Digest: &repb.Digest{
+			Hash:      strings.Repeat("a", 64),
+			SizeBytes: -1,
+		},
+		CacheType:      rspb.CacheType_CAS,
+		DigestFunction: repb.DigestFunction_SHA256,
+	}
+
+	// Interleave invalid digests between valid ones so a positional bug
+	// would misattribute or run off the end of the responses.
+	rns := []*rspb.ResourceName{badHashLength, present, notHex, absent, negativeSize}
+	missing, err := bc.FindMissing(ctx, rns)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []*repb.Digest{
+		badHashLength.GetDigest(),
+		notHex.GetDigest(),
+		absent.GetDigest(),
+		negativeSize.GetDigest(),
+	}, missing)
+
+	// A batch with only invalid digests reports all of them missing.
+	missing, err = bc.FindMissing(ctx, []*rspb.ResourceName{badHashLength, notHex})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []*repb.Digest{badHashLength.GetDigest(), notHex.GetDigest()}, missing)
+
+	// Contains goes through FindMissing and must say false, not error.
+	contains, err := bc.Contains(ctx, badHashLength)
+	require.NoError(t, err)
+	require.False(t, contains)
 }
 
 func generateKMSKey(t *testing.T, kmsDir string, id string) string {


### PR DESCRIPTION
Pebble cache treats these as missing, so do the same.