### PR TITLE
Use slightly nicer icon for workflow cancel button

### DIFF
--- a/app/invocation/invocation_cancel_button.tsx
+++ b/app/invocation/invocation_cancel_button.tsx
@@ -1,4 +1,4 @@
-import { Slash as SlashIcon } from "lucide-react";
+import { Ban } from "lucide-react";
 import React from "react";
 import { invocation } from "../../proto/invocation_ts_proto";
 import { OutlinedButton } from "../components/button/button";
@@ -38,7 +38,7 @@ export default class InvocationCancelButtonComponent extends React.Component<Inv
           disabled={isLoading || alreadyCancelled}
           onClick={this.onClick.bind(this)}
           title={alreadyCancelled ? "Invocation has already been cancelled and is now being cleaned up." : undefined}>
-          {isLoading ? <Spinner className="icon" /> : <SlashIcon />}
+          {isLoading ? <Spinner className="icon" /> : <Ban />}
           <div>Cancel</div>
         </OutlinedButton>
       </div>


### PR DESCRIPTION
The slash icon looks a bit awkward. Switch to a circle with slash, which looks more like a cancel icon. I think it used to be a circle with slash, but the recent lucide upgrade might've renamed it.