### PR TITLE
Fix flake in crypter test

### DIFF
--- a/enterprise/server/crypter_key_cache/crypter_key_cache.go
+++ b/enterprise/server/crypter_key_cache/crypter_key_cache.go
@@ -265,7 +265,18 @@ func (c *KeyCache) refreshKey(ctx context.Context, ck CacheKey, cacheError bool)
 		}
 		return k, err
 	})
-	return v, err
+	if err != nil {
+		return nil, err
+	}
+
+	// The singleflight group runs the refresh on a context without cancelation, so that
+	// the refresh can succeed even if the caller's ctx is done.
+	// The group's `wait` then non-deterministically selects between the result from `refreshKey` and the done context.
+	// If the context is done, return the same result here so that the results are consistent.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, ctxErr
+	}
+	return v, nil
 }
 
 func (c *KeyCache) loadKey(ctx context.Context, em *sgpb.EncryptionMetadata) (*crypter.DerivedKey, error) {


### PR DESCRIPTION
**Root cause:** `singleflight.Group.Do` runs the refresh on a context with cancelation stripped (`context.WithoutCancel`), so with an already-canceled caller context the refresh still succeeds; the group's `wait` then selects between the completed call and the done context, and when it randomly picks the completed call, `EncryptionKey` returns a key with a nil error — making `TestAlreadyCanceledContextDoesNotPoisonCache`'s `require.Error` flaky.

**Patch:** after `sf.Do` returns successfully in `refreshKey`, explicitly return `ctx.Err()` if the caller's context is done, instead of depending on which branch the singleflight select happened to take. This makes a canceled caller deterministically get a context error while still letting the detached refresh populate the cache, so the follow-up lookup with a live context succeeds.

Flake fixed by `[bb fix`](https://github.com/buildbuddy-io/buildbuddy/pull/13081)!