### PR TITLE
Track and retry slow fetches for git checkout and merge

### DIFF
--- a/enterprise/server/cmd/ci_runner/BUILD
+++ b/enterprise/server/cmd/ci_runner/BUILD
@@ -80,7 +80,9 @@ go_test(
     srcs = ["main_test.go"],
     embed = [":ci_runner_lib"],
     deps = [
+        "//enterprise/server/workflow/config",
         "//server/testutil/testgit",
+        "//server/testutil/testshell",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -2088,7 +2088,8 @@ func (ws *workspace) mergeWithBaseIfRequested(ctx context.Context, actionTrigger
 	}
 
 	// TODO: Display merge commit in UI
-	if _, err := git(ctx, ws.log, "merge", "--no-edit", mergeBase); err != nil && !isAlreadyUpToDate(err) {
+	// git merge may fetch objects due to git_fetch_filters; run with fetch stats.
+	if err := ws.runGitWithFetchStats(ctx, "merge", "--no-edit", mergeBase); err != nil && !isAlreadyUpToDate(err) {
 		errMsg := err.Output
 		if _, err := git(ctx, ws.log, "merge", "--abort"); err != nil {
 			errMsg += "\n" + err.Output
@@ -2273,15 +2274,16 @@ func (ws *workspace) checkoutRef(ctx context.Context) error {
 		}
 	}
 
+	checkoutArgs := []string{"checkout", "--force"}
 	if checkoutLocalBranchName != "" {
 		// Create the local branch if it doesn't already exist, then update it to point to the checkout ref
-		if _, err := git(ctx, ws.log, "checkout", "--force", "-B", checkoutLocalBranchName, checkoutRef); err != nil {
-			return err
-		}
-	} else {
-		if _, err := git(ctx, ws.log, "checkout", "--force", checkoutRef); err != nil {
-			return err
-		}
+		checkoutArgs = append(checkoutArgs, "-B", checkoutLocalBranchName)
+	}
+	checkoutArgs = append(checkoutArgs, checkoutRef)
+	// The checkout may result in a fetch due to git_fetch_filters; run it with
+	// fetch stats.
+	if err := ws.runGitWithFetchStats(ctx, checkoutArgs...); err != nil {
+		return err
 	}
 	return nil
 }
@@ -2403,10 +2405,35 @@ func (ws *workspace) fetch(ctx context.Context, remoteURL string, refs []string,
 	fetchArgs = append(fetchArgs, remoteName)
 	fetchArgs = append(fetchArgs, refs...)
 
+	if fetchErr := ws.runGitWithFetchStats(ctx, fetchArgs...); fetchErr != nil {
+		return status.WrapError(fetchErr, fetchErr.Output)
+	}
+	return nil
+}
+
+// runGitWithFetchStats runs a git command that fetches data from the remote,
+// adding the time spent and bytes fetched to the workspace git fetch stats,
+// and retrying the command if git aborted a transfer because the rate was too
+// slow (see --git_fetch_low_speed_retries). Besides `git fetch` itself, this
+// applies to `git checkout` and `git merge`, because when refs were fetched
+// with a filter such as blob:none, those commands lazily fetch the
+// filtered-out objects they need.
+//
+// TODO: lazy fetch stats (e.g. fetches triggered by `git checkout`) currently
+// rely on git's output being a tty, because git only logs the "total_bytes"
+// trace2 events that byte counting parses when progress meters are shown.
+// Explicit fetches force meters with --progress, but lazy fetches run as git
+// child processes whose argv we don't control, so their meters are enabled
+// only by git's isatty check, which passes because runCommand runs git on a
+// pty that the children inherit. If commands ever stop running on a pty,
+// lazily fetched bytes would silently go uncounted. A tty-independent
+// approach would be to measure new pack files created during the command,
+// since lazy fetches always store fetched objects as kept packs.
+func (ws *workspace) runGitWithFetchStats(ctx context.Context, args ...string) *commandError {
 	// Have git log trace2 events to a file under .git/info, from which the
-	// exact number of fetched bytes is parsed once the fetch completes. The
-	// log is deleted after parsing.
-	fetchEnv := map[string]string{}
+	// number of fetched bytes is parsed once the command completes. The log is
+	// deleted after parsing.
+	env := map[string]string{}
 	// GIT_TRACE2 requires an abspath.
 	trace2Path, err := filepath.Abs(filepath.Join(".git", "info", "fetch_trace2.jsonl"))
 	if err != nil {
@@ -2415,10 +2442,10 @@ func (ws *workspace) fetch(ctx context.Context, remoteURL string, refs []string,
 		// Remove any leftover log (e.g. if a previous run was interrupted
 		// mid-fetch), since git appends to the log file.
 		_ = os.Remove(trace2Path)
-		fetchEnv["GIT_TRACE2_EVENT"] = trace2Path
+		env["GIT_TRACE2_EVENT"] = trace2Path
 		// Progress data events can be nested inside other trace2 regions;
 		// raise the nesting limit (default 2) so they aren't dropped.
-		fetchEnv["GIT_TRACE2_EVENT_NESTING"] = "5"
+		env["GIT_TRACE2_EVENT_NESTING"] = "5"
 	}
 
 	lowSpeedRetries := 0
@@ -2431,32 +2458,32 @@ func (ws *workspace) fetch(ctx context.Context, remoteURL string, refs []string,
 		// Respect low-speed settings that are already present in the
 		// environment (e.g. set on the image or in the action env).
 		if os.Getenv("GIT_HTTP_LOW_SPEED_LIMIT") == "" {
-			fetchEnv["GIT_HTTP_LOW_SPEED_LIMIT"] = strconv.FormatInt(*gitFetchLowSpeedLimit, 10)
+			env["GIT_HTTP_LOW_SPEED_LIMIT"] = strconv.FormatInt(*gitFetchLowSpeedLimit, 10)
 		}
 		if os.Getenv("GIT_HTTP_LOW_SPEED_TIME") == "" {
 			// Git configures the low-speed window in whole seconds; round up
 			// so that a sub-second value doesn't truncate to 0, which would
 			// disable the low-speed check entirely.
-			fetchEnv["GIT_HTTP_LOW_SPEED_TIME"] = strconv.Itoa(int(math.Ceil(gitFetchLowSpeedTime.Seconds())))
+			env["GIT_HTTP_LOW_SPEED_TIME"] = strconv.Itoa(int(math.Ceil(gitFetchLowSpeedTime.Seconds())))
 		}
 	}
 
-	var fetchErr *commandError
+	var cmdErr *commandError
 	for attempt := 0; ; attempt++ {
-		fetchStart := time.Now()
-		_, fetchErr = gitWithEnv(ctx, ws.log, fetchEnv, fetchArgs...)
-		ws.gitFetchDuration += time.Since(fetchStart)
-		if fetchErr == nil || attempt >= lowSpeedRetries || !isTransferTooSlow(fetchErr) {
+		start := time.Now()
+		_, cmdErr = gitWithEnv(ctx, ws.log, env, args...)
+		ws.gitFetchDuration += time.Since(start)
+		if cmdErr == nil || attempt >= lowSpeedRetries || !isTransferTooSlow(cmdErr) {
 			break
 		}
 		ws.gitFetchRetryCount++
 		writeCommandSummary(ws.log, "The fetch was aborted because the transfer rate was too slow. Retrying (attempt %d of %d)...", attempt+1, lowSpeedRetries)
 	}
-	// Count fetched bytes even if the fetch failed, since a failed fetch may
+	// Count fetched bytes even if the command failed, since a failed fetch may
 	// be retried (e.g. with a different depth) and we want the total to
 	// reflect all data transferred. Retried attempts append to the same log,
 	// so any bytes they recorded before being aborted are counted too.
-	if fetchEnv["GIT_TRACE2_EVENT"] != "" {
+	if env["GIT_TRACE2_EVENT"] != "" {
 		if f, err := os.Open(trace2Path); err != nil {
 			backendLog.Warningf("Could not open the git trace2 event log; git fetch stats may be undercounted: %s", err)
 		} else {
@@ -2465,10 +2492,7 @@ func (ws *workspace) fetch(ctx context.Context, remoteURL string, refs []string,
 		}
 		_ = os.Remove(trace2Path)
 	}
-	if fetchErr != nil {
-		return status.WrapError(fetchErr, fetchErr.Output)
-	}
-	return nil
+	return cmdErr
 }
 
 // parseGitFetchedBytes returns the total number of bytes fetched by a git

--- a/enterprise/server/cmd/ci_runner/main_test.go
+++ b/enterprise/server/cmd/ci_runner/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net/http"
@@ -14,7 +15,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/workflow/config"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testgit"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testshell"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -180,6 +183,239 @@ func TestGitFetchRetriesSlowTransfer(t *testing.T) {
 	fetchedCommitSHA, gitErr := git(t.Context(), io.Discard, "rev-parse", "FETCH_HEAD")
 	require.Nil(t, gitErr)
 	require.Equal(t, wantCommitSHA, strings.TrimSpace(fetchedCommitSHA))
+}
+
+func TestGitCheckoutRetriesSlowLazyFetch(t *testing.T) {
+	flags.Set(t, "git_fetch_low_speed_retries", 1)
+	flags.Set(t, "git_fetch_low_speed_limit", 1)
+	// Git and libcurl configure the low-speed window in whole seconds, so one
+	// second is the shortest interval and gives the fastest possible check.
+	flags.Set(t, "git_fetch_low_speed_time", time.Second)
+	// Fetch with blob:none so that the checkout has to lazily fetch the blobs
+	// it needs from the remote.
+	flags.Set(t, "git_fetch_filters", []string{"blob:none"})
+	flags.Set(t, "pushed_branch", "master")
+	for _, envVar := range []string{"GIT_HTTP_LOW_SPEED_LIMIT", "GIT_HTTP_LOW_SPEED_TIME"} {
+		originalValue, wasSet := os.LookupEnv(envVar)
+		require.NoError(t, os.Unsetenv(envVar))
+		t.Cleanup(func() {
+			if wasSet {
+				require.NoError(t, os.Setenv(envVar, originalValue))
+				return
+			}
+			require.NoError(t, os.Unsetenv(envVar))
+		})
+	}
+	// Fetch from the proxy URL as-is. Otherwise fetch() embeds the REPO_USER
+	// and REPO_TOKEN credentials in the URL if they are set, which they are
+	// when this test itself runs in a BuildBuddy workflow.
+	t.Setenv("USE_SYSTEM_GIT_CREDENTIALS", "1")
+
+	// Serve a real repository over HTTP.
+	remote := testgit.StartServer(t, testgit.ServerOptions{LogWriter: io.Discard})
+	remote.CreateProject("test-org", "test-repo", &testgit.ProjectSettings{Public: true})
+	sourceDir, wantCommitSHA := testgit.MakeTempRepo(t, map[string]string{"README.md": "test repo"})
+	remote.Push("test-org", "test-repo", remote.AccessToken(), sourceDir)
+
+	// Proxy the Git server. Once armed, the proxy leaves the next upload-pack
+	// response hanging after its first byte until Git aborts it; all other
+	// responses pass through.
+	upstreamURL, err := url.Parse(remote.RepoURL("test-org", "test-repo", ""))
+	require.NoError(t, err)
+	var stallNextFetch atomic.Bool
+	proxy := httputil.NewSingleHostReverseProxy(upstreamURL)
+	proxy.ModifyResponse = func(response *http.Response) error {
+		if response.Request.Method == http.MethodPost && strings.HasSuffix(response.Request.URL.Path, "/git-upload-pack") && stallNextFetch.CompareAndSwap(true, false) {
+			response.Body = &stallingReadCloser{ctx: response.Request.Context(), ReadCloser: response.Body}
+		}
+		return nil
+	}
+	proxyServer := httptest.NewServer(proxy)
+	t.Cleanup(proxyServer.Close)
+
+	checkoutDir := t.TempDir()
+	originalWorkingDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(checkoutDir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(originalWorkingDir))
+	})
+	invocationLog := newInvocationLog(nil)
+	invocationLog.writer = io.Discard
+	ws := &workspace{
+		rootDir: checkoutDir,
+		log:     &buildEventReporter{log: invocationLog},
+	}
+	require.NoError(t, ws.init(t.Context()))
+	// Filtered fetches require the partialClone extension, which the runner
+	// normally enables while configuring the repository.
+	_, gitErr := git(t.Context(), io.Discard, "config", "extensions.partialClone", "true")
+	require.Nil(t, gitErr)
+
+	// Fetch the pushed branch without blobs. This fetch is not stalled, so
+	// expect no retries. Fetched byte counts are not asserted in this test,
+	// since the git version on the test executors is too old to log the
+	// trace2 progress events that byte counting is parsed from.
+	require.NoError(t, ws.fetch(t.Context(), proxyServer.URL, []string{"refs/heads/master"}, 1))
+	require.Equal(t, int64(0), ws.gitFetchRetryCount)
+
+	// Check out the fetched branch, stalling the lazy blob fetch that the
+	// checkout triggers. Expect the checkout to be aborted by Git's low-speed
+	// check and retried.
+	stallNextFetch.Store(true)
+	require.NoError(t, ws.checkoutRef(t.Context()))
+	require.Equal(t, int64(1), ws.gitFetchRetryCount)
+
+	// The checked-out working tree should contain the lazily fetched README
+	// at the pushed commit.
+	readme, err := os.ReadFile("README.md")
+	require.NoError(t, err)
+	require.Equal(t, "test repo", string(readme))
+	headCommitSHA, gitErr := git(t.Context(), io.Discard, "rev-parse", "HEAD")
+	require.Nil(t, gitErr)
+	require.Equal(t, wantCommitSHA, strings.TrimSpace(headCommitSHA))
+}
+
+func TestGitMergeRetriesSlowLazyFetch(t *testing.T) {
+	flags.Set(t, "git_fetch_low_speed_retries", 1)
+	flags.Set(t, "git_fetch_low_speed_limit", 1)
+	// Git and libcurl configure the low-speed window in whole seconds, so one
+	// second is the shortest interval and gives the fastest possible check.
+	flags.Set(t, "git_fetch_low_speed_time", time.Second)
+	// Fetch with blob:none so that the merge has to lazily fetch the blobs it
+	// needs from the remote.
+	flags.Set(t, "git_fetch_filters", []string{"blob:none"})
+	flags.Set(t, "pushed_branch", "feature")
+	flags.Set(t, "target_branch", "master")
+	for _, envVar := range []string{"GIT_HTTP_LOW_SPEED_LIMIT", "GIT_HTTP_LOW_SPEED_TIME"} {
+		originalValue, wasSet := os.LookupEnv(envVar)
+		require.NoError(t, os.Unsetenv(envVar))
+		t.Cleanup(func() {
+			if wasSet {
+				require.NoError(t, os.Setenv(envVar, originalValue))
+				return
+			}
+			require.NoError(t, os.Unsetenv(envVar))
+		})
+	}
+	// Fetch from the proxy URL as-is. Otherwise fetch() embeds the REPO_USER
+	// and REPO_TOKEN credentials in the URL if they are set, which they are
+	// when this test itself runs in a BuildBuddy workflow.
+	t.Setenv("USE_SYSTEM_GIT_CREDENTIALS", "1")
+
+	// Serve a repository over HTTP in which a feature branch and master have
+	// diverged, so that merging master into the feature branch needs master's
+	// updated README blob.
+	remote := testgit.StartServer(t, testgit.ServerOptions{LogWriter: io.Discard})
+	remote.CreateProject("test-org", "test-repo", &testgit.ProjectSettings{Public: true})
+	sourceDir, _ := testgit.MakeTempRepo(t, map[string]string{"README.md": "base readme"})
+	testshell.Run(t, sourceDir, `
+		git checkout -q -b feature
+		echo -n "feature change" > feature.txt
+		git add . && git commit -qm "feature change"
+		git checkout -q master
+		echo -n "updated readme" > README.md
+		git add . && git commit -qm "master change"
+	`)
+	remote.Push("test-org", "test-repo", remote.AccessToken(), sourceDir)
+	// Push the feature branch with the same credential settings that
+	// remote.Push uses. In particular the credential helper list must be
+	// reset, because on macOS the system gitconfig enables the osxkeychain
+	// helper, which hangs forever on unattended hosts waiting for keychain
+	// access.
+	testshell.Run(t, sourceDir, `
+		export GIT_ASKPASS=/usr/bin/true
+		git -c credential.helper= push -q origin feature
+	`)
+	masterReadmeOID := strings.TrimSpace(testshell.Run(t, sourceDir, `git rev-parse master:README.md`))
+
+	// Proxy the Git server. The merge's lazy fetch is identified by its
+	// request body wanting master's README blob; once armed, the proxy leaves
+	// the response to that fetch hanging after its first byte until Git
+	// aborts it. All other responses pass through, including those of the
+	// target branch fetch that precedes the merge.
+	upstreamURL, err := url.Parse(remote.RepoURL("test-org", "test-repo", ""))
+	require.NoError(t, err)
+	var stallNextLazyFetch atomic.Bool
+	type stallMarker struct{}
+	proxy := httputil.NewSingleHostReverseProxy(upstreamURL)
+	proxy.ModifyResponse = func(response *http.Response) error {
+		if response.Request.Context().Value(stallMarker{}) != nil {
+			response.Body = &stallingReadCloser{ctx: response.Request.Context(), ReadCloser: response.Body}
+		}
+		return nil
+	}
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/git-upload-pack") {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			r.Body = io.NopCloser(bytes.NewReader(body))
+			if strings.Contains(string(body), masterReadmeOID) && stallNextLazyFetch.CompareAndSwap(true, false) {
+				r = r.WithContext(context.WithValue(r.Context(), stallMarker{}, true))
+			}
+		}
+		proxy.ServeHTTP(w, r)
+	}))
+	t.Cleanup(proxyServer.Close)
+	flags.Set(t, "pushed_repo_url", proxyServer.URL)
+	flags.Set(t, "target_repo_url", proxyServer.URL)
+
+	checkoutDir := t.TempDir()
+	originalWorkingDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(checkoutDir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(originalWorkingDir))
+	})
+	invocationLog := newInvocationLog(nil)
+	invocationLog.writer = io.Discard
+	ws := &workspace{
+		rootDir: checkoutDir,
+		log:     &buildEventReporter{log: invocationLog},
+	}
+	require.NoError(t, ws.init(t.Context()))
+	// Filtered fetches require the partialClone extension, and the merge
+	// commit needs a committer identity. The runner normally sets both while
+	// configuring the repository.
+	for _, kv := range [][2]string{
+		{"extensions.partialClone", "true"},
+		{"user.email", "ci-runner@buildbuddy.io"},
+		{"user.name", "BuildBuddy"},
+	} {
+		_, gitErr := git(t.Context(), io.Discard, "config", kv[0], kv[1])
+		require.Nil(t, gitErr)
+	}
+
+	// Fetch and check out the feature branch. Neither is stalled, so expect
+	// no retries.
+	require.NoError(t, ws.fetch(t.Context(), proxyServer.URL, []string{"refs/heads/feature"}, 1))
+	require.NoError(t, ws.checkoutRef(t.Context()))
+	require.Equal(t, int64(0), ws.gitFetchRetryCount)
+
+	// Merge with the base branch, stalling the lazy fetch of master's README
+	// blob that the merge triggers. Expect the merge to be aborted by Git's
+	// low-speed check and retried. MergeWithBase is enabled by default for
+	// pull request triggers.
+	stallNextLazyFetch.Store(true)
+	triggers := &config.Triggers{PullRequest: &config.PullRequestTrigger{}}
+	require.NoError(t, ws.mergeWithBaseIfRequested(t.Context(), triggers))
+	require.Nil(t, ws.setupError, "setup error: %v", ws.setupError)
+	require.False(t, stallNextLazyFetch.Load(), "expected the proxy to have stalled the merge's lazy fetch")
+	require.Equal(t, int64(1), ws.gitFetchRetryCount)
+
+	// The merge commit should combine both branches, with the lazily fetched
+	// README at master's version and the feature branch's file intact.
+	readme, err := os.ReadFile("README.md")
+	require.NoError(t, err)
+	require.Equal(t, "updated readme", string(readme))
+	featureFile, err := os.ReadFile("feature.txt")
+	require.NoError(t, err)
+	require.Equal(t, "feature change", string(featureFile))
+	_, gitErr := git(t.Context(), io.Discard, "rev-parse", "--verify", "HEAD^2")
+	require.Nil(t, gitErr, "expected HEAD to be a merge commit")
 }
 
 func TestIsTransferTooSlow(t *testing.T) {

--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -1685,13 +1685,18 @@ message RunTargetAnalyzed {
 // --skip_auto_checkout). Fetches performed by the action itself, such as
 // bazel-triggered fetches of external git repos, are not counted.
 message GitFetchCompleted {
-  // Total number of bytes fetched, parsed from git trace2 event logs.
+  // Total number of bytes fetched, parsed from git trace2 event logs. This
+  // includes objects fetched lazily during checkout and merge, which happens
+  // when fetch filters such as blob:none are used.
   int64 total_bytes = 1;
 
-  // Total time spent running git fetch commands.
+  // Total time spent running git commands that fetch from the remote. In
+  // addition to git fetch commands, this counts git checkout and git merge
+  // commands in full, since with fetch filters in use the bulk of their time
+  // is typically spent lazily fetching filtered-out objects.
   google.protobuf.Duration duration = 2;
 
-  // Total number of git fetch retries after low-speed aborts.
+  // Total number of git command retries after low-speed transfer aborts.
   int64 retry_count = 3;
 }
 

--- a/server/util/mockgitserver/mockgitserver.go
+++ b/server/util/mockgitserver/mockgitserver.go
@@ -82,6 +82,18 @@ func CreateProject(gitProjectRoot, owner, repo string, settings *ProjectSettings
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("git init --bare failed: %q (%w)", strings.TrimSpace(stderr.String()), err)
 	}
+	// Support partial clones, like real git hosts such as GitHub do.
+	// allowFilter lets clients fetch with --filter (e.g. blob:none), and
+	// allowAnySHA1InWant lets the resulting lazy fetches request the
+	// filtered-out objects directly by object ID.
+	for _, key := range []string{"uploadpack.allowFilter", "uploadpack.allowAnySHA1InWant"} {
+		cmd := exec.Command("git", "-C", repoPath, "config", key, "true")
+		stderr := &bytes.Buffer{}
+		cmd.Stderr = stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("git config %s: %q (%w)", key, strings.TrimSpace(stderr.String()), err)
+		}
+	}
 	// Create git-daemon-export-ok file to make it available for serving.
 	if err := os.WriteFile(filepath.Join(repoPath, "git-daemon-export-ok"), nil, 0644); err != nil {
 		return fmt.Errorf("create git-daemon-export-ok: %w", err)


### PR DESCRIPTION
Due to `git_fetch_filters`, both `git checkout` and `git merge` can also do fetches, in addition to the `git fetch` command itself. Track those two commands as part of metrics, and also enable low-speed retries for those as well.