### PR TITLE
Support CDC without flagd

### DIFF
--- a/docs/config-rbe.md
+++ b/docs/config-rbe.md
@@ -17,6 +17,7 @@ RBE configuration must be enabled in your `config.yaml` file, but most configura
 **Optional**
 
 - `enable_remote_exec:` True if remote execution should be enabled.
+- `chunking_enabled:` Enables content-defined chunking for remote execution. Executors upload outputs and download inputs using content-defined chunks. Bazel-side chunking is supported by the cache server by default and can be enabled with Bazel's `--experimental_remote_cache_chunking` flag.
 - `default_pool_name:` The default executor pool to use if one is not specified.
 
 ## Example section
@@ -24,6 +25,21 @@ RBE configuration must be enabled in your `config.yaml` file, but most configura
 ```yaml title="config.yaml"
 remote_execution:
   enable_remote_exec: true
+```
+
+### Content-defined chunking
+
+The app server sends the chunking configuration to executors with each execution task, so executors do not need a separate chunking configuration.
+
+`cache.chunking.ac_key_salt` should be set to a stable, random secret before enabling chunking. It prevents clients from predicting the internal action-cache keys used for chunk manifests. Use the same value on every app server and cache proxy. Changing or removing it makes existing chunked-only manifests stored with the old value unavailable.
+
+```yaml title="config.yaml"
+remote_execution:
+  enable_remote_exec: true
+  chunking_enabled: true
+cache:
+  chunking:
+    ac_key_salt: "replace-with-a-stable-random-secret"
 ```
 
 ## Executor config

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -94,6 +94,7 @@ var (
 
 	writeExecutionProgressStateToRedis = flag.Bool("remote_execution.write_execution_progress_state_to_redis", false, "If enabled, write initial execution metadata and progress updates (stage changes) to redis. This state is cleared when the execution is complete.", flag.Internal)
 	writeExecutionsToPrimaryDB         = flag.Bool("remote_execution.write_executions_to_primary_db", true, "If enabled, write executions and invocation-execution links to the primary DB.", flag.Internal)
+	chunkingEnabled                    = flag.Bool("remote_execution.chunking_enabled", false, "If true, executors upload outputs and download inputs using content-defined chunks.")
 
 	teeInstanceNamePrefix = flag.String("remote_execution.tee_instance_name_prefix", "", "Instance name prefix used to identify tee'ed actions", flag.Internal)
 )
@@ -954,14 +955,20 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 	}
 
 	efp := s.env.GetExperimentFlagProvider()
-	if efp != nil && chunking.Enabled(ctx, efp) && efp.Boolean(ctx, "executor.upload_outputs_chunked", false) {
+	uploadOutputsChunked := *chunkingEnabled
+	downloadInputsChunked := *chunkingEnabled
+	if efp != nil {
+		uploadOutputsChunked = efp.Boolean(ctx, "executor.upload_outputs_chunked", uploadOutputsChunked)
+		downloadInputsChunked = efp.Boolean(ctx, "executor.download_inputs_chunked", downloadInputsChunked)
+	}
+	if chunking.Enabled(ctx, efp) && uploadOutputsChunked {
 		executionTask.Experiments = append(executionTask.Experiments, "executor.upload_outputs_chunked")
 		executionTask.FastCdc_2020Params = chunking.FastCDCWriteParams(ctx, efp)
-		if efp.Boolean(ctx, cdc.SpliceWithoutValidationExperiment, false) {
+		if efp != nil && efp.Boolean(ctx, cdc.SpliceWithoutValidationExperiment, false) {
 			executionTask.Experiments = append(executionTask.Experiments, cdc.SpliceWithoutValidationExperiment)
 		}
 	}
-	if efp != nil && chunking.Enabled(ctx, efp) && efp.Boolean(ctx, "executor.download_inputs_chunked", false) {
+	if chunking.Enabled(ctx, efp) && downloadInputsChunked {
 		executionTask.Experiments = append(executionTask.Experiments, "executor.download_inputs_chunked")
 	}
 

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -2,7 +2,9 @@ package execution_server_test
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -209,6 +211,47 @@ func TestDispatch(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, task.GetRequestMetadata().GetToolDetails(), "ToolDetails should be nil")
 	assert.Equal(t, iid, task.GetRequestMetadata().GetToolInvocationId(), "invocation ID should be passed along")
+	assert.NotContains(t, task.GetExperiments(), "executor.upload_outputs_chunked")
+	assert.NotContains(t, task.GetExperiments(), "executor.download_inputs_chunked")
+	assert.Nil(t, task.GetFastCdc_2020Params())
+}
+
+func TestDispatch_ChunkingConfigWithNoopExperimentProvider(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("enabled=%t", enabled), func(t *testing.T) {
+			flags.Set(t, "remote_execution.chunking_enabled", enabled)
+			env, _, _ := setupEnv(t)
+			require.NoError(t, experiments.Register(env))
+			require.NotNil(t, env.GetExperimentFlagProvider())
+
+			ctx := context.Background()
+			s := env.GetRemoteExecutionService()
+			ctx = withIncomingMetadata(t, ctx, &repb.RequestMetadata{
+				ToolInvocationId: "10243d8a-a329-4f46-abfb-bfbceed12baa",
+			})
+			ctx, err := env.GetAuthenticator().(*testauth.TestAuthenticator).WithAuthenticatedUser(ctx, "US1")
+			require.NoError(t, err)
+
+			action := &repb.Action{}
+			arn := uploadAction(ctx, t, env, "" /*=instanceName*/, repb.DigestFunction_SHA256, action)
+			ctx, err = prefix.AttachUserPrefixToContext(ctx, env.GetAuthenticator())
+			require.NoError(t, err)
+			require.NoError(t, s.Dispatch(ctx, &repb.ExecuteRequest{ActionDigest: arn.GetDigest()}, action, arn.NewUploadString()))
+
+			sched := env.GetSchedulerService().(*schedulerServerMock)
+			require.Len(t, sched.scheduleReqs, 1)
+			task := &repb.ExecutionTask{}
+			require.NoError(t, proto.Unmarshal(sched.scheduleReqs[0].SerializedTask, task))
+			assert.Equal(t, enabled, slices.Contains(task.GetExperiments(), "executor.upload_outputs_chunked"))
+			assert.Equal(t, enabled, slices.Contains(task.GetExperiments(), "executor.download_inputs_chunked"))
+			if enabled {
+				require.NotNil(t, task.GetFastCdc_2020Params())
+				assert.Equal(t, uint64(1024*1024), task.GetFastCdc_2020Params().GetAvgChunkSizeBytes())
+			} else {
+				assert.Nil(t, task.GetFastCdc_2020Params())
+			}
+		})
+	}
 }
 
 func TestDispatch_UploadOutputsChunkedMaxWriteSize(t *testing.T) {
@@ -227,6 +270,13 @@ func TestDispatch_UploadOutputsChunkedMaxWriteSize(t *testing.T) {
       "defaultVariant": "on"
     },
     "executor.upload_outputs_chunked": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true
+      },
+      "defaultVariant": "on"
+    },
+    "executor.download_inputs_chunked": {
       "state": "ENABLED",
       "variants": {
         "on": true
@@ -281,6 +331,7 @@ func TestDispatch_UploadOutputsChunkedMaxWriteSize(t *testing.T) {
 	err = proto.Unmarshal(sched.scheduleReqs[0].SerializedTask, task)
 	require.NoError(t, err)
 	require.Contains(t, task.GetExperiments(), "executor.upload_outputs_chunked")
+	require.Contains(t, task.GetExperiments(), "executor.download_inputs_chunked")
 	require.Contains(t, task.GetExperiments(), "splice-without-validation")
 	require.Equal(t, int64(123456789), task.GetFastCdc_2020Params().GetBuildbuddyMaxChunkedWriteSizeBytes())
 }


### PR DESCRIPTION
Self-hosted on-prem deployments may not run flagd, which currently leaves executor CDC upload and download paths disabled. This adds a cache.chunking_enabled config flag fallback so operators can enable those CDC paths directly, while flagd experiment values still take precedence when available.

Apps already support `Split/Splice` by default from the client, so the only changes needed are adding executor support.