### PR TITLE
Track NVIDIA GPU memory usage for executions

### DIFF
--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -1481,6 +1481,21 @@ export default class InvocationActionCardComponent extends React.Component<Props
         <div>
           <div>Peak memory: {format.bytesIEC(usageStats.peakMemoryBytes)}</div>
           <div>MilliCPU: {computeMilliCpu(this.state.actionResult!)}</div>
+          {usageStats.gpuUsage && (
+            <div className="value-with-help-tooltip">
+              Peak GPU memory: {format.bytesIEC(usageStats.gpuUsage.peakTotalMemoryBytes)}
+              {usageStats.gpuUsage.deviceUsage.length > 0 && (
+                <HelpTooltip aria-label="Peak GPU memory by device">
+                  {usageStats.gpuUsage.deviceUsage.map((device) => (
+                    <div key={device.id}>
+                      {device.vendor === build.bazel.remote.execution.v2.GPUDeviceUsage.Vendor.NVIDIA && "NVIDIA "}
+                      {device.id}: {format.bytesIEC(device.peakMemoryBytes)}
+                    </div>
+                  ))}
+                </HelpTooltip>
+              )}
+            </div>
+          )}
           {usageStats.peakFileSystemUsage?.map((fs) => (
             <div>
               Peak disk usage: {fs.target} ({fs.fstype}): {format.bytesIEC(fs.usedBytes)} of{" "}

--- a/app/trace/trace_events.ts
+++ b/app/trace/trace_events.ts
@@ -103,6 +103,7 @@ export const TIME_SERIES_METADATA = new Map<string, SeriesMetadata[]>([
   // enterprise/server/execution_service/execution_service.go
   ["CPU usage (cores)", [{ argKey: "cpu" }]],
   ["Memory usage (KB)", [{ argKey: "memory" }]],
+  ["GPU memory usage (KB)", [{ argKey: "gpu-memory" }]],
   ["Disk read bandwidth (MB/s)", [{ argKey: "disk-read-bw" }]],
   ["Disk read IOPS", [{ argKey: "disk-read-iops" }]],
   ["Disk write bandwidth (MB/s)", [{ argKey: "disk-write-bw" }]],

--- a/deps/go_deps.MODULE.bazel
+++ b/deps/go_deps.MODULE.bazel
@@ -292,6 +292,7 @@ use_repo(
     "com_github_mwitkow_grpc_proxy",
     "com_github_ncruces_go_sqlite3",
     "com_github_nishanths_exhaustive",
+    "com_github_nvidia_go_nvml",
     "com_github_open_feature_flagd_core",
     "com_github_open_feature_go_sdk",
     "com_github_open_feature_go_sdk_contrib_providers_flagd",

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -31,6 +31,7 @@ go_library(
         "//enterprise/server/remote_execution/executor/oomkiller",
         "//enterprise/server/remote_execution/executorplatform",
         "//enterprise/server/remote_execution/filecache",
+        "//enterprise/server/remote_execution/gpu",
         "//enterprise/server/remote_execution/runner",
         "//enterprise/server/remote_execution/snaputil",
         "//enterprise/server/scheduling/priority_task_scheduler",

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -25,6 +25,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/executor/oomkiller"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/executorplatform"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/gpu"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/runner"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaputil"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/priority_task_scheduler"
@@ -342,6 +343,9 @@ func main() {
 	if err := log.Configure(); err != nil {
 		fmt.Printf("Error configuring logging: %s", err)
 		os.Exit(1)
+	}
+	if err := gpu.Configure(); err != nil {
+		log.Fatalf("Could not configure GPU memory tracking: %s", err)
 	}
 
 	if err := xds.Bootstrap(rootContext, nil /*=client*/); err != nil {

--- a/enterprise/server/execution_service/execution_service.go
+++ b/enterprise/server/execution_service/execution_service.go
@@ -719,6 +719,7 @@ func (es *ExecutionService) WriteExecutionProfile(ctx context.Context, w io.Writ
 	timestampsMillis := timeseries.DeltaDecode(stats.GetTimeline().GetTimestamps())
 	cumulativeCPUMillis := timeseries.DeltaDecode(stats.GetTimeline().GetCpuSamples())
 	memoryUsageKB := timeseries.DeltaDecode(stats.GetTimeline().GetMemoryKbSamples())
+	gpuMemoryUsageKB := timeseries.DeltaDecode(stats.GetTimeline().GetGpuUsage().GetTotalMemoryKbSamples())
 	cumulativeDiskRbytes := timeseries.DeltaDecode(stats.GetTimeline().GetRbytesTotalSamples())
 	cumulativeDiskWbytes := timeseries.DeltaDecode(stats.GetTimeline().GetWbytesTotalSamples())
 	cumulativeDiskRios := timeseries.DeltaDecode(stats.GetTimeline().GetRiosTotalSamples())
@@ -734,6 +735,9 @@ func (es *ExecutionService) WriteExecutionProfile(ctx context.Context, w io.Writ
 	}
 	if len(memoryUsageKB) > 0 && len(timestampsMillis) != len(memoryUsageKB) {
 		return status.UnknownErrorf("length mismatch: timestamps[%d], memory[%d]", len(timestampsMillis), len(memoryUsageKB))
+	}
+	if len(gpuMemoryUsageKB) > 0 && len(timestampsMillis) != len(gpuMemoryUsageKB) {
+		return status.UnknownErrorf("length mismatch: timestamps[%d], GPU memory[%d]", len(timestampsMillis), len(gpuMemoryUsageKB))
 	}
 	if len(cumulativeDiskRbytes) > 0 && len(timestampsMillis) != len(cumulativeDiskRbytes) {
 		return status.UnknownErrorf("length mismatch: timestamps[%d], disk read bytes[%d]", len(timestampsMillis), len(cumulativeDiskRbytes))
@@ -865,6 +869,10 @@ func (es *ExecutionService) WriteExecutionProfile(ctx context.Context, w io.Writ
 	for _, m := range memoryUsageKB {
 		memoryUsage = append(memoryUsage, float64(m))
 	}
+	var gpuMemoryUsage []float64
+	for _, m := range gpuMemoryUsageKB {
+		gpuMemoryUsage = append(gpuMemoryUsage, float64(m))
+	}
 
 	// Derive disk bandwidth in MB/s.
 	const diskBandwidthScale = 1e-3 // 1 byte/ms = 1e-3 MB/s
@@ -891,6 +899,11 @@ func (es *ExecutionService) WriteExecutionProfile(ctx context.Context, w io.Writ
 			name: "Memory usage (KB)",
 			key:  "memory",
 			data: memoryUsage,
+		},
+		{
+			name: "GPU memory usage (KB)",
+			key:  "gpu-memory",
+			data: gpuMemoryUsage,
 		},
 		{
 			name: "Disk read bandwidth (MB/s)",

--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -417,6 +417,12 @@ func (p *Paths) CgroupVersion() int {
 	return 0 // unknown
 }
 
+// V2Dir returns the cgroup v2 directory for the container with the given name
+// (cgroup v2 only).
+func (p *Paths) V2Dir(name string) string {
+	return strings.ReplaceAll(p.V2DirTemplate, cidPlaceholder, name)
+}
+
 // Stats returns cgroup stats for the cgroup matching the given name. If
 // blockDevice is non-nil, IO stats are included for the device, otherwise IO
 // stats are not reported.
@@ -430,9 +436,52 @@ func (p *Paths) Stats(ctx context.Context, name string, blockDevice *block_io.De
 	}
 
 	// cgroup v2 has all cgroup files under a single dir.
-	dir := strings.ReplaceAll(p.V2DirTemplate, cidPlaceholder, name)
+	return Stats(ctx, p.V2Dir(name), blockDevice)
+}
 
-	return Stats(ctx, dir, blockDevice)
+// ReadCgroupProcs returns the process IDs of the processes in the cgroup at
+// the given path, including processes in descendant cgroups. Descendants are
+// included because a cgroup with child cgroups usually has no processes of
+// its own; for example, some container runtime configurations place container
+// processes in a child cgroup of the container's top-level cgroup.
+func ReadCgroupProcs(path string) (map[int]struct{}, error) {
+	pids := make(map[int]struct{})
+	err := filepath.WalkDir(path, func(entryPath string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			// Tolerate descendant cgroups that are removed while walking, but
+			// report a missing root so that callers can tell that the cgroup
+			// itself is gone.
+			if entryPath != path && errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
+		if !entry.IsDir() {
+			return nil
+		}
+		b, err := os.ReadFile(filepath.Join(entryPath, "cgroup.procs"))
+		if err != nil {
+			if entryPath != path && errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
+			return fmt.Errorf("read cgroup.procs: %w", err)
+		}
+		for field := range strings.FieldsSeq(string(b)) {
+			pid, err := strconv.Atoi(field)
+			if err != nil {
+				return fmt.Errorf("parse cgroup PID %q: %w", field, err)
+			}
+			if pid <= 0 {
+				return fmt.Errorf("cgroup PID is out of range (%d)", pid)
+			}
+			pids[pid] = struct{}{}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return pids, nil
 }
 
 // ReadMemoryEvents reads the "memory.events" file under the given cgroup

--- a/enterprise/server/remote_execution/cgroup/cgroup_test.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup_test.go
@@ -131,6 +131,31 @@ func TestSettingsMap(t *testing.T) {
 	}
 }
 
+func TestReadCgroupProcs(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cgroup.procs"), []byte("123\n456\n123\n"), 0o644))
+	// Place a process in a child cgroup. Some container runtime
+	// configurations place container processes in a child cgroup of the
+	// container's top-level cgroup, which then lists no processes of its own.
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "child"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "child", "cgroup.procs"), []byte("789\n"), 0o644))
+
+	// Processes listed in the cgroup and in its descendants should all appear
+	// in the returned set, with duplicate entries collapsed.
+	pids, err := ReadCgroupProcs(dir)
+	require.NoError(t, err)
+	require.Equal(t, map[int]struct{}{123: {}, 456: {}, 789: {}}, pids)
+}
+
+func TestReadCgroupProcsMissingCgroup(t *testing.T) {
+	dir := t.TempDir()
+
+	// A missing cgroup should surface as ErrNotExist so callers can
+	// distinguish a deleted cgroup from an unreadable one.
+	_, err := ReadCgroupProcs(filepath.Join(dir, "removed"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
 func TestReadMemoryMax(t *testing.T) {
 	dir := t.TempDir()
 

--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -142,6 +142,12 @@ type UsageStats struct {
 	// execution. This is reset between tasks so that we can determine a task's
 	// peak memory usage when using a recycled runner.
 	peakMemoryUsageBytes int64
+	// peakGPUUsage is the peak GPU memory usage observed during the current
+	// task execution. It is tracked separately from the live reading, which
+	// drops to zero once the task's processes exit. This is reset between
+	// tasks so that we can determine a task's peak GPU usage when using a
+	// recycled runner.
+	peakGPUUsage *repb.GPUUsage
 	// baselineCPUNanos is the CPU usage from when a task last finished
 	// executing. This is needed so that we can determine a task's CPU usage
 	// when using a recycled runner.
@@ -166,6 +172,7 @@ type timelineState struct {
 	lastTimestampUnixMillis int64
 	lastCPUMillis           int64
 	lastMemoryKB            int64
+	lastGPUMemoryKB         int64
 	lastDiskRbytes          int64
 	lastWbytes              int64
 	lastDiskRios            int64
@@ -174,7 +181,7 @@ type timelineState struct {
 	// - The size calculation in updateTimeline()
 	// - The test
 	// - The trace format adapter logic in execution_service.go
-	// - TIME_SERIES_EVENT_NAMES_AND_ARG_KEYS in trace_events.ts
+	// - TIME_SERIES_METADATA in trace_events.ts
 }
 
 func (s *UsageStats) clock() clockwork.Clock {
@@ -193,6 +200,7 @@ func (s *UsageStats) Reset() {
 
 	if s.last != nil {
 		s.last.MemoryBytes = 0
+		s.last.GpuUsage = nil
 	}
 	s.baselineCPUNanos = s.last.GetCpuNanos()
 	s.baselineCPUPressure = s.last.GetCpuPressure()
@@ -200,6 +208,7 @@ func (s *UsageStats) Reset() {
 	s.baselineIOPressure = s.last.GetIoPressure()
 	s.baselineIOStats = s.last.GetCgroupIoStats()
 	s.peakMemoryUsageBytes = 0
+	s.peakGPUUsage = nil
 
 	now := s.clock().Now()
 	if *recordUsageTimelines {
@@ -239,6 +248,7 @@ func (s *UsageStats) taskStatsLocked(includeTimeline bool) *repb.UsageStats {
 
 	taskStats.CpuNanos -= s.baselineCPUNanos
 	taskStats.PeakMemoryBytes = s.peakMemoryUsageBytes
+	taskStats.GpuUsage = s.peakGPUUsage.CloneVT()
 
 	// Update all IO stats to be relative to the baseline
 	ioStats := taskStats.CgroupIoStats
@@ -289,6 +299,9 @@ func (s *UsageStats) updateTimeline(now time.Time) {
 		len(st.GetRbytesTotalSamples()) +
 		len(st.GetWiosTotalSamples()) +
 		len(st.GetRiosTotalSamples())
+	if gpuTimeline := st.GetGpuUsage(); gpuTimeline != nil {
+		totalLength += len(gpuTimeline.GetTotalMemoryKbSamples())
+	}
 	if 8*totalLength > timeseriesSizeLimitBytes {
 		return
 	}
@@ -310,6 +323,32 @@ func (s *UsageStats) updateTimeline(now time.Time) {
 	memDelta := mem - s.timelineState.lastMemoryKB
 	s.timeline.MemoryKbSamples = append(s.timeline.MemoryKbSamples, memDelta)
 	s.timelineState.lastMemoryKB = mem
+
+	// Update GPU memory samples with the current total usage across GPUs, in
+	// KB (1000 bytes).
+	gpuUsage := s.last.GetGpuUsage()
+	gpuTimeline := s.timeline.GetGpuUsage()
+	if gpuUsage.GetTotalMemoryBytes() > 0 && gpuTimeline == nil {
+		// Start the GPU series lazily on the first nonzero reading, so that
+		// tasks which never use a GPU don't record an all-zero series.
+		// Backfill zeros for the samples recorded before this one; the current
+		// sample's timestamp was already appended above, hence the minus one.
+		gpuTimeline = &repb.GPUUsageTimeline{
+			TotalMemoryKbSamples: make([]int64, len(s.timeline.GetTimestamps())-1),
+		}
+		s.timeline.GpuUsage = gpuTimeline
+	}
+	if gpuTimeline != nil {
+		// A nil reading means GPU usage was unavailable at this poll (e.g. an
+		// NVML query failed), so carry the last observation forward rather
+		// than record a false zero.
+		gpuMemoryKB := s.timelineState.lastGPUMemoryKB
+		if gpuUsage != nil {
+			gpuMemoryKB = gpuUsage.GetTotalMemoryBytes() / 1e3
+		}
+		gpuTimeline.TotalMemoryKbSamples = append(gpuTimeline.TotalMemoryKbSamples, gpuMemoryKB-s.timelineState.lastGPUMemoryKB)
+		s.timelineState.lastGPUMemoryKB = gpuMemoryKB
+	}
 
 	// Update disk rbytes samples with cumulative bytes read.
 	diskRbytes := s.last.GetCgroupIoStats().GetRbytes()
@@ -347,6 +386,37 @@ func (s *UsageStats) Update(lifetimeStats *repb.UsageStats) {
 	s.last = lifetimeStats.CloneVT()
 	if lifetimeStats.GetMemoryBytes() > s.peakMemoryUsageBytes {
 		s.peakMemoryUsageBytes = lifetimeStats.GetMemoryBytes()
+	}
+	// Fold the latest point-in-time GPU reading into the task peaks. The
+	// total tracks the largest sum observed in a single reading while each
+	// device entry tracks its own high-water mark, so the total can be less
+	// than the sum of device peaks.
+	if gpuUsage := lifetimeStats.GetGpuUsage(); gpuUsage.GetTotalMemoryBytes() > 0 {
+		if s.peakGPUUsage == nil {
+			s.peakGPUUsage = &repb.GPUUsage{}
+		}
+		if gpuUsage.GetTotalMemoryBytes() > s.peakGPUUsage.GetPeakTotalMemoryBytes() {
+			s.peakGPUUsage.PeakTotalMemoryBytes = gpuUsage.GetTotalMemoryBytes()
+		}
+		for _, device := range gpuUsage.GetDeviceUsage() {
+			if device.GetMemoryBytes() <= 0 {
+				continue
+			}
+			var peakDevice *repb.GPUDeviceUsage
+			for _, d := range s.peakGPUUsage.GetDeviceUsage() {
+				if d.GetId() == device.GetId() {
+					peakDevice = d
+					break
+				}
+			}
+			if peakDevice == nil {
+				peakDevice = &repb.GPUDeviceUsage{Id: device.GetId(), Vendor: device.GetVendor()}
+				s.peakGPUUsage.DeviceUsage = append(s.peakGPUUsage.DeviceUsage, peakDevice)
+			}
+			if device.GetMemoryBytes() > peakDevice.GetPeakMemoryBytes() {
+				peakDevice.PeakMemoryBytes = device.GetMemoryBytes()
+			}
+		}
 	}
 	if *recordUsageTimelines && s.timeline != nil {
 		s.updateTimeline(s.clock().Now())

--- a/enterprise/server/remote_execution/container/container_test.go
+++ b/enterprise/server/remote_execution/container/container_test.go
@@ -476,6 +476,51 @@ func TestUsageStats(t *testing.T) {
 	}, s.TaskStats(), protocmp.Transform()))
 }
 
+func TestUsageStats_GPUUsageReportsPeaks(t *testing.T) {
+	stats := &container.UsageStats{}
+	stats.Reset()
+
+	// Observe two GPUs whose per-device peaks occur during different samples.
+	// The peak total should be the largest simultaneous sum, not the sum of the
+	// independent per-device peaks.
+	stats.Update(&repb.UsageStats{GpuUsage: &repb.GPUUsage{
+		TotalMemoryBytes: 300,
+		DeviceUsage: []*repb.GPUDeviceUsage{
+			{Id: "GPU-a", MemoryBytes: 100, Vendor: repb.GPUDeviceUsage_NVIDIA},
+			{Id: "GPU-b", MemoryBytes: 200, Vendor: repb.GPUDeviceUsage_NVIDIA},
+		},
+	}})
+	stats.Update(&repb.UsageStats{GpuUsage: &repb.GPUUsage{
+		TotalMemoryBytes: 300,
+		DeviceUsage: []*repb.GPUDeviceUsage{
+			{Id: "GPU-a", MemoryBytes: 250},
+			{Id: "GPU-b", MemoryBytes: 50},
+		},
+	}})
+	stats.Update(&repb.UsageStats{GpuUsage: &repb.GPUUsage{
+		TotalMemoryBytes: 400,
+		DeviceUsage: []*repb.GPUDeviceUsage{
+			{Id: "GPU-a", MemoryBytes: 200},
+			{Id: "GPU-b", MemoryBytes: 200},
+		},
+	}})
+
+	// A final empty sample after the processes exit should not discard the GPU
+	// peaks observed while the task was running.
+	stats.Update(&repb.UsageStats{})
+	require.Empty(t, cmp.Diff(&repb.GPUUsage{
+		PeakTotalMemoryBytes: 400,
+		DeviceUsage: []*repb.GPUDeviceUsage{
+			{Id: "GPU-a", PeakMemoryBytes: 250, Vendor: repb.GPUDeviceUsage_NVIDIA},
+			{Id: "GPU-b", PeakMemoryBytes: 200, Vendor: repb.GPUDeviceUsage_NVIDIA},
+		},
+	}, stats.TaskStats().GetGpuUsage(), protocmp.Transform()))
+
+	// A recycled runner should not carry GPU peaks into the next task.
+	stats.Reset()
+	require.Nil(t, stats.TaskStats().GetGpuUsage())
+}
+
 func TestUsageStats_ConcurrentUpdateAndBasicTaskStats(t *testing.T) {
 	flags.Set(t, "executor.record_usage_timelines", true)
 
@@ -571,6 +616,73 @@ func TestUsageStats_Timeseries(t *testing.T) {
 	}, timestamps, "timestamps")
 	assert.Equal(t, []int64{0, 7000, 9500}, cpuSamples, "cpu samples")
 	assert.Equal(t, []int64{0, 500, 400}, memKBSamples, "memory kb samples")
+}
+
+func TestUsageStats_ZeroGPUUsageOmitted(t *testing.T) {
+	flags.Set(t, "executor.record_usage_timelines", true)
+
+	stats := &container.UsageStats{}
+	stats.Reset()
+
+	// Successful GPU readings that never observe any memory should not add an
+	// empty summary or an all-zero timeline to the task stats.
+	stats.Update(&repb.UsageStats{GpuUsage: &repb.GPUUsage{
+		DeviceUsage: []*repb.GPUDeviceUsage{
+			{Id: "GPU-a"},
+		},
+	}})
+	stats.Update(&repb.UsageStats{GpuUsage: &repb.GPUUsage{}})
+
+	taskStats := stats.TaskStats()
+	require.Nil(t, taskStats.GetGpuUsage())
+	require.Nil(t, taskStats.GetTimeline().GetGpuUsage())
+}
+
+func TestUsageStats_GPUTimeseries(t *testing.T) {
+	flags.Set(t, "executor.record_usage_timelines", true)
+
+	start := time.Unix(100, 0)
+	clock := clockwork.NewFakeClockAt(start)
+	stats := &container.UsageStats{Clock: clock}
+	stats.Reset()
+
+	// GPU tracking starts after the initial timeline sample. The total GPU
+	// series should be backfilled with zero for that initial sample.
+	clock.Advance(100 * time.Millisecond)
+	stats.Update(&repb.UsageStats{GpuUsage: &repb.GPUUsage{
+		TotalMemoryBytes: 100_000,
+		DeviceUsage: []*repb.GPUDeviceUsage{
+			{Id: "GPU-a", MemoryBytes: 100_000},
+		},
+	}})
+
+	// An unavailable reading should preserve the last observation instead of
+	// reporting a false zero.
+	clock.Advance(100 * time.Millisecond)
+	stats.Update(&repb.UsageStats{})
+
+	// A larger reading spread across two devices should be recorded as the
+	// new total.
+	clock.Advance(100 * time.Millisecond)
+	stats.Update(&repb.UsageStats{GpuUsage: &repb.GPUUsage{
+		TotalMemoryBytes: 400_000,
+		DeviceUsage: []*repb.GPUDeviceUsage{
+			{Id: "GPU-a", MemoryBytes: 150_000},
+			{Id: "GPU-b", MemoryBytes: 250_000},
+		},
+	}})
+
+	// A successful empty reading should bring total GPU usage back to zero.
+	clock.Advance(100 * time.Millisecond)
+	stats.Update(&repb.UsageStats{GpuUsage: &repb.GPUUsage{}})
+
+	timeline := stats.TaskStats().GetTimeline()
+	assert.Equal(t, []int64{0, 100, 100, 400, 0}, timeseries.DeltaDecode(timeline.GetGpuUsage().GetTotalMemoryKbSamples()))
+
+	// Recycled runners should begin the next task without the previous task's
+	// final GPU reading or timeline.
+	stats.Reset()
+	require.Nil(t, stats.TaskStats().GetTimeline().GetGpuUsage())
 }
 
 // fakePausableContainer is a FakeContainer whose Pause sleeps for a

--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -26,6 +26,7 @@ go_library(
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/executor_auth",
+        "//enterprise/server/remote_execution/gpu",
         "//enterprise/server/util/oci",
         "//proto:remote_execution_go_proto",
         "//proto:scheduler_go_proto",
@@ -141,11 +142,20 @@ go_test(
 # - Install `nvidia-container-toolkit` (need `nvidia-ctk` in PATH)
 # - Run `sudo nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml` which
 #   creates a CDI spec.
-# - Run the executor with OCI runtime enabled and --executor.oci.cdi_devices=nvidia.com/gpu=all
+# - Run the executor with OCI runtime enabled and these flags:
+#   --executor.oci.cdi_devices=nvidia.com/gpu=all
+#   --executor.gpu_memory_tracking_enabled
+#   --executor.record_usage_timelines
 # - Run this test against the executor with bazel, e.g. --config=local-rbe-linux
 sh_test(
     name = "nvidia_gpu_test",
     srcs = ["nvidia_gpu_test.sh"],
+    # Bazel sets PATH on the action, which overrides the CUDA image's PATH.
+    # Preserve the image's declared PATH so nvcc and entrypoint tools such as
+    # ldconfig remain available.
+    env = {
+        "PATH": "/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    },
     exec_properties = {
         "test.workload-isolation-type": "oci",
         "test.container-image": "docker://nvidia/cuda:12.4.1-devel-ubuntu22.04",

--- a/enterprise/server/remote_execution/containers/ociruntime/nvidia_gpu_test.sh
+++ b/enterprise/server/remote_execution/containers/ociruntime/nvidia_gpu_test.sh
@@ -3,11 +3,15 @@ set -euo pipefail
 
 : "${TMPDIR:=/tmp}"
 
+# Verify that the container can discover the GPUs exposed by the runtime.
 nvidia-smi -L
 
+# Build a small CUDA probe that grows its allocation by 64 MiB every two
+# seconds, then releases everything long enough for polling to observe zero.
 cat > "$TMPDIR"/cuda_probe.cu <<EOF
 #include <cstdio>
 #include <cuda_runtime.h>
+#include <unistd.h>
 
 int main() {
   int n = 0;
@@ -28,18 +32,40 @@ int main() {
     return 4;
   }
 
-  float *d = nullptr;
-  err = cudaMalloc(&d, sizeof(float) * 1024);
-  if (err != cudaSuccess) {
-    std::fprintf(stderr, "cudaMalloc: %s\n", cudaGetErrorString(err));
-    return 5;
+  constexpr size_t allocation_bytes = 64 * 1024 * 1024;
+  constexpr int allocation_count = 5;
+  void *allocations[allocation_count] = {};
+  for (int i = 0; i < allocation_count; i++) {
+    err = cudaMalloc(&allocations[i], allocation_bytes);
+    if (err != cudaSuccess) {
+      std::fprintf(stderr, "cudaMalloc: %s\n", cudaGetErrorString(err));
+      return 5;
+    }
+    std::printf("cuda_allocated_bytes=%zu\n", allocation_bytes * (i + 1));
+    std::fflush(stdout);
+    sleep(2);
   }
-  cudaFree(d);
+  for (int i = 0; i < allocation_count; i++) {
+    err = cudaFree(allocations[i]);
+    if (err != cudaSuccess) {
+      std::fprintf(stderr, "cudaFree: %s\n", cudaGetErrorString(err));
+      return 6;
+    }
+  }
+  err = cudaDeviceReset();
+  if (err != cudaSuccess) {
+    std::fprintf(stderr, "cudaDeviceReset: %s\n", cudaGetErrorString(err));
+    return 7;
+  }
+  std::printf("cuda_freed_all=1\n");
+  std::fflush(stdout);
+  sleep(2);
 
-  std::printf("cuda_malloc_ok=1\n");
+  std::printf("cuda_probe_done=1\n");
   return 0;
 }
 EOF
 
+# Compile and run the probe using the CUDA toolkit from the test image.
 nvcc -O2 "$TMPDIR"/cuda_probe.cu -o "$TMPDIR"/cuda_probe
 "$TMPDIR"/cuda_probe

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -39,6 +39,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/executor_auth"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/gpu"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/oci"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -829,9 +830,7 @@ func (c *ociContainer) Exec(ctx context.Context, cmd *repb.Command, stdio *inter
 }
 
 func (c *ociContainer) RecordStats(ctx context.Context) func() (*repb.UsageStats, error) {
-	stop := c.stats.TrackExecution(ctx, func(ctx context.Context) (*repb.UsageStats, error) {
-		return c.cgroupPaths.Stats(ctx, c.cid, c.blockDevice)
-	})
+	stop := c.startStatsTracking(ctx)
 	return func() (*repb.UsageStats, error) {
 		stop()
 		return c.stats.TaskStats(), nil
@@ -964,9 +963,7 @@ func (c *ociContainer) Stats(ctx context.Context) (*repb.UsageStats, error) {
 // Also incorporates cgroup events into the command result - oom_kill events
 // in particular are translated to errors.
 func (c *ociContainer) doWithStatsTracking(ctx context.Context, invokeRuntimeFn func(ctx context.Context) *interfaces.CommandResult) *interfaces.CommandResult {
-	stop := c.stats.TrackExecution(ctx, func(ctx context.Context) (*repb.UsageStats, error) {
-		return c.cgroupPaths.Stats(ctx, c.cid, c.blockDevice)
-	})
+	stop := c.startStatsTracking(ctx)
 	res := invokeRuntimeFn(ctx)
 	stop()
 	// statsCh will report stats for processes inside the container, and
@@ -1008,6 +1005,17 @@ func (c *ociContainer) doWithStatsTracking(ctx context.Context, invokeRuntimeFn 
 	}
 
 	return res
+}
+
+func (c *ociContainer) startStatsTracking(ctx context.Context) func() {
+	return c.stats.TrackExecution(ctx, func(ctx context.Context) (*repb.UsageStats, error) {
+		stats, err := c.cgroupPaths.Stats(ctx, c.cid, c.blockDevice)
+		if err != nil {
+			return nil, err
+		}
+		stats.GpuUsage = gpu.CgroupUsage(c.cgroupPath())
+		return stats, nil
+	})
 }
 
 // checkOOMKill checks for oom_kill memory events in the cgroup and returns an

--- a/enterprise/server/remote_execution/containers/podman/BUILD
+++ b/enterprise/server/remote_execution/containers/podman/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//enterprise/server/remote_execution/cgroup",
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",
+        "//enterprise/server/remote_execution/gpu",
         "//enterprise/server/util/oci",
         "//proto:remote_execution_go_proto",
         "//server/environment",

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -20,6 +20,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/cgroup"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/gpu"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/oci"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -428,7 +429,14 @@ func (c *podmanCommandContainer) doWithStatsTracking(ctx context.Context, runPod
 		if err != nil {
 			return nil, err
 		}
-		return c.cgroupPaths.Stats(ctx, cid, c.blockDevice)
+		stats, err := c.cgroupPaths.Stats(ctx, cid, c.blockDevice)
+		if err != nil {
+			return nil, err
+		}
+		if c.cgroupPaths.CgroupVersion() == 2 {
+			stats.GpuUsage = gpu.CgroupUsage(c.cgroupPaths.V2Dir(cid))
+		}
+		return stats, nil
 	})
 	res := runPodmanFn(ctx)
 	stop()

--- a/enterprise/server/remote_execution/gpu/BUILD
+++ b/enterprise/server/remote_execution/gpu/BUILD
@@ -1,0 +1,46 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "gpu",
+    srcs = [
+        "gpu.go",
+        "gpu_linux.go",
+        "gpu_unsupported.go",
+    ],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/gpu",
+    deps = [
+        "//proto:remote_execution_go_proto",
+        "//server/util/flag",
+    ] + select({
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//enterprise/server/remote_execution/cgroup",
+            "//server/util/log",
+            "@com_github_nvidia_go_nvml//pkg/nvml",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+go_test(
+    name = "gpu_test",
+    srcs = ["gpu_linux_test.go"],
+    embed = [":gpu"],
+    target_compatible_with = select({
+        "@io_bazel_rules_go//go/platform:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = select({
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//proto:remote_execution_go_proto",
+            "//server/util/testing/flags",
+            "@com_github_google_go_cmp//cmp",
+            "@com_github_nvidia_go_nvml//pkg/nvml",
+            "@com_github_nvidia_go_nvml//pkg/nvml/mock",
+            "@com_github_stretchr_testify//require",
+            "@org_golang_google_protobuf//testing/protocmp",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/enterprise/server/remote_execution/gpu/gpu.go
+++ b/enterprise/server/remote_execution/gpu/gpu.go
@@ -1,0 +1,39 @@
+package gpu
+
+import (
+	"errors"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+var (
+	gpuMemoryTrackingEnabled = flag.Bool("executor.gpu_memory_tracking_enabled", false, "Whether to measure GPU memory used by task processes. Requires a Linux executor with the NVIDIA Management Library (libnvidia-ml) available at runtime.")
+	gpuMemoryPollInterval    = flag.Duration("executor.gpu_memory_poll_interval", 250*time.Millisecond, "How often to sample GPU process memory. Shorter poll intervals add more CPU overhead.")
+)
+
+// Configure validates the GPU memory tracking configuration and initializes
+// its platform implementation when tracking is enabled. The configure and
+// cgroupUsage functions are defined per platform in gpu_linux.go and
+// gpu_unsupported.go.
+func Configure() error {
+	if !*gpuMemoryTrackingEnabled {
+		return nil
+	}
+	if *gpuMemoryPollInterval < time.Millisecond {
+		return errors.New("executor.gpu_memory_poll_interval must be at least 1ms")
+	}
+	return configure()
+}
+
+// CgroupUsage returns the latest GPU memory reading for a cgroup v2 path.
+// The reading holds point-in-time usage; callers that need task-level peaks
+// must fold successive readings, which container.UsageStats.Update does.
+func CgroupUsage(cgroupPath string) *repb.GPUUsage {
+	if !*gpuMemoryTrackingEnabled {
+		return nil
+	}
+	return cgroupUsage(cgroupPath)
+}

--- a/enterprise/server/remote_execution/gpu/gpu_linux.go
+++ b/enterprise/server/remote_execution/gpu/gpu_linux.go
@@ -22,7 +22,7 @@ import (
 var (
 	// defaultMemoryMonitor is the executor-wide monitor, set by configure when
 	// GPU memory tracking is enabled.
-	defaultMemoryMonitor *MemoryMonitor
+	defaultMemoryMonitor *memoryMonitor
 )
 
 // memoryReading maps GPU ID to PID to GPU memory usage in bytes, as measured
@@ -34,8 +34,8 @@ type readFunc func() (memoryReading, error)
 // gpuDevice pairs an NVML device handle with its UUID, which is queried once
 // at discovery time.
 type gpuDevice struct {
-	nvml.Device
-	uuid string
+	device nvml.Device
+	uuid   string
 }
 
 // discoverDevices returns the accessible NVIDIA GPUs and their stable UUIDs.
@@ -59,7 +59,7 @@ func discoverDevices(library nvml.Interface) ([]gpuDevice, error) {
 		if ret != nvml.SUCCESS {
 			return nil, fmt.Errorf("get device %d UUID: %w", index, ret)
 		}
-		devices = append(devices, gpuDevice{Device: device, uuid: uuid})
+		devices = append(devices, gpuDevice{device: device, uuid: uuid})
 	}
 	return devices, nil
 }
@@ -72,11 +72,11 @@ func discoverDevices(library nvml.Interface) ([]gpuDevice, error) {
 // graphics context appears in both lists with its total usage (confirmed
 // empirically). Such processes are deduplicated by PID rather than summed.
 func (d gpuDevice) processMemory() (map[int]int64, error) {
-	compute, ret := d.GetComputeRunningProcesses()
+	compute, ret := d.device.GetComputeRunningProcesses()
 	if ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("query compute processes: %w", ret)
 	}
-	graphics, ret := d.GetGraphicsRunningProcesses()
+	graphics, ret := d.device.GetGraphicsRunningProcesses()
 	if ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("query graphics processes: %w", ret)
 	}
@@ -101,23 +101,22 @@ func (d gpuDevice) processMemory() (map[int]int64, error) {
 	return memoryBytesByPID, nil
 }
 
-// MemoryMonitor samples NVIDIA GPU memory usage and attributes it to cgroups.
-type MemoryMonitor struct {
+// memoryMonitor samples NVIDIA GPU memory usage and attributes it to cgroups.
+type memoryMonitor struct {
 	library nvml.Interface
 	devices []gpuDevice
 
-	startOnce sync.Once
-
-	mu sync.RWMutex
+	// mu guards lastReading.
+	mu sync.Mutex
 	// lastReading is the most recent complete poll. A nil map means that no
 	// successful reading is available.
 	lastReading memoryReading
 }
 
-// newMemoryMonitor initializes NVML and discovers GPUs once so polling only
-// queries process memory. If discovery fails, NVML is shut down before
-// returning the error.
-func newMemoryMonitor(library nvml.Interface) (*MemoryMonitor, error) {
+// newMemoryMonitor initializes NVML, discovers GPUs once so polling only
+// queries process memory, and starts the background poller. If discovery
+// fails, NVML is shut down before returning the error.
+func newMemoryMonitor(library nvml.Interface) (*memoryMonitor, error) {
 	if ret := library.Init(); ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("initialize NVML: %w", ret)
 	}
@@ -129,23 +128,15 @@ func newMemoryMonitor(library nvml.Interface) (*MemoryMonitor, error) {
 		}
 		return nil, err
 	}
-	return &MemoryMonitor{library: library, devices: devices}, nil
+	m := &memoryMonitor{library: library, devices: devices}
+	go m.monitor(context.Background(), m.read)
+	return m, nil
 }
 
-// CgroupGPUUsage starts GPU monitoring on its first call and returns the most
-// recent GPU memory usage for processes in the given cgroup. It returns nil
-// when no successful NVML reading is available or the cgroup's process list
-// cannot be read.
-func (m *MemoryMonitor) CgroupGPUUsage(cgroupPath string) *repb.GPUUsage {
-	m.startOnce.Do(func() {
-		go m.monitor(context.Background(), m.read)
-	})
-	return m.cgroupGPUUsage(cgroupPath)
-}
-
-// cgroupGPUUsage filters the latest process readings to the processes in the
-// requested cgroup and aggregates their memory by GPU.
-func (m *MemoryMonitor) cgroupGPUUsage(cgroupPath string) *repb.GPUUsage {
+// cgroupGPUUsage returns the most recent GPU memory usage for processes in
+// the given cgroup, aggregated by GPU. It returns nil when no successful NVML
+// reading is available or the cgroup's process list cannot be read.
+func (m *memoryMonitor) cgroupGPUUsage(cgroupPath string) *repb.GPUUsage {
 	pids, err := cgroup.ReadCgroupProcs(cgroupPath)
 	if err != nil {
 		// The cgroup may be deleted while a final stats poll is in flight, so
@@ -156,15 +147,16 @@ func (m *MemoryMonitor) cgroupGPUUsage(cgroupPath string) *repb.GPUUsage {
 		return nil
 	}
 
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+	m.mu.Lock()
+	lastReading := m.lastReading
+	m.mu.Unlock()
 
-	if m.lastReading == nil {
+	if lastReading == nil {
 		return nil
 	}
 
 	memoryBytesByGPU := make(map[string]int64)
-	for gpuID, memoryBytesByPID := range m.lastReading {
+	for gpuID, memoryBytesByPID := range lastReading {
 		for pid, memoryBytes := range memoryBytesByPID {
 			if _, ok := pids[pid]; ok {
 				memoryBytesByGPU[gpuID] += memoryBytes
@@ -176,6 +168,7 @@ func (m *MemoryMonitor) cgroupGPUUsage(cgroupPath string) *repb.GPUUsage {
 	for gpuID := range memoryBytesByGPU {
 		gpuIDs = append(gpuIDs, gpuID)
 	}
+	// Sort by ID so clients see per-GPU stats in a deterministic order.
 	slices.Sort(gpuIDs)
 
 	usage := &repb.GPUUsage{}
@@ -193,7 +186,9 @@ func (m *MemoryMonitor) cgroupGPUUsage(cgroupPath string) *repb.GPUUsage {
 
 // monitor polls NVML and replaces the published reading after each poll. A
 // failed poll clears the published reading rather than leaving stale data.
-func (m *MemoryMonitor) monitor(ctx context.Context, read readFunc) {
+func (m *memoryMonitor) monitor(ctx context.Context, read readFunc) {
+	ticker := time.NewTicker(*gpuMemoryPollInterval)
+	defer ticker.Stop()
 	var lastError string
 	for {
 		reading, err := read()
@@ -208,12 +203,10 @@ func (m *MemoryMonitor) monitor(ctx context.Context, read readFunc) {
 			lastError = ""
 		}
 
-		timer := time.NewTimer(*gpuMemoryPollInterval)
 		select {
 		case <-ctx.Done():
-			timer.Stop()
 			return
-		case <-timer.C:
+		case <-ticker.C:
 		}
 	}
 }
@@ -221,7 +214,7 @@ func (m *MemoryMonitor) monitor(ctx context.Context, read readFunc) {
 // read returns a reading of the memory used by each process on each GPU. If
 // any GPU query fails, the whole reading is discarded, so a partial reading
 // is never presented as total usage.
-func (m *MemoryMonitor) read() (memoryReading, error) {
+func (m *memoryMonitor) read() (memoryReading, error) {
 	reading := make(memoryReading)
 	for _, device := range m.devices {
 		memoryBytesByPID, err := device.processMemory()
@@ -235,7 +228,7 @@ func (m *MemoryMonitor) read() (memoryReading, error) {
 	return reading, nil
 }
 
-func (m *MemoryMonitor) setReading(reading memoryReading) {
+func (m *memoryMonitor) setReading(reading memoryReading) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.lastReading = reading
@@ -257,5 +250,5 @@ func cgroupUsage(cgroupPath string) *repb.GPUUsage {
 		// Configure was not called; usage is unknown.
 		return nil
 	}
-	return defaultMemoryMonitor.CgroupGPUUsage(cgroupPath)
+	return defaultMemoryMonitor.cgroupGPUUsage(cgroupPath)
 }

--- a/enterprise/server/remote_execution/gpu/gpu_linux.go
+++ b/enterprise/server/remote_execution/gpu/gpu_linux.go
@@ -1,0 +1,261 @@
+//go:build linux && !android && cgo
+
+package gpu
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/cgroup"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+var (
+	// defaultMemoryMonitor is the executor-wide monitor, set by configure when
+	// GPU memory tracking is enabled.
+	defaultMemoryMonitor *MemoryMonitor
+)
+
+// memoryReading maps GPU ID to PID to GPU memory usage in bytes, as measured
+// in a single polling pass over all GPUs.
+type memoryReading map[string]map[int]int64
+
+type readFunc func() (memoryReading, error)
+
+// gpuDevice pairs an NVML device handle with its UUID, which is queried once
+// at discovery time.
+type gpuDevice struct {
+	nvml.Device
+	uuid string
+}
+
+// discoverDevices returns the accessible NVIDIA GPUs and their stable UUIDs.
+// Zero accessible GPUs is reported as an error, since enabling GPU tracking
+// on an executor without GPUs indicates a misconfiguration.
+func discoverDevices(library nvml.Interface) ([]gpuDevice, error) {
+	count, ret := library.DeviceGetCount()
+	if ret != nvml.SUCCESS {
+		return nil, fmt.Errorf("get device count: %w", ret)
+	}
+	if count == 0 {
+		return nil, errors.New("NVML reported no NVIDIA GPUs")
+	}
+	devices := make([]gpuDevice, 0, count)
+	for index := range count {
+		device, ret := library.DeviceGetHandleByIndex(index)
+		if ret != nvml.SUCCESS {
+			return nil, fmt.Errorf("get device %d: %w", index, ret)
+		}
+		uuid, ret := device.GetUUID()
+		if ret != nvml.SUCCESS {
+			return nil, fmt.Errorf("get device %d UUID: %w", index, ret)
+		}
+		devices = append(devices, gpuDevice{Device: device, uuid: uuid})
+	}
+	return devices, nil
+}
+
+// processMemory returns GPU memory usage in bytes by PID for the compute
+// (e.g. CUDA) and graphics (e.g. OpenGL) processes using the device.
+//
+// Per the NVML docs, usedGpuMemory in each process list is "all of the memory
+// used by the application", so a process holding both a compute and a
+// graphics context appears in both lists with its total usage (confirmed
+// empirically). Such processes are deduplicated by PID rather than summed.
+func (d gpuDevice) processMemory() (map[int]int64, error) {
+	compute, ret := d.GetComputeRunningProcesses()
+	if ret != nvml.SUCCESS {
+		return nil, fmt.Errorf("query compute processes: %w", ret)
+	}
+	graphics, ret := d.GetGraphicsRunningProcesses()
+	if ret != nvml.SUCCESS {
+		return nil, fmt.Errorf("query graphics processes: %w", ret)
+	}
+	memoryBytesByPID := make(map[int]int64, len(compute)+len(graphics))
+	for _, info := range slices.Concat(compute, graphics) {
+		// NVML reports "value not available" as all ones, e.g. under WSL and
+		// on some virtualized GPUs. Skip such processes since there is no
+		// memory value to attribute.
+		if info.UsedGpuMemory == math.MaxUint64 {
+			continue
+		}
+		if uint64(info.Pid) > uint64(math.MaxInt) {
+			return nil, fmt.Errorf("PID is out of range (%d)", info.Pid)
+		}
+		if info.UsedGpuMemory > math.MaxInt64 {
+			return nil, fmt.Errorf("memory is out of range (%d bytes)", info.UsedGpuMemory)
+		}
+		// The lists are sampled at slightly different times, so take the max
+		// of the samples to better approximate the peak.
+		memoryBytesByPID[int(info.Pid)] = max(memoryBytesByPID[int(info.Pid)], int64(info.UsedGpuMemory))
+	}
+	return memoryBytesByPID, nil
+}
+
+// MemoryMonitor samples NVIDIA GPU memory usage and attributes it to cgroups.
+type MemoryMonitor struct {
+	library nvml.Interface
+	devices []gpuDevice
+
+	startOnce sync.Once
+
+	mu sync.RWMutex
+	// lastReading is the most recent complete poll. A nil map means that no
+	// successful reading is available.
+	lastReading memoryReading
+}
+
+// newMemoryMonitor initializes NVML and discovers GPUs once so polling only
+// queries process memory. If discovery fails, NVML is shut down before
+// returning the error.
+func newMemoryMonitor(library nvml.Interface) (*MemoryMonitor, error) {
+	if ret := library.Init(); ret != nvml.SUCCESS {
+		return nil, fmt.Errorf("initialize NVML: %w", ret)
+	}
+	devices, err := discoverDevices(library)
+	if err != nil {
+		err = fmt.Errorf("discover GPUs: %w", err)
+		if ret := library.Shutdown(); ret != nvml.SUCCESS {
+			err = errors.Join(err, fmt.Errorf("shutdown NVML: %w", ret))
+		}
+		return nil, err
+	}
+	return &MemoryMonitor{library: library, devices: devices}, nil
+}
+
+// CgroupGPUUsage starts GPU monitoring on its first call and returns the most
+// recent GPU memory usage for processes in the given cgroup. It returns nil
+// when no successful NVML reading is available or the cgroup's process list
+// cannot be read.
+func (m *MemoryMonitor) CgroupGPUUsage(cgroupPath string) *repb.GPUUsage {
+	m.startOnce.Do(func() {
+		go m.monitor(context.Background(), m.read)
+	})
+	return m.cgroupGPUUsage(cgroupPath)
+}
+
+// cgroupGPUUsage filters the latest process readings to the processes in the
+// requested cgroup and aggregates their memory by GPU.
+func (m *MemoryMonitor) cgroupGPUUsage(cgroupPath string) *repb.GPUUsage {
+	pids, err := cgroup.ReadCgroupProcs(cgroupPath)
+	if err != nil {
+		// The cgroup may be deleted while a final stats poll is in flight, so
+		// don't warn about a missing cgroup.
+		if !errors.Is(err, os.ErrNotExist) {
+			log.Warningf("Could not read NVIDIA GPU usage for cgroup %q because reading its process list returned %s", cgroupPath, err)
+		}
+		return nil
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.lastReading == nil {
+		return nil
+	}
+
+	memoryBytesByGPU := make(map[string]int64)
+	for gpuID, memoryBytesByPID := range m.lastReading {
+		for pid, memoryBytes := range memoryBytesByPID {
+			if _, ok := pids[pid]; ok {
+				memoryBytesByGPU[gpuID] += memoryBytes
+			}
+		}
+	}
+
+	gpuIDs := make([]string, 0, len(memoryBytesByGPU))
+	for gpuID := range memoryBytesByGPU {
+		gpuIDs = append(gpuIDs, gpuID)
+	}
+	slices.Sort(gpuIDs)
+
+	usage := &repb.GPUUsage{}
+	for _, gpuID := range gpuIDs {
+		memoryBytes := memoryBytesByGPU[gpuID]
+		usage.TotalMemoryBytes += memoryBytes
+		usage.DeviceUsage = append(usage.DeviceUsage, &repb.GPUDeviceUsage{
+			Id:          gpuID,
+			MemoryBytes: memoryBytes,
+			Vendor:      repb.GPUDeviceUsage_NVIDIA,
+		})
+	}
+	return usage
+}
+
+// monitor polls NVML and replaces the published reading after each poll. A
+// failed poll clears the published reading rather than leaving stale data.
+func (m *MemoryMonitor) monitor(ctx context.Context, read readFunc) {
+	var lastError string
+	for {
+		reading, err := read()
+		if err != nil {
+			m.setReading(nil)
+			if err.Error() != lastError {
+				log.Warningf("Could not query NVIDIA GPU memory usage with NVML: %s", err)
+				lastError = err.Error()
+			}
+		} else {
+			m.setReading(reading)
+			lastError = ""
+		}
+
+		timer := time.NewTimer(*gpuMemoryPollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+	}
+}
+
+// read returns a reading of the memory used by each process on each GPU. If
+// any GPU query fails, the whole reading is discarded, so a partial reading
+// is never presented as total usage.
+func (m *MemoryMonitor) read() (memoryReading, error) {
+	reading := make(memoryReading)
+	for _, device := range m.devices {
+		memoryBytesByPID, err := device.processMemory()
+		if err != nil {
+			return nil, fmt.Errorf("query GPU %q processes: %w", device.uuid, err)
+		}
+		if len(memoryBytesByPID) > 0 {
+			reading[device.uuid] = memoryBytesByPID
+		}
+	}
+	return reading, nil
+}
+
+func (m *MemoryMonitor) setReading(reading memoryReading) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.lastReading = reading
+}
+
+// configure creates the executor-wide memory monitor.
+func configure() error {
+	monitor, err := newMemoryMonitor(nvml.New())
+	if err != nil {
+		return err
+	}
+	defaultMemoryMonitor = monitor
+	return nil
+}
+
+// cgroupUsage returns the latest reading from the executor-wide monitor.
+func cgroupUsage(cgroupPath string) *repb.GPUUsage {
+	if defaultMemoryMonitor == nil {
+		// Configure was not called; usage is unknown.
+		return nil
+	}
+	return defaultMemoryMonitor.CgroupGPUUsage(cgroupPath)
+}

--- a/enterprise/server/remote_execution/gpu/gpu_linux_test.go
+++ b/enterprise/server/remote_execution/gpu/gpu_linux_test.go
@@ -57,7 +57,7 @@ func TestNewMemoryMonitor_NoGPUsAvailable_ReturnsError(t *testing.T) {
 }
 
 func TestDeviceProcessMemory_UnavailableValueReported_ValueIsIgnored(t *testing.T) {
-	device := gpuDevice{Device: &mock.Device{
+	device := gpuDevice{device: &mock.Device{
 		GetComputeRunningProcessesFunc: func() ([]nvml.ProcessInfo, nvml.Return) {
 			return []nvml.ProcessInfo{
 				{Pid: 123, UsedGpuMemory: 2 * 1024 * 1024},
@@ -79,7 +79,7 @@ func TestDeviceProcessMemory_ProcessHoldingComputeAndGraphicsMemory_UsageIsCount
 	// PID 100 holds both a compute and a graphics context, so NVML reports it
 	// in both lists with its total usage. PIDs 200 and 300 hold only one
 	// context type each.
-	device := gpuDevice{Device: &mock.Device{
+	device := gpuDevice{device: &mock.Device{
 		GetComputeRunningProcessesFunc: func() ([]nvml.ProcessInfo, nvml.Return) {
 			return []nvml.ProcessInfo{
 				{Pid: 100, UsedGpuMemory: 5 * 1024 * 1024},
@@ -116,7 +116,7 @@ func TestMemoryMonitorRead_MultipleReads_OnlyLatestReadingIsReported(t *testing.
 			return nil, nvml.SUCCESS
 		},
 	}
-	m := &MemoryMonitor{devices: []gpuDevice{{Device: device, uuid: "GPU-a"}}}
+	m := &memoryMonitor{devices: []gpuDevice{{device: device, uuid: "GPU-a"}}}
 
 	first, err := m.read()
 	require.NoError(t, err)
@@ -136,8 +136,8 @@ func TestMemoryMonitorRead_MultipleReads_OnlyLatestReadingIsReported(t *testing.
 }
 
 func TestMemoryMonitorRead_MultipleGPUsWithSingleGPUFailing_EntireReadingIsDiscarded(t *testing.T) {
-	m := &MemoryMonitor{devices: []gpuDevice{
-		{uuid: "GPU-a", Device: &mock.Device{
+	m := &memoryMonitor{devices: []gpuDevice{
+		{uuid: "GPU-a", device: &mock.Device{
 			GetComputeRunningProcessesFunc: func() ([]nvml.ProcessInfo, nvml.Return) {
 				return []nvml.ProcessInfo{{Pid: 123, UsedGpuMemory: 2 * 1024 * 1024}}, nvml.SUCCESS
 			},
@@ -145,7 +145,7 @@ func TestMemoryMonitorRead_MultipleGPUsWithSingleGPUFailing_EntireReadingIsDisca
 				return nil, nvml.SUCCESS
 			},
 		}},
-		{uuid: "GPU-b", Device: &mock.Device{
+		{uuid: "GPU-b", device: &mock.Device{
 			GetComputeRunningProcessesFunc: func() ([]nvml.ProcessInfo, nvml.Return) {
 				return nil, nvml.ERROR_GPU_IS_LOST
 			},
@@ -161,7 +161,7 @@ func TestMemoryMonitorCgroupGPUUsage_CgroupAndUnrelatedProcesses_OnlyCgroupMemor
 	cgroupPath := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(cgroupPath, "cgroup.procs"), []byte("123\n456\n"), 0o644))
 
-	m := &MemoryMonitor{lastReading: memoryReading{
+	m := &memoryMonitor{lastReading: memoryReading{
 		"GPU-b": {
 			123: 7 * 1024 * 1024,
 		},
@@ -187,7 +187,7 @@ func TestMemoryMonitorCgroupGPUUsage_NoAvailableData_UsageIsNil(t *testing.T) {
 	cgroupPath := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(cgroupPath, "cgroup.procs"), nil, 0o644))
 
-	m := &MemoryMonitor{}
+	m := &memoryMonitor{}
 	usage := m.cgroupGPUUsage(cgroupPath)
 	require.Nil(t, usage)
 }
@@ -196,7 +196,7 @@ func TestMemoryMonitorCgroupGPUUsage_EmptyReading_ZeroUsageIsReported(t *testing
 	cgroupPath := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(cgroupPath, "cgroup.procs"), nil, 0o644))
 
-	m := &MemoryMonitor{lastReading: memoryReading{}}
+	m := &memoryMonitor{lastReading: memoryReading{}}
 	usage := m.cgroupGPUUsage(cgroupPath)
 	require.NotNil(t, usage)
 	require.Empty(t, cmp.Diff(&repb.GPUUsage{}, usage, protocmp.Transform()))

--- a/enterprise/server/remote_execution/gpu/gpu_linux_test.go
+++ b/enterprise/server/remote_execution/gpu/gpu_linux_test.go
@@ -1,0 +1,203 @@
+//go:build linux && !android && cgo
+
+package gpu
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+func TestConfigure_GPUMemoryTrackingDisabled_DoesNotFail(t *testing.T) {
+	flags.Set(t, "executor.gpu_memory_tracking_enabled", false)
+	flags.Set(t, "executor.gpu_memory_poll_interval", time.Duration(0))
+
+	err := Configure()
+	require.NoError(t, err)
+}
+
+func TestConfigure_InvalidPollInterval_Fails(t *testing.T) {
+	flags.Set(t, "executor.gpu_memory_tracking_enabled", true)
+	flags.Set(t, "executor.gpu_memory_poll_interval", time.Duration(0))
+
+	err := Configure()
+	require.ErrorContains(t, err, "must be at least 1ms")
+}
+
+func TestNewMemoryMonitor_NVMLFailsToInitialize_ReturnsNVMLError(t *testing.T) {
+	library := &mock.Interface{
+		InitFunc: func() nvml.Return { return nvml.ERROR_LIBRARY_NOT_FOUND },
+	}
+
+	_, err := newMemoryMonitor(library)
+	require.ErrorContains(t, err, "initialize NVML")
+}
+
+func TestNewMemoryMonitor_NoGPUsAvailable_ReturnsError(t *testing.T) {
+	library := &mock.Interface{
+		InitFunc:           func() nvml.Return { return nvml.SUCCESS },
+		DeviceGetCountFunc: func() (int, nvml.Return) { return 0, nvml.SUCCESS },
+		ShutdownFunc:       func() nvml.Return { return nvml.SUCCESS },
+	}
+
+	_, err := newMemoryMonitor(library)
+	require.ErrorContains(t, err, "reported no NVIDIA GPUs")
+	require.Len(t, library.ShutdownCalls(), 1)
+}
+
+func TestDeviceProcessMemory_UnavailableValueReported_ValueIsIgnored(t *testing.T) {
+	device := gpuDevice{Device: &mock.Device{
+		GetComputeRunningProcessesFunc: func() ([]nvml.ProcessInfo, nvml.Return) {
+			return []nvml.ProcessInfo{
+				{Pid: 123, UsedGpuMemory: 2 * 1024 * 1024},
+				// Uint64 means "unavailable"
+				{Pid: 456, UsedGpuMemory: math.MaxUint64},
+			}, nvml.SUCCESS
+		},
+		GetGraphicsRunningProcessesFunc: func() ([]nvml.ProcessInfo, nvml.Return) {
+			return nil, nvml.SUCCESS
+		},
+	}}
+
+	memoryBytesByPID, err := device.processMemory()
+	require.NoError(t, err)
+	require.Equal(t, map[int]int64{123: 2 * 1024 * 1024}, memoryBytesByPID)
+}
+
+func TestDeviceProcessMemory_ProcessHoldingComputeAndGraphicsMemory_UsageIsCountedOnce(t *testing.T) {
+	// PID 100 holds both a compute and a graphics context, so NVML reports it
+	// in both lists with its total usage. PIDs 200 and 300 hold only one
+	// context type each.
+	device := gpuDevice{Device: &mock.Device{
+		GetComputeRunningProcessesFunc: func() ([]nvml.ProcessInfo, nvml.Return) {
+			return []nvml.ProcessInfo{
+				{Pid: 100, UsedGpuMemory: 5 * 1024 * 1024},
+				{Pid: 200, UsedGpuMemory: 2 * 1024 * 1024},
+			}, nvml.SUCCESS
+		},
+		GetGraphicsRunningProcessesFunc: func() ([]nvml.ProcessInfo, nvml.Return) {
+			return []nvml.ProcessInfo{
+				{Pid: 100, UsedGpuMemory: 5 * 1024 * 1024},
+				{Pid: 300, UsedGpuMemory: 3 * 1024 * 1024},
+			}, nvml.SUCCESS
+		},
+	}}
+
+	memoryBytesByPID, err := device.processMemory()
+	require.NoError(t, err)
+	require.Equal(t, map[int]int64{
+		100: 5 * 1024 * 1024,
+		200: 2 * 1024 * 1024,
+		300: 3 * 1024 * 1024,
+	}, memoryBytesByPID)
+}
+
+func TestMemoryMonitorRead_MultipleReads_OnlyLatestReadingIsReported(t *testing.T) {
+	processes := []nvml.ProcessInfo{
+		{Pid: 123, UsedGpuMemory: 2 * 1024 * 1024},
+		{Pid: 456, UsedGpuMemory: 3 * 1024 * 1024},
+	}
+	device := &mock.Device{
+		GetComputeRunningProcessesFunc: func() ([]nvml.ProcessInfo, nvml.Return) {
+			return processes, nvml.SUCCESS
+		},
+		GetGraphicsRunningProcessesFunc: func() ([]nvml.ProcessInfo, nvml.Return) {
+			return nil, nvml.SUCCESS
+		},
+	}
+	m := &MemoryMonitor{devices: []gpuDevice{{Device: device, uuid: "GPU-a"}}}
+
+	first, err := m.read()
+	require.NoError(t, err)
+	require.Equal(t, memoryReading{
+		"GPU-a": {
+			123: 2 * 1024 * 1024,
+			456: 3 * 1024 * 1024,
+		},
+	}, first)
+
+	processes = []nvml.ProcessInfo{{Pid: 789, UsedGpuMemory: 7 * 1024 * 1024}}
+	second, err := m.read()
+	require.NoError(t, err)
+	require.Equal(t, memoryReading{
+		"GPU-a": {789: 7 * 1024 * 1024},
+	}, second)
+}
+
+func TestMemoryMonitorRead_MultipleGPUsWithSingleGPUFailing_EntireReadingIsDiscarded(t *testing.T) {
+	m := &MemoryMonitor{devices: []gpuDevice{
+		{uuid: "GPU-a", Device: &mock.Device{
+			GetComputeRunningProcessesFunc: func() ([]nvml.ProcessInfo, nvml.Return) {
+				return []nvml.ProcessInfo{{Pid: 123, UsedGpuMemory: 2 * 1024 * 1024}}, nvml.SUCCESS
+			},
+			GetGraphicsRunningProcessesFunc: func() ([]nvml.ProcessInfo, nvml.Return) {
+				return nil, nvml.SUCCESS
+			},
+		}},
+		{uuid: "GPU-b", Device: &mock.Device{
+			GetComputeRunningProcessesFunc: func() ([]nvml.ProcessInfo, nvml.Return) {
+				return nil, nvml.ERROR_GPU_IS_LOST
+			},
+		}},
+	}}
+
+	reading, err := m.read()
+	require.ErrorContains(t, err, "GPU-b")
+	require.Nil(t, reading)
+}
+
+func TestMemoryMonitorCgroupGPUUsage_CgroupAndUnrelatedProcesses_OnlyCgroupMemoryIsSummed(t *testing.T) {
+	cgroupPath := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(cgroupPath, "cgroup.procs"), []byte("123\n456\n"), 0o644))
+
+	m := &MemoryMonitor{lastReading: memoryReading{
+		"GPU-b": {
+			123: 7 * 1024 * 1024,
+		},
+		"GPU-a": {
+			123: 2 * 1024 * 1024,
+			456: 3 * 1024 * 1024,
+			// PID 789 is not in the cgroup.
+			789: 100 * 1024 * 1024,
+		},
+	}}
+	want := &repb.GPUUsage{
+		TotalMemoryBytes: 12 * 1024 * 1024,
+		DeviceUsage: []*repb.GPUDeviceUsage{
+			{Id: "GPU-a", MemoryBytes: 5 * 1024 * 1024, Vendor: repb.GPUDeviceUsage_NVIDIA},
+			{Id: "GPU-b", MemoryBytes: 7 * 1024 * 1024, Vendor: repb.GPUDeviceUsage_NVIDIA},
+		},
+	}
+	usage := m.cgroupGPUUsage(cgroupPath)
+	require.Empty(t, cmp.Diff(want, usage, protocmp.Transform()))
+}
+
+func TestMemoryMonitorCgroupGPUUsage_NoAvailableData_UsageIsNil(t *testing.T) {
+	cgroupPath := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(cgroupPath, "cgroup.procs"), nil, 0o644))
+
+	m := &MemoryMonitor{}
+	usage := m.cgroupGPUUsage(cgroupPath)
+	require.Nil(t, usage)
+}
+
+func TestMemoryMonitorCgroupGPUUsage_EmptyReading_ZeroUsageIsReported(t *testing.T) {
+	cgroupPath := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(cgroupPath, "cgroup.procs"), nil, 0o644))
+
+	m := &MemoryMonitor{lastReading: memoryReading{}}
+	usage := m.cgroupGPUUsage(cgroupPath)
+	require.NotNil(t, usage)
+	require.Empty(t, cmp.Diff(&repb.GPUUsage{}, usage, protocmp.Transform()))
+}

--- a/enterprise/server/remote_execution/gpu/gpu_unsupported.go
+++ b/enterprise/server/remote_execution/gpu/gpu_unsupported.go
@@ -1,0 +1,17 @@
+//go:build !linux || android || !cgo
+
+package gpu
+
+import (
+	"errors"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+func configure() error {
+	return errors.New("GPU memory tracking requires a Linux build with cgo enabled")
+}
+
+func cgroupUsage(cgroupPath string) *repb.GPUUsage {
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.46.1-0.20260605085020-0da5b91b1c2c
 	github.com/GoogleCloudPlatform/cloudsql-proxy v1.35.0
 	github.com/Masterminds/semver/v3 v3.4.0
+	github.com/NVIDIA/go-nvml v0.13.3-1
 	github.com/RoaringBitmap/roaring v1.9.1
 	github.com/VictoriaMetrics/metrics v1.33.1
 	github.com/anishathalye/porcupine v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -750,6 +750,8 @@ github.com/Microsoft/hcsshim v0.9.6/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfy
 github.com/Microsoft/hcsshim v0.11.0/go.mod h1:OEthFdQv/AD2RAdzR6Mm1N1KPCztGKDurW1Z8b8VGMM=
 github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5hlzMzRKMLyo42nCZ9oml8AdTlq/0cvIaBv6tK1RehU=
 github.com/Microsoft/hcsshim/test v0.0.0-20210227013316-43a75bb4edd3/go.mod h1:mw7qgWloBUl75W/gVH3cQszUg1+gUITj7D6NY7ywVnY=
+github.com/NVIDIA/go-nvml v0.13.3-1 h1:P76U2h88OZSiMtdhRsJjSF5DXyXUqHIXKeDicVAaae0=
+github.com/NVIDIA/go-nvml v0.13.3-1/go.mod h1:ahi2psRYoa+wYUBIrZPRO+wJs9lcvMhxSSkjjvsJJNQ=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2852,6 +2852,48 @@ message UsageStats {
 
   // Network statistics for the network interface assigned to the action.
   NetworkStats network_stats = 10;
+
+  // GPU memory usage sampled during the task.
+  GPUUsage gpu_usage = 11;
+}
+
+// GPU memory usage sampled during a task's execution.
+message GPUUsage {
+  // GPU memory usage grouped by GPU.
+  repeated GPUDeviceUsage device_usage = 1;
+
+  // Maximum total GPU memory used by the task's processes across all GPUs.
+  int64 peak_total_memory_bytes = 2;
+
+  // Most recently recorded total GPU memory usage of the task across all
+  // GPUs. This field is only used for point-in-time readings and is not
+  // reported in task results (peak_total_memory_bytes is reported instead).
+  int64 total_memory_bytes = 3;
+}
+
+// GPU memory usage sampled on a GPU during a task's execution.
+message GPUDeviceUsage {
+  enum Vendor {
+    // The GPU vendor was not reported.
+    UNKNOWN_GPU_VENDOR = 0;
+
+    // NVIDIA Corporation.
+    NVIDIA = 1;
+  }
+
+  // GPU hardware vendor.
+  Vendor vendor = 1;
+
+  // GPU UUID reported by the GPU driver.
+  string id = 2;
+
+  // Maximum total GPU memory used by the task's processes on this GPU.
+  int64 peak_memory_bytes = 3;
+
+  // Most recently recorded GPU memory usage of the task on this GPU. This
+  // field is only used for point-in-time readings and is not reported in
+  // task results (peak_memory_bytes is reported instead).
+  int64 memory_bytes = 4;
 }
 
 // Network statistics for an action.
@@ -2913,6 +2955,17 @@ message UsageTimeline {
 
   // Delta-encoded total write operations, totaled across all block devices.
   repeated int64 wios_total_samples = 8;
+
+  // GPU memory usage timelines. This is unset when GPU memory tracking is not
+  // enabled or no GPU memory reading was available.
+  GPUUsageTimeline gpu_usage = 9;
+}
+
+// GPU memory usage sampled over a task's execution.
+message GPUUsageTimeline {
+  // Delta-encoded total GPU memory usage in kilobytes (1000 bytes). Samples
+  // correspond one-to-one with UsageTimeline.timestamps.
+  repeated int64 total_memory_kb_samples = 1;
 }
 
 // Pressure Stall Information, commonly known as PSI.


### PR DESCRIPTION
TL;DR start capturing GPU stats using [nvidia/go-nvml](https://github.com/nvidia/go-nvml)

Behind a flag (`executor.gpu_memory_tracking_enabled`), measures and reports GPU usage (peak usage + timelines) in task `UsageStats`.

Only NVIDIA GPUs are supported to start with, but the design is generic so we can support more vendors later. Does not wire up scheduling, task sizing, or ClickHouse storage yet.

- Adds a `gpu.MemoryMonitor` that continuously polls memory usage per GPU, per PID
  - The implementation uses https://github.com/nvidia/go-nvml, which requires cgo + a dynamically linked executor build in order to use NVIDIA's dlls. I think this is OK because (1) we already use cgo because of uffd, (2) the executor reasonably handles the static build case by failing startup if the GPU tracking flag is enabled, and (3) if the nvml dep causes issues in the future, we could build a separate, small binary that handles these calls, and run it as a child process.
  - I looked at using nvidia-smi instead, but the parsing was unfortunately a bit complicated, because it doesn't have a way to delimit each round of output. So we wind up needing a "staleness" heuristic after which we assume the process is no longer running. I'm not a fan of this sort of heuristic because it could lead to significantly less accurate metrics in some cases, and I want to be confident that the metrics are working properly. To work around this limitation, we could start an nvidia-smi process at every poll interval, but I measured the process overhead and it seems a bit too high (7% of a core for a 250ms poll interval, and seems more likely to cause problems under resource pressure due to pid / memory churn)
- Adds support to `podman` + `oci` isolation types to collect and report GPU usage (peak usage + timelines)
  - This works by reading `cgroup.procs` to get all the PIDs in the container cgroup, then matching those PIDs against the data we've most recently collected from `nvidia-smi`
- Updates the UI to render the peak GPU memory usage, with per-device info rendered in a tooltip.
- Updates the execution timing profile logic to support rendering the GPU memory usage timeseries.
- Updates the test CUDA program (`nvidia_gpu_test.sh`) to allocate more GPU memory over time, so that we can manually test this feature.

Part of https://github.com/buildbuddy-io/buildbuddy-internal/issues/8138

**Screenshots**

---

<img width="762" height="307" alt="image" src="https://github.com/user-attachments/assets/c55872c9-d377-4ac5-8a60-0c0080b3aba1" />

---

<img width="792" height="358" alt="image" src="https://github.com/user-attachments/assets/5c46ffa3-46bf-4a2e-bb08-bea023e8309e" />
