### PR TITLE
Post-migration CDC chunk size cleanup

### DIFF
--- a/enterprise/server/remote_cache/chunking/chunking_test.go
+++ b/enterprise/server/remote_cache/chunking/chunking_test.go
@@ -38,9 +38,9 @@ func TestAvgChunkSizeOverride(t *testing.T) {
 	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
 		"cache.avg_chunk_size_override": {
 			State:          memprovider.Enabled,
-			DefaultVariant: "one_mb",
+			DefaultVariant: "half_mb",
 			Variants: map[string]any{
-				"one_mb": 1 * 1024 * 1024,
+				"half_mb": 512 * 1024,
 			},
 		},
 	})
@@ -50,7 +50,7 @@ func TestAvgChunkSizeOverride(t *testing.T) {
 
 	ctx := context.Background()
 
-	require.Equal(t, uint64(1*1024*1024), chunking.FastCDCParams(ctx, fp).GetAvgChunkSizeBytes())
+	require.Equal(t, uint64(512*1024), chunking.FastCDCParams(ctx, fp).GetAvgChunkSizeBytes())
 }
 
 func TestStore_SharedValidationMarkerSkipsRehashForIdenticalManifest(t *testing.T) {

--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -79,7 +79,7 @@ func NewActionCacheServer(env environment.Env) (*ActionCacheServer, error) {
 	}, nil
 }
 
-func checkFilesExist(ctx context.Context, cache interfaces.Cache, instanceName string, digestFunction repb.DigestFunction_Value, chunkingEnabled bool, efp interfaces.ExperimentFlagProvider, digests []*rspb.ResourceName) error {
+func checkFilesExist(ctx context.Context, cache interfaces.Cache, instanceName string, digestFunction repb.DigestFunction_Value, chunkingEnabled bool, maxChunkSizeBytes int64, digests []*rspb.ResourceName) error {
 	missing, err := cache.FindMissing(findmissing.ContextWithPurpose(ctx, repb.FindMissingBlobsRequest_AC_VALIDATION), digests)
 	if err != nil {
 		return err
@@ -90,9 +90,8 @@ func checkFilesExist(ctx context.Context, cache interfaces.Cache, instanceName s
 	if !chunkingEnabled {
 		return status.NotFoundErrorf("ActionResult output file %q not found in cache", chunking.DigestsSummary(missing))
 	}
-	minFallbackSizeBytes := chunking.MinChunkedReadFallbackSizeBytes(ctx, efp)
 	for _, d := range missing {
-		if d.GetSizeBytes() <= minFallbackSizeBytes || chunking.ShouldDiscardLegacyChunkedBlob(ctx, efp, d.GetSizeBytes()) {
+		if d.GetSizeBytes() <= maxChunkSizeBytes {
 			return status.NotFoundErrorf("ActionResult output file %q not found in cache", digest.String(d))
 		}
 	}
@@ -118,18 +117,16 @@ func checkFilesExist(ctx context.Context, cache interfaces.Cache, instanceName s
 	return eg.Wait()
 }
 
-func readOutputTree(ctx context.Context, cache interfaces.Cache, instanceName string, digestFunction repb.DigestFunction_Value, chunkingEnabled bool, efp interfaces.ExperimentFlagProvider, chunkedReadLimiter *semaphore.Weighted, treeDigest *repb.Digest) (*repb.Tree, error) {
+func readOutputTree(ctx context.Context, cache interfaces.Cache, instanceName string, digestFunction repb.DigestFunction_Value, chunkingEnabled bool, maxChunkSizeBytes int64, chunkedReadLimiter *semaphore.Weighted, treeDigest *repb.Digest) (*repb.Tree, error) {
 	rn := digest.NewResourceName(treeDigest, instanceName, rspb.CacheType_CAS, digestFunction).ToProto()
 	blob, err := cache.Get(ctx, rn)
 	if err != nil {
 		isNotFound := status.IsNotFoundError(err) || os.IsNotExist(err)
 		treeSizeBytes := treeDigest.GetSizeBytes()
-		minFallbackSizeBytes := chunking.MinChunkedReadFallbackSizeBytes(ctx, efp)
 		if !isNotFound ||
 			!chunkingEnabled ||
-			treeSizeBytes <= minFallbackSizeBytes ||
-			treeSizeBytes > rpcutil.GRPCMaxSizeBytes ||
-			chunking.ShouldDiscardLegacyChunkedBlob(ctx, efp, treeSizeBytes) {
+			treeSizeBytes <= maxChunkSizeBytes ||
+			treeSizeBytes > rpcutil.GRPCMaxSizeBytes {
 			return nil, err
 		}
 		// Avoid unbounded fan-out across chunked Tree reconstructions.
@@ -157,6 +154,7 @@ func readOutputTree(ctx context.Context, cache interfaces.Cache, instanceName st
 }
 
 func ValidateActionResult(ctx context.Context, cache interfaces.Cache, remoteInstanceName string, digestFunction repb.DigestFunction_Value, chunkingEnabled bool, efp interfaces.ExperimentFlagProvider, r *repb.ActionResult) error {
+	maxChunkSizeBytes := chunking.MaxChunkSizeBytes(ctx, efp)
 	outputFileDigests := make([]*rspb.ResourceName, 0, len(r.OutputFiles))
 	mu := &sync.Mutex{}
 	appendDigest := func(d *repb.Digest) {
@@ -176,7 +174,7 @@ func ValidateActionResult(ctx context.Context, cache interfaces.Cache, remoteIns
 	for _, d := range r.OutputDirectories {
 		dc := d
 		g.Go(func() error {
-			tree, err := readOutputTree(gCtx, cache, remoteInstanceName, digestFunction, chunkingEnabled, efp, chunkedTreeReadLimiter, dc.GetTreeDigest())
+			tree, err := readOutputTree(gCtx, cache, remoteInstanceName, digestFunction, chunkingEnabled, maxChunkSizeBytes, chunkedTreeReadLimiter, dc.GetTreeDigest())
 			if err != nil {
 				return err
 			}
@@ -195,7 +193,7 @@ func ValidateActionResult(ctx context.Context, cache interfaces.Cache, remoteIns
 		return err
 	}
 
-	return checkFilesExist(ctx, cache, remoteInstanceName, digestFunction, chunkingEnabled, efp, outputFileDigests)
+	return checkFilesExist(ctx, cache, remoteInstanceName, digestFunction, chunkingEnabled, maxChunkSizeBytes, outputFileDigests)
 }
 
 func setWorkerMetadata(ar *repb.ActionResult) {

--- a/server/remote_cache/action_cache_server/action_cache_server_test.go
+++ b/server/remote_cache/action_cache_server/action_cache_server_test.go
@@ -699,7 +699,7 @@ func TestValidateActionResult_ChunkedOutputFile(t *testing.T) {
 	require.NoError(t, err)
 	cache := te.GetCache()
 
-	chunk1RN, chunk1Data := testdigest.RandomCASResourceBuf(t, 2*1024*1024)
+	chunk1RN, chunk1Data := testdigest.RandomCASResourceBuf(t, 3*1024*1024)
 	chunk2RN, chunk2Data := testdigest.RandomCASResourceBuf(t, 2*1024*1024)
 	require.NoError(t, cache.Set(ctx, chunk1RN, chunk1Data))
 	require.NoError(t, cache.Set(ctx, chunk2RN, chunk2Data))
@@ -732,7 +732,7 @@ func TestValidateActionResult_ChunkedOutputFile(t *testing.T) {
 }
 
 func TestValidateActionResult_ChunkedOutputDirectoryTree(t *testing.T) {
-	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 1)
+	flags.Set(t, "cache.avg_chunk_size_bytes", 1024)
 
 	ctx := context.Background()
 	te := testenv.GetTestEnv(t)
@@ -745,7 +745,7 @@ func TestValidateActionResult_ChunkedOutputDirectoryTree(t *testing.T) {
 	tree := &repb.Tree{
 		Root: &repb.Directory{
 			Files: []*repb.FileNode{
-				{Name: "output.bin", Digest: outputRN.GetDigest()},
+				{Name: strings.Repeat("x", 5*1024), Digest: outputRN.GetDigest()},
 			},
 		},
 	}
@@ -773,7 +773,7 @@ func TestValidateActionResult_ChunkedOutputDirectoryTree(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, status.IsNotFoundError(err))
 
-	tree.Root.Files[0].Name = "xutput.bin"
+	tree.Root.Files[0].Name = "y" + tree.Root.Files[0].GetName()[1:]
 	corruptTreeData, err := proto.Marshal(tree)
 	require.NoError(t, err)
 	require.Len(t, corruptTreeData, len(treeData))
@@ -795,7 +795,7 @@ func TestValidateActionResult_ChunkedOutputDirectoryTree(t *testing.T) {
 }
 
 func TestValidateActionResult_ChunkedOutputDirectoryTreeInfersDigestFunction(t *testing.T) {
-	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 1)
+	flags.Set(t, "cache.avg_chunk_size_bytes", 1024)
 
 	ctx := context.Background()
 	te := testenv.GetTestEnv(t)
@@ -803,7 +803,9 @@ func TestValidateActionResult_ChunkedOutputDirectoryTreeInfersDigestFunction(t *
 	require.NoError(t, err)
 	cache := te.GetCache()
 
-	treeData, err := proto.Marshal(&repb.Tree{Root: &repb.Directory{}})
+	treeData, err := proto.Marshal(&repb.Tree{Root: &repb.Directory{
+		Files: []*repb.FileNode{{Name: strings.Repeat("x", 5*1024)}},
+	}})
 	require.NoError(t, err)
 	treeDigest, _ := storeChunkedBlob(t, ctx, cache, treeData, repb.DigestFunction_SHA1)
 	ar := &repb.ActionResult{OutputDirectories: []*repb.OutputDirectory{{TreeDigest: treeDigest}}}
@@ -836,7 +838,7 @@ func TestValidateActionResult_DoesNotReconstructOversizedOutputDirectoryTree(t *
 }
 
 func TestValidateActionResult_ManyChunkedOutputFiles(t *testing.T) {
-	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 1024)
+	flags.Set(t, "cache.avg_chunk_size_bytes", 1024)
 
 	ctx := context.Background()
 	te := testenv.GetTestEnv(t)
@@ -878,8 +880,8 @@ func TestValidateActionResult_ManyChunkedOutputFiles(t *testing.T) {
 	assert.True(t, status.IsNotFoundError(err))
 }
 
-func TestValidateActionResult_DiscardsLegacyChunkedOutputFileForAvgChunkSizeOverride(t *testing.T) {
-	flags.Set(t, "cache.avg_chunk_size_bytes", 512*1024)
+func TestValidateActionResult_DiscardsChunkedOutputFileBelowCurrentWriteThreshold(t *testing.T) {
+	flags.Set(t, "cache.avg_chunk_size_bytes", 1024*1024)
 	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 2*1024*1024)
 
 	ctx := context.Background()
@@ -913,23 +915,9 @@ func TestValidateActionResult_DiscardsLegacyChunkedOutputFileForAvgChunkSizeOver
 		},
 	}
 
-	efp := actionCacheFlagProvider{intValues: map[string]int64{"cache.avg_chunk_size_override": 1024 * 1024}}
-	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, efp, ar)
+	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar)
 	require.Error(t, err)
 	assert.True(t, status.IsNotFoundError(err))
-}
-
-type actionCacheFlagProvider struct {
-	interfaces.ExperimentFlagProvider
-	intValues map[string]int64
-}
-
-func (p actionCacheFlagProvider) Int64(ctx context.Context, flagName string, defaultValue int64, opts ...any) int64 {
-	v, ok := p.intValues[flagName]
-	if ok {
-		return v
-	}
-	return defaultValue
 }
 
 func TestRecordOriginScorecard(t *testing.T) {

--- a/server/remote_cache/chunking/chunking.go
+++ b/server/remote_cache/chunking/chunking.go
@@ -34,7 +34,7 @@ import (
 
 var (
 	chunkedManifestSalt             = flag.String("cache.chunking.ac_key_salt", "", "If set, salt the AC key with this value.")
-	avgChunkSizeBytes               = flag.Int64("cache.avg_chunk_size_bytes", 512*1024, "This is the average size of a chunk. Only blobs larger (non-inclusive) than 4x this value will be chunked. The maximum chunk size will be 4x this value, and the minimum will be 1/4 this value (default 512KB).")
+	avgChunkSizeBytes               = flag.Int64("cache.avg_chunk_size_bytes", 1024*1024, "This is the average size of a chunk. Only blobs larger (non-inclusive) than 4x this value will be chunked. The maximum chunk size will be 4x this value, and the minimum will be 1/4 this value.")
 	minChunkedReadFallbackSizeBytes = flag.Int64("cache.min_chunked_read_fallback_size_bytes", 2*1024*1024, "Only blobs larger (non-inclusive) than this value will use the server-side chunked read fallback after a normal blob lookup misses.")
 )
 
@@ -88,9 +88,8 @@ func MaxChunkSizeBytes(ctx context.Context, efp interfaces.ExperimentFlagProvide
 }
 
 // MaxSupportedChunkSizeBytes is the process-wide chunk size buffer consumers
-// must support. This supports temporarily doubling cache.avg_chunk_size_override
-// from the default 512KiB to 1MiB; do not set the override higher without
-// increasing this and auditing buffer consumers.
+// must support. Before doubling the average chunk size to 2MiB, raise this to
+// 8MiB and audit all buffer consumers.
 func MaxSupportedChunkSizeBytes() int64 {
 	return 4 * 1024 * 1024
 }
@@ -103,22 +102,11 @@ func MaxCompressedChunkReadSizeBytes() int64 {
 // MinChunkedReadFallbackSizeBytes can be configured independently from the
 // write threshold so server-side miss fallback paths can still read older
 // chunked blobs that were written with a smaller chunk size, but is clamped to
-// at most MaxChunkSizeBytes().
+// at most MaxChunkSizeBytes(). Presence and AC validation should instead use
+// MaxChunkSizeBytes(), so blobs below the current write threshold are not
+// accepted as manifest-only.
 func MinChunkedReadFallbackSizeBytes(ctx context.Context, efp interfaces.ExperimentFlagProvider) int64 {
 	return min(*minChunkedReadFallbackSizeBytes, MaxChunkSizeBytes(ctx, efp))
-}
-
-// ShouldDiscardLegacyChunkedBlob reports whether a missing whole CAS blob should
-// skip manifest fallback while migrating to a larger avg chunk-size override.
-func ShouldDiscardLegacyChunkedBlob(ctx context.Context, efp interfaces.ExperimentFlagProvider, digestSizeBytes int64) bool {
-	if efp == nil {
-		return false
-	}
-	if AvgChunkSizeBytes(ctx, efp) <= *avgChunkSizeBytes {
-		return false
-	}
-	return digestSizeBytes > MinChunkedReadFallbackSizeBytes(ctx, efp) &&
-		digestSizeBytes <= MaxChunkSizeBytes(ctx, efp)
 }
 
 func MaxWriteSizeBytes(ctx context.Context, efp interfaces.ExperimentFlagProvider) int64 {

--- a/server/remote_cache/chunking/chunking_test.go
+++ b/server/remote_cache/chunking/chunking_test.go
@@ -32,6 +32,13 @@ type getMultiBatchRecordingCache struct {
 	batches    [][]*rspb.ResourceName
 }
 
+func TestAvgChunkSizeDefault(t *testing.T) {
+	ctx := context.Background()
+	require.Equal(t, int64(1024*1024), chunking.AvgChunkSizeBytes(ctx, nil))
+	require.Equal(t, uint64(1024*1024), chunking.FastCDCParams(ctx, nil).GetAvgChunkSizeBytes())
+	require.Equal(t, int64(4*1024*1024), chunking.MaxChunkSizeBytes(ctx, nil))
+}
+
 func (c *getMultiBatchRecordingCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
 	c.batchSizes = append(c.batchSizes, len(resources))
 	c.batches = append(c.batches, resources)
@@ -663,20 +670,6 @@ func (p booleanFlagProvider) Int64(ctx context.Context, flagName string, default
 		return v
 	}
 	return defaultValue
-}
-
-func TestShouldDiscardLegacyChunkedBlob(t *testing.T) {
-	flags.Set(t, "cache.avg_chunk_size_bytes", 512*1024)
-	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 2*1024*1024)
-
-	ctx := context.Background()
-	efp := booleanFlagProvider{intValues: map[string]int64{"cache.avg_chunk_size_override": 1024 * 1024}}
-	assert.False(t, chunking.ShouldDiscardLegacyChunkedBlob(ctx, nil, 3*1024*1024))
-	assert.False(t, chunking.ShouldDiscardLegacyChunkedBlob(ctx, booleanFlagProvider{}, 3*1024*1024))
-	assert.False(t, chunking.ShouldDiscardLegacyChunkedBlob(ctx, efp, 2*1024*1024))
-	assert.True(t, chunking.ShouldDiscardLegacyChunkedBlob(ctx, efp, 3*1024*1024))
-	assert.True(t, chunking.ShouldDiscardLegacyChunkedBlob(ctx, efp, 4*1024*1024))
-	assert.False(t, chunking.ShouldDiscardLegacyChunkedBlob(ctx, efp, 4*1024*1024+1))
 }
 
 func TestEnabled_FallsBackToExperimentFlag(t *testing.T) {

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -140,11 +140,12 @@ func (s *ContentAddressableStorageServer) FindMissingBlobs(ctx context.Context, 
 
 	// The chunked-manifest fallback lookup is skipped when the caller signals
 	// that these digests are individual content-defined chunks, not whole blobs.
-	// Otherwise, use the read fallback threshold so old chunked blobs still
-	// count as present, except for the override-only chunk-size migration range.
+	// Otherwise, only check manifests for blobs above the current whole-blob
+	// write threshold. Blobs at or below the threshold should be uploaded as
+	// whole blobs.
 	if efp := s.env.GetExperimentFlagProvider(); len(missing) > 0 && !cdc.IsChunked(ctx) && chunking.Enabled(ctx, efp) {
 		checker := chunking.NewMissingChunkChecker(s.cache, repb.FindMissingBlobsRequest_FMB_CHUNK_VALIDATION)
-		chunkedReadFallbackSizeBytes := chunking.MinChunkedReadFallbackSizeBytes(ctx, efp)
+		maxChunkSizeBytes := chunking.MaxChunkSizeBytes(ctx, efp)
 
 		var mu sync.Mutex
 		stillMissing := make([]*repb.Digest, 0, len(missing))
@@ -163,7 +164,7 @@ func (s *ContentAddressableStorageServer) FindMissingBlobs(ctx context.Context, 
 		eg, egCtx := errgroup.WithContext(ctx)
 		eg.SetLimit(concurrency)
 		for _, d := range missing {
-			if d.GetSizeBytes() <= chunkedReadFallbackSizeBytes || chunking.ShouldDiscardLegacyChunkedBlob(ctx, efp, d.GetSizeBytes()) {
+			if d.GetSizeBytes() <= maxChunkSizeBytes {
 				markMissing(d)
 				continue
 			}

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
@@ -1215,6 +1215,63 @@ func TestSplitBlobNotFound(t *testing.T) {
 	require.True(t, status.IsNotFoundError(err), "expected NotFoundError, got: %v", err)
 }
 
+func TestSplitBlobRejectsLayeredManifest(t *testing.T) {
+	flags.Set(t, "cache.avg_chunk_size_bytes", 1024*1024)
+	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 2*1024*1024)
+
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(t, err)
+
+	clientConn := runCASServer(ctx, t, te)
+	casClient := repb.NewContentAddressableStorageClient(clientConn)
+	cache := te.GetCache()
+
+	leaf1RN, leaf1 := testdigest.RandomCASResourceBuf(t, 1024*1024)
+	leaf2RN, leaf2 := testdigest.RandomCASResourceBuf(t, 1024*1024)
+	leaf3RN, leaf3 := testdigest.RandomCASResourceBuf(t, 1024*1024)
+	nestedData := bytes.Join([][]byte{leaf1, leaf2, leaf3}, nil)
+	nestedDigest, err := digest.Compute(bytes.NewReader(nestedData), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+	for i, leaf := range []struct {
+		rn   *rspb.ResourceName
+		data []byte
+	}{
+		{leaf1RN, leaf1},
+		{leaf2RN, leaf2},
+		{leaf3RN, leaf3},
+	} {
+		require.NoError(t, cache.Set(ctx, leaf.rn, leaf.data), "store leaf %d", i)
+	}
+	require.NoError(t, (&chunking.Manifest{
+		BlobDigest:     nestedDigest,
+		ChunkDigests:   []*repb.Digest{leaf1RN.GetDigest(), leaf2RN.GetDigest(), leaf3RN.GetDigest()},
+		DigestFunction: repb.DigestFunction_SHA256,
+	}).Store(ctx, cache))
+
+	directRN, directData := testdigest.RandomCASResourceBuf(t, 2*1024*1024)
+	require.NoError(t, cache.Set(ctx, directRN, directData))
+	parentData := bytes.Join([][]byte{nestedData, directData}, nil)
+	parentDigest, err := digest.Compute(bytes.NewReader(parentData), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	// Inject a legacy layered manifest directly. Normal manifest storage rejects
+	// this because nestedDigest is not itself present in the CAS.
+	require.NoError(t, (&chunking.Manifest{
+		BlobDigest:     parentDigest,
+		ChunkDigests:   []*repb.Digest{nestedDigest, directRN.GetDigest()},
+		DigestFunction: repb.DigestFunction_SHA256,
+	}).StoreWithoutVerification(ctx, cache))
+
+	_, err = casClient.SplitBlob(ctx, &repb.SplitBlobRequest{
+		BlobDigest:     parentDigest,
+		DigestFunction: repb.DigestFunction_SHA256,
+	})
+	require.Error(t, err)
+	require.True(t, status.IsNotFoundError(err), "expected NotFoundError, got: %v", err)
+}
+
 func TestSpliceBlobSingleChunk(t *testing.T) {
 	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
 		"cache.chunking_enabled": {
@@ -1301,7 +1358,9 @@ func TestFindMissingBlobsWithChunkedBlob(t *testing.T) {
 	chunk1RN, chunk1 := testdigest.RandomCASResourceBuf(t, 1024*1024)
 	chunk2RN, chunk2 := testdigest.RandomCASResourceBuf(t, 1024*1024)
 	chunk3RN, chunk3 := testdigest.RandomCASResourceBuf(t, 1024*1024)
-	fullBlob := append(append(chunk1, chunk2...), chunk3...)
+	chunk4RN, chunk4 := testdigest.RandomCASResourceBuf(t, 1024*1024)
+	chunk5RN, chunk5 := testdigest.RandomCASResourceBuf(t, 1024*1024)
+	fullBlob := bytes.Join([][]byte{chunk1, chunk2, chunk3, chunk4, chunk5}, nil)
 
 	blobDigest, err := digest.Compute(bytes.NewReader(fullBlob), repb.DigestFunction_SHA256)
 	require.NoError(t, err)
@@ -1309,10 +1368,15 @@ func TestFindMissingBlobsWithChunkedBlob(t *testing.T) {
 	require.NoError(t, cache.Set(ctx, chunk1RN, chunk1))
 	require.NoError(t, cache.Set(ctx, chunk2RN, chunk2))
 	require.NoError(t, cache.Set(ctx, chunk3RN, chunk3))
+	require.NoError(t, cache.Set(ctx, chunk4RN, chunk4))
+	require.NoError(t, cache.Set(ctx, chunk5RN, chunk5))
 
 	manifest := &chunking.Manifest{
-		BlobDigest:     blobDigest,
-		ChunkDigests:   []*repb.Digest{chunk1RN.GetDigest(), chunk2RN.GetDigest(), chunk3RN.GetDigest()},
+		BlobDigest: blobDigest,
+		ChunkDigests: []*repb.Digest{
+			chunk1RN.GetDigest(), chunk2RN.GetDigest(), chunk3RN.GetDigest(),
+			chunk4RN.GetDigest(), chunk5RN.GetDigest(),
+		},
 		InstanceName:   "",
 		DigestFunction: repb.DigestFunction_SHA256,
 	}
@@ -1337,40 +1401,25 @@ func TestFindMissingBlobsWithChunkedBlob(t *testing.T) {
 	require.ElementsMatch(t, digestStrings(blobDigest, regularDigest), digestStrings(rsp.MissingBlobDigests...))
 }
 
-func TestFindMissingBlobsUsesReadFallbackThreshold(t *testing.T) {
+func TestChunkedBlobAtCurrentWriteThresholdIsMissingButReadable(t *testing.T) {
 	flags.Set(t, "cache.avg_chunk_size_bytes", 1024*1024)
 	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 2*1024*1024)
 
-	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
-	})
-	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
-
-	fp, err := experiments.NewFlagProvider(t.Name())
-	require.NoError(t, err)
-
 	ctx := context.Background()
 	te := testenv.GetTestEnv(t)
-	te.SetExperimentFlagProvider(fp)
-
-	ctx, err = prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
 	require.NoError(t, err)
 
 	clientConn := runCASServer(ctx, t, te)
 	casClient := repb.NewContentAddressableStorageClient(clientConn)
+	bsClient := bspb.NewByteStreamClient(clientConn)
 	cache := te.GetCache()
 
 	chunk1RN, chunk1 := testdigest.RandomCASResourceBuf(t, 1024*1024)
 	chunk2RN, chunk2 := testdigest.RandomCASResourceBuf(t, 1024*1024)
 	chunk3RN, chunk3 := testdigest.RandomCASResourceBuf(t, 1024*1024)
-	fullBlob := append(append(chunk1, chunk2...), chunk3...)
+	chunk4RN, chunk4 := testdigest.RandomCASResourceBuf(t, 1024*1024)
+	fullBlob := bytes.Join([][]byte{chunk1, chunk2, chunk3, chunk4}, nil)
 
 	blobDigest, err := digest.Compute(bytes.NewReader(fullBlob), repb.DigestFunction_SHA256)
 	require.NoError(t, err)
@@ -1378,74 +1427,11 @@ func TestFindMissingBlobsUsesReadFallbackThreshold(t *testing.T) {
 	require.NoError(t, cache.Set(ctx, chunk1RN, chunk1))
 	require.NoError(t, cache.Set(ctx, chunk2RN, chunk2))
 	require.NoError(t, cache.Set(ctx, chunk3RN, chunk3))
+	require.NoError(t, cache.Set(ctx, chunk4RN, chunk4))
 
 	manifest := &chunking.Manifest{
 		BlobDigest:     blobDigest,
-		ChunkDigests:   []*repb.Digest{chunk1RN.GetDigest(), chunk2RN.GetDigest(), chunk3RN.GetDigest()},
-		InstanceName:   "",
-		DigestFunction: repb.DigestFunction_SHA256,
-	}
-	require.NoError(t, manifest.Store(ctx, cache))
-
-	rsp, err := casClient.FindMissingBlobs(ctx, &repb.FindMissingBlobsRequest{
-		BlobDigests: []*repb.Digest{blobDigest},
-	})
-	require.NoError(t, err)
-
-	require.Empty(t, rsp.MissingBlobDigests)
-
-	rsp, err = casClient.FindMissingBlobs(cdc.ContextWithChunked(ctx), &repb.FindMissingBlobsRequest{
-		BlobDigests: []*repb.Digest{blobDigest},
-	})
-	require.NoError(t, err)
-	require.Len(t, rsp.MissingBlobDigests, 1)
-	require.Equal(t, blobDigest.GetHash(), rsp.MissingBlobDigests[0].GetHash())
-}
-
-func TestFindMissingBlobsDiscardsLegacyChunkedBlobForAvgChunkSizeOverride(t *testing.T) {
-	flags.Set(t, "cache.avg_chunk_size_bytes", 512*1024)
-	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 2*1024*1024)
-
-	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.avg_chunk_size_override": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "one_mb",
-			Variants: map[string]any{
-				"one_mb": 1 * 1024 * 1024,
-			},
-		},
-	})
-	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
-
-	fp, err := experiments.NewFlagProvider(t.Name())
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	te := testenv.GetTestEnv(t)
-	te.SetExperimentFlagProvider(fp)
-
-	ctx, err = prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
-	require.NoError(t, err)
-
-	clientConn := runCASServer(ctx, t, te)
-	casClient := repb.NewContentAddressableStorageClient(clientConn)
-	cache := te.GetCache()
-
-	chunk1RN, chunk1 := testdigest.RandomCASResourceBuf(t, 1024*1024)
-	chunk2RN, chunk2 := testdigest.RandomCASResourceBuf(t, 1024*1024)
-	chunk3RN, chunk3 := testdigest.RandomCASResourceBuf(t, 1024*1024)
-	fullBlob := append(append(chunk1, chunk2...), chunk3...)
-
-	blobDigest, err := digest.Compute(bytes.NewReader(fullBlob), repb.DigestFunction_SHA256)
-	require.NoError(t, err)
-
-	require.NoError(t, cache.Set(ctx, chunk1RN, chunk1))
-	require.NoError(t, cache.Set(ctx, chunk2RN, chunk2))
-	require.NoError(t, cache.Set(ctx, chunk3RN, chunk3))
-
-	manifest := &chunking.Manifest{
-		BlobDigest:     blobDigest,
-		ChunkDigests:   []*repb.Digest{chunk1RN.GetDigest(), chunk2RN.GetDigest(), chunk3RN.GetDigest()},
+		ChunkDigests:   []*repb.Digest{chunk1RN.GetDigest(), chunk2RN.GetDigest(), chunk3RN.GetDigest(), chunk4RN.GetDigest()},
 		InstanceName:   "",
 		DigestFunction: repb.DigestFunction_SHA256,
 	}
@@ -1457,6 +1443,11 @@ func TestFindMissingBlobsDiscardsLegacyChunkedBlobForAvgChunkSizeOverride(t *tes
 	require.NoError(t, err)
 	require.Len(t, rsp.MissingBlobDigests, 1)
 	require.Equal(t, blobDigest.GetHash(), rsp.MissingBlobDigests[0].GetHash())
+
+	var downloaded bytes.Buffer
+	rn := digest.NewCASResourceName(blobDigest, "", repb.DigestFunction_SHA256)
+	require.NoError(t, cachetools.GetBlob(ctx, bsClient, rn, &downloaded))
+	require.Equal(t, fullBlob, downloaded.Bytes())
 }
 
 func TestBatchReadBlobsWithChunkedBlob(t *testing.T) {


### PR DESCRIPTION
This is post-migration cleanup that makes the deployed 1 MiB average CDC chunk size the default and removes migration-only logic.

- All production groups already use the 1 MiB override, so merging this does not change production behavior; removing the override afterward yields the same 1 MiB average and 4 MiB threshold.
- FindMissingBlobs and every AC validation path use the same effective current threshold, preventing an AC result from validating when its output would be reported missing.
- Manifest-only blobs at or below 4 MiB are treated as missing and rewritten as whole blobs, while Read and BatchRead retain the 2 MiB fallback so legacy 2–4 MiB manifests remain readable during that transition.
- Internal chunk FindMissingBlobs requests still bypass manifest fallback, preventing layered manifests.
- All proxies must be fully deployed with these defaults before proxy intercept-and-chunk is re-enabled, to prevent double chunking and layered manifests.