### PR TITLE
handle leading, trailing, repeated whitespace in rbe prober bazel args

### DIFF
--- a/enterprise/server/test/integration/bazelrbe_prober/bazelrbe_prober_test.go
+++ b/enterprise/server/test/integration/bazelrbe_prober/bazelrbe_prober_test.go
@@ -70,11 +70,12 @@ func runProberTest(t *testing.T, bazelRunfilepath, proberName, extraBazelArgs st
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	// Include extra whitespace to verify that --bazel_args ignores empty fields.
+	// Include extra whitespace and a quoted value to verify shell-style parsing.
 	bazelArgs := "  --remote_executor=" + env.GetRemoteExecutionTarget() +
 		"  --remote_instance_name=buildbuddy-io/buildbuddy/ci" +
 		"  --remote_default_exec_properties=OSFamily=" + runtime.GOOS +
-		"  --remote_default_exec_properties=Arch=" + runtime.GOARCH
+		"  --remote_default_exec_properties=Arch=" + runtime.GOARCH +
+		"  --build_metadata=SHLEX_TEST='value with spaces'"
 	if extraBazelArgs != "" {
 		bazelArgs += "  " + extraBazelArgs
 	}

--- a/enterprise/server/test/integration/bazelrbe_prober/bazelrbe_prober_test.go
+++ b/enterprise/server/test/integration/bazelrbe_prober/bazelrbe_prober_test.go
@@ -70,13 +70,15 @@ func runProberTest(t *testing.T, bazelRunfilepath, proberName, extraBazelArgs st
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	bazelArgs := "--remote_executor=" + env.GetRemoteExecutionTarget() +
-		" --remote_instance_name=buildbuddy-io/buildbuddy/ci" +
-		" --remote_default_exec_properties=OSFamily=" + runtime.GOOS +
-		" --remote_default_exec_properties=Arch=" + runtime.GOARCH
+	// Include extra whitespace to verify that --bazel_args ignores empty fields.
+	bazelArgs := "  --remote_executor=" + env.GetRemoteExecutionTarget() +
+		"  --remote_instance_name=buildbuddy-io/buildbuddy/ci" +
+		"  --remote_default_exec_properties=OSFamily=" + runtime.GOOS +
+		"  --remote_default_exec_properties=Arch=" + runtime.GOARCH
 	if extraBazelArgs != "" {
-		bazelArgs += " " + extraBazelArgs
+		bazelArgs += "  " + extraBazelArgs
 	}
+	bazelArgs += "  "
 
 	args := []string{
 		"--bazel_binary=" + bazelBinary,

--- a/tools/probers/bazelrbe/BUILD
+++ b/tools/probers/bazelrbe/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//server/util/log",
+        "//server/util/shlex",
         "//server/util/status",
     ],
 )

--- a/tools/probers/bazelrbe/bazelrbe.go
+++ b/tools/probers/bazelrbe/bazelrbe.go
@@ -14,13 +14,14 @@ import (
 	mrand "math/rand/v2"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/shlex"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 )
 
 var (
 	bazelBinary         = flag.String("bazel_binary", "bazel", "Path to bazel binary")
-	bazelArgs           = flag.String("bazel_args", "", "Whitespace-separated list of args to pass to Bazel")
-	bazelStartupOptions = flag.String("bazel_startup_options", "", "Whitespace-separated list of Bazel startup options to pass (appear before the command)")
+	bazelArgs           = flag.String("bazel_args", "", "Shell-style list of args to pass to Bazel")
+	bazelStartupOptions = flag.String("bazel_startup_options", "", "Shell-style list of Bazel startup options to pass (appear before the command)")
 	proberName          = flag.String("prober_name", "", "Short, human-readable name of this prober. This name must be a valid bazel package name (only '.', '@', '-', '_' and alphanumeric characters allowed).")
 	containerImage      = flag.String("container_image", "none", "Container image in which to execute prober actions. Set to 'none' to use the executor default.")
 
@@ -140,7 +141,10 @@ func runProbe() error {
 		"--max_idle_secs=5",
 	}
 	if *bazelStartupOptions != "" {
-		startupArgs := strings.Fields(*bazelStartupOptions)
+		startupArgs, err := shlex.Split(*bazelStartupOptions)
+		if err != nil {
+			return status.InvalidArgumentErrorf("invalid --bazel_startup_options: %s", err)
+		}
 		args = append(args, startupArgs...)
 	}
 	args = append(args,
@@ -148,7 +152,10 @@ func runProbe() error {
 		"//"+*proberName+":all",
 	)
 	if *bazelArgs != "" {
-		extraArgs := strings.Fields(*bazelArgs)
+		extraArgs, err := shlex.Split(*bazelArgs)
+		if err != nil {
+			return status.InvalidArgumentErrorf("invalid --bazel_args: %s", err)
+		}
 		args = append(args, extraArgs...)
 	}
 	args = append(args, "--remote_header=x-buildbuddy-trace=force")

--- a/tools/probers/bazelrbe/bazelrbe.go
+++ b/tools/probers/bazelrbe/bazelrbe.go
@@ -19,8 +19,8 @@ import (
 
 var (
 	bazelBinary         = flag.String("bazel_binary", "bazel", "Path to bazel binary")
-	bazelArgs           = flag.String("bazel_args", "", "Space separated list of args to pass to Bazel")
-	bazelStartupOptions = flag.String("bazel_startup_options", "", "Space separated list of Bazel startup options to pass (appear before the command)")
+	bazelArgs           = flag.String("bazel_args", "", "Whitespace-separated list of args to pass to Bazel")
+	bazelStartupOptions = flag.String("bazel_startup_options", "", "Whitespace-separated list of Bazel startup options to pass (appear before the command)")
 	proberName          = flag.String("prober_name", "", "Short, human-readable name of this prober. This name must be a valid bazel package name (only '.', '@', '-', '_' and alphanumeric characters allowed).")
 	containerImage      = flag.String("container_image", "none", "Container image in which to execute prober actions. Set to 'none' to use the executor default.")
 
@@ -140,7 +140,7 @@ func runProbe() error {
 		"--max_idle_secs=5",
 	}
 	if *bazelStartupOptions != "" {
-		startupArgs := strings.Split(*bazelStartupOptions, " ")
+		startupArgs := strings.Fields(*bazelStartupOptions)
 		args = append(args, startupArgs...)
 	}
 	args = append(args,
@@ -148,7 +148,7 @@ func runProbe() error {
 		"//"+*proberName+":all",
 	)
 	if *bazelArgs != "" {
-		extraArgs := strings.Split(*bazelArgs, " ")
+		extraArgs := strings.Fields(*bazelArgs)
 		args = append(args, extraArgs...)
 	}
 	args = append(args, "--remote_header=x-buildbuddy-trace=force")


### PR DESCRIPTION
Ignore leading, trailing, and repeated whitespace in Bazel args and startup options.