### PR TITLE
[FC] Always cache chunked ext4s in the remote cache

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -147,7 +147,6 @@ go_test(
     deps = [
         ":firecracker",
         "//enterprise/server/action_cache_server_proxy",
-        "//enterprise/server/backends/pebble_cache",
         "//enterprise/server/byte_stream_server_proxy",
         "//enterprise/server/clientidentity",
         "//enterprise/server/oci/ociregistry",

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -147,6 +147,7 @@ go_test(
     deps = [
         ":firecracker",
         "//enterprise/server/action_cache_server_proxy",
+        "//enterprise/server/backends/pebble_cache",
         "//enterprise/server/byte_stream_server_proxy",
         "//enterprise/server/clientidentity",
         "//enterprise/server/oci/ociregistry",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -693,6 +693,11 @@ type FirecrackerContainer struct {
 	supportsRemoteSnapshots bool
 	recyclingEnabled        bool
 
+	// TODO: Cleanup after remote container image reads/writes are fully rolled out.
+	// remoteContainerImageAccess is resolved once per container so the remote
+	// cache is used consistently for its chunked container image.
+	remoteContainerImageAccess snaploader.RemoteContainerImageAccessOptions
+
 	// If set, the snapshot used to load the VM
 	snapshot *snaploader.Snapshot
 
@@ -839,6 +844,7 @@ func NewContainer(ctx context.Context, env environment.Env, task *repb.Execution
 	taskPlatform := platform.GetProto(task.GetAction(), task.GetCommand())
 	allowsRemoteSnapshots := platform.AllowsRemoteSnapshots(task.GetCommand(), taskPlatform, task.GetPlatformOverrides())
 	c.supportsRemoteSnapshots = *snaputil.EnableRemoteSnapshotSharing && (allowsRemoteSnapshots || *forceRemoteSnapshotting)
+	c.remoteContainerImageAccess = snaploader.GetRemoteContainerImageAccessOptions(ctx, task, c.supportsRemoteSnapshots)
 	if span.IsRecording() {
 		span.SetAttributes(attribute.Bool("supports_remote_snapshots", c.supportsRemoteSnapshots))
 	}
@@ -1497,7 +1503,7 @@ func (c *FirecrackerContainer) cachedContainerfs(ctx context.Context) *snaploade
 	}
 	c.containerfsSnapshotOnce.Do(func() {
 		instanceName := c.snapshotKeySet.GetBranchKey().GetInstanceName()
-		snap, err := snaploader.GetCachedContainerImage(ctx, c.loader, instanceName, c.containerImage)
+		snap, err := snaploader.GetCachedContainerImage(ctx, c.loader, instanceName, c.containerImage, c.remoteContainerImageAccess.RemoteReadsEnabled)
 		if err != nil {
 			if !status.IsNotFoundError(err) {
 				log.CtxWarningf(ctx, "Failed to look up cached containerfs for image %q: %s", c.containerImage, err)
@@ -1523,7 +1529,7 @@ func (c *FirecrackerContainer) initRootfsStore(ctx context.Context) error {
 	} else {
 		// If a chunked containerfs is not cached, we need to convert the ext4 image into chunks.
 		containerExt4Path := filepath.Join(c.getChroot(), containerFSName)
-		cf, err = snaploader.UnpackContainerImage(c.vmCtx, c.loader, c.snapshotKeySet.GetBranchKey().GetInstanceName(), c.containerImage, containerExt4Path, cowChunkDir, cowChunkSizeBytes())
+		cf, err = snaploader.UnpackContainerImage(c.vmCtx, c.loader, c.snapshotKeySet.GetBranchKey().GetInstanceName(), c.containerImage, containerExt4Path, cowChunkDir, cowChunkSizeBytes(), c.remoteContainerImageAccess)
 	}
 	if err != nil {
 		return status.WrapError(err, "unpack container image")

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1523,8 +1523,7 @@ func (c *FirecrackerContainer) initRootfsStore(ctx context.Context) error {
 	} else {
 		// If a chunked containerfs is not cached, we need to convert the ext4 image into chunks.
 		containerExt4Path := filepath.Join(c.getChroot(), containerFSName)
-		instanceName := c.snapshotKeySet.GetBranchKey().GetInstanceName()
-		cf, err = snaploader.UnpackContainerImage(c.vmCtx, c.loader, instanceName, c.containerImage, containerExt4Path, cowChunkDir, cowChunkSizeBytes())
+		cf, err = snaploader.UnpackContainerImage(c.vmCtx, c.loader, c.snapshotKeySet.GetBranchKey().GetInstanceName(), c.containerImage, containerExt4Path, cowChunkDir, cowChunkSizeBytes())
 	}
 	if err != nil {
 		return status.WrapError(err, "unpack container image")

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1496,7 +1496,8 @@ func (c *FirecrackerContainer) cachedContainerfs(ctx context.Context) *snaploade
 		return nil
 	}
 	c.containerfsSnapshotOnce.Do(func() {
-		snap, err := snaploader.GetCachedContainerImage(ctx, c.loader, c.containerImage)
+		instanceName := c.snapshotKeySet.GetBranchKey().GetInstanceName()
+		snap, err := snaploader.GetCachedContainerImage(ctx, c.loader, instanceName, c.containerImage)
 		if err != nil {
 			if !status.IsNotFoundError(err) {
 				log.CtxWarningf(ctx, "Failed to look up cached containerfs for image %q: %s", c.containerImage, err)
@@ -1522,7 +1523,8 @@ func (c *FirecrackerContainer) initRootfsStore(ctx context.Context) error {
 	} else {
 		// If a chunked containerfs is not cached, we need to convert the ext4 image into chunks.
 		containerExt4Path := filepath.Join(c.getChroot(), containerFSName)
-		cf, err = snaploader.UnpackContainerImage(c.vmCtx, c.loader, c.containerImage, containerExt4Path, cowChunkDir, cowChunkSizeBytes())
+		instanceName := c.snapshotKeySet.GetBranchKey().GetInstanceName()
+		cf, err = snaploader.UnpackContainerImage(c.vmCtx, c.loader, instanceName, c.containerImage, containerExt4Path, cowChunkDir, cowChunkSizeBytes())
 	}
 	if err != nil {
 		return status.WrapError(err, "unpack container image")

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1496,8 +1496,7 @@ func (c *FirecrackerContainer) cachedContainerfs(ctx context.Context) *snaploade
 		return nil
 	}
 	c.containerfsSnapshotOnce.Do(func() {
-		instanceName := c.snapshotKeySet.GetBranchKey().GetInstanceName()
-		snap, err := snaploader.GetCachedContainerImage(ctx, c.loader, instanceName, c.containerImage, c.supportsRemoteSnapshots)
+		snap, err := snaploader.GetCachedContainerImage(ctx, c.loader, c.containerImage)
 		if err != nil {
 			if !status.IsNotFoundError(err) {
 				log.CtxWarningf(ctx, "Failed to look up cached containerfs for image %q: %s", c.containerImage, err)
@@ -1523,7 +1522,7 @@ func (c *FirecrackerContainer) initRootfsStore(ctx context.Context) error {
 	} else {
 		// If a chunked containerfs is not cached, we need to convert the ext4 image into chunks.
 		containerExt4Path := filepath.Join(c.getChroot(), containerFSName)
-		cf, err = snaploader.UnpackContainerImage(c.vmCtx, c.loader, c.snapshotKeySet.GetBranchKey().GetInstanceName(), c.containerImage, containerExt4Path, cowChunkDir, cowChunkSizeBytes(), c.supportsRemoteSnapshots)
+		cf, err = snaploader.UnpackContainerImage(c.vmCtx, c.loader, c.containerImage, containerExt4Path, cowChunkDir, cowChunkSizeBytes())
 	}
 	if err != nil {
 		return status.WrapError(err, "unpack container image")

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -625,7 +625,9 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	}
 
 	// Sanity check: the image should not be cached yet.
-	coldContainer := newContainer("instance-a")
+	instanceA := snaputil.SnapshotPartitionPrefix + "/instance-a"
+	instanceB := snaputil.SnapshotPartitionPrefix + "/instance-b"
+	coldContainer := newContainer(instanceA)
 	cached, err := coldContainer.IsImageCached(ctx)
 	require.NoError(t, err)
 	require.False(t, cached)
@@ -641,7 +643,7 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	testfs.WriteRandomString(t, workDir, "containerfs.ext4", 4*chunkSize)
 	ext4Path := filepath.Join(workDir, "containerfs.ext4")
 	cow, err := snaploader.UnpackContainerImage(
-		ctx, loader, imageRef, ext4Path,
+		ctx, loader, instanceA, imageRef, ext4Path,
 		testfs.MakeDirAll(t, workDir, "chunks"), chunkSize)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -649,7 +651,7 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	})
 
 	// A container for a subsequent task should now see the cached containerfs.
-	c := newContainer("instance-a")
+	c := newContainer(instanceA)
 	cached, err = c.IsImageCached(ctx)
 	require.NoError(t, err)
 	require.True(t, cached)
@@ -665,7 +667,7 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 
 	// A container with a different remote instance should reuse the cached
 	// containerfs rather than converting and uploading its own copy.
-	c = newContainer("instance-b")
+	c = newContainer(instanceB)
 	require.NoError(t, c.PullImage(ctx, oci.Credentials{}))
 	require.Equal(t, int32(0), blobRequests.Load())
 }

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -621,7 +621,8 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	ext4Path := filepath.Join(workDir, "containerfs.ext4")
 	cow, err := snaploader.UnpackContainerImage(
 		ctx, loader, instanceName, imageRef, ext4Path,
-		testfs.MakeDirAll(t, workDir, "chunks"), chunkSize)
+		testfs.MakeDirAll(t, workDir, "chunks"), chunkSize,
+		snaploader.RemoteContainerImageAccessOptions{RemoteReadsEnabled: true, RemoteWritesEnabled: true})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		cow.Close()

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/action_cache_server_proxy"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/pebble_cache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/byte_stream_server_proxy"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/clientidentity"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/oci/ociregistry"
@@ -172,7 +171,6 @@ type envOpts struct {
 	cacheSize        int64
 	filecacheRootDir string
 	runProxy         bool
-	usePebble        bool
 }
 
 func getTestEnv(ctx context.Context, t testing.TB, opts envOpts) *testenv.TestEnv {
@@ -208,31 +206,12 @@ func getTestEnv(ctx context.Context, t testing.TB, opts envOpts) *testenv.TestEn
 	if cacheSize == 0 {
 		cacheSize = diskCacheSize
 	}
-	var cache interfaces.Cache
-	if opts.usePebble {
-		const snapshotPartitionID = "snapshots"
-		pc, err := pebble_cache.NewPebbleCache(env, &pebble_cache.Options{
-			RootDirectory: testRootDir,
-			MaxSizeBytes:  cacheSize,
-			Partitions: []disk.Partition{
-				{ID: snapshotPartitionID, MaxSizeBytes: cacheSize},
-			},
-			PartitionMappings: []disk.PartitionMapping{
-				{Prefix: snaputil.SnapshotPartitionPrefix, PartitionID: snapshotPartitionID},
-			},
-		})
-		require.NoError(t, err)
-		require.NoError(t, pc.Start())
-		t.Cleanup(func() { require.NoError(t, pc.Stop()) })
-		cache = pc
-	} else {
-		dc, err := disk_cache.NewDiskCache(env, &disk_cache.Options{RootDirectory: testRootDir}, cacheSize)
-		if err != nil {
-			t.Error(err)
-		}
-		cache = dc
+	dc, err := disk_cache.NewDiskCache(env, &disk_cache.Options{RootDirectory: testRootDir}, cacheSize)
+	if err != nil {
+		t.Error(err)
 	}
-	env.SetCache(cache)
+	env.SetCache(dc)
+
 	casServer, err := content_addressable_storage_server.NewContentAddressableStorageServer(env)
 	if err != nil {
 		t.Error(err)
@@ -571,7 +550,6 @@ func TestFirecrackerPullImageIfNecessary_CachedImageRequiresReauth(t *testing.T)
 
 func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	ctx := context.Background()
-	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
 	flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.1/32"})
 
 	// Mock requests to the container registry.
@@ -599,7 +577,7 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	manifestRequests.Store(0)
 	blobRequests.Store(0)
 
-	env := getTestEnv(ctx, t, envOpts{usePebble: true})
+	env := getTestEnv(ctx, t, envOpts{})
 	opts := firecracker.ContainerOpts{
 		ContainerImage:         imageRef,
 		ActionWorkingDirectory: testfs.MakeTempDir(t),
@@ -611,7 +589,8 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 		},
 		ExecutorConfig: getExecutorConfig(t),
 	}
-	newContainer := func(instanceName string) *firecracker.FirecrackerContainer {
+	instanceName := snaputil.SnapshotPartitionPrefix + "/instance"
+	newContainer := func() *firecracker.FirecrackerContainer {
 		containerOpts := opts
 		containerOpts.ActionWorkingDirectory = testfs.MakeTempDir(t)
 		c, err := firecracker.NewContainer(ctx, env, &repb.ExecutionTask{
@@ -625,9 +604,7 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	}
 
 	// Sanity check: the image should not be cached yet.
-	instanceA := snaputil.SnapshotPartitionPrefix + "/instance-a"
-	instanceB := snaputil.SnapshotPartitionPrefix + "/instance-b"
-	coldContainer := newContainer(instanceA)
+	coldContainer := newContainer()
 	cached, err := coldContainer.IsImageCached(ctx)
 	require.NoError(t, err)
 	require.False(t, cached)
@@ -643,7 +620,7 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	testfs.WriteRandomString(t, workDir, "containerfs.ext4", 4*chunkSize)
 	ext4Path := filepath.Join(workDir, "containerfs.ext4")
 	cow, err := snaploader.UnpackContainerImage(
-		ctx, loader, instanceA, imageRef, ext4Path,
+		ctx, loader, instanceName, imageRef, ext4Path,
 		testfs.MakeDirAll(t, workDir, "chunks"), chunkSize)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -651,7 +628,7 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	})
 
 	// A container for a subsequent task should now see the cached containerfs.
-	c := newContainer(instanceA)
+	c := newContainer()
 	cached, err = c.IsImageCached(ctx)
 	require.NoError(t, err)
 	require.True(t, cached)
@@ -664,12 +641,6 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	require.Equal(t, int32(0), blobRequests.Load())
 	// The manifest should still have been fetched, in order to authenticate with the registry.
 	require.Greater(t, manifestRequests.Load(), int32(0))
-
-	// A container with a different remote instance should reuse the cached
-	// containerfs rather than converting and uploading its own copy.
-	c = newContainer(instanceB)
-	require.NoError(t, c.PullImage(ctx, oci.Credentials{}))
-	require.Equal(t, int32(0), blobRequests.Load())
 }
 
 func TestFirecrackerSnapshotAndResume(t *testing.T) {

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/action_cache_server_proxy"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/pebble_cache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/byte_stream_server_proxy"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/clientidentity"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/oci/ociregistry"
@@ -171,6 +172,7 @@ type envOpts struct {
 	cacheSize        int64
 	filecacheRootDir string
 	runProxy         bool
+	usePebble        bool
 }
 
 func getTestEnv(ctx context.Context, t testing.TB, opts envOpts) *testenv.TestEnv {
@@ -206,11 +208,31 @@ func getTestEnv(ctx context.Context, t testing.TB, opts envOpts) *testenv.TestEn
 	if cacheSize == 0 {
 		cacheSize = diskCacheSize
 	}
-	dc, err := disk_cache.NewDiskCache(env, &disk_cache.Options{RootDirectory: testRootDir}, cacheSize)
-	if err != nil {
-		t.Error(err)
+	var cache interfaces.Cache
+	if opts.usePebble {
+		const snapshotPartitionID = "snapshots"
+		pc, err := pebble_cache.NewPebbleCache(env, &pebble_cache.Options{
+			RootDirectory: testRootDir,
+			MaxSizeBytes:  cacheSize,
+			Partitions: []disk.Partition{
+				{ID: snapshotPartitionID, MaxSizeBytes: cacheSize},
+			},
+			PartitionMappings: []disk.PartitionMapping{
+				{Prefix: snaputil.SnapshotPartitionPrefix, PartitionID: snapshotPartitionID},
+			},
+		})
+		require.NoError(t, err)
+		require.NoError(t, pc.Start())
+		t.Cleanup(func() { require.NoError(t, pc.Stop()) })
+		cache = pc
+	} else {
+		dc, err := disk_cache.NewDiskCache(env, &disk_cache.Options{RootDirectory: testRootDir}, cacheSize)
+		if err != nil {
+			t.Error(err)
+		}
+		cache = dc
 	}
-	env.SetCache(dc)
+	env.SetCache(cache)
 	casServer, err := content_addressable_storage_server.NewContentAddressableStorageServer(env)
 	if err != nil {
 		t.Error(err)
@@ -549,8 +571,7 @@ func TestFirecrackerPullImageIfNecessary_CachedImageRequiresReauth(t *testing.T)
 
 func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	ctx := context.Background()
-	// Keep snapshot sharing local-only to simplify test setup.
-	flags.Set(t, "executor.enable_remote_snapshot_sharing", false)
+	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
 	flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.1/32"})
 
 	// Mock requests to the container registry.
@@ -578,7 +599,7 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	manifestRequests.Store(0)
 	blobRequests.Store(0)
 
-	env := getTestEnv(ctx, t, envOpts{})
+	env := getTestEnv(ctx, t, envOpts{usePebble: true})
 	opts := firecracker.ContainerOpts{
 		ContainerImage:         imageRef,
 		ActionWorkingDirectory: testfs.MakeTempDir(t),
@@ -590,10 +611,12 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 		},
 		ExecutorConfig: getExecutorConfig(t),
 	}
-	newContainer := func() *firecracker.FirecrackerContainer {
+	newContainer := func(instanceName string) *firecracker.FirecrackerContainer {
 		containerOpts := opts
 		containerOpts.ActionWorkingDirectory = testfs.MakeTempDir(t)
-		c, err := firecracker.NewContainer(ctx, env, &repb.ExecutionTask{}, containerOpts)
+		c, err := firecracker.NewContainer(ctx, env, &repb.ExecutionTask{
+			ExecuteRequest: &repb.ExecuteRequest{InstanceName: instanceName},
+		}, containerOpts)
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			require.NoError(t, c.Remove(context.Background()))
@@ -602,7 +625,7 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	}
 
 	// Sanity check: the image should not be cached yet.
-	coldContainer := newContainer()
+	coldContainer := newContainer("instance-a")
 	cached, err := coldContainer.IsImageCached(ctx)
 	require.NoError(t, err)
 	require.False(t, cached)
@@ -617,18 +640,16 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	// of the cache entry matters.
 	testfs.WriteRandomString(t, workDir, "containerfs.ext4", 4*chunkSize)
 	ext4Path := filepath.Join(workDir, "containerfs.ext4")
-	instanceName := coldContainer.SnapshotKeySet().GetBranchKey().GetInstanceName()
 	cow, err := snaploader.UnpackContainerImage(
-		ctx, loader, instanceName, imageRef, ext4Path,
-		testfs.MakeDirAll(t, workDir, "chunks"), chunkSize,
-		false /*=remoteEnabled*/)
+		ctx, loader, imageRef, ext4Path,
+		testfs.MakeDirAll(t, workDir, "chunks"), chunkSize)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		cow.Close()
 	})
 
 	// A container for a subsequent task should now see the cached containerfs.
-	c := newContainer()
+	c := newContainer("instance-a")
 	cached, err = c.IsImageCached(ctx)
 	require.NoError(t, err)
 	require.True(t, cached)
@@ -641,6 +662,12 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	require.Equal(t, int32(0), blobRequests.Load())
 	// The manifest should still have been fetched, in order to authenticate with the registry.
 	require.Greater(t, manifestRequests.Load(), int32(0))
+
+	// A container with a different remote instance should reuse the cached
+	// containerfs rather than converting and uploading its own copy.
+	c = newContainer("instance-b")
+	require.NoError(t, c.PullImage(ctx, oci.Credentials{}))
+	require.Equal(t, int32(0), blobRequests.Load())
 }
 
 func TestFirecrackerSnapshotAndResume(t *testing.T) {

--- a/enterprise/server/remote_execution/execution_server/BUILD
+++ b/enterprise/server/remote_execution/execution_server/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//enterprise/server/remote_execution/action_merger",
         "//enterprise/server/remote_execution/oom",
         "//enterprise/server/remote_execution/operation",
+        "//enterprise/server/remote_execution/snaputil",
         "//enterprise/server/tasksize",
         "//enterprise/server/util/ci_runner_env",
         "//enterprise/server/util/execution",

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/action_merger"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/oom"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/operation"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaputil"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/tasksize"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ci_runner_env"
 	"github.com/buildbuddy-io/buildbuddy/proto/invocation_status"
@@ -967,6 +968,15 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 
 	if efp != nil && efp.Boolean(ctx, "remote_execution.publish_post_completion_stats", false) {
 		executionTask.Experiments = append(executionTask.Experiments, "remote_execution.publish_post_completion_stats")
+	}
+
+	if efp != nil && platform.ContainerType(props.WorkloadIsolationType) == platform.FirecrackerContainerType {
+		if efp.Boolean(ctx, snaputil.RemoteContainerImageReadsExperiment, false) {
+			executionTask.Experiments = append(executionTask.Experiments, snaputil.RemoteContainerImageReadsExperiment)
+		}
+		if efp.Boolean(ctx, snaputil.RemoteContainerImageWritesExperiment, false) {
+			executionTask.Experiments = append(executionTask.Experiments, snaputil.RemoteContainerImageWritesExperiment)
+		}
 	}
 
 	// Add in secrets for any action explicitly requesting secrets, and all workflows.

--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -40,6 +40,7 @@ go_test(
     srcs = ["snaploader_test.go"],
     deps = [
         ":snaploader",
+        "//enterprise/server/backends/pebble_cache",
         "//enterprise/server/remote_execution/copy_on_write",
         "//enterprise/server/remote_execution/filecache",
         "//enterprise/server/remote_execution/snaputil",
@@ -53,11 +54,15 @@ go_test(
         "//server/testutil/testcache",
         "//server/testutil/testenv",
         "//server/testutil/testfs",
+        "//server/util/disk",
         "//server/util/log",
         "//server/util/platform",
         "//server/util/prefix",
         "//server/util/random",
+        "//server/util/status",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
+        "@org_golang_google_grpc//:grpc",
     ],
 )

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -47,10 +47,9 @@ const (
 	rootfsFileName         = "rootfs.ext4"
 	misnamedRootfsFileName = "rootfs" // TODO(bduffany): consolidate.
 
-	// Container images are immutable content, so use one shared namespace in the
-	// snapshot partition for all cached, chunked EXT4s.
-	// They should be shared across remote instance names.
-	containerImageInstanceName = snaputil.SnapshotPartitionPrefix + "/chunked-images"
+	// Container images are immutable content, so use one shared namespace within
+	// each cache partition for all cached, chunked EXT4s.
+	containerImageInstanceNameSuffix = "chunked-images"
 
 	// Rootfs access during guest boot mixes filesystem metadata and file data
 	// reads, so large sequential prefetch windows cause substantial read
@@ -709,8 +708,8 @@ func (l *FileCacheLoader) UnpackSnapshot(ctx context.Context, snapshot *Snapshot
 
 	for _, fileNode := range snapshot.manifest.Files {
 		outputPath := filepath.Join(outputDirectory, fileNode.GetName())
-		remoteInstanceName, remoteEnabled := snapshot.remoteChunkAccessForFile(fileNode.GetName())
-		if _, err := snaputil.GetArtifact(ctx, l.env.GetFileCache(), l.env.GetByteStreamClient(), remoteEnabled, fileNode.GetDigest(), remoteInstanceName, outputPath); err != nil {
+		remoteEnabled := remoteFallbackEnabledForFile(snapshot.supportsRemoteChunks, fileNode.GetName())
+		if _, err := snaputil.GetArtifact(ctx, l.env.GetFileCache(), l.env.GetByteStreamClient(), remoteEnabled, fileNode.GetDigest(), snapshot.key.GetInstanceName(), outputPath); err != nil {
 			return nil, err
 		}
 	}
@@ -718,16 +717,28 @@ func (l *FileCacheLoader) UnpackSnapshot(ctx context.Context, snapshot *Snapshot
 	unpacked := &UnpackedSnapshot{
 		ChunkedFiles: make(map[string]*copy_on_write.COWStore, len(snapshot.manifest.ChunkedFiles)),
 	}
+	succeeded := false
+	defer func() {
+		if succeeded {
+			return
+		}
+		for name, cow := range unpacked.ChunkedFiles {
+			if err := cow.Close(); err != nil {
+				log.CtxWarningf(ctx, "Failed to close partially unpacked COW %q: %s", name, err)
+			}
+		}
+	}()
 	// Construct COWs from chunks.
 	for _, cf := range snapshot.manifest.ChunkedFiles {
-		remoteInstanceName, remoteEnabled := snapshot.remoteChunkAccessForFile(cf.GetName())
-		cow, err := l.unpackCOW(ctx, cf, remoteInstanceName, outputDirectory, remoteEnabled)
+		remoteEnabled := remoteFallbackEnabledForFile(snapshot.supportsRemoteChunks, cf.GetName())
+		cow, err := l.unpackCOW(ctx, cf, snapshot.key.GetInstanceName(), outputDirectory, remoteEnabled)
 		if err != nil {
 			return nil, status.WrapError(err, "unpack COW")
 		}
 		unpacked.ChunkedFiles[cf.GetName()] = cow
 	}
 
+	succeeded = true
 	return unpacked, nil
 }
 
@@ -921,52 +932,54 @@ func isRootfsSnapshot(name string) bool {
 	return name == rootfsFileName || name == misnamedRootfsFileName
 }
 
-// remoteChunkAccessForFile returns the CAS instance name from which the file's
-// chunks should be read and whether remote fallback is enabled for the file.
-func remoteChunkAccessForFile(name, snapshotInstanceName string, supportsRemoteFallback bool) (string, bool) {
-	if supportsRemoteFallback {
-		return snapshotInstanceName, true
+// containerImageInstanceName returns a stable container-image namespace that
+// is routed to the same cache partition as snapshotInstanceName.
+//
+// Keeping untouched image chunks and dirtied rootfs chunks in the same
+// partition ensures that a snapshot manifest can validate all of its chunks.
+func containerImageInstanceName(snapshotInstanceName string) string {
+	for _, partitionPrefix := range []string{
+		snaputil.SnapshotPartitionPrefix,
+		snaputil.DevboxPartitionPrefix,
+	} {
+		if snapshotInstanceName == partitionPrefix || strings.HasPrefix(snapshotInstanceName, partitionPrefix+"/") {
+			return partitionPrefix + "/" + containerImageInstanceNameSuffix
+		}
 	}
-	// Rootfs snapshots combine immutable ext4 image chunks, which can and
-	// should be shared remotely, with modified disk chunks, which should only
-	// be written remotely when explicitly requested. Consequently, a local
-	// rootfs manifest may intentionally reference remote immutable chunks even
-	// when the rest of the VM snapshot is local-only. These immutable chunks are
-	// stored in the shared snapshot partition rather than the task's instance.
-	if *snaputil.EnableRemoteSnapshotSharing && isRootfsSnapshot(name) {
-		return containerImageInstanceName, true
-	}
-	return snapshotInstanceName, false
+	return containerImageInstanceNameSuffix
 }
 
-func (s *Snapshot) remoteChunkAccessForFile(name string) (string, bool) {
-	return remoteChunkAccessForFile(name, s.key.GetInstanceName(), s.supportsRemoteChunks)
+// remoteFallbackEnabledForFile reports whether a missing local artifact may be
+// read from the remote cache. Rootfs snapshots may reference immutable image
+// chunks remotely even when general remote snapshot support is disabled.
+func remoteFallbackEnabledForFile(supportsRemoteFallback bool, name string) bool {
+	return supportsRemoteFallback || (*snaputil.EnableRemoteSnapshotSharing && isRootfsSnapshot(name))
 }
 
 func (l *FileCacheLoader) checkAllArtifactsExist(ctx context.Context, manifest *fcpb.SnapshotManifest, instanceName string, supportsRemoteFallback bool) error {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	missingDigestsByInstance := make(map[string][]*repb.Digest)
+	var missingRemoteDigests []*repb.Digest
 	for _, f := range manifest.GetFiles() {
 		if !l.env.GetFileCache().ContainsFile(ctx, f) {
-			remoteInstanceName, remoteEnabled := remoteChunkAccessForFile(f.GetName(), instanceName, supportsRemoteFallback)
+			remoteEnabled := remoteFallbackEnabledForFile(supportsRemoteFallback, f.GetName())
 			if remoteEnabled {
-				missingDigestsByInstance[remoteInstanceName] = append(missingDigestsByInstance[remoteInstanceName], f.GetDigest())
+				missingRemoteDigests = append(missingRemoteDigests, f.GetDigest())
 			} else {
 				return status.NotFoundErrorf("file %q not found (digest %q)", f.GetName(), digest.String(f.GetDigest()))
 			}
 		}
 	}
 	for _, cf := range manifest.GetChunkedFiles() {
-		remoteInstanceName, remoteEnabled := remoteChunkAccessForFile(cf.GetName(), instanceName, supportsRemoteFallback)
+		remoteEnabled := remoteFallbackEnabledForFile(supportsRemoteFallback, cf.GetName())
 		for _, c := range cf.GetChunks() {
 			node := &repb.FileNode{
 				Digest: c.GetDigest(),
 			}
 			if !l.env.GetFileCache().ContainsFile(ctx, node) {
 				if remoteEnabled {
-					missingDigestsByInstance[remoteInstanceName] = append(missingDigestsByInstance[remoteInstanceName], c.GetDigest())
+					missingRemoteDigests = append(missingRemoteDigests, c.GetDigest())
 				} else {
 					return status.NotFoundErrorf("chunked file %q missing chunk at offset 0x%x (digest %q)", cf.GetName(), c.GetOffset(), digest.String(node.Digest))
 				}
@@ -974,21 +987,23 @@ func (l *FileCacheLoader) checkAllArtifactsExist(ctx context.Context, manifest *
 		}
 	}
 
-	// If remote fallback is enabled for any files, allow using a local manifest
-	// when its locally missing artifacts are available in the remote cache.
-	for remoteInstanceName, missingDigests := range missingDigestsByInstance {
-		ctx = snaputil.GetSnapshotAccessContext(ctx)
-		rsp, err := l.env.GetContentAddressableStorageClient().FindMissingBlobs(ctx, &repb.FindMissingBlobsRequest{
-			InstanceName:   remoteInstanceName,
-			BlobDigests:    missingDigests,
-			DigestFunction: repb.DigestFunction_BLAKE3,
-			Purpose:        repb.FindMissingBlobsRequest_SNAPSHOT,
-		})
-		if err != nil {
-			return status.WrapError(err, "querying remote cache to check for snapshot artifacts")
-		} else if len(rsp.MissingBlobDigests) > 0 {
-			return status.NotFoundErrorf("digests not found when querying remote cache to check for snapshot artifacts")
-		}
+	if len(missingRemoteDigests) == 0 {
+		return nil
+	}
+
+	// Allow using a local manifest when its locally missing artifacts are
+	// available in the remote cache partition selected by the snapshot instance.
+	ctx = snaputil.GetSnapshotAccessContext(ctx)
+	rsp, err := l.env.GetContentAddressableStorageClient().FindMissingBlobs(ctx, &repb.FindMissingBlobsRequest{
+		InstanceName:   instanceName,
+		BlobDigests:    missingRemoteDigests,
+		DigestFunction: repb.DigestFunction_BLAKE3,
+		Purpose:        repb.FindMissingBlobsRequest_SNAPSHOT,
+	})
+	if err != nil {
+		return status.WrapError(err, "querying remote cache to check for snapshot artifacts")
+	} else if len(rsp.MissingBlobDigests) > 0 {
+		return status.NotFoundErrorf("digests not found when querying remote cache to check for snapshot artifacts")
 	}
 	return nil
 }
@@ -1421,15 +1436,15 @@ func groupID(ctx context.Context, env environment.Env) (string, error) {
 // containerImageSnapshotKey returns the key under which the chunked
 // containerfs for the given container image is cached.
 //
-// Container images are immutable content, so use one shared namespace in the
-// snapshot partition rather than converting and uploading the same image once
-// per remote instance.
+// Container images are immutable content, so use one shared namespace per
+// cache partition rather than converting and uploading the same image once per
+// remote instance.
 //
 // TODO: Use the image manifest digest, rather than just the name, to account for
 // situations where the image is updated for the same ref (e.g. if it's using the latest tag)
-func containerImageSnapshotKey(imageRef string) *fcpb.SnapshotKeySet {
+func containerImageSnapshotKey(instanceName, imageRef string) *fcpb.SnapshotKeySet {
 	return &fcpb.SnapshotKeySet{BranchKey: &fcpb.SnapshotKey{
-		InstanceName:      containerImageInstanceName,
+		InstanceName:      containerImageInstanceName(instanceName),
 		ConfigurationHash: hashStrings("__UnpackContainerImage", imageRef),
 	}}
 }
@@ -1452,12 +1467,12 @@ func remoteContainerImageWritesEnabled() bool {
 
 // GetCachedContainerImage returns the cached snapshot for the given
 // container image.
-func GetCachedContainerImage(ctx context.Context, l *FileCacheLoader, imageRef string) (*Snapshot, error) {
+func GetCachedContainerImage(ctx context.Context, l *FileCacheLoader, instanceName, imageRef string) (*Snapshot, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
 	remoteEnabled := remoteContainerImageReadsEnabled()
-	snap, err := l.GetSnapshot(ctx, containerImageSnapshotKey(imageRef), &GetSnapshotOptions{
+	snap, err := l.GetSnapshot(ctx, containerImageSnapshotKey(instanceName, imageRef), &GetSnapshotOptions{
 		SupportsRemoteManifest: remoteEnabled,
 		SupportsRemoteChunks:   remoteEnabled,
 		// A chunked container image is immutable for a given image ref, so
@@ -1483,6 +1498,11 @@ func UnpackContainerImageSnapshot(ctx context.Context, l *FileCacheLoader, snap 
 	}
 	cf := unpacked.ChunkedFiles[rootfsFileName]
 	if cf == nil {
+		for name, cow := range unpacked.ChunkedFiles {
+			if err := cow.Close(); err != nil {
+				log.CtxWarningf(ctx, "Failed to close unexpected container image COW %q: %s", name, err)
+			}
+		}
 		return nil, status.InternalError("missing rootfs artifact in snapshot")
 	}
 	return cf, nil
@@ -1493,14 +1513,14 @@ func UnpackContainerImageSnapshot(ctx context.Context, l *FileCacheLoader, snap 
 //
 // If the image is not cached, this func will split up the given ext4 image
 // file and create a new ChunkedFile from it, then add that to cache.
-func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, imageRef, imageExt4Path string, outDir string, chunkSize int64) (*copy_on_write.COWStore, error) {
+func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, instanceName, imageRef, imageExt4Path string, outDir string, chunkSize int64) (*copy_on_write.COWStore, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	snap, err := GetCachedContainerImage(ctx, l, imageRef)
+	snap, err := GetCachedContainerImage(ctx, l, instanceName, imageRef)
 	if err != nil {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return nil, ctxErr
+		if ctx.Err() != nil {
+			return nil, status.FromContextError(ctx)
 		}
 		if !status.IsNotFoundError(err) {
 			log.CtxWarningf(ctx, "Failed to read cached container image %q; converting the pulled image instead: %s", imageRef, err)
@@ -1511,15 +1531,24 @@ func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, imageRef, ima
 		if err == nil {
 			return cow, nil
 		}
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return nil, ctxErr
+		// Unpacking may have created chunk directories before failing. Remove
+		// them so ConvertFileToCOW receives the empty data directory it requires.
+		if removeErr := os.RemoveAll(outDir); removeErr != nil {
+			return nil, status.WrapErrorf(removeErr, "clean up container image chunks after cached image unpack failed: %s", err)
+		}
+		if mkdirErr := os.MkdirAll(outDir, 0755); mkdirErr != nil {
+			return nil, status.WrapErrorf(mkdirErr, "recreate container image chunk directory after cached image unpack failed: %s", err)
+		}
+		if ctx.Err() != nil {
+			return nil, status.FromContextError(ctx)
 		}
 		log.CtxWarningf(ctx, "Failed to unpack cached container image %q; converting the pulled image instead: %s", imageRef, err)
 	}
 	// containerfs is not available in cache; convert the EXT4 image to a
 	// ChunkedFile then add it to cache.
 	start := time.Now()
-	cow, err := copy_on_write.ConvertFileToCOW(ctx, l.env, imageExt4Path, chunkSize, outDir, containerImageInstanceName, remoteContainerImageReadsEnabled(), snaputil.ConvertToCOWConcurrency)
+	imageInstanceName := containerImageInstanceName(instanceName)
+	cow, err := copy_on_write.ConvertFileToCOW(ctx, l.env, imageExt4Path, chunkSize, outDir, imageInstanceName, remoteContainerImageReadsEnabled(), snaputil.ConvertToCOWConcurrency)
 	if err != nil {
 		return nil, status.WrapError(err, "convert image to COW")
 	}
@@ -1533,13 +1562,13 @@ func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, imageRef, ima
 		// cached chunks and fetch missing immutable chunks from the remote cache.
 		WriteManifestLocally: true,
 	}
-	key := containerImageSnapshotKey(imageRef)
+	key := containerImageSnapshotKey(instanceName, imageRef)
 	if err := l.CacheSnapshot(ctx, key.GetBranchKey(), opts); err != nil {
-		if ctxErr := ctx.Err(); ctxErr != nil {
+		if ctx.Err() != nil {
 			if closeErr := cow.Close(); closeErr != nil {
 				log.CtxWarningf(ctx, "Failed to close container image COW after context cancellation: %s", closeErr)
 			}
-			return nil, ctxErr
+			return nil, status.FromContextError(ctx)
 		}
 		log.CtxWarningf(ctx, "Failed to cache converted container image %q; continuing with the local COW: %s", imageRef, err)
 	}

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -47,10 +47,6 @@ const (
 	rootfsFileName         = "rootfs.ext4"
 	misnamedRootfsFileName = "rootfs" // TODO(bduffany): consolidate.
 
-	// Container images are immutable content, so use one shared namespace within
-	// each cache partition for all cached, chunked EXT4s.
-	containerImageInstanceNameSuffix = "chunked-images"
-
 	// Rootfs access during guest boot mixes filesystem metadata and file data
 	// reads, so large sequential prefetch windows cause substantial read
 	// amplification. Keep this separate from the generic COW default, which was
@@ -717,6 +713,7 @@ func (l *FileCacheLoader) UnpackSnapshot(ctx context.Context, snapshot *Snapshot
 	unpacked := &UnpackedSnapshot{
 		ChunkedFiles: make(map[string]*copy_on_write.COWStore, len(snapshot.manifest.ChunkedFiles)),
 	}
+
 	succeeded := false
 	defer func() {
 		if succeeded {
@@ -728,6 +725,7 @@ func (l *FileCacheLoader) UnpackSnapshot(ctx context.Context, snapshot *Snapshot
 			}
 		}
 	}()
+
 	// Construct COWs from chunks.
 	for _, cf := range snapshot.manifest.ChunkedFiles {
 		remoteEnabled := remoteFallbackEnabledForFile(snapshot.supportsRemoteChunks, cf.GetName())
@@ -932,23 +930,6 @@ func isRootfsSnapshot(name string) bool {
 	return name == rootfsFileName || name == misnamedRootfsFileName
 }
 
-// containerImageInstanceName returns a stable container-image namespace that
-// is routed to the same cache partition as snapshotInstanceName.
-//
-// Keeping untouched image chunks and dirtied rootfs chunks in the same
-// partition ensures that a snapshot manifest can validate all of its chunks.
-func containerImageInstanceName(snapshotInstanceName string) string {
-	for _, partitionPrefix := range []string{
-		snaputil.SnapshotPartitionPrefix,
-		snaputil.DevboxPartitionPrefix,
-	} {
-		if snapshotInstanceName == partitionPrefix || strings.HasPrefix(snapshotInstanceName, partitionPrefix+"/") {
-			return partitionPrefix + "/" + containerImageInstanceNameSuffix
-		}
-	}
-	return containerImageInstanceNameSuffix
-}
-
 // remoteFallbackEnabledForFile reports whether a missing local artifact may be
 // read from the remote cache. Rootfs snapshots may reference immutable image
 // chunks remotely even when general remote snapshot support is disabled.
@@ -991,8 +972,9 @@ func (l *FileCacheLoader) checkAllArtifactsExist(ctx context.Context, manifest *
 		return nil
 	}
 
-	// Allow using a local manifest when its locally missing artifacts are
-	// available in the remote cache partition selected by the snapshot instance.
+	// If remoteEnabled=true, allow using a snapshot even
+	// if all snapshot chunks don't exist locally. The snaploader can fallback
+	// to fetching chunks from the remote cache.
 	ctx = snaputil.GetSnapshotAccessContext(ctx)
 	rsp, err := l.env.GetContentAddressableStorageClient().FindMissingBlobs(ctx, &repb.FindMissingBlobsRequest{
 		InstanceName:   instanceName,
@@ -1435,16 +1417,9 @@ func groupID(ctx context.Context, env environment.Env) (string, error) {
 
 // containerImageSnapshotKey returns the key under which the chunked
 // containerfs for the given container image is cached.
-//
-// Container images are immutable content, so use one shared namespace per
-// cache partition rather than converting and uploading the same image once per
-// remote instance.
-//
-// TODO: Use the image manifest digest, rather than just the name, to account for
-// situations where the image is updated for the same ref (e.g. if it's using the latest tag)
 func containerImageSnapshotKey(instanceName, imageRef string) *fcpb.SnapshotKeySet {
 	return &fcpb.SnapshotKeySet{BranchKey: &fcpb.SnapshotKey{
-		InstanceName:      containerImageInstanceName(instanceName),
+		InstanceName:      instanceName,
 		ConfigurationHash: hashStrings("__UnpackContainerImage", imageRef),
 	}}
 }
@@ -1452,8 +1427,8 @@ func containerImageSnapshotKey(instanceName, imageRef string) *fcpb.SnapshotKeyS
 // remoteContainerImageReadsEnabled returns whether chunked container images can
 // be read from the remote cache.
 //
-// Caching container images remotely is beneficial because any executor starting a
-// clean VM from the image can use them, skipping the expensive image pull
+// Caching container images remotely is beneficial because another executor
+// using the same image can share the cached chunks, skipping the expensive image pull
 // and ext4 conversion phases. Enable it as long as remote snapshot sharing is enabled.
 func remoteContainerImageReadsEnabled() bool {
 	return *snaputil.EnableRemoteSnapshotSharing
@@ -1476,9 +1451,7 @@ func GetCachedContainerImage(ctx context.Context, l *FileCacheLoader, instanceNa
 		SupportsRemoteManifest: remoteEnabled,
 		SupportsRemoteChunks:   remoteEnabled,
 		// A chunked container image is immutable for a given image ref, so
-		// there is never a newer version to read. Prefer the local manifest,
-		// which also lets a remote hit be written back to the local filecache
-		// so that later runs on this executor don't depend on the remote cache.
+		// there is never a newer version to read. Prefer a local manifest and snapshot chunks.
 		ReadPolicy: platform.ReadLocalSnapshotFirst,
 	})
 	if err != nil {
@@ -1508,6 +1481,13 @@ func UnpackContainerImageSnapshot(ctx context.Context, l *FileCacheLoader, snap 
 	return cf, nil
 }
 
+func resetContainerImageOutputDir(outDir string) error {
+	if err := os.RemoveAll(outDir); err != nil {
+		return err
+	}
+	return os.MkdirAll(outDir, 0755)
+}
+
 // UnpackContainerImage returns a ChunkedFile representing the given container
 // image. The chunk dir is stored as a child directory of the given outDir.
 //
@@ -1517,6 +1497,13 @@ func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, instanceName,
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
+	// Both cached snapshot unpacking and EXT4 conversion require an empty chunk
+	// directory. Clear stale output before attempting the cache lookup.
+	if err := resetContainerImageOutputDir(outDir); err != nil {
+		return nil, status.WrapError(err, "prepare container image chunk directory")
+	}
+
+	// First check if all chunks for the image are available from the cache.
 	snap, err := GetCachedContainerImage(ctx, l, instanceName, imageRef)
 	if err != nil {
 		if ctx.Err() != nil {
@@ -1533,11 +1520,8 @@ func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, instanceName,
 		}
 		// Unpacking may have created chunk directories before failing. Remove
 		// them so ConvertFileToCOW receives the empty data directory it requires.
-		if removeErr := os.RemoveAll(outDir); removeErr != nil {
-			return nil, status.WrapErrorf(removeErr, "clean up container image chunks after cached image unpack failed: %s", err)
-		}
-		if mkdirErr := os.MkdirAll(outDir, 0755); mkdirErr != nil {
-			return nil, status.WrapErrorf(mkdirErr, "recreate container image chunk directory after cached image unpack failed: %s", err)
+		if resetErr := resetContainerImageOutputDir(outDir); resetErr != nil {
+			return nil, status.WrapErrorf(resetErr, "reset container image chunk directory after cached image unpack failed: %s", err)
 		}
 		if ctx.Err() != nil {
 			return nil, status.FromContextError(ctx)
@@ -1547,8 +1531,7 @@ func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, instanceName,
 	// containerfs is not available in cache; convert the EXT4 image to a
 	// ChunkedFile then add it to cache.
 	start := time.Now()
-	imageInstanceName := containerImageInstanceName(instanceName)
-	cow, err := copy_on_write.ConvertFileToCOW(ctx, l.env, imageExt4Path, chunkSize, outDir, imageInstanceName, remoteContainerImageReadsEnabled(), snaputil.ConvertToCOWConcurrency)
+	cow, err := copy_on_write.ConvertFileToCOW(ctx, l.env, imageExt4Path, chunkSize, outDir, instanceName, remoteContainerImageReadsEnabled(), snaputil.ConvertToCOWConcurrency)
 	if err != nil {
 		return nil, status.WrapError(err, "convert image to COW")
 	}

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -1424,29 +1424,54 @@ func containerImageSnapshotKey(instanceName, imageRef string) *fcpb.SnapshotKeyS
 	}}
 }
 
-// remoteContainerImageReadsEnabled returns whether chunked container images can
-// be read from the remote cache.
+// TODO: Remove once remote container image reads/writes are fully rolled out.
+// RemoteContainerImageAccessOptions controls whether a task uses the remote
+// cache for its chunked container image.
 //
-// Caching container images remotely is beneficial because another executor
-// using the same image can share the cached chunks, skipping the expensive image pull
-// and ext4 conversion phases. Enable it as long as remote snapshot sharing is enabled.
-func remoteContainerImageReadsEnabled() bool {
-	return *snaputil.EnableRemoteSnapshotSharing
+// Caching container images remotely lets another executor using the same image
+// share the cached chunks, skipping the expensive image pull and ext4
+// conversion phases.
+//
+// This should be resolved once per VM and reused, so the decision is applied
+// consistently across the manifest lookup, the conversion, and the cache write.
+type RemoteContainerImageAccessOptions struct {
+	// RemoteReadsEnabled allows reading chunked EXT4s from the remote cache.
+	RemoteReadsEnabled bool
+	// RemoteWritesEnabled allows caching a chunked EXT4 remotely.
+	RemoteWritesEnabled bool
 }
 
-// remoteContainerImageWritesEnabled returns whether chunked container images
-// should be written to the remote cache.
-func remoteContainerImageWritesEnabled() bool {
-	return remoteContainerImageReadsEnabled() && !*snaputil.RemoteSnapshotReadonly
+// GetRemoteContainerImageAccessOptions decides whether this task should use the
+// remote cache for its chunked container image.
+//
+// Tasks that support remote snapshots always do. Other tasks follow their experiment assignment.
+func GetRemoteContainerImageAccessOptions(ctx context.Context, task *repb.ExecutionTask, supportsRemoteSnapshots bool) RemoteContainerImageAccessOptions {
+	if !*snaputil.EnableRemoteSnapshotSharing {
+		return RemoteContainerImageAccessOptions{}
+	}
+	if supportsRemoteSnapshots {
+		return RemoteContainerImageAccessOptions{
+			RemoteReadsEnabled:  true,
+			RemoteWritesEnabled: true,
+		}
+	}
+	reads := slices.Contains(task.GetExperiments(), snaputil.RemoteContainerImageReadsExperiment)
+	writes := slices.Contains(task.GetExperiments(), snaputil.RemoteContainerImageWritesExperiment)
+	log.CtxInfof(ctx, "Using remote chunked EXT4 access options: reads=%t writes=%t", reads, writes)
+	return RemoteContainerImageAccessOptions{
+		RemoteReadsEnabled: reads,
+		// Writes do not require reads: populating the remote cache ahead of
+		// enabling reads is a valid way to ramp.
+		RemoteWritesEnabled: writes && !*snaputil.RemoteSnapshotReadonly,
+	}
 }
 
 // GetCachedContainerImage returns the cached snapshot for the given
 // container image.
-func GetCachedContainerImage(ctx context.Context, l *FileCacheLoader, instanceName, imageRef string) (*Snapshot, error) {
+func GetCachedContainerImage(ctx context.Context, l *FileCacheLoader, instanceName, imageRef string, remoteEnabled bool) (*Snapshot, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	remoteEnabled := remoteContainerImageReadsEnabled()
 	snap, err := l.GetSnapshot(ctx, containerImageSnapshotKey(instanceName, imageRef), &GetSnapshotOptions{
 		SupportsRemoteManifest: remoteEnabled,
 		SupportsRemoteChunks:   remoteEnabled,
@@ -1493,7 +1518,7 @@ func resetContainerImageOutputDir(outDir string) error {
 //
 // If the image is not cached, this func will split up the given ext4 image
 // file and create a new ChunkedFile from it, then add that to cache.
-func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, instanceName, imageRef, imageExt4Path string, outDir string, chunkSize int64) (*copy_on_write.COWStore, error) {
+func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, instanceName, imageRef, imageExt4Path string, outDir string, chunkSize int64, imageOpts RemoteContainerImageAccessOptions) (*copy_on_write.COWStore, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
@@ -1504,7 +1529,7 @@ func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, instanceName,
 	}
 
 	// First check if all chunks for the image are available from the cache.
-	snap, err := GetCachedContainerImage(ctx, l, instanceName, imageRef)
+	snap, err := GetCachedContainerImage(ctx, l, instanceName, imageRef, imageOpts.RemoteReadsEnabled)
 	if err != nil {
 		if ctx.Err() != nil {
 			return nil, status.FromContextError(ctx)
@@ -1531,7 +1556,7 @@ func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, instanceName,
 	// containerfs is not available in cache; convert the EXT4 image to a
 	// ChunkedFile then add it to cache.
 	start := time.Now()
-	cow, err := copy_on_write.ConvertFileToCOW(ctx, l.env, imageExt4Path, chunkSize, outDir, instanceName, remoteContainerImageReadsEnabled(), snaputil.ConvertToCOWConcurrency)
+	cow, err := copy_on_write.ConvertFileToCOW(ctx, l.env, imageExt4Path, chunkSize, outDir, instanceName, imageOpts.RemoteReadsEnabled, snaputil.ConvertToCOWConcurrency)
 	if err != nil {
 		return nil, status.WrapError(err, "convert image to COW")
 	}
@@ -1539,7 +1564,7 @@ func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, instanceName,
 	opts := &CacheSnapshotOptions{
 		ChunkedFiles:          map[string]*copy_on_write.COWStore{rootfsFileName: cow},
 		Recycled:              false,
-		CacheSnapshotRemotely: remoteContainerImageWritesEnabled(),
+		CacheSnapshotRemotely: imageOpts.RemoteWritesEnabled,
 		CacheSnapshotLocally:  true,
 		// Always write the manifest locally too. Future lookups can reuse locally
 		// cached chunks and fetch missing immutable chunks from the remote cache.

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -47,6 +47,11 @@ const (
 	rootfsFileName         = "rootfs.ext4"
 	misnamedRootfsFileName = "rootfs" // TODO(bduffany): consolidate.
 
+	// Container images are immutable content, so use one shared namespace in the
+	// snapshot partition for all cached, chunked EXT4s.
+	// They should be shared across remote instance names.
+	containerImageInstanceName = snaputil.SnapshotPartitionPrefix + "/chunked-images"
+
 	// Rootfs access during guest boot mixes filesystem metadata and file data
 	// reads, so large sequential prefetch windows cause substantial read
 	// amplification. Keep this separate from the generic COW default, which was
@@ -704,7 +709,8 @@ func (l *FileCacheLoader) UnpackSnapshot(ctx context.Context, snapshot *Snapshot
 
 	for _, fileNode := range snapshot.manifest.Files {
 		outputPath := filepath.Join(outputDirectory, fileNode.GetName())
-		if _, err := snaputil.GetArtifact(ctx, l.env.GetFileCache(), l.env.GetByteStreamClient(), snapshot.supportsRemoteChunks, fileNode.GetDigest(), snapshot.key.InstanceName, outputPath); err != nil {
+		remoteInstanceName, remoteEnabled := snapshot.remoteChunkAccessForFile(fileNode.GetName())
+		if _, err := snaputil.GetArtifact(ctx, l.env.GetFileCache(), l.env.GetByteStreamClient(), remoteEnabled, fileNode.GetDigest(), remoteInstanceName, outputPath); err != nil {
 			return nil, err
 		}
 	}
@@ -714,7 +720,8 @@ func (l *FileCacheLoader) UnpackSnapshot(ctx context.Context, snapshot *Snapshot
 	}
 	// Construct COWs from chunks.
 	for _, cf := range snapshot.manifest.ChunkedFiles {
-		cow, err := l.unpackCOW(ctx, cf, snapshot.key.InstanceName, outputDirectory, snapshot.supportsRemoteChunks)
+		remoteInstanceName, remoteEnabled := snapshot.remoteChunkAccessForFile(cf.GetName())
+		cow, err := l.unpackCOW(ctx, cf, remoteInstanceName, outputDirectory, remoteEnabled)
 		if err != nil {
 			return nil, status.WrapError(err, "unpack COW")
 		}
@@ -910,28 +917,56 @@ func (l *FileCacheLoader) cacheManifestLocally(ctx context.Context, key *fcpb.Sn
 	return nil
 }
 
+func isRootfsSnapshot(name string) bool {
+	return name == rootfsFileName || name == misnamedRootfsFileName
+}
+
+// remoteChunkAccessForFile returns the CAS instance name from which the file's
+// chunks should be read and whether remote fallback is enabled for the file.
+func remoteChunkAccessForFile(name, snapshotInstanceName string, supportsRemoteFallback bool) (string, bool) {
+	if supportsRemoteFallback {
+		return snapshotInstanceName, true
+	}
+	// Rootfs snapshots combine immutable ext4 image chunks, which can and
+	// should be shared remotely, with modified disk chunks, which should only
+	// be written remotely when explicitly requested. Consequently, a local
+	// rootfs manifest may intentionally reference remote immutable chunks even
+	// when the rest of the VM snapshot is local-only. These immutable chunks are
+	// stored in the shared snapshot partition rather than the task's instance.
+	if *snaputil.EnableRemoteSnapshotSharing && isRootfsSnapshot(name) {
+		return containerImageInstanceName, true
+	}
+	return snapshotInstanceName, false
+}
+
+func (s *Snapshot) remoteChunkAccessForFile(name string) (string, bool) {
+	return remoteChunkAccessForFile(name, s.key.GetInstanceName(), s.supportsRemoteChunks)
+}
+
 func (l *FileCacheLoader) checkAllArtifactsExist(ctx context.Context, manifest *fcpb.SnapshotManifest, instanceName string, supportsRemoteFallback bool) error {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	missingDigests := make([]*repb.Digest, 0)
+	missingDigestsByInstance := make(map[string][]*repb.Digest)
 	for _, f := range manifest.GetFiles() {
 		if !l.env.GetFileCache().ContainsFile(ctx, f) {
-			if supportsRemoteFallback {
-				missingDigests = append(missingDigests, f.GetDigest())
+			remoteInstanceName, remoteEnabled := remoteChunkAccessForFile(f.GetName(), instanceName, supportsRemoteFallback)
+			if remoteEnabled {
+				missingDigestsByInstance[remoteInstanceName] = append(missingDigestsByInstance[remoteInstanceName], f.GetDigest())
 			} else {
 				return status.NotFoundErrorf("file %q not found (digest %q)", f.GetName(), digest.String(f.GetDigest()))
 			}
 		}
 	}
 	for _, cf := range manifest.GetChunkedFiles() {
+		remoteInstanceName, remoteEnabled := remoteChunkAccessForFile(cf.GetName(), instanceName, supportsRemoteFallback)
 		for _, c := range cf.GetChunks() {
 			node := &repb.FileNode{
 				Digest: c.GetDigest(),
 			}
 			if !l.env.GetFileCache().ContainsFile(ctx, node) {
-				if supportsRemoteFallback {
-					missingDigests = append(missingDigests, c.GetDigest())
+				if remoteEnabled {
+					missingDigestsByInstance[remoteInstanceName] = append(missingDigestsByInstance[remoteInstanceName], c.GetDigest())
 				} else {
 					return status.NotFoundErrorf("chunked file %q missing chunk at offset 0x%x (digest %q)", cf.GetName(), c.GetOffset(), digest.String(node.Digest))
 				}
@@ -939,13 +974,12 @@ func (l *FileCacheLoader) checkAllArtifactsExist(ctx context.Context, manifest *
 		}
 	}
 
-	// If `supportsRemoteFallback` is enabled, allow using a local manifest even
-	// if all snapshot chunks don't exist locally. The snaploader can fallback
-	// to fetching chunks from the remote cache.
-	if supportsRemoteFallback && len(missingDigests) > 0 {
+	// If remote fallback is enabled for any files, allow using a local manifest
+	// when its locally missing artifacts are available in the remote cache.
+	for remoteInstanceName, missingDigests := range missingDigestsByInstance {
 		ctx = snaputil.GetSnapshotAccessContext(ctx)
 		rsp, err := l.env.GetContentAddressableStorageClient().FindMissingBlobs(ctx, &repb.FindMissingBlobsRequest{
-			InstanceName:   instanceName,
+			InstanceName:   remoteInstanceName,
 			BlobDigests:    missingDigests,
 			DigestFunction: repb.DigestFunction_BLAKE3,
 			Purpose:        repb.FindMissingBlobsRequest_SNAPSHOT,
@@ -992,7 +1026,7 @@ func (l *FileCacheLoader) unpackCOW(ctx context.Context, file *fcpb.ChunkedFile,
 		RemoteInstanceName: remoteInstanceName,
 		RemoteEnabled:      remoteEnabled,
 	}
-	if file.GetName() == rootfsFileName || file.GetName() == misnamedRootfsFileName {
+	if isRootfsSnapshot(file.GetName()) {
 		opts.EagerFetchChunks = rootfsEagerFetchChunks
 	}
 	cow, err := copy_on_write.NewCOWStore(ctx, l.env, file.GetName(), chunks, opts)
@@ -1387,25 +1421,50 @@ func groupID(ctx context.Context, env environment.Env) (string, error) {
 // containerImageSnapshotKey returns the key under which the chunked
 // containerfs for the given container image is cached.
 //
-// TODO: use an Action for this key instead (to allow remote snapshot
-// sharing).
-func containerImageSnapshotKey(instanceName, imageRef string) *fcpb.SnapshotKeySet {
+// Container images are immutable content, so use one shared namespace in the
+// snapshot partition rather than converting and uploading the same image once
+// per remote instance.
+//
+// TODO: Use the image manifest digest, rather than just the name, to account for
+// situations where the image is updated for the same ref (e.g. if it's using the latest tag)
+func containerImageSnapshotKey(imageRef string) *fcpb.SnapshotKeySet {
 	return &fcpb.SnapshotKeySet{BranchKey: &fcpb.SnapshotKey{
-		InstanceName:      instanceName,
+		InstanceName:      containerImageInstanceName,
 		ConfigurationHash: hashStrings("__UnpackContainerImage", imageRef),
 	}}
 }
 
+// remoteContainerImageReadsEnabled returns whether chunked container images can
+// be read from the remote cache.
+//
+// Caching container images remotely is beneficial because any executor starting a
+// clean VM from the image can use them, skipping the expensive image pull
+// and ext4 conversion phases. Enable it as long as remote snapshot sharing is enabled.
+func remoteContainerImageReadsEnabled() bool {
+	return *snaputil.EnableRemoteSnapshotSharing
+}
+
+// remoteContainerImageWritesEnabled returns whether chunked container images
+// should be written to the remote cache.
+func remoteContainerImageWritesEnabled() bool {
+	return remoteContainerImageReadsEnabled() && !*snaputil.RemoteSnapshotReadonly
+}
+
 // GetCachedContainerImage returns the cached snapshot for the given
 // container image.
-func GetCachedContainerImage(ctx context.Context, l *FileCacheLoader, instanceName, imageRef string, remoteEnabled bool) (*Snapshot, error) {
+func GetCachedContainerImage(ctx context.Context, l *FileCacheLoader, imageRef string) (*Snapshot, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	snap, err := l.GetSnapshot(ctx, containerImageSnapshotKey(instanceName, imageRef), &GetSnapshotOptions{
+	remoteEnabled := remoteContainerImageReadsEnabled()
+	snap, err := l.GetSnapshot(ctx, containerImageSnapshotKey(imageRef), &GetSnapshotOptions{
 		SupportsRemoteManifest: remoteEnabled,
 		SupportsRemoteChunks:   remoteEnabled,
-		ReadPolicy:             platform.AlwaysReadNewestSnapshot,
+		// A chunked container image is immutable for a given image ref, so
+		// there is never a newer version to read. Prefer the local manifest,
+		// which also lets a remote hit be written back to the local filecache
+		// so that later runs on this executor don't depend on the remote cache.
+		ReadPolicy: platform.ReadLocalSnapshotFirst,
 	})
 	if err != nil {
 		return nil, err
@@ -1434,21 +1493,33 @@ func UnpackContainerImageSnapshot(ctx context.Context, l *FileCacheLoader, snap 
 //
 // If the image is not cached, this func will split up the given ext4 image
 // file and create a new ChunkedFile from it, then add that to cache.
-func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, instanceName, imageRef, imageExt4Path string, outDir string, chunkSize int64, remoteEnabled bool) (*copy_on_write.COWStore, error) {
+func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, imageRef, imageExt4Path string, outDir string, chunkSize int64) (*copy_on_write.COWStore, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	snap, err := GetCachedContainerImage(ctx, l, instanceName, imageRef, remoteEnabled)
-	if err != nil && !(status.IsNotFoundError(err) || status.IsUnavailableError(err)) {
-		return nil, err
+	snap, err := GetCachedContainerImage(ctx, l, imageRef)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		if !status.IsNotFoundError(err) {
+			log.CtxWarningf(ctx, "Failed to read cached container image %q; converting the pulled image instead: %s", imageRef, err)
+		}
 	}
 	if snap != nil {
-		return UnpackContainerImageSnapshot(ctx, l, snap, outDir)
+		cow, err := UnpackContainerImageSnapshot(ctx, l, snap, outDir)
+		if err == nil {
+			return cow, nil
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		log.CtxWarningf(ctx, "Failed to unpack cached container image %q; converting the pulled image instead: %s", imageRef, err)
 	}
 	// containerfs is not available in cache; convert the EXT4 image to a
 	// ChunkedFile then add it to cache.
 	start := time.Now()
-	cow, err := copy_on_write.ConvertFileToCOW(ctx, l.env, imageExt4Path, chunkSize, outDir, instanceName, remoteEnabled, snaputil.ConvertToCOWConcurrency)
+	cow, err := copy_on_write.ConvertFileToCOW(ctx, l.env, imageExt4Path, chunkSize, outDir, containerImageInstanceName, remoteContainerImageReadsEnabled(), snaputil.ConvertToCOWConcurrency)
 	if err != nil {
 		return nil, status.WrapError(err, "convert image to COW")
 	}
@@ -1456,13 +1527,21 @@ func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, instanceName,
 	opts := &CacheSnapshotOptions{
 		ChunkedFiles:          map[string]*copy_on_write.COWStore{rootfsFileName: cow},
 		Recycled:              false,
-		CacheSnapshotRemotely: remoteEnabled,
+		CacheSnapshotRemotely: remoteContainerImageWritesEnabled(),
 		CacheSnapshotLocally:  true,
-		WriteManifestLocally:  !remoteEnabled,
+		// Always write the manifest locally too. Future lookups can reuse locally
+		// cached chunks and fetch missing immutable chunks from the remote cache.
+		WriteManifestLocally: true,
 	}
-	key := containerImageSnapshotKey(instanceName, imageRef)
+	key := containerImageSnapshotKey(imageRef)
 	if err := l.CacheSnapshot(ctx, key.GetBranchKey(), opts); err != nil {
-		return nil, status.WrapError(err, "cache containerfs snapshot")
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			if closeErr := cow.Close(); closeErr != nil {
+				log.CtxWarningf(ctx, "Failed to close container image COW after context cancellation: %s", closeErr)
+			}
+			return nil, ctxErr
+		}
+		log.CtxWarningf(ctx, "Failed to cache converted container image %q; continuing with the local COW: %s", imageRef, err)
 	}
 	log.CtxDebugf(ctx, "Converted containerfs to COW in %s", time.Since(start))
 	return cow, nil

--- a/enterprise/server/remote_execution/snaploader/snaploader_test.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader_test.go
@@ -696,7 +696,92 @@ func TestGetSnapshot_CacheIsolation(t *testing.T) {
 	}
 }
 
-func TestContainerImageCache_PartitionRoutingAndRootfsFallback(t *testing.T) {
+func TestGetSnapshot_MixOfLocalAndRemoteChunks(t *testing.T) {
+	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
+	flags.Set(t, "executor.snaploader_max_eager_fetches_per_sec", 0)
+
+	env := setupEnv(t)
+	ctx := context.Background()
+	loader, err := snaploader.New(env)
+	require.NoError(t, err)
+
+	for _, instanceName := range []string{"", "instance-name"} {
+		workDir := testfs.MakeTempDir(t)
+
+		// Save a snapshot remotely.
+		workDirA := testfs.MakeDirAll(t, workDir, "VM-A")
+		const chunkSize = 1
+		const fileSize = chunkSize * 10
+		originalImagePath := makeRandomFile(t, workDirA, "test-file", fileSize)
+		cowA, err := copy_on_write.ConvertFileToCOW(ctx, env, originalImagePath, chunkSize, workDirA, instanceName, true /*remoteEnabled*/, snaputil.ConvertToCOWConcurrency)
+		require.NoError(t, err)
+		t.Cleanup(func() { cowA.Close() })
+		originalWriteBuf := []byte("0123456789")
+		_, err = cowA.WriteAt(originalWriteBuf, 0)
+		require.NoError(t, err)
+		optsA := makeFakeSnapshot(t, workDirA, true /*remoteEnabled*/, map[string]*copy_on_write.COWStore{
+			"scratchfs": cowA,
+		}, "")
+		keyset := keysWithInstanceName(t, ctx, loader, instanceName)
+		// Write the snapshot remotely only.
+		flags.Set(t, "executor.enable_local_snapshot_sharing", false)
+		err = loader.CacheSnapshot(ctx, keyset.GetBranchKey(), optsA)
+		flags.Set(t, "executor.enable_local_snapshot_sharing", true)
+		require.NoError(t, err)
+
+		// Read chunks 1-3 from the remote snapshot. Modify one chunk and save the
+		// snapshot locally only.
+		workDirB := testfs.MakeDirAll(t, workDir, "VM-B")
+		snap, err := loader.GetSnapshot(ctx, keyset, &snaploader.GetSnapshotOptions{
+			SupportsRemoteChunks:   true,
+			SupportsRemoteManifest: true,
+			ReadPolicy:             platform.AlwaysReadNewestSnapshot,
+		})
+		require.NoError(t, err)
+		unpacked, err := loader.UnpackSnapshot(ctx, snap, workDirB)
+		require.NoError(t, err)
+		t.Cleanup(func() { closeAll(unpacked) })
+		readBuf := make([]byte, 3)
+		disk := unpacked.ChunkedFiles["scratchfs"]
+		_, err = disk.ReadAt(readBuf, 1)
+		require.NoError(t, err)
+		require.ElementsMatch(t, originalWriteBuf[1:4], readBuf)
+		// Update one chunk of the snapshot.
+		readBuf[2] = '6'
+		_, err = disk.WriteAt(readBuf, 1)
+		require.NoError(t, err)
+		// Write snapshot locally only.
+		optsB := makeFakeSnapshot(t, workDirB, false /*remoteEnabled*/, map[string]*copy_on_write.COWStore{
+			"scratchfs": disk,
+		}, "")
+		err = loader.CacheSnapshot(ctx, keyset.GetBranchKey(), optsB)
+		require.NoError(t, err)
+
+		// Read chunks 2-5. Should read the modified chunk 3
+		// that was written locally only by VM-B. Should be able to fetch chunks 4-5 from the
+		// remote snapshot, even though they were not cached locally by VM-B.
+		workDirC := testfs.MakeDirAll(t, workDir, "VM-C")
+		// GetSnapshot should use the local snapshot manifest, but fallback to the
+		// remote cache for any missing chunks.
+		snap, err = loader.GetSnapshot(ctx, keyset, &snaploader.GetSnapshotOptions{
+			SupportsRemoteChunks:   true,
+			SupportsRemoteManifest: true,
+			ReadPolicy:             platform.AlwaysReadNewestSnapshot,
+		})
+		require.NoError(t, err)
+		unpackedC, err := loader.UnpackSnapshot(ctx, snap, workDirC)
+		require.NoError(t, err)
+		t.Cleanup(func() { closeAll(unpackedC) })
+		readBufC := make([]byte, 4)
+		diskC := unpackedC.ChunkedFiles["scratchfs"]
+		_, err = diskC.ReadAt(readBufC, 2)
+		require.NoError(t, err)
+		expectedBuf := []byte("2645")
+		require.ElementsMatch(t, expectedBuf, readBufC)
+	}
+}
+
+func TestUnpackContainerImage_RemoteSnapshotDisabledExceptUndirtiedRootfsChunks(t *testing.T) {
 	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
 	flags.Set(t, "executor.snaploader_max_eager_fetches_per_sec", 0)
 
@@ -712,125 +797,83 @@ func TestContainerImageCache_PartitionRoutingAndRootfsFallback(t *testing.T) {
 		env.SetFileCache(fc)
 	}
 
-	testCases := []struct {
-		name           string
-		instanceA      string
-		instanceB      string
-		otherInstances []string
-	}{
-		{
-			name:           "rbe",
-			instanceA:      "rbe-instance-a",
-			instanceB:      "rbe-instance-b",
-			otherInstances: []string{snaputil.SnapshotPartitionPrefix + "/instance", snaputil.DevboxPartitionPrefix + "/instance"},
-		},
-		{
-			name:           "ci_runner",
-			instanceA:      snaputil.SnapshotPartitionPrefix + "/instance-a",
-			instanceB:      snaputil.SnapshotPartitionPrefix + "/instance-b",
-			otherInstances: []string{"rbe-instance", snaputil.DevboxPartitionPrefix + "/instance"},
-		},
-		{
-			name:           "box",
-			instanceA:      snaputil.DevboxPartitionPrefix + "/instance-a",
-			instanceB:      snaputil.DevboxPartitionPrefix + "/instance-b",
-			otherInstances: []string{"rbe-instance", snaputil.SnapshotPartitionPrefix + "/instance"},
-		},
-	}
+	instanceName := "rbe-instance"
+	workDir := testfs.MakeTempDir(t)
+	imageRef := "example.com/image:latest"
+	const imageContents = "0123456789"
+	const chunkSize = 1
+	imagePath := testfs.WriteFile(t, workDir, "rootfs.ext4", imageContents)
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			workDir := testfs.MakeTempDir(t)
-			imageRef := "example.com/" + tc.name + ":latest"
-			const imageContents = "0123456789"
-			const chunkSize = 1
-			imagePath := testfs.WriteFile(t, workDir, "rootfs.ext4", imageContents)
+	// Cache the image using the task's original instance name.
+	imageCOW, err := snaploader.UnpackContainerImage(
+		ctx, loader, instanceName, imageRef, imagePath,
+		testfs.MakeDirAll(t, workDir, "image-chunks"), chunkSize)
+	require.NoError(t, err)
+	require.NoError(t, imageCOW.Close())
 
-			// Cache the image from one instance in this partition.
-			imageCOW, err := snaploader.UnpackContainerImage(
-				ctx, loader, tc.instanceA, imageRef, imagePath,
-				testfs.MakeDirAll(t, workDir, "image-chunks"), chunkSize)
-			require.NoError(t, err)
-			require.NoError(t, imageCOW.Close())
+	// Force subsequent image lookups and chunk reads to use the remote cache.
+	resetLocalFileCache()
 
-			// Force subsequent image lookups and chunk reads to use Pebble.
-			resetLocalFileCache()
+	// Container image manifests are scoped to the original instance name.
+	// Lookups from other instance names should fail.
+	_, err = snaploader.GetCachedContainerImage(ctx, loader, "other-instance", imageRef)
+	require.Error(t, err)
+	require.True(t, status.IsNotFoundError(err))
 
-			// The image manifest must not leak into either of the other cache
-			// partitions.
-			for _, otherInstance := range tc.otherInstances {
-				otherImage, err := snaploader.GetCachedContainerImage(ctx, loader, otherInstance, imageRef)
-				require.Error(t, err)
-				require.True(t, status.IsNotFoundError(err), "unexpected cross-partition lookup error: %s", err)
-				require.Nil(t, otherImage)
-			}
+	// Lookups from the original instance name should succeed.
+	imageSnapshot, err := snaploader.GetCachedContainerImage(ctx, loader, instanceName, imageRef)
+	require.NoError(t, err)
+	rootfs, err := snaploader.UnpackContainerImageSnapshot(
+		ctx, loader, imageSnapshot, testfs.MakeDirAll(t, workDir, "rootfs-chunks"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, rootfs.Close()) })
 
-			// A different instance routed to the same partition should reuse the
-			// remotely cached image manifest and chunks.
-			imageSnapshot, err := snaploader.GetCachedContainerImage(ctx, loader, tc.instanceB, imageRef)
-			require.NoError(t, err)
-			rootfs, err := snaploader.UnpackContainerImageSnapshot(
-				ctx, loader, imageSnapshot, testfs.MakeDirAll(t, workDir, "rootfs-chunks"))
-			require.NoError(t, err)
-			t.Cleanup(func() { require.NoError(t, rootfs.Close()) })
+	// Dirty one chunk without reading the rest, then cache the task
+	// snapshot locally. Its untouched chunks remain only in Pebble.
+	_, err = rootfs.WriteAt([]byte("X"), 1)
+	require.NoError(t, err)
+	taskKeys := keysWithInstanceName(t, ctx, loader, instanceName)
+	localSnapshotOpts := makeFakeSnapshot(t, workDir, false /*remoteEnabled*/, map[string]*copy_on_write.COWStore{
+		"rootfs.ext4": rootfs,
+	}, "")
+	require.NoError(t, loader.CacheSnapshot(ctx, taskKeys.GetBranchKey(), localSnapshotOpts))
 
-			// Dirty one chunk without reading the rest, then cache the task
-			// snapshot locally. Its untouched chunks remain only in Pebble.
-			_, err = rootfs.WriteAt([]byte("X"), 1)
-			require.NoError(t, err)
-			taskKeys := keysWithInstanceName(t, ctx, loader, tc.instanceB)
-			localSnapshotOpts := makeFakeSnapshot(t, workDir, false /*remoteEnabled*/, map[string]*copy_on_write.COWStore{
-				"rootfs.ext4": rootfs,
-			}, "")
-			require.NoError(t, loader.CacheSnapshot(ctx, taskKeys.GetBranchKey(), localSnapshotOpts))
+	// Simulate a RBE action that doesn't support remote snapshots for dirtied chunks.
+	// Immutable rootfs chunks should still be readable from the remote cache.
+	localSnapshot, err := loader.GetSnapshot(ctx, taskKeys, &snaploader.GetSnapshotOptions{
+		SupportsRemoteChunks:   false,
+		SupportsRemoteManifest: false,
+		ReadPolicy:             platform.ReadLocalSnapshotFirst,
+	})
+	require.NoError(t, err)
+	localRootfs, err := snaploader.UnpackContainerImageSnapshot(
+		ctx, loader, localSnapshot, testfs.MakeDirAll(t, workDir, "local-snapshot-chunks"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, localRootfs.Close()) })
+	require.Equal(t, []byte("0X23456789"), mustReadStore(t, localRootfs))
 
-			// Remove any immutable chunks that eager fetching happened to place in
-			// the local filecache, ensuring the next read exercises remote fallback.
-			for _, cf := range imageSnapshot.GetChunkedFiles() {
-				for _, chunk := range cf.GetChunks() {
-					env.GetFileCache().DeleteFile(ctx, &repb.FileNode{Digest: chunk.GetDigest()})
-				}
-			}
-
-			// Plain RBE actions use local VM manifests and advertise no general
-			// remote snapshot support. Immutable rootfs chunks should still fall
-			// back to the remote cache in the task's partition.
-			localSnapshot, err := loader.GetSnapshot(ctx, taskKeys, &snaploader.GetSnapshotOptions{
-				SupportsRemoteChunks:   false,
-				SupportsRemoteManifest: false,
-				ReadPolicy:             platform.ReadLocalSnapshotFirst,
-			})
-			require.NoError(t, err)
-			localRootfs, err := snaploader.UnpackContainerImageSnapshot(
-				ctx, loader, localSnapshot, testfs.MakeDirAll(t, workDir, "local-snapshot-chunks"))
-			require.NoError(t, err)
-			t.Cleanup(func() { require.NoError(t, localRootfs.Close()) })
-			require.Equal(t, []byte("0X23456789"), mustReadStore(t, localRootfs))
-
-			// Saving the mixed rootfs remotely should produce a self-contained
-			// snapshot: immutable image chunks and the dirty chunk are all visible
-			// through the task instance's partition.
-			remoteSnapshotOpts := makeFakeSnapshot(t, workDir, true /*remoteEnabled*/, map[string]*copy_on_write.COWStore{
-				"rootfs.ext4": localRootfs,
-			}, "")
-			require.NoError(t, loader.CacheSnapshot(ctx, taskKeys.GetBranchKey(), remoteSnapshotOpts))
-			resetLocalFileCache()
-			remoteSnapshot, err := loader.GetSnapshot(ctx, taskKeys, &snaploader.GetSnapshotOptions{
-				SupportsRemoteChunks:   true,
-				SupportsRemoteManifest: true,
-				ReadPolicy:             platform.AlwaysReadNewestSnapshot,
-			})
-			require.NoError(t, err)
-			remoteRootfs, err := snaploader.UnpackContainerImageSnapshot(
-				ctx, loader, remoteSnapshot, testfs.MakeDirAll(t, workDir, "remote-snapshot-chunks"))
-			require.NoError(t, err)
-			t.Cleanup(func() { require.NoError(t, remoteRootfs.Close()) })
-			require.Equal(t, []byte("0X23456789"), mustReadStore(t, remoteRootfs))
-		})
-	}
+	// Saving the mixed rootfs remotely should produce a self-contained
+	// snapshot: immutable image chunks and the dirty chunk are all visible
+	// through the task instance's partition.
+	remoteSnapshotOpts := makeFakeSnapshot(t, workDir, true /*remoteEnabled*/, map[string]*copy_on_write.COWStore{
+		"rootfs.ext4": localRootfs,
+	}, "")
+	require.NoError(t, loader.CacheSnapshot(ctx, taskKeys.GetBranchKey(), remoteSnapshotOpts))
+	resetLocalFileCache()
+	remoteSnapshot, err := loader.GetSnapshot(ctx, taskKeys, &snaploader.GetSnapshotOptions{
+		SupportsRemoteChunks:   true,
+		SupportsRemoteManifest: true,
+		ReadPolicy:             platform.AlwaysReadNewestSnapshot,
+	})
+	require.NoError(t, err)
+	remoteRootfs, err := snaploader.UnpackContainerImageSnapshot(
+		ctx, loader, remoteSnapshot, testfs.MakeDirAll(t, workDir, "remote-snapshot-chunks"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, remoteRootfs.Close()) })
+	require.Equal(t, []byte("0X23456789"), mustReadStore(t, remoteRootfs))
 }
 
-func TestUnpackContainerImage_CacheErrorsAreBestEffort(t *testing.T) {
+func TestUnpackContainerImage_UnpackingFromCacheIsBestEffort(t *testing.T) {
 	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
 
 	for _, tc := range []struct {
@@ -838,13 +881,13 @@ func TestUnpackContainerImage_CacheErrorsAreBestEffort(t *testing.T) {
 		failCache func(env *testenv.TestEnv)
 	}{
 		{
-			name: "read",
+			name: "cache read error",
 			failCache: func(env *testenv.TestEnv) {
 				env.SetActionCacheClient(failingGetActionCacheClient{env.GetActionCacheClient()})
 			},
 		},
 		{
-			name: "write",
+			name: "cache write error",
 			failCache: func(env *testenv.TestEnv) {
 				env.SetByteStreamClient(failingWriteByteStreamClient{env.GetByteStreamClient()})
 			},
@@ -865,6 +908,9 @@ func TestUnpackContainerImage_CacheErrorsAreBestEffort(t *testing.T) {
 			cow, err := snaploader.UnpackContainerImage(
 				ctx, loader, "task-instance", "example.com/image:latest", imagePath,
 				testfs.MakeDirAll(t, workDir, "chunks"), 1)
+
+			// Even though there was a cache error, the image should still be unpacked, falling back to re-pulling and
+			// converting the image.
 			require.NoError(t, err)
 			t.Cleanup(func() { require.NoError(t, cow.Close()) })
 			require.Equal(t, expected, mustReadStore(t, cow))
@@ -872,7 +918,7 @@ func TestUnpackContainerImage_CacheErrorsAreBestEffort(t *testing.T) {
 	}
 }
 
-func TestUnpackContainerImage_UnpackFailureCleansOutputBeforeReconvert(t *testing.T) {
+func TestUnpackContainerImage_CleansOutputDirBeforeUnpack(t *testing.T) {
 	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
 
 	env := setupPebbleEnv(t)
@@ -893,20 +939,18 @@ func TestUnpackContainerImage_UnpackFailureCleansOutputBeforeReconvert(t *testin
 	require.NoError(t, err)
 	require.NoError(t, cow.Close())
 
-	// Simulate a cached-image unpack leaving its rootfs chunk directory behind.
-	// This makes the cached unpack fail when it attempts to create the same
-	// directory, forcing UnpackContainerImage to reconvert the pulled image.
-	outDir := testfs.MakeDirAll(t, workDir, "fallback-chunks")
-	partialRootfsDir := testfs.MakeDirAll(t, outDir, "rootfs.ext4")
-	testfs.WriteFile(t, partialRootfsDir, "partial", "stale")
+	// Leave a stale output directory. This should not cause unpack failures.
+	outDir := testfs.MakeDirAll(t, workDir, "cached-chunks")
+	staleRootfsDir := testfs.MakeDirAll(t, outDir, "rootfs.ext4")
+	testfs.WriteFile(t, staleRootfsDir, "partial", "stale")
 
+	// Use a nonexistent EXT4 path to prove the cached snapshot is used. If the
+	// stale directory caused a fallback conversion, this call would fail.
 	cow, err = snaploader.UnpackContainerImage(
-		ctx, loader, "task-instance", imageRef, imagePath, outDir, 1)
+		ctx, loader, "task-instance", imageRef, filepath.Join(workDir, "missing.ext4"), outDir, 1)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, cow.Close()) })
 	require.Equal(t, []byte(imageContents), mustReadStore(t, cow))
-	_, err = os.Stat(partialRootfsDir)
-	require.True(t, os.IsNotExist(err), "partial cached-image output was not removed")
 }
 
 func TestMergeQueueBranch(t *testing.T) {

--- a/enterprise/server/remote_execution/snaploader/snaploader_test.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader_test.go
@@ -807,7 +807,8 @@ func TestUnpackContainerImage_RemoteSnapshotDisabledExceptUndirtiedRootfsChunks(
 	// Cache the image using the task's original instance name.
 	imageCOW, err := snaploader.UnpackContainerImage(
 		ctx, loader, instanceName, imageRef, imagePath,
-		testfs.MakeDirAll(t, workDir, "image-chunks"), chunkSize)
+		testfs.MakeDirAll(t, workDir, "image-chunks"), chunkSize,
+		snaploader.RemoteContainerImageAccessOptions{RemoteReadsEnabled: true, RemoteWritesEnabled: true})
 	require.NoError(t, err)
 	require.NoError(t, imageCOW.Close())
 
@@ -816,12 +817,12 @@ func TestUnpackContainerImage_RemoteSnapshotDisabledExceptUndirtiedRootfsChunks(
 
 	// Container image manifests are scoped to the original instance name.
 	// Lookups from other instance names should fail.
-	_, err = snaploader.GetCachedContainerImage(ctx, loader, "other-instance", imageRef)
+	_, err = snaploader.GetCachedContainerImage(ctx, loader, "other-instance", imageRef, true)
 	require.Error(t, err)
 	require.True(t, status.IsNotFoundError(err))
 
 	// Lookups from the original instance name should succeed.
-	imageSnapshot, err := snaploader.GetCachedContainerImage(ctx, loader, instanceName, imageRef)
+	imageSnapshot, err := snaploader.GetCachedContainerImage(ctx, loader, instanceName, imageRef, true)
 	require.NoError(t, err)
 	rootfs, err := snaploader.UnpackContainerImageSnapshot(
 		ctx, loader, imageSnapshot, testfs.MakeDirAll(t, workDir, "rootfs-chunks"))
@@ -907,7 +908,8 @@ func TestUnpackContainerImage_UnpackingFromCacheIsBestEffort(t *testing.T) {
 			require.NoError(t, err)
 			cow, err := snaploader.UnpackContainerImage(
 				ctx, loader, "task-instance", "example.com/image:latest", imagePath,
-				testfs.MakeDirAll(t, workDir, "chunks"), 1)
+				testfs.MakeDirAll(t, workDir, "chunks"), 1,
+				snaploader.RemoteContainerImageAccessOptions{RemoteReadsEnabled: true, RemoteWritesEnabled: true})
 
 			// Even though there was a cache error, the image should still be unpacked, falling back to re-pulling and
 			// converting the image.
@@ -935,7 +937,8 @@ func TestUnpackContainerImage_CleansOutputDirBeforeUnpack(t *testing.T) {
 	// Populate the container-image cache.
 	cow, err := snaploader.UnpackContainerImage(
 		ctx, loader, "task-instance", imageRef, imagePath,
-		testfs.MakeDirAll(t, workDir, "initial-chunks"), 1)
+		testfs.MakeDirAll(t, workDir, "initial-chunks"), 1,
+		snaploader.RemoteContainerImageAccessOptions{RemoteReadsEnabled: true, RemoteWritesEnabled: true})
 	require.NoError(t, err)
 	require.NoError(t, cow.Close())
 
@@ -947,7 +950,8 @@ func TestUnpackContainerImage_CleansOutputDirBeforeUnpack(t *testing.T) {
 	// Use a nonexistent EXT4 path to prove the cached snapshot is used. If the
 	// stale directory caused a fallback conversion, this call would fail.
 	cow, err = snaploader.UnpackContainerImage(
-		ctx, loader, "task-instance", imageRef, filepath.Join(workDir, "missing.ext4"), outDir, 1)
+		ctx, loader, "task-instance", imageRef, filepath.Join(workDir, "missing.ext4"), outDir, 1,
+		snaploader.RemoteContainerImageAccessOptions{RemoteReadsEnabled: true, RemoteWritesEnabled: true})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, cow.Close()) })
 	require.Equal(t, []byte(imageContents), mustReadStore(t, cow))

--- a/enterprise/server/remote_execution/snaploader/snaploader_test.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader_test.go
@@ -73,14 +73,17 @@ func setupEnv(t *testing.T) *testenv.TestEnv {
 func setupPebbleEnv(t *testing.T) *testenv.TestEnv {
 	env := setupBaseEnv(t)
 	const snapshotPartitionID = "snapshots"
+	const devboxPartitionID = "devbox"
 	pc, err := pebble_cache.NewPebbleCache(env, &pebble_cache.Options{
 		RootDirectory: testfs.MakeTempDir(t),
 		MaxSizeBytes:  1_000_000_000,
 		Partitions: []disk.Partition{
 			{ID: snapshotPartitionID, MaxSizeBytes: 1_000_000_000},
+			{ID: devboxPartitionID, MaxSizeBytes: 1_000_000_000},
 		},
 		PartitionMappings: []disk.PartitionMapping{
 			{Prefix: snaputil.SnapshotPartitionPrefix, PartitionID: snapshotPartitionID},
+			{Prefix: snaputil.DevboxPartitionPrefix, PartitionID: devboxPartitionID},
 		},
 	})
 	require.NoError(t, err)
@@ -693,7 +696,7 @@ func TestGetSnapshot_CacheIsolation(t *testing.T) {
 	}
 }
 
-func TestGetSnapshot_MixOfLocalAndRemoteChunks(t *testing.T) {
+func TestContainerImageCache_PartitionRoutingAndRootfsFallback(t *testing.T) {
 	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
 	flags.Set(t, "executor.snaploader_max_eager_fetches_per_sec", 0)
 
@@ -702,77 +705,129 @@ func TestGetSnapshot_MixOfLocalAndRemoteChunks(t *testing.T) {
 	require.NoError(t, err)
 	loader, err := snaploader.New(env)
 	require.NoError(t, err)
-	workDir := testfs.MakeTempDir(t)
+	resetLocalFileCache := func() {
+		fc, err := filecache.NewFileCache(testfs.MakeTempDir(t), maxFilecacheSizeBytes, false)
+		require.NoError(t, err)
+		fc.WaitForDirectoryScanToComplete()
+		env.SetFileCache(fc)
+	}
 
-	// Cache an immutable rootfs in the shared snapshot partition.
-	workDirA := testfs.MakeDirAll(t, workDir, "VM-A")
-	const chunkSize = 1
-	const fileSize = chunkSize * 10
-	originalImagePath := makeRandomFile(t, workDirA, "rootfs.ext4", fileSize)
-	cowA, err := copy_on_write.ConvertFileToCOW(ctx, env, originalImagePath, chunkSize, workDirA, snaputil.SnapshotPartitionPrefix, true /*remoteEnabled*/, snaputil.ConvertToCOWConcurrency)
-	require.NoError(t, err)
-	t.Cleanup(func() { cowA.Close() })
-	originalWriteBuf := []byte("0123456789")
-	_, err = cowA.WriteAt(originalWriteBuf, 0)
-	require.NoError(t, err)
-	optsA := makeFakeSnapshot(t, workDirA, true /*remoteEnabled*/, map[string]*copy_on_write.COWStore{
-		"rootfs.ext4": cowA,
-	}, "")
-	imageKeys := keysWithInstanceName(t, ctx, loader, snaputil.SnapshotPartitionPrefix)
-	// Write the image snapshot remotely only.
-	flags.Set(t, "executor.enable_local_snapshot_sharing", false)
-	err = loader.CacheSnapshot(ctx, imageKeys.GetBranchKey(), optsA)
-	flags.Set(t, "executor.enable_local_snapshot_sharing", true)
-	require.NoError(t, err)
+	testCases := []struct {
+		name           string
+		instanceA      string
+		instanceB      string
+		otherInstances []string
+	}{
+		{
+			name:           "rbe",
+			instanceA:      "rbe-instance-a",
+			instanceB:      "rbe-instance-b",
+			otherInstances: []string{snaputil.SnapshotPartitionPrefix + "/instance", snaputil.DevboxPartitionPrefix + "/instance"},
+		},
+		{
+			name:           "ci_runner",
+			instanceA:      snaputil.SnapshotPartitionPrefix + "/instance-a",
+			instanceB:      snaputil.SnapshotPartitionPrefix + "/instance-b",
+			otherInstances: []string{"rbe-instance", snaputil.DevboxPartitionPrefix + "/instance"},
+		},
+		{
+			name:           "box",
+			instanceA:      snaputil.DevboxPartitionPrefix + "/instance-a",
+			instanceB:      snaputil.DevboxPartitionPrefix + "/instance-b",
+			otherInstances: []string{"rbe-instance", snaputil.SnapshotPartitionPrefix + "/instance"},
+		},
+	}
 
-	// Read chunks 1-3 from the remote image. Modify one chunk and save the VM
-	// snapshot locally under a plain RBE task instance.
-	workDirB := testfs.MakeDirAll(t, workDir, "VM-B")
-	snap, err := loader.GetSnapshot(ctx, imageKeys, &snaploader.GetSnapshotOptions{
-		SupportsRemoteChunks:   true,
-		SupportsRemoteManifest: true,
-		ReadPolicy:             platform.AlwaysReadNewestSnapshot,
-	})
-	require.NoError(t, err)
-	unpacked, err := loader.UnpackSnapshot(ctx, snap, workDirB)
-	require.NoError(t, err)
-	t.Cleanup(func() { closeAll(unpacked) })
-	readBuf := make([]byte, 3)
-	disk := unpacked.ChunkedFiles["rootfs.ext4"]
-	_, err = disk.ReadAt(readBuf, 1)
-	require.NoError(t, err)
-	require.ElementsMatch(t, originalWriteBuf[1:4], readBuf)
-	// Update one chunk of the snapshot.
-	readBuf[2] = '6'
-	_, err = disk.WriteAt(readBuf, 1)
-	require.NoError(t, err)
-	// Write the VM snapshot locally only.
-	optsB := makeFakeSnapshot(t, workDirB, false /*remoteEnabled*/, map[string]*copy_on_write.COWStore{
-		"rootfs.ext4": disk,
-	}, "")
-	taskKeys := keysWithInstanceName(t, ctx, loader, "task-instance")
-	err = loader.CacheSnapshot(ctx, taskKeys.GetBranchKey(), optsB)
-	require.NoError(t, err)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			workDir := testfs.MakeTempDir(t)
+			imageRef := "example.com/" + tc.name + ":latest"
+			const imageContents = "0123456789"
+			const chunkSize = 1
+			imagePath := testfs.WriteFile(t, workDir, "rootfs.ext4", imageContents)
 
-	// A plain RBE reader doesn't support remote VM snapshots. It should use the
-	// local manifest and fetch only its missing immutable rootfs chunks from the
-	// shared snapshot partition.
-	workDirC := testfs.MakeDirAll(t, workDir, "VM-C")
-	snap, err = loader.GetSnapshot(ctx, taskKeys, &snaploader.GetSnapshotOptions{
-		SupportsRemoteChunks:   false,
-		SupportsRemoteManifest: false,
-		ReadPolicy:             platform.ReadLocalSnapshotFirst,
-	})
-	require.NoError(t, err)
-	unpackedC, err := loader.UnpackSnapshot(ctx, snap, workDirC)
-	require.NoError(t, err)
-	t.Cleanup(func() { closeAll(unpackedC) })
-	readBufC := make([]byte, 4)
-	diskC := unpackedC.ChunkedFiles["rootfs.ext4"]
-	_, err = diskC.ReadAt(readBufC, 2)
-	require.NoError(t, err)
-	expectedBuf := []byte("2645")
-	require.ElementsMatch(t, expectedBuf, readBufC)
+			// Cache the image from one instance in this partition.
+			imageCOW, err := snaploader.UnpackContainerImage(
+				ctx, loader, tc.instanceA, imageRef, imagePath,
+				testfs.MakeDirAll(t, workDir, "image-chunks"), chunkSize)
+			require.NoError(t, err)
+			require.NoError(t, imageCOW.Close())
+
+			// Force subsequent image lookups and chunk reads to use Pebble.
+			resetLocalFileCache()
+
+			// The image manifest must not leak into either of the other cache
+			// partitions.
+			for _, otherInstance := range tc.otherInstances {
+				otherImage, err := snaploader.GetCachedContainerImage(ctx, loader, otherInstance, imageRef)
+				require.Error(t, err)
+				require.True(t, status.IsNotFoundError(err), "unexpected cross-partition lookup error: %s", err)
+				require.Nil(t, otherImage)
+			}
+
+			// A different instance routed to the same partition should reuse the
+			// remotely cached image manifest and chunks.
+			imageSnapshot, err := snaploader.GetCachedContainerImage(ctx, loader, tc.instanceB, imageRef)
+			require.NoError(t, err)
+			rootfs, err := snaploader.UnpackContainerImageSnapshot(
+				ctx, loader, imageSnapshot, testfs.MakeDirAll(t, workDir, "rootfs-chunks"))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, rootfs.Close()) })
+
+			// Dirty one chunk without reading the rest, then cache the task
+			// snapshot locally. Its untouched chunks remain only in Pebble.
+			_, err = rootfs.WriteAt([]byte("X"), 1)
+			require.NoError(t, err)
+			taskKeys := keysWithInstanceName(t, ctx, loader, tc.instanceB)
+			localSnapshotOpts := makeFakeSnapshot(t, workDir, false /*remoteEnabled*/, map[string]*copy_on_write.COWStore{
+				"rootfs.ext4": rootfs,
+			}, "")
+			require.NoError(t, loader.CacheSnapshot(ctx, taskKeys.GetBranchKey(), localSnapshotOpts))
+
+			// Remove any immutable chunks that eager fetching happened to place in
+			// the local filecache, ensuring the next read exercises remote fallback.
+			for _, cf := range imageSnapshot.GetChunkedFiles() {
+				for _, chunk := range cf.GetChunks() {
+					env.GetFileCache().DeleteFile(ctx, &repb.FileNode{Digest: chunk.GetDigest()})
+				}
+			}
+
+			// Plain RBE actions use local VM manifests and advertise no general
+			// remote snapshot support. Immutable rootfs chunks should still fall
+			// back to the remote cache in the task's partition.
+			localSnapshot, err := loader.GetSnapshot(ctx, taskKeys, &snaploader.GetSnapshotOptions{
+				SupportsRemoteChunks:   false,
+				SupportsRemoteManifest: false,
+				ReadPolicy:             platform.ReadLocalSnapshotFirst,
+			})
+			require.NoError(t, err)
+			localRootfs, err := snaploader.UnpackContainerImageSnapshot(
+				ctx, loader, localSnapshot, testfs.MakeDirAll(t, workDir, "local-snapshot-chunks"))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, localRootfs.Close()) })
+			require.Equal(t, []byte("0X23456789"), mustReadStore(t, localRootfs))
+
+			// Saving the mixed rootfs remotely should produce a self-contained
+			// snapshot: immutable image chunks and the dirty chunk are all visible
+			// through the task instance's partition.
+			remoteSnapshotOpts := makeFakeSnapshot(t, workDir, true /*remoteEnabled*/, map[string]*copy_on_write.COWStore{
+				"rootfs.ext4": localRootfs,
+			}, "")
+			require.NoError(t, loader.CacheSnapshot(ctx, taskKeys.GetBranchKey(), remoteSnapshotOpts))
+			resetLocalFileCache()
+			remoteSnapshot, err := loader.GetSnapshot(ctx, taskKeys, &snaploader.GetSnapshotOptions{
+				SupportsRemoteChunks:   true,
+				SupportsRemoteManifest: true,
+				ReadPolicy:             platform.AlwaysReadNewestSnapshot,
+			})
+			require.NoError(t, err)
+			remoteRootfs, err := snaploader.UnpackContainerImageSnapshot(
+				ctx, loader, remoteSnapshot, testfs.MakeDirAll(t, workDir, "remote-snapshot-chunks"))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, remoteRootfs.Close()) })
+			require.Equal(t, []byte("0X23456789"), mustReadStore(t, remoteRootfs))
+		})
+	}
 }
 
 func TestUnpackContainerImage_CacheErrorsAreBestEffort(t *testing.T) {
@@ -808,13 +863,50 @@ func TestUnpackContainerImage_CacheErrorsAreBestEffort(t *testing.T) {
 			expected, err := os.ReadFile(imagePath)
 			require.NoError(t, err)
 			cow, err := snaploader.UnpackContainerImage(
-				ctx, loader, "example.com/image:latest", imagePath,
+				ctx, loader, "task-instance", "example.com/image:latest", imagePath,
 				testfs.MakeDirAll(t, workDir, "chunks"), 1)
 			require.NoError(t, err)
 			t.Cleanup(func() { require.NoError(t, cow.Close()) })
 			require.Equal(t, expected, mustReadStore(t, cow))
 		})
 	}
+}
+
+func TestUnpackContainerImage_UnpackFailureCleansOutputBeforeReconvert(t *testing.T) {
+	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
+
+	env := setupPebbleEnv(t)
+	ctx, err := prefix.AttachUserPrefixToContext(context.Background(), env.GetAuthenticator())
+	require.NoError(t, err)
+	loader, err := snaploader.New(env)
+	require.NoError(t, err)
+
+	workDir := testfs.MakeTempDir(t)
+	const imageRef = "example.com/image:latest"
+	const imageContents = "0123456789"
+	imagePath := testfs.WriteFile(t, workDir, "rootfs.ext4", imageContents)
+
+	// Populate the container-image cache.
+	cow, err := snaploader.UnpackContainerImage(
+		ctx, loader, "task-instance", imageRef, imagePath,
+		testfs.MakeDirAll(t, workDir, "initial-chunks"), 1)
+	require.NoError(t, err)
+	require.NoError(t, cow.Close())
+
+	// Simulate a cached-image unpack leaving its rootfs chunk directory behind.
+	// This makes the cached unpack fail when it attempts to create the same
+	// directory, forcing UnpackContainerImage to reconvert the pulled image.
+	outDir := testfs.MakeDirAll(t, workDir, "fallback-chunks")
+	partialRootfsDir := testfs.MakeDirAll(t, outDir, "rootfs.ext4")
+	testfs.WriteFile(t, partialRootfsDir, "partial", "stale")
+
+	cow, err = snaploader.UnpackContainerImage(
+		ctx, loader, "task-instance", imageRef, imagePath, outDir, 1)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, cow.Close()) })
+	require.Equal(t, []byte(imageContents), mustReadStore(t, cow))
+	_, err = os.Stat(partialRootfsDir)
+	require.True(t, os.IsNotExist(err), "partial cached-image output was not removed")
 }
 
 func TestMergeQueueBranch(t *testing.T) {

--- a/enterprise/server/remote_execution/snaploader/snaploader_test.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader_test.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/pebble_cache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/copy_on_write"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaploader"
@@ -21,19 +23,39 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testcache"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/platform"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 
 	fcpb "github.com/buildbuddy-io/buildbuddy/proto/firecracker"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
+	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
 const maxFilecacheSizeBytes = 20_000_000
+
+type failingGetActionCacheClient struct {
+	repb.ActionCacheClient
+}
+
+func (f failingGetActionCacheClient) GetActionResult(context.Context, *repb.GetActionResultRequest, ...grpc.CallOption) (*repb.ActionResult, error) {
+	return nil, status.InternalError("action cache lookup failed")
+}
+
+type failingWriteByteStreamClient struct {
+	bspb.ByteStreamClient
+}
+
+func (f failingWriteByteStreamClient) Write(context.Context, ...grpc.CallOption) (bspb.ByteStream_WriteClient, error) {
+	return nil, status.InternalError("bytestream write failed")
+}
 
 func init() {
 	// Ensure that we allocate enough memory for the mmap LRU.
@@ -43,6 +65,33 @@ func init() {
 }
 
 func setupEnv(t *testing.T) *testenv.TestEnv {
+	env := setupBaseEnv(t)
+	setupCacheRPC(t, env)
+	return env
+}
+
+func setupPebbleEnv(t *testing.T) *testenv.TestEnv {
+	env := setupBaseEnv(t)
+	const snapshotPartitionID = "snapshots"
+	pc, err := pebble_cache.NewPebbleCache(env, &pebble_cache.Options{
+		RootDirectory: testfs.MakeTempDir(t),
+		MaxSizeBytes:  1_000_000_000,
+		Partitions: []disk.Partition{
+			{ID: snapshotPartitionID, MaxSizeBytes: 1_000_000_000},
+		},
+		PartitionMappings: []disk.PartitionMapping{
+			{Prefix: snaputil.SnapshotPartitionPrefix, PartitionID: snapshotPartitionID},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, pc.Start())
+	t.Cleanup(func() { require.NoError(t, pc.Stop()) })
+	env.SetCache(pc)
+	setupCacheRPC(t, env)
+	return env
+}
+
+func setupBaseEnv(t *testing.T) *testenv.TestEnv {
 	flags.Set(t, "executor.enable_local_snapshot_sharing", true)
 	env := testenv.GetTestEnv(t)
 	filecacheDir := testfs.MakeTempDir(t)
@@ -50,10 +99,13 @@ func setupEnv(t *testing.T) *testenv.TestEnv {
 	require.NoError(t, err)
 	fc.WaitForDirectoryScanToComplete()
 	env.SetFileCache(fc)
+	return env
+}
+
+func setupCacheRPC(t *testing.T, env *testenv.TestEnv) {
 	_, run, lis := testenv.RegisterLocalGRPCServer(t, env)
 	testcache.Setup(t, env, lis)
 	go run()
-	return env
 }
 
 func TestPackAndUnpackChunkedFiles(t *testing.T) {
@@ -645,84 +697,123 @@ func TestGetSnapshot_MixOfLocalAndRemoteChunks(t *testing.T) {
 	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
 	flags.Set(t, "executor.snaploader_max_eager_fetches_per_sec", 0)
 
-	env := setupEnv(t)
-	ctx := context.Background()
+	env := setupPebbleEnv(t)
+	ctx, err := prefix.AttachUserPrefixToContext(context.Background(), env.GetAuthenticator())
+	require.NoError(t, err)
 	loader, err := snaploader.New(env)
 	require.NoError(t, err)
+	workDir := testfs.MakeTempDir(t)
 
-	for _, instanceName := range []string{"", "instance-name"} {
-		workDir := testfs.MakeTempDir(t)
+	// Cache an immutable rootfs in the shared snapshot partition.
+	workDirA := testfs.MakeDirAll(t, workDir, "VM-A")
+	const chunkSize = 1
+	const fileSize = chunkSize * 10
+	originalImagePath := makeRandomFile(t, workDirA, "rootfs.ext4", fileSize)
+	cowA, err := copy_on_write.ConvertFileToCOW(ctx, env, originalImagePath, chunkSize, workDirA, snaputil.SnapshotPartitionPrefix, true /*remoteEnabled*/, snaputil.ConvertToCOWConcurrency)
+	require.NoError(t, err)
+	t.Cleanup(func() { cowA.Close() })
+	originalWriteBuf := []byte("0123456789")
+	_, err = cowA.WriteAt(originalWriteBuf, 0)
+	require.NoError(t, err)
+	optsA := makeFakeSnapshot(t, workDirA, true /*remoteEnabled*/, map[string]*copy_on_write.COWStore{
+		"rootfs.ext4": cowA,
+	}, "")
+	imageKeys := keysWithInstanceName(t, ctx, loader, snaputil.SnapshotPartitionPrefix)
+	// Write the image snapshot remotely only.
+	flags.Set(t, "executor.enable_local_snapshot_sharing", false)
+	err = loader.CacheSnapshot(ctx, imageKeys.GetBranchKey(), optsA)
+	flags.Set(t, "executor.enable_local_snapshot_sharing", true)
+	require.NoError(t, err)
 
-		// Save a snapshot remotely.
-		workDirA := testfs.MakeDirAll(t, workDir, "VM-A")
-		const chunkSize = 1
-		const fileSize = chunkSize * 10
-		originalImagePath := makeRandomFile(t, workDirA, "test-file", fileSize)
-		cowA, err := copy_on_write.ConvertFileToCOW(ctx, env, originalImagePath, chunkSize, workDirA, instanceName, true /*remoteEnabled*/, snaputil.ConvertToCOWConcurrency)
-		require.NoError(t, err)
-		t.Cleanup(func() { cowA.Close() })
-		originalWriteBuf := []byte("0123456789")
-		_, err = cowA.WriteAt(originalWriteBuf, 0)
-		require.NoError(t, err)
-		optsA := makeFakeSnapshot(t, workDirA, true /*remoteEnabled*/, map[string]*copy_on_write.COWStore{
-			"scratchfs": cowA,
-		}, "")
-		keyset := keysWithInstanceName(t, ctx, loader, instanceName)
-		// Write the snapshot remotely only.
-		flags.Set(t, "executor.enable_local_snapshot_sharing", false)
-		err = loader.CacheSnapshot(ctx, keyset.GetBranchKey(), optsA)
-		flags.Set(t, "executor.enable_local_snapshot_sharing", true)
-		require.NoError(t, err)
+	// Read chunks 1-3 from the remote image. Modify one chunk and save the VM
+	// snapshot locally under a plain RBE task instance.
+	workDirB := testfs.MakeDirAll(t, workDir, "VM-B")
+	snap, err := loader.GetSnapshot(ctx, imageKeys, &snaploader.GetSnapshotOptions{
+		SupportsRemoteChunks:   true,
+		SupportsRemoteManifest: true,
+		ReadPolicy:             platform.AlwaysReadNewestSnapshot,
+	})
+	require.NoError(t, err)
+	unpacked, err := loader.UnpackSnapshot(ctx, snap, workDirB)
+	require.NoError(t, err)
+	t.Cleanup(func() { closeAll(unpacked) })
+	readBuf := make([]byte, 3)
+	disk := unpacked.ChunkedFiles["rootfs.ext4"]
+	_, err = disk.ReadAt(readBuf, 1)
+	require.NoError(t, err)
+	require.ElementsMatch(t, originalWriteBuf[1:4], readBuf)
+	// Update one chunk of the snapshot.
+	readBuf[2] = '6'
+	_, err = disk.WriteAt(readBuf, 1)
+	require.NoError(t, err)
+	// Write the VM snapshot locally only.
+	optsB := makeFakeSnapshot(t, workDirB, false /*remoteEnabled*/, map[string]*copy_on_write.COWStore{
+		"rootfs.ext4": disk,
+	}, "")
+	taskKeys := keysWithInstanceName(t, ctx, loader, "task-instance")
+	err = loader.CacheSnapshot(ctx, taskKeys.GetBranchKey(), optsB)
+	require.NoError(t, err)
 
-		// Read chunks 1-3 from the remote snapshot. Modify one chunk and save the
-		// snapshot locally only.
-		workDirB := testfs.MakeDirAll(t, workDir, "VM-B")
-		snap, err := loader.GetSnapshot(ctx, keyset, &snaploader.GetSnapshotOptions{
-			SupportsRemoteChunks:   true,
-			SupportsRemoteManifest: true,
-			ReadPolicy:             platform.AlwaysReadNewestSnapshot,
+	// A plain RBE reader doesn't support remote VM snapshots. It should use the
+	// local manifest and fetch only its missing immutable rootfs chunks from the
+	// shared snapshot partition.
+	workDirC := testfs.MakeDirAll(t, workDir, "VM-C")
+	snap, err = loader.GetSnapshot(ctx, taskKeys, &snaploader.GetSnapshotOptions{
+		SupportsRemoteChunks:   false,
+		SupportsRemoteManifest: false,
+		ReadPolicy:             platform.ReadLocalSnapshotFirst,
+	})
+	require.NoError(t, err)
+	unpackedC, err := loader.UnpackSnapshot(ctx, snap, workDirC)
+	require.NoError(t, err)
+	t.Cleanup(func() { closeAll(unpackedC) })
+	readBufC := make([]byte, 4)
+	diskC := unpackedC.ChunkedFiles["rootfs.ext4"]
+	_, err = diskC.ReadAt(readBufC, 2)
+	require.NoError(t, err)
+	expectedBuf := []byte("2645")
+	require.ElementsMatch(t, expectedBuf, readBufC)
+}
+
+func TestUnpackContainerImage_CacheErrorsAreBestEffort(t *testing.T) {
+	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
+
+	for _, tc := range []struct {
+		name      string
+		failCache func(env *testenv.TestEnv)
+	}{
+		{
+			name: "read",
+			failCache: func(env *testenv.TestEnv) {
+				env.SetActionCacheClient(failingGetActionCacheClient{env.GetActionCacheClient()})
+			},
+		},
+		{
+			name: "write",
+			failCache: func(env *testenv.TestEnv) {
+				env.SetByteStreamClient(failingWriteByteStreamClient{env.GetByteStreamClient()})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := setupPebbleEnv(t)
+			ctx, err := prefix.AttachUserPrefixToContext(context.Background(), env.GetAuthenticator())
+			require.NoError(t, err)
+			tc.failCache(env)
+			loader, err := snaploader.New(env)
+			require.NoError(t, err)
+
+			workDir := testfs.MakeTempDir(t)
+			imagePath := makeRandomFile(t, workDir, "rootfs.ext4", 10)
+			expected, err := os.ReadFile(imagePath)
+			require.NoError(t, err)
+			cow, err := snaploader.UnpackContainerImage(
+				ctx, loader, "example.com/image:latest", imagePath,
+				testfs.MakeDirAll(t, workDir, "chunks"), 1)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, cow.Close()) })
+			require.Equal(t, expected, mustReadStore(t, cow))
 		})
-		require.NoError(t, err)
-		unpacked, err := loader.UnpackSnapshot(ctx, snap, workDirB)
-		require.NoError(t, err)
-		t.Cleanup(func() { closeAll(unpacked) })
-		readBuf := make([]byte, 3)
-		disk := unpacked.ChunkedFiles["scratchfs"]
-		_, err = disk.ReadAt(readBuf, 1)
-		require.NoError(t, err)
-		require.ElementsMatch(t, originalWriteBuf[1:4], readBuf)
-		// Update one chunk of the snapshot.
-		readBuf[2] = '6'
-		_, err = disk.WriteAt(readBuf, 1)
-		require.NoError(t, err)
-		// Write snapshot locally only.
-		optsB := makeFakeSnapshot(t, workDirB, false /*remoteEnabled*/, map[string]*copy_on_write.COWStore{
-			"scratchfs": disk,
-		}, "")
-		err = loader.CacheSnapshot(ctx, keyset.GetBranchKey(), optsB)
-		require.NoError(t, err)
-
-		// Read chunks 2-5. Should read the modified chunk 3
-		// that was written locally only by VM-B. Should be able to fetch chunks 4-5 from the
-		// remote snapshot, even though they were not cached locally by VM-B.
-		workDirC := testfs.MakeDirAll(t, workDir, "VM-C")
-		// GetSnapshot should use the local snapshot manifest, but fallback to the
-		// remote cache for any missing chunks.
-		snap, err = loader.GetSnapshot(ctx, keyset, &snaploader.GetSnapshotOptions{
-			SupportsRemoteChunks:   true,
-			SupportsRemoteManifest: true,
-			ReadPolicy:             platform.AlwaysReadNewestSnapshot,
-		})
-		require.NoError(t, err)
-		unpackedC, err := loader.UnpackSnapshot(ctx, snap, workDirC)
-		require.NoError(t, err)
-		t.Cleanup(func() { closeAll(unpackedC) })
-		readBufC := make([]byte, 4)
-		diskC := unpackedC.ChunkedFiles["scratchfs"]
-		_, err = diskC.ReadAt(readBufC, 2)
-		require.NoError(t, err)
-		expectedBuf := []byte("2645")
-		require.ElementsMatch(t, expectedBuf, readBufC)
 	}
 }
 

--- a/enterprise/server/remote_execution/snaputil/snaputil.go
+++ b/enterprise/server/remote_execution/snaputil/snaputil.go
@@ -60,6 +60,11 @@ const (
 
 	ConvertToCOWConcurrency       = 8
 	WriteSnapshotChunkConcurrency = 8
+
+	// Experiment names controlling whether a Firecracker task may read and
+	// write its chunked container image in the remote cache, regardless of whether remote snapshots are enabled.
+	RemoteContainerImageReadsExperiment  = "executor.remote_container_image_reads_enabled"
+	RemoteContainerImageWritesExperiment = "executor.remote_container_image_writes_enabled"
 )
 
 // ChunkSource represents how a snapshot chunk was initialized


### PR DESCRIPTION
With this PR, firecracker RBE actions can lazily read EXT4 chunks from the remote cache, rather than having to pull the image, convert it to EXT4, and chunk it if the chunks don't already exist locally.

For RBE firecracker actions, by default we don't write remote snapshots, which is why executors frequently had to do the expensive EXT4 conversion process.

This PR adds some additional complexity for local-snapshot-only RBE actions. For RBE, when rootfs chunks are dirtied, they are cached locally only. With this PR, undirtied rootfs chunks (those that are untouched from the original EXT4) can be fetched from the remote cache. 

So within the same snapshot, we can have some chunks that should only be read/written locally (dirtied rootfs chunks), and some chunks that can be read/written both locally and remotely (undirtied rootfs chunks)

Note that we'll still chunk an EXT4 once per instance name, because the instance name is in the manifest (even though with our underlying cache implementation, the CAS snapshot chunks are shareable across instance names). This simplifies the logic and makes this code independent of our cache implementation. If we want to reduce IO even further, we could address this in a followup 