### PR TITLE
Fix a bug in bazelcache prober

### DIFF
--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -38,7 +38,6 @@ type resourceNameType int
 
 const (
 	EmptySha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-	EmptyHash   = ""
 
 	uploadResourceName resourceNameType = iota
 	downloadResourceName
@@ -210,7 +209,7 @@ func Validate(d *repb.Digest, digestFunction repb.DigestFunction_Value) error {
 	if d.GetSizeBytes() < 0 {
 		return status.InvalidArgumentErrorf("Invalid (negative) digest size")
 	}
-	if d.GetSizeBytes() == int64(0) {
+	if d.GetSizeBytes() == 0 {
 		if IsEmptyHash(d, digestFunction) {
 			return nil
 		}
@@ -411,7 +410,7 @@ func IsEmptyHash(d *repb.Digest, digestFunction repb.DigestFunction_Value) bool 
 	case repb.DigestFunction_MD5:
 		return d.GetHash() == "d41d8cd98f00b204e9800998ecf8427e"
 	case repb.DigestFunction_SHA256:
-		return d.GetHash() == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+		return d.GetHash() == EmptySha256
 	case repb.DigestFunction_SHA384:
 		return d.GetHash() == "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
 	case repb.DigestFunction_SHA512:

--- a/tools/probers/bazelcache/bazelcache.go
+++ b/tools/probers/bazelcache/bazelcache.go
@@ -364,7 +364,7 @@ func (p *prober) warmup() error {
 		_, err := p.cas.FindMissingBlobs(ctx, &repb.FindMissingBlobsRequest{
 			InstanceName:   *instanceName,
 			DigestFunction: repb.DigestFunction_SHA256,
-			BlobDigests:    []*repb.Digest{{Hash: digest.EmptyHash, SizeBytes: 0}},
+			BlobDigests:    []*repb.Digest{{Hash: digest.EmptySha256, SizeBytes: 0}},
 		})
 		return err
 	})


### PR DESCRIPTION
Send the actual empty digest for sha256 in the warmup request.