### PR TITLE
Add a flag to sync on commit in disk.FileWriter

### DIFF
--- a/server/util/disk/BUILD
+++ b/server/util/disk/BUILD
@@ -50,6 +50,7 @@ go_test(
     deps = [
         ":disk",
         "//server/testutil/testfs",
+        "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",
     ] + select({
         "@io_bazel_rules_go//go/platform:linux": [

--- a/server/util/disk/disk.go
+++ b/server/util/disk/disk.go
@@ -345,11 +345,6 @@ func (w *writeMover) Commit() error {
 		return err
 	}
 	defer releaseQuota()
-	if *syncOnCommit {
-		if err := w.Sync(); err != nil {
-			return err
-		}
-	}
 	if w.anonymous {
 		// Fast path: try linking the anonymous file directly to finalPath.
 		// This is the common case (writing a new file). linkat fails with
@@ -373,12 +368,32 @@ func (w *writeMover) Commit() error {
 				return err
 			}
 		}
+		// Sync after linking, not before: on journaling filesystems
+		// (XFS/ext4), fsyncing the file also persists the link/rename that
+		// published it, since the directory update and the inode change
+		// share a journal transaction. Syncing before the link would leave
+		// a crash window where metadata written after Commit survives but
+		// the directory entry does not, so callers like pebble_cache's
+		// FindMissing (which consults only metadata) would advertise a
+		// blob that can't be read.
+		if *syncOnCommit {
+			if err := w.Sync(); err != nil {
+				return err
+			}
+		}
 		w.releaseTmpFileBytesMetric()
 		if err := w.File.Close(); err != nil {
 			return err
 		}
 		w.tmpFileIsClosed = true
 		return nil
+	}
+	// This fallback path closes the file before renaming it, so the sync
+	// makes the data durable but not the rename that publishes it.
+	if *syncOnCommit {
+		if err := w.Sync(); err != nil {
+			return err
+		}
 	}
 	tmpName := w.File.Name()
 	if err := w.File.Close(); err != nil {

--- a/server/util/disk/disk.go
+++ b/server/util/disk/disk.go
@@ -38,7 +38,7 @@ var (
 	tmpWriteFileRe = regexp.MustCompile(`\.[0-9a-zA-Z]{10}\.tmp$`)
 
 	fileWriterConcurrencyLimit = flag.Int("file_writer_concurrency_limit", 5_000, "Limit on concurrent file writer operations that may result in syscalls. Can be disabled by setting the value to 0.")
-	syncOnCommit               = flag.Bool("disk.sync_on_commit", false, "Whether disk.FileWriterWithTmpDir should sync the file on commit")
+	syncOnCommit               = flag.Bool("file_writer_sync_on_commit", false, "Whether disk.FileWriterWithTmpDir should sync the file on commit")
 )
 
 type Partition struct {

--- a/server/util/disk/disk.go
+++ b/server/util/disk/disk.go
@@ -350,6 +350,7 @@ func (w *writeMover) Commit() error {
 		// This is the common case (writing a new file). linkat fails with
 		// EEXIST if finalPath already exists, in which case we fall back to
 		// linking to a unique temp name and renaming over the destination.
+		renamedOver := false
 		err := linkAnonymousTmpFile(w.File, w.finalPath)
 		if err != nil {
 			if !errors.Is(err, syscall.EEXIST) {
@@ -367,6 +368,7 @@ func (w *writeMover) Commit() error {
 				RemoveIfExists(linkPath)
 				return err
 			}
+			renamedOver = true
 		}
 		// Sync after linking, not before: on journaling filesystems
 		// (XFS/ext4), fsyncing the file also persists the link/rename that
@@ -377,7 +379,21 @@ func (w *writeMover) Commit() error {
 		// FindMissing (which consults only metadata) would advertise a
 		// blob that can't be read.
 		if *syncOnCommit {
-			if err := w.Sync(); err != nil {
+			if err := w.File.Sync(); err != nil {
+				// The link above already published the file at finalPath.
+				// After a fresh link, nothing can reference it yet (callers
+				// record metadata only after Commit succeeds), so undo the
+				// publish rather than leave an orphan that eviction never
+				// sees. After a rename over an existing file, keep it:
+				// metadata from the earlier write may point at finalPath,
+				// and removing it would leave that metadata dangling.
+				deleted := false
+				if !renamedOver {
+					deleted = RemoveIfExists(w.finalPath) == nil
+				}
+				if !deleted {
+					log.CtxWarningf(w.ctx, "Left orphaned file at %s", w.finalPath)
+				}
 				return err
 			}
 		}
@@ -391,7 +407,7 @@ func (w *writeMover) Commit() error {
 	// This fallback path closes the file before renaming it, so the sync
 	// makes the data durable but not the rename that publishes it.
 	if *syncOnCommit {
-		if err := w.Sync(); err != nil {
+		if err := w.File.Sync(); err != nil {
 			return err
 		}
 	}

--- a/server/util/disk/disk.go
+++ b/server/util/disk/disk.go
@@ -38,6 +38,7 @@ var (
 	tmpWriteFileRe = regexp.MustCompile(`\.[0-9a-zA-Z]{10}\.tmp$`)
 
 	fileWriterConcurrencyLimit = flag.Int("file_writer_concurrency_limit", 5_000, "Limit on concurrent file writer operations that may result in syscalls. Can be disabled by setting the value to 0.")
+	syncOnCommit               = flag.Bool("disk.sync_on_commit", false, "Whether disk.FileWriterWithTmpDir should sync the file on commit")
 )
 
 type Partition struct {
@@ -344,6 +345,11 @@ func (w *writeMover) Commit() error {
 		return err
 	}
 	defer releaseQuota()
+	if *syncOnCommit {
+		if err := w.Sync(); err != nil {
+			return err
+		}
+	}
 	if w.anonymous {
 		// Fast path: try linking the anonymous file directly to finalPath.
 		// This is the common case (writing a new file). linkat fails with

--- a/server/util/disk/disk_linux_test.go
+++ b/server/util/disk/disk_linux_test.go
@@ -25,7 +25,7 @@ import (
 func TestFileWriter_UsesOTmpfile(t *testing.T) {
 	for _, syncOnCommit := range []bool{false, true} {
 		t.Run(fmt.Sprintf("sync=%v", syncOnCommit), func(t *testing.T) {
-			flags.Set(t, "disk.sync_on_commit", syncOnCommit)
+			flags.Set(t, "file_writer_sync_on_commit", syncOnCommit)
 			dir := testfs.MakeTempDir(t)
 			finalPath := filepath.Join(dir, "out.bin")
 
@@ -62,7 +62,7 @@ func TestFileWriter_UsesOTmpfile(t *testing.T) {
 func TestFileWriter_OverwritesExisting(t *testing.T) {
 	for _, syncOnCommit := range []bool{false, true} {
 		t.Run(fmt.Sprintf("sync=%v", syncOnCommit), func(t *testing.T) {
-			flags.Set(t, "disk.sync_on_commit", syncOnCommit)
+			flags.Set(t, "file_writer_sync_on_commit", syncOnCommit)
 			dir := testfs.MakeTempDir(t)
 			finalPath := filepath.Join(dir, "out.bin")
 			require.NoError(t, os.WriteFile(finalPath, []byte("old"), 0644))

--- a/server/util/disk/disk_linux_test.go
+++ b/server/util/disk/disk_linux_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testmount"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,52 +23,62 @@ import (
 // FileWriterWithTmpDir is using O_TMPFILE + linkat instead of an
 // open/write/rename cycle through a named temp file.
 func TestFileWriter_UsesOTmpfile(t *testing.T) {
-	dir := testfs.MakeTempDir(t)
-	finalPath := filepath.Join(dir, "out.bin")
+	for _, syncOnCommit := range []bool{false, true} {
+		t.Run(fmt.Sprintf("sync=%v", syncOnCommit), func(t *testing.T) {
+			flags.Set(t, "disk.sync_on_commit", syncOnCommit)
+			dir := testfs.MakeTempDir(t)
+			finalPath := filepath.Join(dir, "out.bin")
 
-	w, err := disk.FileWriter(context.Background(), finalPath)
-	require.NoError(t, err)
+			w, err := disk.FileWriter(context.Background(), finalPath)
+			require.NoError(t, err)
 
-	_, err = w.Write([]byte("hello world"))
-	require.NoError(t, err)
+			_, err = w.Write([]byte("hello world"))
+			require.NoError(t, err)
 
-	// Before Commit, the directory should be empty: O_TMPFILE has no name.
-	entries, err := os.ReadDir(dir)
-	require.NoError(t, err)
-	require.Empty(t, entries, "expected no temp file in tmp dir while writing with O_TMPFILE")
+			// Before Commit, the directory should be empty: O_TMPFILE has no name.
+			entries, err := os.ReadDir(dir)
+			require.NoError(t, err)
+			require.Empty(t, entries, "expected no temp file in tmp dir while writing with O_TMPFILE")
 
-	require.NoError(t, w.Commit())
-	require.NoError(t, w.Close())
+			require.NoError(t, w.Commit())
+			require.NoError(t, w.Close())
 
-	// After Commit, only the final file should exist.
-	entries, err = os.ReadDir(dir)
-	require.NoError(t, err)
-	require.Len(t, entries, 1)
-	require.Equal(t, "out.bin", entries[0].Name())
+			// After Commit, only the final file should exist.
+			entries, err = os.ReadDir(dir)
+			require.NoError(t, err)
+			require.Len(t, entries, 1)
+			require.Equal(t, "out.bin", entries[0].Name())
 
-	got, err := os.ReadFile(finalPath)
-	require.NoError(t, err)
-	require.Equal(t, "hello world", string(got))
+			got, err := os.ReadFile(finalPath)
+			require.NoError(t, err)
+			require.Equal(t, "hello world", string(got))
+		})
+	}
 }
 
 // TestFileWriter_OverwritesExisting verifies that committing the writer
 // overwrites a pre-existing file at the destination, matching the previous
 // rename-based behavior.
 func TestFileWriter_OverwritesExisting(t *testing.T) {
-	dir := testfs.MakeTempDir(t)
-	finalPath := filepath.Join(dir, "out.bin")
-	require.NoError(t, os.WriteFile(finalPath, []byte("old"), 0644))
+	for _, syncOnCommit := range []bool{false, true} {
+		t.Run(fmt.Sprintf("sync=%v", syncOnCommit), func(t *testing.T) {
+			flags.Set(t, "disk.sync_on_commit", syncOnCommit)
+			dir := testfs.MakeTempDir(t)
+			finalPath := filepath.Join(dir, "out.bin")
+			require.NoError(t, os.WriteFile(finalPath, []byte("old"), 0644))
 
-	w, err := disk.FileWriter(context.Background(), finalPath)
-	require.NoError(t, err)
-	_, err = w.Write([]byte("new"))
-	require.NoError(t, err)
-	require.NoError(t, w.Commit())
-	require.NoError(t, w.Close())
+			w, err := disk.FileWriter(context.Background(), finalPath)
+			require.NoError(t, err)
+			_, err = w.Write([]byte("new"))
+			require.NoError(t, err)
+			require.NoError(t, w.Commit())
+			require.NoError(t, w.Close())
 
-	got, err := os.ReadFile(finalPath)
-	require.NoError(t, err)
-	require.Equal(t, "new", string(got))
+			got, err := os.ReadFile(finalPath)
+			require.NoError(t, err)
+			require.Equal(t, "new", string(got))
+		})
+	}
 }
 
 func TestMain(m *testing.M) {

--- a/server/util/disk/disk_test.go
+++ b/server/util/disk/disk_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 )
 
 func TestGetDirUsage(t *testing.T) {
@@ -25,38 +26,43 @@ func TestGetDirUsage(t *testing.T) {
 }
 
 func TestWriteMover_CloseCleansUp(t *testing.T) {
-	for _, shouldCancel := range []bool{true, false} {
-		t.Run(fmt.Sprintf("cancel=%v", shouldCancel), func(t *testing.T) {
-			for _, shouldCommit := range []bool{true, false} {
-				t.Run(fmt.Sprintf("commit=%v", shouldCommit), func(t *testing.T) {
-					dir := testfs.MakeTempDir(t)
-					ctx, cancel := context.WithCancel(context.Background())
-					defer cancel()
-					path := filepath.Join(dir, "testfile")
-					w, err := disk.FileWriter(ctx, path)
-					require.NoError(t, err)
-					_, err = w.Write([]byte("hello"))
-					require.NoError(t, err)
+	for _, syncOnCommit := range []bool{false, true} {
+		t.Run(fmt.Sprintf("sync=%v", syncOnCommit), func(t *testing.T) {
+			for _, shouldCancel := range []bool{true, false} {
+				t.Run(fmt.Sprintf("cancel=%v", shouldCancel), func(t *testing.T) {
+					for _, shouldCommit := range []bool{true, false} {
+						t.Run(fmt.Sprintf("commit=%v", shouldCommit), func(t *testing.T) {
+							flags.Set(t, "disk.sync_on_commit", syncOnCommit)
+							dir := testfs.MakeTempDir(t)
+							ctx, cancel := context.WithCancel(context.Background())
+							defer cancel()
+							path := filepath.Join(dir, "testfile")
+							w, err := disk.FileWriter(ctx, path)
+							require.NoError(t, err)
+							_, err = w.Write([]byte("hello"))
+							require.NoError(t, err)
 
-					if shouldCommit {
-						require.NoError(t, w.Commit())
-					}
+							if shouldCommit {
+								require.NoError(t, w.Commit())
+							}
 
-					if shouldCancel {
-						// Cancel the context to simulate a timeout or RPC cancellation.
-						// This should cause w.Close to fail to get writer quota, but it
-						// shoud still clean up the temp file.
-						cancel()
-					}
-					w.Close()
-					entries, err := os.ReadDir(dir)
-					require.NoError(t, err)
-					for _, ent := range entries {
-						if shouldCommit {
-							require.Equal(t, "testfile", ent.Name())
-						} else {
-							t.Errorf("Unexpected file %v", ent.Name())
-						}
+							if shouldCancel {
+								// Cancel the context to simulate a timeout or RPC cancellation.
+								// This should cause w.Close to fail to get writer quota, but it
+								// shoud still clean up the temp file.
+								cancel()
+							}
+							w.Close()
+							entries, err := os.ReadDir(dir)
+							require.NoError(t, err)
+							for _, ent := range entries {
+								if shouldCommit {
+									require.Equal(t, "testfile", ent.Name())
+								} else {
+									t.Errorf("Unexpected file %v", ent.Name())
+								}
+							}
+						})
 					}
 				})
 			}

--- a/server/util/disk/disk_test.go
+++ b/server/util/disk/disk_test.go
@@ -32,7 +32,7 @@ func TestWriteMover_CloseCleansUp(t *testing.T) {
 				t.Run(fmt.Sprintf("cancel=%v", shouldCancel), func(t *testing.T) {
 					for _, shouldCommit := range []bool{true, false} {
 						t.Run(fmt.Sprintf("commit=%v", shouldCommit), func(t *testing.T) {
-							flags.Set(t, "disk.sync_on_commit", syncOnCommit)
+							flags.Set(t, "file_writer_sync_on_commit", syncOnCommit)
 							dir := testfs.MakeTempDir(t)
 							ctx, cancel := context.WithCancel(context.Background())
 							defer cancel()


### PR DESCRIPTION
Currently, we don't force a sync, which can cause 2 issues:
1. We claim to have written a file, and then maybe write to metadata to pebble, but the file is missing.
2. The page cache fills up with unflushed writes, and then is forced to flush all of them at once under memory pressure. Adding the sync smooths this out.