### PR TITLE
Remove some log noise from pebble cache and metacache

### DIFF
--- a/enterprise/server/backends/metacache/metacache.go
+++ b/enterprise/server/backends/metacache/metacache.go
@@ -712,9 +712,6 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 	foundMap := make(map[*repb.Digest][]byte, len(hits))
 	handleBatch := func() error {
 		for {
-			if err := ctx.Err(); err != nil {
-				return err
-			}
 			i := int(next.Add(1)) - 1
 			if i >= len(hits) {
 				return nil
@@ -731,6 +728,9 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 			buf := bytes.NewBuffer(make([]byte, 0, c.readBufSize(r, hit.md, rc)))
 			_, copyErr := io.Copy(buf, rc)
 			closeErr := rc.Close()
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			if copyErr != nil {
 				log.Warningf("[%s] GetMulti encountered error when copying %s: %s", c.opts.Name, r.GetDigest().GetHash(), copyErr)
 				continue

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1850,6 +1850,9 @@ func (p *PebbleCache) makeFileRecord(groupID string, encryption *sgpb.Encryption
 func (p *PebbleCache) lookupFileMetadataAndVersion(ctx context.Context, db pebble.IPebbleDB, key filestore.PebbleKey, fileMetadata *sgpb.FileMetadata) (filestore.PebbleKeyVersion, error) {
 	var lastErr error
 	for minVersion, version := p.minAndMaxDatabaseVersions(); version >= minVersion; version-- {
+		if ctx.Err() != nil {
+			return -1, ctx.Err()
+		}
 		keyBytes, err := key.Bytes(version)
 		if err != nil {
 			return -1, err

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2151,9 +2151,6 @@ func (p *PebbleCache) GetMulti(ctx context.Context, resources []*rspb.ResourceNa
 	foundMap := make(map[*repb.Digest][]byte, len(resources))
 	handleBatch := func() error {
 		for {
-			if err := ctx.Err(); err != nil {
-				return err
-			}
 			i := int(next.Add(1)) - 1
 			if i >= len(resources) {
 				return nil
@@ -2169,6 +2166,9 @@ func (p *PebbleCache) GetMulti(ctx context.Context, resources []*rspb.ResourceNa
 			buf := bytes.NewBuffer(make([]byte, 0, p.readBufSize(r, md, rc)))
 			_, copyErr := io.Copy(buf, rc)
 			closeErr := rc.Close()
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			if copyErr != nil {
 				log.CtxWarningf(ctx, "[%s] GetMulti encountered error when copying %s: %s", p.name, r.GetDigest().GetHash(), copyErr)
 				continue
@@ -3477,7 +3477,9 @@ func (e *partitionEvictor) doEvict(sample *approxlru.Sample[*evictionKey]) {
 	err = pebble.GetProto(db, sample.Key.bytes, md)
 	defer md.ReturnToVTPool()
 	if err != nil {
-		log.Infof("[%s] failed to read file metadata for key %s: %s", e.cacheName, sample.Key, err)
+		if !status.IsNotFoundError(err) && !os.IsNotExist(err) {
+			log.Infof("[%s] failed to read file metadata for key %s: %s", e.cacheName, sample.Key, err)
+		}
 		return
 	}
 	atime := time.UnixMicro(md.GetLastAccessUsec())


### PR DESCRIPTION
In both, in GetMulti, check if the context expired before logging failures. If it did, there's no reason to log that. We can just return.

In the pebble cache, when we try to evict a row, if we fail to read it because it's missing, don't log that. It means it was already evicted.