### PR TITLE
[FC] Share cached ext4s across instance names

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -147,6 +147,7 @@ go_test(
     deps = [
         ":firecracker",
         "//enterprise/server/action_cache_server_proxy",
+        "//enterprise/server/backends/pebble_cache",
         "//enterprise/server/byte_stream_server_proxy",
         "//enterprise/server/clientidentity",
         "//enterprise/server/oci/ociregistry",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1496,8 +1496,7 @@ func (c *FirecrackerContainer) cachedContainerfs(ctx context.Context) *snaploade
 		return nil
 	}
 	c.containerfsSnapshotOnce.Do(func() {
-		instanceName := c.snapshotKeySet.GetBranchKey().GetInstanceName()
-		snap, err := snaploader.GetCachedContainerImage(ctx, c.loader, instanceName, c.containerImage)
+		snap, err := snaploader.GetCachedContainerImage(ctx, c.loader, c.containerImage)
 		if err != nil {
 			if !status.IsNotFoundError(err) {
 				log.CtxWarningf(ctx, "Failed to look up cached containerfs for image %q: %s", c.containerImage, err)
@@ -1523,7 +1522,7 @@ func (c *FirecrackerContainer) initRootfsStore(ctx context.Context) error {
 	} else {
 		// If a chunked containerfs is not cached, we need to convert the ext4 image into chunks.
 		containerExt4Path := filepath.Join(c.getChroot(), containerFSName)
-		cf, err = snaploader.UnpackContainerImage(c.vmCtx, c.loader, c.snapshotKeySet.GetBranchKey().GetInstanceName(), c.containerImage, containerExt4Path, cowChunkDir, cowChunkSizeBytes())
+		cf, err = snaploader.UnpackContainerImage(c.vmCtx, c.loader, c.containerImage, containerExt4Path, cowChunkDir, cowChunkSizeBytes())
 	}
 	if err != nil {
 		return status.WrapError(err, "unpack container image")

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1497,7 +1497,7 @@ func (c *FirecrackerContainer) cachedContainerfs(ctx context.Context) *snaploade
 	}
 	c.containerfsSnapshotOnce.Do(func() {
 		instanceName := c.snapshotKeySet.GetBranchKey().GetInstanceName()
-		snap, err := snaploader.GetCachedContainerImage(ctx, c.loader, instanceName, c.containerImage, c.supportsRemoteSnapshots)
+		snap, err := snaploader.GetCachedContainerImage(ctx, c.loader, instanceName, c.containerImage)
 		if err != nil {
 			if !status.IsNotFoundError(err) {
 				log.CtxWarningf(ctx, "Failed to look up cached containerfs for image %q: %s", c.containerImage, err)
@@ -1523,7 +1523,7 @@ func (c *FirecrackerContainer) initRootfsStore(ctx context.Context) error {
 	} else {
 		// If a chunked containerfs is not cached, we need to convert the ext4 image into chunks.
 		containerExt4Path := filepath.Join(c.getChroot(), containerFSName)
-		cf, err = snaploader.UnpackContainerImage(c.vmCtx, c.loader, c.snapshotKeySet.GetBranchKey().GetInstanceName(), c.containerImage, containerExt4Path, cowChunkDir, cowChunkSizeBytes(), c.supportsRemoteSnapshots)
+		cf, err = snaploader.UnpackContainerImage(c.vmCtx, c.loader, c.snapshotKeySet.GetBranchKey().GetInstanceName(), c.containerImage, containerExt4Path, cowChunkDir, cowChunkSizeBytes())
 	}
 	if err != nil {
 		return status.WrapError(err, "unpack container image")

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/action_cache_server_proxy"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/pebble_cache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/byte_stream_server_proxy"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/clientidentity"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/oci/ociregistry"
@@ -171,6 +172,7 @@ type envOpts struct {
 	cacheSize        int64
 	filecacheRootDir string
 	runProxy         bool
+	usePebble        bool
 }
 
 func getTestEnv(ctx context.Context, t testing.TB, opts envOpts) *testenv.TestEnv {
@@ -206,11 +208,24 @@ func getTestEnv(ctx context.Context, t testing.TB, opts envOpts) *testenv.TestEn
 	if cacheSize == 0 {
 		cacheSize = diskCacheSize
 	}
-	dc, err := disk_cache.NewDiskCache(env, &disk_cache.Options{RootDirectory: testRootDir}, cacheSize)
-	if err != nil {
-		t.Error(err)
+	var cache interfaces.Cache
+	if opts.usePebble {
+		pc, err := pebble_cache.NewPebbleCache(env, &pebble_cache.Options{
+			RootDirectory: testRootDir,
+			MaxSizeBytes:  cacheSize,
+		})
+		require.NoError(t, err)
+		require.NoError(t, pc.Start())
+		t.Cleanup(func() { require.NoError(t, pc.Stop()) })
+		cache = pc
+	} else {
+		dc, err := disk_cache.NewDiskCache(env, &disk_cache.Options{RootDirectory: testRootDir}, cacheSize)
+		if err != nil {
+			t.Error(err)
+		}
+		cache = dc
 	}
-	env.SetCache(dc)
+	env.SetCache(cache)
 	casServer, err := content_addressable_storage_server.NewContentAddressableStorageServer(env)
 	if err != nil {
 		t.Error(err)
@@ -549,8 +564,6 @@ func TestFirecrackerPullImageIfNecessary_CachedImageRequiresReauth(t *testing.T)
 
 func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	ctx := context.Background()
-	// Keep snapshot sharing local-only to simplify test setup.
-	flags.Set(t, "executor.enable_remote_snapshot_sharing", false)
 	flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.1/32"})
 
 	// Mock requests to the container registry.
@@ -578,7 +591,7 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	manifestRequests.Store(0)
 	blobRequests.Store(0)
 
-	env := getTestEnv(ctx, t, envOpts{})
+	env := getTestEnv(ctx, t, envOpts{usePebble: true})
 	opts := firecracker.ContainerOpts{
 		ContainerImage:         imageRef,
 		ActionWorkingDirectory: testfs.MakeTempDir(t),
@@ -590,10 +603,12 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 		},
 		ExecutorConfig: getExecutorConfig(t),
 	}
-	newContainer := func() *firecracker.FirecrackerContainer {
+	newContainer := func(instanceName string) *firecracker.FirecrackerContainer {
 		containerOpts := opts
 		containerOpts.ActionWorkingDirectory = testfs.MakeTempDir(t)
-		c, err := firecracker.NewContainer(ctx, env, &repb.ExecutionTask{}, containerOpts)
+		c, err := firecracker.NewContainer(ctx, env, &repb.ExecutionTask{
+			ExecuteRequest: &repb.ExecuteRequest{InstanceName: instanceName},
+		}, containerOpts)
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			require.NoError(t, c.Remove(context.Background()))
@@ -602,7 +617,7 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	}
 
 	// Sanity check: the image should not be cached yet.
-	coldContainer := newContainer()
+	coldContainer := newContainer("instance-a")
 	cached, err := coldContainer.IsImageCached(ctx)
 	require.NoError(t, err)
 	require.False(t, cached)
@@ -617,9 +632,8 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	// of the cache entry matters.
 	testfs.WriteRandomString(t, workDir, "containerfs.ext4", 4*chunkSize)
 	ext4Path := filepath.Join(workDir, "containerfs.ext4")
-	instanceName := coldContainer.SnapshotKeySet().GetBranchKey().GetInstanceName()
 	cow, err := snaploader.UnpackContainerImage(
-		ctx, loader, instanceName, imageRef, ext4Path,
+		ctx, loader, imageRef, ext4Path,
 		testfs.MakeDirAll(t, workDir, "chunks"), chunkSize)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -627,7 +641,7 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	})
 
 	// A container for a subsequent task should now see the cached containerfs.
-	c := newContainer()
+	c := newContainer("instance-a")
 	cached, err = c.IsImageCached(ctx)
 	require.NoError(t, err)
 	require.True(t, cached)
@@ -640,6 +654,12 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	require.Equal(t, int32(0), blobRequests.Load())
 	// The manifest should still have been fetched, in order to authenticate with the registry.
 	require.Greater(t, manifestRequests.Load(), int32(0))
+
+	// A container with a different remote instance should reuse the cached
+	// containerfs rather than converting and uploading its own copy.
+	c = newContainer("instance-b")
+	require.NoError(t, c.PullImage(ctx, oci.Credentials{}))
+	require.Equal(t, int32(0), blobRequests.Load())
 }
 
 func TestFirecrackerSnapshotAndResume(t *testing.T) {

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -620,8 +620,7 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	instanceName := coldContainer.SnapshotKeySet().GetBranchKey().GetInstanceName()
 	cow, err := snaploader.UnpackContainerImage(
 		ctx, loader, instanceName, imageRef, ext4Path,
-		testfs.MakeDirAll(t, workDir, "chunks"), chunkSize,
-		false /*=remoteEnabled*/)
+		testfs.MakeDirAll(t, workDir, "chunks"), chunkSize)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		cow.Close()

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -1387,8 +1387,9 @@ func groupID(ctx context.Context, env environment.Env) (string, error) {
 // containerImageSnapshotKey returns the key under which the chunked
 // containerfs for the given container image is cached.
 //
-// TODO: use an Action for this key instead (to allow remote snapshot
-// sharing).
+// TODO: The key is scoped to the task's remote instance name, so tasks
+// running under different instance names (e.g. workflows vs. plain RBE
+// actions) don't reuse each other's converted images.
 func containerImageSnapshotKey(instanceName, imageRef string) *fcpb.SnapshotKeySet {
 	return &fcpb.SnapshotKeySet{BranchKey: &fcpb.SnapshotKey{
 		InstanceName:      instanceName,
@@ -1396,16 +1397,37 @@ func containerImageSnapshotKey(instanceName, imageRef string) *fcpb.SnapshotKeyS
 	}}
 }
 
+// remoteContainerImageReadsEnabled returns whether chunked container images can
+// be read from the remote cache.
+//
+// Caching container images remotely is beneficial because any executor starting a
+// clean VM from the image can use them, skipping the expensive image pull
+// and ext4 conversion phases. Enable it as long as remote snapshot sharing is enabled.
+func remoteContainerImageReadsEnabled() bool {
+	return *snaputil.EnableRemoteSnapshotSharing
+}
+
+// remoteContainerImageWritesEnabled returns whether chunked container images
+// should be written to the remote cache.
+func remoteContainerImageWritesEnabled() bool {
+	return remoteContainerImageReadsEnabled() && !*snaputil.RemoteSnapshotReadonly
+}
+
 // GetCachedContainerImage returns the cached snapshot for the given
 // container image.
-func GetCachedContainerImage(ctx context.Context, l *FileCacheLoader, instanceName, imageRef string, remoteEnabled bool) (*Snapshot, error) {
+func GetCachedContainerImage(ctx context.Context, l *FileCacheLoader, instanceName, imageRef string) (*Snapshot, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
+	remoteEnabled := remoteContainerImageReadsEnabled()
 	snap, err := l.GetSnapshot(ctx, containerImageSnapshotKey(instanceName, imageRef), &GetSnapshotOptions{
 		SupportsRemoteManifest: remoteEnabled,
 		SupportsRemoteChunks:   remoteEnabled,
-		ReadPolicy:             platform.AlwaysReadNewestSnapshot,
+		// A chunked container image is immutable for a given image ref, so
+		// there is never a newer version to read. Prefer the local manifest,
+		// which also lets a remote hit be written back to the local filecache
+		// so that later runs on this executor don't depend on the remote cache.
+		ReadPolicy: platform.ReadLocalSnapshotFirst,
 	})
 	if err != nil {
 		return nil, err
@@ -1434,11 +1456,11 @@ func UnpackContainerImageSnapshot(ctx context.Context, l *FileCacheLoader, snap 
 //
 // If the image is not cached, this func will split up the given ext4 image
 // file and create a new ChunkedFile from it, then add that to cache.
-func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, instanceName, imageRef, imageExt4Path string, outDir string, chunkSize int64, remoteEnabled bool) (*copy_on_write.COWStore, error) {
+func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, instanceName, imageRef, imageExt4Path string, outDir string, chunkSize int64) (*copy_on_write.COWStore, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	snap, err := GetCachedContainerImage(ctx, l, instanceName, imageRef, remoteEnabled)
+	snap, err := GetCachedContainerImage(ctx, l, instanceName, imageRef)
 	if err != nil && !(status.IsNotFoundError(err) || status.IsUnavailableError(err)) {
 		return nil, err
 	}
@@ -1448,7 +1470,7 @@ func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, instanceName,
 	// containerfs is not available in cache; convert the EXT4 image to a
 	// ChunkedFile then add it to cache.
 	start := time.Now()
-	cow, err := copy_on_write.ConvertFileToCOW(ctx, l.env, imageExt4Path, chunkSize, outDir, instanceName, remoteEnabled, snaputil.ConvertToCOWConcurrency)
+	cow, err := copy_on_write.ConvertFileToCOW(ctx, l.env, imageExt4Path, chunkSize, outDir, instanceName, remoteContainerImageReadsEnabled(), snaputil.ConvertToCOWConcurrency)
 	if err != nil {
 		return nil, status.WrapError(err, "convert image to COW")
 	}
@@ -1456,9 +1478,12 @@ func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, instanceName,
 	opts := &CacheSnapshotOptions{
 		ChunkedFiles:          map[string]*copy_on_write.COWStore{rootfsFileName: cow},
 		Recycled:              false,
-		CacheSnapshotRemotely: remoteEnabled,
+		CacheSnapshotRemotely: remoteContainerImageWritesEnabled(),
 		CacheSnapshotLocally:  true,
-		WriteManifestLocally:  !remoteEnabled,
+		// Always write the manifest locally too. The chunks are cached locally
+		// either way, so this lets a subsequent clean VM on this executor reuse
+		// them without depending on the remote manifest still being valid.
+		WriteManifestLocally: true,
 	}
 	key := containerImageSnapshotKey(instanceName, imageRef)
 	if err := l.CacheSnapshot(ctx, key.GetBranchKey(), opts); err != nil {

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -1387,12 +1387,10 @@ func groupID(ctx context.Context, env environment.Env) (string, error) {
 // containerImageSnapshotKey returns the key under which the chunked
 // containerfs for the given container image is cached.
 //
-// TODO: The key is scoped to the task's remote instance name, so tasks
-// running under different instance names (e.g. workflows vs. plain RBE
-// actions) don't reuse each other's converted images.
-func containerImageSnapshotKey(instanceName, imageRef string) *fcpb.SnapshotKeySet {
+// Container images are immutable content, so use one shared namespace rather
+// than converting and uploading the same image once per remote instance.
+func containerImageSnapshotKey(imageRef string) *fcpb.SnapshotKeySet {
 	return &fcpb.SnapshotKeySet{BranchKey: &fcpb.SnapshotKey{
-		InstanceName:      instanceName,
 		ConfigurationHash: hashStrings("__UnpackContainerImage", imageRef),
 	}}
 }
@@ -1415,12 +1413,12 @@ func remoteContainerImageWritesEnabled() bool {
 
 // GetCachedContainerImage returns the cached snapshot for the given
 // container image.
-func GetCachedContainerImage(ctx context.Context, l *FileCacheLoader, instanceName, imageRef string) (*Snapshot, error) {
+func GetCachedContainerImage(ctx context.Context, l *FileCacheLoader, imageRef string) (*Snapshot, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
 	remoteEnabled := remoteContainerImageReadsEnabled()
-	snap, err := l.GetSnapshot(ctx, containerImageSnapshotKey(instanceName, imageRef), &GetSnapshotOptions{
+	snap, err := l.GetSnapshot(ctx, containerImageSnapshotKey(imageRef), &GetSnapshotOptions{
 		SupportsRemoteManifest: remoteEnabled,
 		SupportsRemoteChunks:   remoteEnabled,
 		// A chunked container image is immutable for a given image ref, so
@@ -1456,11 +1454,11 @@ func UnpackContainerImageSnapshot(ctx context.Context, l *FileCacheLoader, snap 
 //
 // If the image is not cached, this func will split up the given ext4 image
 // file and create a new ChunkedFile from it, then add that to cache.
-func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, instanceName, imageRef, imageExt4Path string, outDir string, chunkSize int64) (*copy_on_write.COWStore, error) {
+func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, imageRef, imageExt4Path string, outDir string, chunkSize int64) (*copy_on_write.COWStore, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	snap, err := GetCachedContainerImage(ctx, l, instanceName, imageRef)
+	snap, err := GetCachedContainerImage(ctx, l, imageRef)
 	if err != nil && !(status.IsNotFoundError(err) || status.IsUnavailableError(err)) {
 		return nil, err
 	}
@@ -1470,7 +1468,7 @@ func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, instanceName,
 	// containerfs is not available in cache; convert the EXT4 image to a
 	// ChunkedFile then add it to cache.
 	start := time.Now()
-	cow, err := copy_on_write.ConvertFileToCOW(ctx, l.env, imageExt4Path, chunkSize, outDir, instanceName, remoteContainerImageReadsEnabled(), snaputil.ConvertToCOWConcurrency)
+	cow, err := copy_on_write.ConvertFileToCOW(ctx, l.env, imageExt4Path, chunkSize, outDir, "" /*=instanceName*/, remoteContainerImageReadsEnabled(), snaputil.ConvertToCOWConcurrency)
 	if err != nil {
 		return nil, status.WrapError(err, "convert image to COW")
 	}
@@ -1485,7 +1483,7 @@ func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, instanceName,
 		// them without depending on the remote manifest still being valid.
 		WriteManifestLocally: true,
 	}
-	key := containerImageSnapshotKey(instanceName, imageRef)
+	key := containerImageSnapshotKey(imageRef)
 	if err := l.CacheSnapshot(ctx, key.GetBranchKey(), opts); err != nil {
 		return nil, status.WrapError(err, "cache containerfs snapshot")
 	}


### PR DESCRIPTION
Instance name was added [here](https://github.com/buildbuddy-io/buildbuddy/pull/5484)

The root cause should be fixed after this [PR](https://github.com/buildbuddy-io/buildbuddy/pull/11908)

Even after this change, we'll only skip the image pull within each group, because the manifest for the ext4 still contains the group ID