### PR TITLE
Fix Pebble cache sampling test clock race

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -2912,6 +2912,14 @@ func TestSampling(t *testing.T) {
 	require.NoError(t, err)
 
 	minEvictionAge := 1 * time.Hour
+	evictionTimeout := 15 * time.Second
+	evictionPollInterval := 100 * time.Millisecond
+	// Each unsuccessful poll advances the fake clock to wake the sampler. Keep
+	// newer entries ineligible throughout the entire polling window.
+	maxClockAdvance := time.Duration(evictionTimeout/evictionPollInterval) * pebble_cache.SamplerSleepDuration
+	newerAtimeGap := maxClockAdvance + time.Minute
+	require.Less(t, newerAtimeGap, minEvictionAge)
+
 	clock := clockwork.NewFakeClock()
 	opts := &pebble_cache.Options{
 		RootDirectory: testfs.MakeTempDir(t),
@@ -2943,7 +2951,6 @@ func TestSampling(t *testing.T) {
 	// encrypted. The encrypted key should have the same digest prefix as the
 	// unencrypted key and come before the unencrypted key in lexicographical
 	// order.
-	newerAtimeGap := 5 * time.Minute
 	clock.Advance(newerAtimeGap)
 	err = pc.Set(ctx, rn, buf)
 	require.NoError(t, err)
@@ -2964,23 +2971,22 @@ func TestSampling(t *testing.T) {
 	// fake clock while waking the sampler.
 	clock.Advance(minEvictionAge - newerAtimeGap)
 
-	waitForEviction := func(timeout time.Duration) {
-		interval := 100 * time.Millisecond
-		for i := 0; i < int(timeout/interval); i++ {
+	waitForEviction := func() {
+		for i := 0; i < int(evictionTimeout/evictionPollInterval); i++ {
 			if exists, err := pc.Contains(anonCtx, rn); err == nil && !exists {
 				log.Infof("i = %d: unencrypted test digest is evicted", i)
 				return
 			}
-			time.Sleep(interval)
+			time.Sleep(evictionPollInterval)
 			// generateSamplesForEviction might be sleeping, so advance
 			// enough to wake it up. Alternatively, we could call
 			// pc.Start() after the cache already has some data so that
 			// generateSamplesForEviction never sleeps.
 			clock.Advance(pebble_cache.SamplerSleepDuration)
 		}
-		t.Fatalf("unencrypted test digest (%v) is not evicted after %v", rn, timeout)
+		t.Fatalf("unencrypted test digest (%v) is not evicted after %v", rn, evictionTimeout)
 	}
-	waitForEviction(15 * time.Second)
+	waitForEviction()
 
 	// The unencrypted key should no longer exist.
 	unencryptedExists, err := pc.Contains(anonCtx, rn)

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -2941,9 +2941,10 @@ func TestSampling(t *testing.T) {
 
 	// Advance time (to force newer atime) and write the same digest
 	// encrypted. The encrypted key should have the same digest prefix as the
-	// unencrypted key and come before the unencrypted key in lexicographical f
+	// unencrypted key and come before the unencrypted key in lexicographical
 	// order.
-	clock.Advance(5 * time.Minute)
+	newerAtimeGap := 5 * time.Minute
+	clock.Advance(newerAtimeGap)
 	err = pc.Set(ctx, rn, buf)
 	require.NoError(t, err)
 
@@ -2957,9 +2958,11 @@ func TestSampling(t *testing.T) {
 		randomResources = append(randomResources, rn)
 	}
 
-	// Now advance the clock past the min eviction age to allow eviction to
-	// kick in. The unencrypted test digest should be evicted.
-	clock.Advance(minEvictionAge - 1*time.Minute)
+	// Now advance the clock to the min eviction age to allow eviction to
+	// kick in. The unencrypted test digest should be evicted. Keep the newer
+	// entries younger by the full atime gap, since waitForEviction advances the
+	// fake clock while waking the sampler.
+	clock.Advance(minEvictionAge - newerAtimeGap)
 
 	waitForEviction := func(timeout time.Duration) {
 		interval := 100 * time.Millisecond


### PR DESCRIPTION
`pebble_cache_test.TestSampling` has started failing consistently in dev. [invocation link](https://buildbuddy.buildbuddy.dev/invocation/d339fe8a-7bad-4df5-8ff5-0d2885716a36?target=%2F%2Fenterprise%2Fserver%2Fbackends%2Fpebble_cache%3Apebble_cache_test&targetStatus=6)
That may be a symptom of slower executions in dev. I'm investigating that.

In the meantime, let's see if this change gets the test to green consistently in dev.

<img width="1049" height="84" alt="Screenshot 2026-08-28 at 11 14 29 AM" src="https://github.com/user-attachments/assets/96608850-b3fe-4560-b8c3-ab158bfad4a1" />
