### PR TITLE
Define a "static" Go build tag for statically linked builds

### DIFF
--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-# Target this platforms with --platforms for a static build linked against musl libc.
+# Target this platform with --config=static for a static build linked against musl libc.
 # Only meant to be used as a target platform.
 platform(
     name = "linux_x86_64_musl",
@@ -11,7 +11,7 @@ platform(
     ],
 )
 
-# Target this platforms with --platforms for a static build linked against musl libc.
+# Target this platform with --config=static-arm64 for a static build linked against musl libc.
 # Only meant to be used as a target platform.
 platform(
     name = "linux_arm64_musl",

--- a/rules/platform_transitions.bzl
+++ b/rules/platform_transitions.bzl
@@ -15,11 +15,13 @@ linux_arm64_alias, _linux_arm64_alias = (
 linux_x86_64_musl_alias, _linux_x86_64_musl_alias = (
     with_cfg(native.alias)
         .set("platforms", [Label("//platforms:linux_x86_64_musl")])
+        .extend(Label("@io_bazel_rules_go//go/config:tags"), ["static"])
         .build()
 )
 
 linux_arm64_musl_alias, _linux_arm64_musl_alias = (
     with_cfg(native.alias)
         .set("platforms", [Label("//platforms:linux_arm64_musl")])
+        .extend(Label("@io_bazel_rules_go//go/config:tags"), ["static"])
         .build()
 )

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -413,6 +413,13 @@ common:mac-workflows --config=cache
 common:mac-workflows --config=workflows
 common:mac-workflows --build_metadata=TAGS=mac-workflow
 
-# Build fully static binaries linked against musl on Linux.
+# For static builds, apply a 'static' tag for use with go:build directives.
+common:static-shared --@io_bazel_rules_go//go/config:tags=static
+
+# Build fully static binaries linked against musl on Linux (x86_64)
+common:static --config=static-shared
 common:static --platforms=//platforms:linux_x86_64_musl
+
+# Build fully static binaries linked against musl on Linux (arm64)
+common:static-arm64 --config=static-shared
 common:static-arm64 --platforms=//platforms:linux_arm64_musl


### PR DESCRIPTION
In https://github.com/buildbuddy-io/buildbuddy/pull/13069 I would like to use `linux && !android && !static` as the `go:build` constraint for a package which loads an NVIDIA DLL using `dlopen`, because binaries that are statically linked with musl cannot call `dlopen`. This PR implements this custom "static" tag to make this work.