### PR TITLE
Make `ReferenceCache.CreateReference()` return an `io.Writer` instead of accepting an `io.Reader`

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2277,7 +2277,27 @@ func (p *PebbleCache) ReadReference(ctx context.Context, r *rspb.ResourceName) (
 	return &refpb.Reference{Metadata: md}, nil
 }
 
-func (p *PebbleCache) CreateReference(ctx context.Context, r *rspb.ResourceName, reader io.Reader) (*refpb.Reference, error) {
+type referenceWriter struct {
+	wc interfaces.CommittedWriteCloser
+	md *sgpb.FileMetadata
+}
+
+func (w *referenceWriter) Write(p []byte) (int, error) {
+	return w.wc.Write(p)
+}
+
+func (w *referenceWriter) Close() error {
+	return w.wc.Close()
+}
+
+func (w *referenceWriter) Commit() (*refpb.Reference, error) {
+	if err := w.wc.Commit(); err != nil {
+		return nil, err
+	}
+	return &refpb.Reference{Metadata: w.md}, nil
+}
+
+func (p *PebbleCache) CreateReference(ctx context.Context, r *rspb.ResourceName) (interfaces.ReferenceWriter, error) {
 	if p.gcsBlobstore == nil {
 		return nil, status.FailedPreconditionError("pebble cache is not backed by shared storage; cannot create references")
 	}
@@ -2301,23 +2321,16 @@ func (p *PebbleCache) CreateReference(ctx context.Context, r *rspb.ResourceName,
 
 	// Commit only captures the blob's metadata instead of registering it in
 	// this cache.
-	var md *sgpb.FileMetadata
-	wc, err := p.wrapWriter(ctx, fileRecord, bw, shouldCompress, nil, func(m *sgpb.FileMetadata) error {
-		md = m
+	rw := &referenceWriter{}
+	wc, err := p.wrapWriter(ctx, fileRecord, bw, shouldCompress, nil, func(md *sgpb.FileMetadata) error {
+		rw.md = md
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	defer wc.Close()
-
-	if _, err := io.Copy(wc, reader); err != nil {
-		return nil, err
-	}
-	if err := wc.Commit(); err != nil {
-		return nil, err
-	}
-	return &refpb.Reference{Metadata: md}, nil
+	rw.wc = wc
+	return rw, nil
 }
 
 func validateReference(ref *refpb.Reference) error {

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -3201,7 +3201,12 @@ func TestCreateReference(t *testing.T) {
 
 	// Blobs at or above minGCSFileSize are staged in GCS and referenceable.
 	gcsRN, gcsBuf := testdigest.RandomCASResourceBuf(t, 100)
-	ref, err := pc.CreateReference(ctx, gcsRN, bytes.NewReader(gcsBuf))
+	w, err := pc.CreateReference(ctx, gcsRN)
+	require.NoError(t, err)
+	defer w.Close()
+	_, err = w.Write(gcsBuf)
+	require.NoError(t, err)
+	ref, err := w.Commit()
 	require.NoError(t, err)
 	require.NotEmpty(t, ref.GetMetadata().GetStorageMetadata().GetGcsMetadata().GetBlobName())
 	require.Equal(t, gcsRN.GetDigest().GetHash(), ref.GetMetadata().GetFileRecord().GetDigest().GetHash())
@@ -3229,8 +3234,8 @@ func TestCreateReference(t *testing.T) {
 
 	// Blobs below minGCSFileSize cannot be referenced, and nothing is
 	// written anywhere for them.
-	diskRN, diskBuf := testdigest.RandomCASResourceBuf(t, 50)
-	_, err = pc.CreateReference(ctx, diskRN, bytes.NewReader(diskBuf))
+	diskRN, _ := testdigest.RandomCASResourceBuf(t, 50)
+	_, err = pc.CreateReference(ctx, diskRN)
 	require.True(t, status.IsNotFoundError(err), "expected NotFound, got %v", err)
 	_, err = pc.Get(ctx, diskRN)
 	require.True(t, status.IsNotFoundError(err), "expected NotFound, got %v", err)

--- a/enterprise/server/util/distributed_client/distributed_client_test.go
+++ b/enterprise/server/util/distributed_client/distributed_client_test.go
@@ -1427,7 +1427,7 @@ func (c *fakeReferenceCache) ReadReference(ctx context.Context, r *rspb.Resource
 	return nil, status.UnimplementedError("not implemented")
 }
 
-func (c *fakeReferenceCache) CreateReference(ctx context.Context, r *rspb.ResourceName, reader io.Reader) (*refpb.Reference, error) {
+func (c *fakeReferenceCache) CreateReference(ctx context.Context, r *rspb.ResourceName) (interfaces.ReferenceWriter, error) {
 	return nil, status.UnimplementedError("not implemented")
 }
 
@@ -1622,7 +1622,7 @@ func (c *serverReferenceCache) ReadReference(ctx context.Context, r *rspb.Resour
 	return nil, status.NotFoundError("no reference available")
 }
 
-func (c *serverReferenceCache) CreateReference(ctx context.Context, r *rspb.ResourceName, reader io.Reader) (*refpb.Reference, error) {
+func (c *serverReferenceCache) CreateReference(ctx context.Context, r *rspb.ResourceName) (interfaces.ReferenceWriter, error) {
 	return nil, status.UnimplementedError("not implemented")
 }
 

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -326,18 +326,28 @@ type StoppableCache interface {
 	Stop() error
 }
 
+// A WriteCloser whose Commit finalizes and returns a reference.
+type ReferenceWriter interface {
+	io.Writer
+	io.Closer
+	Commit() (*refpb.Reference, error)
+}
+
 // A Cache implementation that supports reading and writing refpb.References.
 type ReferenceCache interface {
 	Cache
 
-	// Creates a reference to the resource named by r from the bytes read from
-	// reader by writing them to shared storage, without writing r as an entry
-	// in this cache (so that the created reference can be claimed by another
-	// cache). The returned reference can be dereferenced with Dereference() or
+	// Returns a writer that stages the written bytes as the resource named by
+	// r in shared storage, without writing r as an entry in this cache (so
+	// that the created reference can be claimed by another cache). The
+	// reference returned by Commit can be dereferenced with Dereference() or
 	// stored with WriteReference() by an identically-configured ReferenceCache;
 	// no cache owns the staged blob until a cache stores the reference, and at
 	// most one may do so without cloning.
-	CreateReference(ctx context.Context, r *rspb.ResourceName, reader io.Reader) (*refpb.Reference, error)
+	//
+	// To release resources, callers *must* call Close() on the returned
+	// ReferenceWriter regardless of whether the commit succeeds or not.
+	CreateReference(ctx context.Context, r *rspb.ResourceName) (ReferenceWriter, error)
 
 	// Reads the provided resource from the cache and returns a reference to it.
 	// The provided reference can be dereferenced into an io.ReadCloser using


### PR DESCRIPTION
Per Vanja's (pasted from Slack) comment in https://github.com/buildbuddy-io/buildbuddy/pull/12982

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7911