### PR TITLE
add `--container_image` flag to rbe prober

### DIFF
--- a/tools/probers/bazelrbe/bazelrbe.go
+++ b/tools/probers/bazelrbe/bazelrbe.go
@@ -22,6 +22,7 @@ var (
 	bazelArgs           = flag.String("bazel_args", "", "Space separated list of args to pass to Bazel")
 	bazelStartupOptions = flag.String("bazel_startup_options", "", "Space separated list of Bazel startup options to pass (appear before the command)")
 	proberName          = flag.String("prober_name", "", "Short, human-readable name of this prober. This name must be a valid bazel package name (only '.', '@', '-', '_' and alphanumeric characters allowed).")
+	containerImage      = flag.String("container_image", "none", "Container image in which to execute prober actions. Set to 'none' to use the executor default.")
 
 	numTargets         = flag.Int("num_targets", 10, "Number targets to generate")
 	numInputsPerTarget = flag.Int("num_inputs_per_target", 10, "Number of inputs each generated target will have")
@@ -52,14 +53,17 @@ genrule(
 		  srcs=($(SRCS))
 		  outs=($(OUTS))
 		  for ((i=0; i < $${#srcs[@]}; i++)); do
-			src=$${srcs[i]}  
+			src=$${srcs[i]}
 			out=$${outs[i]}
 			/bin/cat "$$src" > "$$out"
 		  done
       """,
-	  exec_properties = {"salt": "%d"},
+	  exec_properties = {
+	      "container-image": %q,
+	      "salt": "%d",
+	  },
 )
-`, targetName, strings.Join(srcs, ","), strings.Join(outs, ","), salt), nil
+`, targetName, strings.Join(srcs, ","), strings.Join(outs, ","), *containerImage, salt), nil
 }
 
 func createWorkspace(dir string, numTargets, numInputsPerTarget, inputSizeBytes int) error {


### PR DESCRIPTION
Currently, the RBE probers do not specify a container image, meaning they get the executor default image (based on Ubuntu 16.04).

This change keeps that default behavior, but lets us pass specific container images, so we can use the smaller, newer Ubuntu 22.04 RBE image (363 MB compressed) instead of the larger, staler Ubuntu 16.04 RBE image (1.1 GB compressed).