### PR TITLE
Firecracker: reduce eager fetching 8x for rootfs

### DIFF
--- a/enterprise/server/remote_execution/copy_on_write/BUILD
+++ b/enterprise/server/remote_execution/copy_on_write/BUILD
@@ -36,6 +36,7 @@ go_test(
     deps = [
         ":copy_on_write",
         "//enterprise/server/remote_execution/copy_on_write/cow_cgo_testutil",
+        "//enterprise/server/remote_execution/filecache",
         "//enterprise/server/remote_execution/snaputil",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
@@ -68,6 +69,7 @@ go_test(
     deps = [
         ":copy_on_write",
         "//enterprise/server/remote_execution/copy_on_write/cow_cgo_testutil",
+        "//enterprise/server/remote_execution/filecache",
         "//enterprise/server/remote_execution/snaputil",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -49,8 +49,8 @@ const (
 
 	// If we access a chunk, we will queue this number of contiguous chunks
 	// to be eagerly fetched in the background, anticipating that they will
-	// also be accessed
-	numChunksToEagerFetch = 32
+	// also be accessed.
+	defaultNumChunksToEagerFetch = 32
 
 	// Number of goroutines to run concurrently to handle LRU evictions.
 	lruEvictionConcurrency = 2
@@ -163,10 +163,11 @@ type COWStore struct {
 	// Chunk offsets to be eagerly fetched. This is using a bounded stack data
 	// structure so that if the buffer is full, a new item can still be appended,
 	// evicting the least recently added chunk.
-	eagerFetchStack *boundedstack.BoundedStack[int64]
-	eagerFetchEg    *errgroup.Group
-	quitOnce        sync.Once
-	quitChan        chan struct{}
+	eagerFetchStack  *boundedstack.BoundedStack[int64]
+	eagerFetchEg     *errgroup.Group
+	eagerFetchChunks int
+	quitOnce         sync.Once
+	quitChan         chan struct{}
 
 	// usageLock protects chunkOperationToUsageSummary
 	usageLock                    sync.Mutex
@@ -186,6 +187,10 @@ type COWOptions struct {
 	DataDir            string
 	RemoteInstanceName string
 	RemoteEnabled      bool
+
+	// EagerFetchChunks controls how many chunks following an accessed chunk are
+	// fetched speculatively. If unset, the default eager-fetch window is used.
+	EagerFetchChunks int
 
 	// By default, mmapped chunks are managed by the executor-wide shared LRU.
 	//
@@ -212,6 +217,11 @@ func NewCOWStore(ctx context.Context, env environment.Env, name string, chunks [
 	chunkMap := make(map[int64]*Mmap, len(chunks))
 	for _, c := range chunks {
 		chunkMap[c.Offset] = c
+	}
+
+	eagerFetchChunks := opts.EagerFetchChunks
+	if eagerFetchChunks <= 0 {
+		eagerFetchChunks = defaultNumChunksToEagerFetch
 	}
 
 	var lru *MmapLRU
@@ -257,6 +267,7 @@ func NewCOWStore(ctx context.Context, env environment.Env, name string, chunks [
 		ioBlockSize:                  int64(stat.Sys().(*syscall.Stat_t).Blksize),
 		eagerFetchStack:              eagerFetchStack,
 		eagerFetchEg:                 &errgroup.Group{},
+		eagerFetchChunks:             eagerFetchChunks,
 		quitChan:                     make(chan struct{}),
 		chunkOperationToUsageSummary: make(map[string]usageSummary, 0),
 		mmapLRU:                      lru,
@@ -831,7 +842,7 @@ func (s *COWStore) eagerFetchNextChunks(offset int64) {
 		return
 	}
 	currentOffset := offset + s.chunkSizeBytes
-	for i := 0; i < numChunksToEagerFetch; i++ {
+	for i := 0; i < s.eagerFetchChunks; i++ {
 		s.eagerFetchStack.Push(currentOffset)
 		currentOffset += s.chunkSizeBytes
 	}

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
@@ -13,9 +13,11 @@ import (
 	"sync"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/copy_on_write"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/copy_on_write/cow_cgo_testutil"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaputil"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
@@ -169,6 +171,60 @@ func TestCOW_OnWriteHook(t *testing.T) {
 		{Offset: 10, Length: 2, ChunkIndex: 2},
 		{Offset: 12, Length: 3, ChunkIndex: 3},
 	}, events)
+}
+
+func TestCOW_EagerFetchChunksOption(t *testing.T) {
+	flags.Set(t, "executor.enable_local_snapshot_sharing", true)
+	flags.Set(t, "executor.enable_remote_snapshot_sharing", false)
+
+	ctx := t.Context()
+	env := testenv.GetTestEnv(t)
+	fc, err := filecache.NewFileCache(testfs.MakeTempDir(t), 1_000_000, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, fc.Close()) })
+	fc.WaitForDirectoryScanToComplete()
+	env.SetFileCache(fc)
+
+	const chunkSizeBytes = int64(4096)
+	digests := make([]*repb.Digest, 3)
+	for i := range digests {
+		data := bytes.Repeat([]byte{byte(i + 1)}, int(chunkSizeBytes))
+		d, err := digest.Compute(bytes.NewReader(data), repb.DigestFunction_BLAKE3)
+		require.NoError(t, err)
+		digests[i] = d
+		path := filepath.Join(testfs.MakeTempDir(t), fmt.Sprintf("chunk-%d", i))
+		require.NoError(t, os.WriteFile(path, data, 0644))
+		require.NoError(t, fc.AddFile(ctx, &repb.FileNode{Digest: d}, path))
+	}
+
+	newStore := func(eagerFetchChunks int) (*copy_on_write.COWStore, []*copy_on_write.Mmap) {
+		dataDir := testfs.MakeTempDir(t)
+		lru, err := copy_on_write.GetSharedMmapLRU(dataDir)
+		require.NoError(t, err)
+		chunks := make([]*copy_on_write.Mmap, 0, len(digests))
+		for i, d := range digests {
+			chunk, err := copy_on_write.NewLazyMmap(ctx, env, dataDir, int64(i)*chunkSizeBytes, d, "", false, lru)
+			require.NoError(t, err)
+			chunks = append(chunks, chunk)
+		}
+		cow, err := copy_on_write.NewCOWStore(ctx, env, "test", chunks, copy_on_write.COWOptions{
+			ChunkSizeBytes:   chunkSizeBytes,
+			TotalSizeBytes:   int64(len(chunks)) * chunkSizeBytes,
+			DataDir:          dataDir,
+			EagerFetchChunks: eagerFetchChunks,
+		})
+		require.NoError(t, err)
+		return cow, chunks
+	}
+
+	enabled, enabledChunks := newStore(1)
+	t.Cleanup(func() { require.NoError(t, enabled.Close()) })
+	_, err = enabled.ReadAt(make([]byte, 1), 0)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return enabledChunks[1].Source() == snaputil.ChunkSourceLocalFilecache
+	}, 5*time.Second, 10*time.Millisecond)
+	require.Equal(t, snaputil.ChunkSourceUnmapped, enabledChunks[2].Source())
 }
 
 func TestCOW_Concurrency(t *testing.T) {

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -46,6 +46,12 @@ const (
 	// File name used for the rootfs snapshot artifact.
 	rootfsFileName = "rootfs.ext4"
 
+	// Rootfs access during guest boot mixes filesystem metadata and file data
+	// reads, so large sequential prefetch windows cause substantial read
+	// amplification. Keep this separate from the generic COW default, which was
+	// tuned for loading VM snapshots.
+	rootfsEagerFetchChunks = 4
+
 	// Number of goroutines to run concurrently when uploading a
 	// chunked file's contents to cache (one goroutine is spawned per chunk).
 	chunkedFileWriteConcurrency = 4
@@ -978,13 +984,17 @@ func (l *FileCacheLoader) unpackCOW(ctx context.Context, file *fcpb.ChunkedFile,
 		}
 		chunks = append(chunks, c)
 	}
-	cow, err := copy_on_write.NewCOWStore(ctx, l.env, file.GetName(), chunks, copy_on_write.COWOptions{
+	opts := copy_on_write.COWOptions{
 		ChunkSizeBytes:     file.GetChunkSize(),
 		TotalSizeBytes:     file.GetSize(),
 		DataDir:            dataDir,
 		RemoteInstanceName: remoteInstanceName,
 		RemoteEnabled:      remoteEnabled,
-	})
+	}
+	if file.GetName() == rootfsFileName {
+		opts.EagerFetchChunks = rootfsEagerFetchChunks
+	}
+	cow, err := copy_on_write.NewCOWStore(ctx, l.env, file.GetName(), chunks, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -44,7 +44,7 @@ import (
 
 const (
 	// File name used for the rootfs snapshot artifact.
-	rootfsFileName = "rootfs.ext4"
+	rootfsFileName         = "rootfs.ext4"
 	misnamedRootfsFileName = "rootfs" // TODO(bduffany): consolidate.
 
 	// Rootfs access during guest boot mixes filesystem metadata and file data

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -45,7 +45,7 @@ import (
 const (
 	// File name used for the rootfs snapshot artifact.
 	rootfsFileName = "rootfs.ext4"
-	misnamedRootfsFileName = "rootfs"  // TODO(bduffany): consolidate.
+	misnamedRootfsFileName = "rootfs" // TODO(bduffany): consolidate.
 
 	// Rootfs access during guest boot mixes filesystem metadata and file data
 	// reads, so large sequential prefetch windows cause substantial read

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -45,6 +45,7 @@ import (
 const (
 	// File name used for the rootfs snapshot artifact.
 	rootfsFileName = "rootfs.ext4"
+	misnamedRootfsFileName = "rootfs"  // TODO(bduffany): consolidate.
 
 	// Rootfs access during guest boot mixes filesystem metadata and file data
 	// reads, so large sequential prefetch windows cause substantial read
@@ -991,7 +992,7 @@ func (l *FileCacheLoader) unpackCOW(ctx context.Context, file *fcpb.ChunkedFile,
 		RemoteInstanceName: remoteInstanceName,
 		RemoteEnabled:      remoteEnabled,
 	}
-	if file.GetName() == rootfsFileName {
+	if file.GetName() == rootfsFileName || file.GetName() == misnamedRootfsFileName {
 		opts.EagerFetchChunks = rootfsEagerFetchChunks
 	}
 	cow, err := copy_on_write.NewCOWStore(ctx, l.env, file.GetName(), chunks, opts)


### PR DESCRIPTION
Context: I am working on improving performance of box commands which run on normal (non-workflow) machines. I noticed in some traces that we're fetching nearly the entire rootfs every time, which seems overzealous. I benchmarked it and reducing our prefetching from 32 chunks to 4 improved performance (and reduces writes on the disk).

I did not change the prefetch window for other filesystems, but I suspect it could also be improved.

```
• Median results from three local runs per window:

   Prefetch window    Rootfs chunk reads    ByteStream transfer    Ready time    VM dial
  ━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━  ━━━━━━━━━
                 0                    20               20.5 MiB        816 ms     433 ms
  ─────────────────  ────────────────────  ─────────────────────  ────────────  ─────────
                 1                    37               40.9 MiB        830 ms     460 ms
  ─────────────────  ────────────────────  ─────────────────────  ────────────  ─────────
                 2                    51               60.8 MiB        799 ms     448 ms
  ─────────────────  ────────────────────  ─────────────────────  ────────────  ─────────
                 4                    75               92.5 MiB        745 ms     462 ms
  ─────────────────  ────────────────────  ─────────────────────  ────────────  ─────────
                 8                   119              149.2 MiB        779 ms     462 ms
  ─────────────────  ────────────────────  ─────────────────────  ────────────  ─────────
                16                   185              249.8 MiB        802 ms     518 ms
  ─────────────────  ────────────────────  ─────────────────────  ────────────  ─────────
                32                   258              329.5 MiB        884 ms     543 ms
```