### PR TITLE
Add option for hardlinks on macOS

### DIFF
--- a/server/util/fastcopy/fastcopy.go
+++ b/server/util/fastcopy/fastcopy.go
@@ -3,3 +3,4 @@ package fastcopy
 import "flag"
 
 var enableFastcopyReflinking = flag.Bool("executor.enable_fastcopy_reflinking", false, "If true, attempt to use `cp --reflink=auto` to link files")
+var useMacOSHardlinks = flag.Bool("executor.use_hardlinks_macos", false, "If true, use hardlinks on macOS instead of copy-on-write clones")

--- a/server/util/fastcopy/fastcopy.go
+++ b/server/util/fastcopy/fastcopy.go
@@ -3,4 +3,3 @@ package fastcopy
 import "flag"
 
 var enableFastcopyReflinking = flag.Bool("executor.enable_fastcopy_reflinking", false, "If true, attempt to use `cp --reflink=auto` to link files")
-var useMacOSHardlinks = flag.Bool("executor.use_hardlinks_macos", false, "If true, use hardlinks on macOS instead of copy-on-write clones")

--- a/server/util/fastcopy/fastcopy_darwin.go
+++ b/server/util/fastcopy/fastcopy_darwin.go
@@ -4,17 +4,24 @@ package fastcopy
 
 import (
 	"errors"
+	"os"
 
 	"golang.org/x/sys/unix"
 )
 
 func Clone(source, destination string) error {
-	return FastCopy(source, destination)
-}
-
-func FastCopy(source, destination string) error {
 	if err := unix.Clonefile(source, destination, unix.CLONE_NOFOLLOW); err != nil && !errors.Is(err, unix.EEXIST) {
 		return err
 	}
 	return nil
+}
+
+func FastCopy(source, destination string) error {
+	if *useMacOSHardlinks {
+		if err := os.Link(source, destination); err != nil && !errors.Is(err, os.ErrExist) {
+			return err
+		}
+		return nil
+	}
+	return Clone(source, destination)
 }

--- a/server/util/fastcopy/fastcopy_darwin.go
+++ b/server/util/fastcopy/fastcopy_darwin.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var useMacOSHardlinks = flag.Bool("executor.use_hardlinks_macos", false, "If true, use hardlinks on macOS instead of copy-on-write clones")
+var localCacheUseHardlinks = flag.Bool("executor.local_cache_use_hardlinks", false, "If true, use hardlinks instead of copy-on-write clones")
 
 func Clone(source, destination string) error {
 	if err := unix.Clonefile(source, destination, unix.CLONE_NOFOLLOW); err != nil && !errors.Is(err, unix.EEXIST) {
@@ -19,7 +19,7 @@ func Clone(source, destination string) error {
 }
 
 func FastCopy(source, destination string) error {
-	if *useMacOSHardlinks {
+	if *localCacheUseHardlinks {
 		if err := unix.Linkat(unix.AT_FDCWD, source, unix.AT_FDCWD, destination, 0); err != nil && !errors.Is(err, unix.EEXIST) {
 			return err
 		}

--- a/server/util/fastcopy/fastcopy_darwin.go
+++ b/server/util/fastcopy/fastcopy_darwin.go
@@ -4,9 +4,12 @@ package fastcopy
 
 import (
 	"errors"
+	"flag"
 
 	"golang.org/x/sys/unix"
 )
+
+var useMacOSHardlinks = flag.Bool("executor.use_hardlinks_macos", false, "If true, use hardlinks on macOS instead of copy-on-write clones")
 
 func Clone(source, destination string) error {
 	if err := unix.Clonefile(source, destination, unix.CLONE_NOFOLLOW); err != nil && !errors.Is(err, unix.EEXIST) {

--- a/server/util/fastcopy/fastcopy_darwin.go
+++ b/server/util/fastcopy/fastcopy_darwin.go
@@ -4,7 +4,6 @@ package fastcopy
 
 import (
 	"errors"
-	"os"
 
 	"golang.org/x/sys/unix"
 )
@@ -18,7 +17,7 @@ func Clone(source, destination string) error {
 
 func FastCopy(source, destination string) error {
 	if *useMacOSHardlinks {
-		if err := os.Link(source, destination); err != nil && !errors.Is(err, os.ErrExist) {
+		if err := unix.Linkat(unix.AT_FDCWD, source, unix.AT_FDCWD, destination, 0); err != nil && !errors.Is(err, unix.EEXIST) {
 			return err
 		}
 		return nil

--- a/server/util/fastcopy/fastcopy_test.go
+++ b/server/util/fastcopy/fastcopy_test.go
@@ -80,7 +80,7 @@ func TestFastCopyDarwinForceHardlinks(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, os.SameFile(sourceInfo, cloneInfo))
 
-	flags.Set(t, "executor.use_hardlinks_macos", true)
+	flags.Set(t, "executor.local_cache_use_hardlinks", true)
 	hardlink := path.Join(ws, "hardlink")
 	require.NoError(t, fastcopy.FastCopy(source, hardlink))
 	hardlinkInfo, err := os.Stat(hardlink)
@@ -122,7 +122,7 @@ func TestFastCopyDarwinHardlinksSymlinkWithoutFollowing(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("test runs on macOS only")
 	}
-	flags.Set(t, "executor.use_hardlinks_macos", true)
+	flags.Set(t, "executor.local_cache_use_hardlinks", true)
 
 	for _, dangling := range []bool{false, true} {
 		t.Run(fmt.Sprintf("dangling=%t", dangling), func(t *testing.T) {

--- a/server/util/fastcopy/fastcopy_test.go
+++ b/server/util/fastcopy/fastcopy_test.go
@@ -2,6 +2,7 @@ package fastcopy_test
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path"
@@ -109,8 +110,44 @@ func TestFastCopySymlink(t *testing.T) {
 	err = fastcopy.FastCopy(source, target)
 	require.NoError(t, err)
 
-	_, err = os.Stat(target)
+	targetInfo, err := os.Lstat(target)
 	require.NoError(t, err, "target symlink should exist")
+	require.True(t, targetInfo.Mode()&os.ModeSymlink != 0, "target should be a symlink")
+	actualLinkTarget, err := os.Readlink(target)
+	require.NoError(t, err)
+	require.Equal(t, linkTarget, actualLinkTarget)
+}
+
+func TestFastCopyDarwinHardlinksSymlinkWithoutFollowing(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("test runs on macOS only")
+	}
+	flags.Set(t, "executor.use_hardlinks_macos", true)
+
+	for _, dangling := range []bool{false, true} {
+		t.Run(fmt.Sprintf("dangling=%t", dangling), func(t *testing.T) {
+			ws := testfs.MakeTempDir(t)
+			linkTarget := path.Join(ws, "link-target")
+			if !dangling {
+				testfs.MakeTempFile(t, ws, "link-target")
+			}
+			source := path.Join(ws, "source")
+			require.NoError(t, os.Symlink(linkTarget, source))
+
+			target := path.Join(ws, "target")
+			require.NoError(t, fastcopy.FastCopy(source, target))
+
+			sourceInfo, err := os.Lstat(source)
+			require.NoError(t, err)
+			targetInfo, err := os.Lstat(target)
+			require.NoError(t, err)
+			require.True(t, targetInfo.Mode()&os.ModeSymlink != 0, "target should be a symlink")
+			require.True(t, os.SameFile(sourceInfo, targetInfo), "source and target should hardlink the same symlink inode")
+			actualLinkTarget, err := os.Readlink(target)
+			require.NoError(t, err)
+			require.Equal(t, linkTarget, actualLinkTarget)
+		})
+	}
 }
 
 func TestFastCopyXFSReflink(t *testing.T) {

--- a/server/util/fastcopy/fastcopy_test.go
+++ b/server/util/fastcopy/fastcopy_test.go
@@ -63,6 +63,36 @@ func TestFastCopyFileExist(t *testing.T) {
 	require.Equal(t, before.ModTime(), after.ModTime(), "target should not have been modified")
 }
 
+func TestFastCopyDarwinForceHardlinks(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("test runs on macOS only")
+	}
+
+	ws := testfs.MakeTempDir(t)
+	source := testfs.MakeTempFile(t, ws, "source")
+
+	clone := path.Join(ws, "clone")
+	require.NoError(t, fastcopy.FastCopy(source, clone))
+	sourceInfo, err := os.Stat(source)
+	require.NoError(t, err)
+	cloneInfo, err := os.Stat(clone)
+	require.NoError(t, err)
+	require.False(t, os.SameFile(sourceInfo, cloneInfo))
+
+	flags.Set(t, "executor.use_hardlinks_macos", true)
+	hardlink := path.Join(ws, "hardlink")
+	require.NoError(t, fastcopy.FastCopy(source, hardlink))
+	hardlinkInfo, err := os.Stat(hardlink)
+	require.NoError(t, err)
+	require.True(t, os.SameFile(sourceInfo, hardlinkInfo))
+
+	forcedClone := path.Join(ws, "forced-clone")
+	require.NoError(t, fastcopy.Clone(source, forcedClone))
+	forcedCloneInfo, err := os.Stat(forcedClone)
+	require.NoError(t, err)
+	require.False(t, os.SameFile(sourceInfo, forcedCloneInfo))
+}
+
 func TestFastCopySymlink(t *testing.T) {
 	ws := testfs.MakeTempDir(t)
 	linkTarget := testfs.MakeTempFile(t, ws, "foo")

--- a/server/util/fastcopy/fastcopy_test.go
+++ b/server/util/fastcopy/fastcopy_test.go
@@ -110,12 +110,8 @@ func TestFastCopySymlink(t *testing.T) {
 	err = fastcopy.FastCopy(source, target)
 	require.NoError(t, err)
 
-	targetInfo, err := os.Lstat(target)
+	_, err = os.Stat(target)
 	require.NoError(t, err, "target symlink should exist")
-	require.True(t, targetInfo.Mode()&os.ModeSymlink != 0, "target should be a symlink")
-	actualLinkTarget, err := os.Readlink(target)
-	require.NoError(t, err)
-	require.Equal(t, linkTarget, actualLinkTarget)
 }
 
 func TestFastCopyDarwinHardlinksSymlinkWithoutFollowing(t *testing.T) {


### PR DESCRIPTION
Using copy-on-write is preferred but it turns out that those reflinks
end up in extra security scans by macOS (unless you run under a trusted
"developer tool" which the executor does not). We're a bit worried there
are some potential macOS bugs here when you create many of these, but
it's worth a try if the security scanning is a notable slowdown. For
large dylibs the scan can easily be 4 seconds when launching a binary,
and it happens per action x per dylib since the scan result is stored
per inode.
