### PR TITLE
cli: apply --binary to every remote bazel patch

### DIFF
--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -345,26 +345,8 @@ func runCommand(name string, args ...string) (string, error) {
 	return stdout.String(), nil
 }
 
-func isBinaryFile(path string) (bool, error) {
-	fileDetails, err := runCommand("file", "--mime", path)
-	if err != nil {
-		return false, fmt.Errorf("inspect file mime: %w", err)
-	}
-	isBinary := strings.Contains(fileDetails, "charset=binary")
-	return isBinary, nil
-}
-
 func diffUntrackedFile(path string) (string, error) {
-	isBinary, err := isBinaryFile(path)
-	if err != nil {
-		return "", fmt.Errorf("check whether %q is binary: %w", path, err)
-	}
-
-	args := []string{"diff", "--no-index", "/dev/null", path}
-	if isBinary {
-		args = append(args, "--binary")
-	}
-	patch, err := runGit(args...)
+	patch, err := runGit("diff", "--no-index", "--binary", "/dev/null", path)
 	if err != nil {
 		// `git diff` returns exit code 1 if there is (valid) diff. Explicitly
 		// check for this case.
@@ -552,50 +534,13 @@ func generatePatches(baseCommit string) ([][]byte, error) {
 			duration.String(), totalSizeMB)
 	}()
 
-	modifiedFiles, err := runGit("diff", baseCommit, "--name-only")
-	if err != nil {
-		return nil, status.WrapError(err, "get modified files")
-	}
-	modifiedFiles = strings.Trim(modifiedFiles, "\n")
-
-	binaryFilesToExclude := make([]string, 0)
-	binaryFiles := make([]string, 0)
-	if modifiedFiles != "" {
-		for mf := range strings.SplitSeq(modifiedFiles, "\n") {
-			isBinary, err := isBinaryFile(mf)
-			if err != nil {
-				return nil, status.WrapError(err, "check binary file")
-			}
-			if isBinary {
-				binaryFilesToExclude = append(binaryFilesToExclude, fmt.Sprintf(":!%s", mf))
-				binaryFiles = append(binaryFiles, mf)
-			}
-		}
-	}
-
-	// Generate patches for non-binary files
-	args := []string{"diff", baseCommit}
-	if len(binaryFilesToExclude) > 0 {
-		args = append(args, binaryFilesToExclude...)
-	}
-	patch, err := runGit(args...)
+	// `--binary` is inert for a text diff and the only applyable form for a binary one.
+	patch, err := runGit("diff", "--binary", baseCommit)
 	if err != nil {
 		return nil, status.WrapError(err, "git diff")
 	}
 	if patch != "" {
 		patches = append(patches, []byte(patch))
-	}
-
-	// Generate patches for binary files
-	if len(binaryFiles) > 0 {
-		binaryArgs := append([]string{"diff", baseCommit, "--binary", "--"}, binaryFiles...)
-		binaryPatch, err := runGit(binaryArgs...)
-		if err != nil {
-			return nil, status.WrapError(err, "git diff --binary")
-		}
-		if binaryPatch != "" {
-			patches = append(patches, []byte(binaryPatch))
-		}
 	}
 
 	// Generate patches for non-tracked files

--- a/cli/remotebazel/remotebazel_test.go
+++ b/cli/remotebazel/remotebazel_test.go
@@ -736,8 +736,11 @@ func TestGitConfig_FetchURL(t *testing.T) {
 func TestGeneratingPatches(t *testing.T) {
 	// Setup the "remote" repo
 	remoteRepoPath, _ := testgit.MakeTempRepo(t, map[string]string{
-		"hello.txt": "echo HI",
-		"b.bin":     "",
+		"hello.txt":      "echo HI",
+		"b.bin":          "",
+		"deleted.bin":    "\x00\x01\x02\x03\x04",
+		"attributed.md":  "v1",
+		".gitattributes": "attributed.md binary\n",
 	})
 
 	// Setup a "local" repo
@@ -760,26 +763,45 @@ func TestGeneratingPatches(t *testing.T) {
 
 		# Generate a binary diff on an untracked file
 		echo -ne '\x00\x01\x02\x03\x04' > b2.bin
+
+		# Delete a pre-existing binary file
+		rm deleted.bin
+
+		# Diff a file git treats as binary by attribute, though its bytes are text
+		echo "v2" > attributed.md
 `)
 
 	config, err := Config()
 	require.NoError(t, err)
 
-	require.Equal(t, 4, len(config.Patches))
+	all := ""
 	for _, patchBytes := range config.Patches {
-		p := string(patchBytes)
-		if strings.Contains(p, "hello.txt") {
-			require.Contains(t, p, "HELLO")
-		} else if strings.Contains(p, "bye.txt") {
-			require.Contains(t, p, "BYE")
-		} else if strings.Contains(p, "b.bin") {
-			require.Contains(t, p, "GIT binary patch")
-		} else if strings.Contains(p, "b2.bin") {
-			require.Contains(t, p, "GIT binary patch")
-		} else {
-			require.FailNowf(t, "unexpected patch %s", p)
-		}
+		all += string(patchBytes)
 	}
+	require.Contains(t, all, "HELLO")
+	require.Contains(t, all, "BYE")
+	// Every file git renders as binary needs the binary format, deletions and
+	// attribute-marked files included.
+	for _, binaryFile := range []string{"b.bin", "b2.bin", "deleted.bin", "attributed.md"} {
+		require.Contains(t, all, binaryFile)
+	}
+	require.Equal(t, 4, strings.Count(all, "GIT binary patch"))
+
+	// The runner applies the patchset; a binary patch without its full index line fails there.
+	runnerRepoPath := testgit.MakeTempRepoClone(t, remoteRepoPath)
+	for i, patchBytes := range config.Patches {
+		patchPath := filepath.Join(t.TempDir(), fmt.Sprintf("%d.patch", i))
+		require.NoError(t, os.WriteFile(patchPath, patchBytes, 0644))
+		testshell.Run(t, runnerRepoPath, fmt.Sprintf("git apply %q", patchPath))
+	}
+	for _, file := range []string{"hello.txt", "bye.txt", "b.bin", "b2.bin", "attributed.md"} {
+		want, err := os.ReadFile(filepath.Join(localRepoPath, file))
+		require.NoError(t, err)
+		got, err := os.ReadFile(filepath.Join(runnerRepoPath, file))
+		require.NoError(t, err)
+		require.Equal(t, want, got, "%s should match the local working tree", file)
+	}
+	require.NoFileExists(t, filepath.Join(runnerRepoPath, "deleted.bin"))
 }
 
 func TestWorkingDirectory(t *testing.T) {


### PR DESCRIPTION
Deleting a tracked binary file breaks every `bb remote` run — the runner fails with "cannot apply binary patch to '<path>' without full index line" before bazel starts.

generatePatches decides which paths need `git diff --binary` by running `file --mime` on them. That cannot see a deleted path, and it disagrees with git about files marked `binary` in .gitattributes whose bytes read as text. Either mismatch produces a patch the runner cannot apply.

`--binary` is inert for a text diff — byte-identical output, autocrlf included — so pass it always and drop the classification, the file(1) dependency, and the `:!<path>` exclusions, which git calls ambiguous once a path is gone.

The test covers both mismatches and applies the patchset to a clone. The old code produces 2 of the 4 binary patches it expects.