### PR TITLE
Fix spurious `NOT_FOUND` errors from reference verification on distributed cache reads

### DIFF
--- a/enterprise/server/util/distributed_client/BUILD
+++ b/enterprise/server/util/distributed_client/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//server/util/authutil",
         "//server/util/background",
         "//server/util/bytebufferpool",
+        "//server/util/claims",
         "//server/util/compression",
         "//server/util/findmissing",
         "//server/util/flag",
@@ -35,8 +36,10 @@ go_library(
         "//server/util/status",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//reflection",
+        "@org_golang_google_grpc//status",
     ],
 )
 

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -21,6 +21,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/background"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bytebufferpool"
+	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/compression"
 	"github.com/buildbuddy-io/buildbuddy/server/util/findmissing"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
@@ -35,6 +36,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/reflection"
 
@@ -42,6 +44,7 @@ import (
 	refpb "github.com/buildbuddy-io/buildbuddy/proto/reference"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
+	gstatus "google.golang.org/grpc/status"
 )
 
 const (
@@ -773,19 +776,16 @@ func (c *Proxy) RemoteReader(ctx context.Context, peer string, r *rspb.ResourceN
 		// proto to the pool, but the reference may live longer, so clone it.
 		ref := rc.rsp.GetReference().CloneVT()
 
-		// Confirm the provided reference matches what was requested.
+		// Confirm the reference identifies the requested content. Only the
+		// digest is compared: the metadata may legitimately mis-match.
 		fr := ref.GetMetadata().GetFileRecord()
-		frd := fr.GetDigest()
-		if frd.GetHash() != r.GetDigest().GetHash() ||
-			frd.GetSizeBytes() != r.GetDigest().GetSizeBytes() ||
-			fr.GetDigestFunction() != r.GetDigestFunction() ||
-			fr.GetIsolation().GetCacheType() != r.GetCacheType() ||
-			fr.GetIsolation().GetRemoteInstanceName() != r.GetInstanceName() {
-			rc.Close()
-			return nil, status.InternalErrorf("peer %q returned a reference for %s/%d (cache type %s, instance %q), but %s/%d (cache type %s, instance %q) was requested",
-				peer,
-				frd.GetHash(), frd.GetSizeBytes(), fr.GetIsolation().GetCacheType(), fr.GetIsolation().GetRemoteInstanceName(),
-				r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes(), r.GetCacheType(), r.GetInstanceName())
+		frd := ref.GetMetadata().GetFileRecord().GetDigest()
+		refMatches := frd.GetHash() == r.GetDigest().GetHash() &&
+			frd.GetSizeBytes() == r.GetDigest().GetSizeBytes() &&
+			fr.GetDigestFunction() == r.GetDigestFunction() &&
+			fr.GetIsolation().GetCacheType() == r.GetCacheType()
+		if fr.GetIsolation().GetCacheType() != rspb.CacheType_CAS {
+			refMatches = refMatches && fr.GetIsolation().GetRemoteInstanceName() == r.GetInstanceName()
 		}
 
 		// If the server is also streaming the data, serve those bytes to the
@@ -803,19 +803,39 @@ func (c *Proxy) RemoteReader(ctx context.Context, peer string, r *rspb.ResourceN
 				byteReader = dr
 			}
 			recordReadResponseMetrics("bytes", r)
+			if !refMatches {
+				// Verification is best-effort: log bad refs, but don't fail.
+				c.log.Errorf("Reference verification failed for %q from peer %q: reference identifies %s/%d", ResourceIsolationString(r), peer, frd.GetHash(), frd.GetSizeBytes())
+				metrics.DistributedCacheReferenceVerificationCount.With(
+					prometheus.Labels{
+						metrics.GroupID:                  groupIDForMetrics(ctx),
+						metrics.VerificationOutcomeLabel: VerificationFailure,
+						metrics.StatusHumanReadableLabel: codes.Internal.String(),
+					}).Inc()
+				return byteReader, nil
+			}
 			refReader, err := c.dereference(ctx, peer, ref, requested, offset, limit)
 			if err != nil {
 				// Verification is best-effort: the byte stream is
 				// authoritative, so log and serve it.
 				c.log.Warningf("Cannot verify reference for %q from peer %q: %s", ResourceIsolationString(r), peer, err)
 				metrics.DistributedCacheReferenceVerificationCount.With(
-					prometheus.Labels{metrics.VerificationOutcomeLabel: VerificationError}).Inc()
+					prometheus.Labels{
+						metrics.GroupID:                  groupIDForMetrics(ctx),
+						metrics.VerificationOutcomeLabel: VerificationError,
+						metrics.StatusHumanReadableLabel: gstatus.Code(err).String(),
+					}).Inc()
 				return byteReader, nil
 			}
-			return NewVerifyingReadCloser(byteReader, refReader, c.log, r, peer), nil
+			return NewVerifyingReadCloser(byteReader, refReader, c.log, r, peer, groupIDForMetrics(ctx)), nil
 		}
 
 		// The reference is the whole response: dereference it.
+		if !refMatches {
+			rc.Close()
+			return nil, status.InternalErrorf("peer %q returned a reference for %s/%d, but %s/%d was requested",
+				peer, frd.GetHash(), frd.GetSizeBytes(), r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes())
+		}
 		if err := rc.Close(); err != nil {
 			c.log.Warningf("Error closing read stream after receiving a reference: %s", err)
 		}
@@ -834,6 +854,15 @@ func (c *Proxy) RemoteReader(ctx context.Context, peer string, r *rspb.ResourceN
 	}
 	recordReadResponseMetrics("bytes", r)
 	return dr, nil
+}
+
+// groupIDForMetrics returns the authenticated group ID in ctx, for metric
+// labels.
+func groupIDForMetrics(ctx context.Context) string {
+	if c, err := claims.ClaimsFromContext(ctx); err == nil {
+		return c.GroupID
+	}
+	return interfaces.AuthAnonymousUser
 }
 
 // recordReadResponseMetrics records that a peer read's payload was received
@@ -863,19 +892,21 @@ type verifyingReadCloser struct {
 	log       log.Logger
 	resource  *rspb.ResourceName
 	peer      string
+	groupID   string
 
 	scratch  []byte
 	compared int64
 	done     bool
 }
 
-func NewVerifyingReadCloser(primary, secondary io.ReadCloser, log log.Logger, r *rspb.ResourceName, peer string) io.ReadCloser {
+func NewVerifyingReadCloser(primary, secondary io.ReadCloser, log log.Logger, r *rspb.ResourceName, peer, groupID string) io.ReadCloser {
 	return &verifyingReadCloser{
 		primary:   primary,
 		secondary: secondary,
 		log:       log,
 		resource:  r,
 		peer:      peer,
+		groupID:   groupID,
 	}
 }
 
@@ -891,7 +922,7 @@ func (v *verifyingReadCloser) verify(p []byte) {
 		if err == io.EOF || err == io.ErrUnexpectedEOF {
 			v.report(VerificationFailure, status.InternalErrorf("dereferenced bytes ended early at offset %d", v.compared))
 		} else {
-			v.report(VerificationError, status.InternalErrorf("error reading dereferenced bytes at offset %d: %s", v.compared, err))
+			v.report(VerificationError, status.WrapErrorf(err, "error reading dereferenced bytes at offset %d", v.compared))
 		}
 		return
 	}
@@ -914,7 +945,7 @@ func (v *verifyingReadCloser) verifyEOF() {
 	case n != 0 || err == nil:
 		v.report(VerificationFailure, status.InternalErrorf("dereferenced bytes continue past streamed bytes at offset %d", v.compared))
 	default:
-		v.report(VerificationError, status.InternalErrorf("error reading dereferenced bytes at offset %d: %s", v.compared, err))
+		v.report(VerificationError, status.WrapErrorf(err, "error reading dereferenced bytes at offset %d", v.compared))
 	}
 }
 
@@ -927,7 +958,11 @@ func (v *verifyingReadCloser) report(verificationStatus string, err error) {
 		v.log.Warningf("Reference verification error for %q from peer %q: %s", ResourceIsolationString(v.resource), v.peer, err)
 	}
 	metrics.DistributedCacheReferenceVerificationCount.With(
-		prometheus.Labels{metrics.VerificationOutcomeLabel: verificationStatus}).Inc()
+		prometheus.Labels{
+			metrics.GroupID:                  v.groupID,
+			metrics.VerificationOutcomeLabel: verificationStatus,
+			metrics.StatusHumanReadableLabel: gstatus.Code(err).String(),
+		}).Inc()
 }
 
 func (v *verifyingReadCloser) Read(p []byte) (int, error) {

--- a/enterprise/server/util/distributed_client/distributed_client_test.go
+++ b/enterprise/server/util/distributed_client/distributed_client_test.go
@@ -1581,6 +1581,22 @@ func TestRemoteReadReference(t *testing.T) {
 		require.Contains(t, err.Error(), "returned a reference for")
 	})
 
+	t.Run("stored instance name may differ", func(t *testing.T) {
+		// CAS entries are deduped across instance names, so the reference can
+		// carry the first writer's instance name without identifying
+		// different content.
+		storedRN := rn.CloneVT()
+		storedRN.InstanceName = "instance-at-first-write"
+		peer := startReferenceReadServer(t, makeReference(storedRN, blobName, repb.Compressor_IDENTITY))
+		c, _ := newReferenceTestProxy(t, te, map[string][]byte{blobName: buf})
+		r, err := c.RemoteReader(ctx, peer, rn, 0, 0)
+		require.NoError(t, err)
+		got, err := io.ReadAll(r)
+		require.NoError(t, err)
+		require.NoError(t, r.Close())
+		require.Equal(t, buf, got)
+	})
+
 	t.Run("cache that cannot dereference is rejected", func(t *testing.T) {
 		peer := startReferenceReadServer(t, makeReference(rn, blobName, repb.Compressor_IDENTITY))
 		localPeer := fmt.Sprintf("localhost:%d", testport.FindFree(t))
@@ -1970,6 +1986,18 @@ func TestRemoteReadVerification(t *testing.T) {
 	rn, buf := testdigest.RandomCASResourceBuf(t, 100)
 	chunks := [][]byte{buf[:40], buf[40:]}
 
+	// deltas returns the nonzero outcome-count changes between two
+	// verificationCounts snapshots.
+	deltas := func(before, after map[string]float64) map[string]float64 {
+		d := map[string]float64{}
+		for s, c := range after {
+			if diff := c - before[s]; diff != 0 {
+				d[s] = diff
+			}
+		}
+		return d
+	}
+
 	t.Run("matching bytes", func(t *testing.T) {
 		peer, _ := startVerifyingReadServer(t, makeReference(rn, blobName, repb.Compressor_IDENTITY), chunks)
 		c, _ := newReferenceTestProxy(t, te, map[string][]byte{blobName: buf})
@@ -2006,6 +2034,42 @@ func TestRemoteReadVerification(t *testing.T) {
 		require.Equal(t, buf, got)
 	})
 
+	t.Run("mismatched reference digest is non-fatal", func(t *testing.T) {
+		otherRN, _ := testdigest.RandomCASResourceBuf(t, 100)
+		peer, _ := startVerifyingReadServer(t, makeReference(otherRN, blobName, repb.Compressor_IDENTITY), chunks)
+		c, fake := newReferenceTestProxy(t, te, map[string][]byte{blobName: buf})
+		before := verificationCounts(t)
+		r, err := c.RemoteReader(ctx, peer, rn, 0, 0)
+		require.NoError(t, err)
+		got, err := io.ReadAll(r)
+		require.NoError(t, err)
+		require.NoError(t, r.Close())
+		// The streamed bytes are authoritative.
+		require.Equal(t, buf, got)
+		// The bad reference was counted as a failure and never dereferenced.
+		require.Equal(t, map[string]float64{distributed_client.VerificationFailure: 1}, deltas(before, verificationCounts(t)))
+		gotRN, _, _ := fake.LastDereference()
+		require.Nil(t, gotRN)
+	})
+
+	t.Run("stored instance name difference does not fail verification", func(t *testing.T) {
+		// CAS entries are deduped across instance names, so the reference can
+		// carry the first writer's instance name without identifying
+		// different content.
+		storedRN := rn.CloneVT()
+		storedRN.InstanceName = "instance-at-first-write"
+		peer, _ := startVerifyingReadServer(t, makeReference(storedRN, blobName, repb.Compressor_IDENTITY), chunks)
+		c, _ := newReferenceTestProxy(t, te, map[string][]byte{blobName: buf})
+		before := verificationCounts(t)
+		r, err := c.RemoteReader(ctx, peer, rn, 0, 0)
+		require.NoError(t, err)
+		got, err := io.ReadAll(r)
+		require.NoError(t, err)
+		require.NoError(t, r.Close())
+		require.Equal(t, buf, got)
+		require.Equal(t, map[string]float64{distributed_client.VerificationSuccess: 1}, deltas(before, verificationCounts(t)))
+	})
+
 	t.Run("missing dereferencer is non-fatal", func(t *testing.T) {
 		peer, _ := startVerifyingReadServer(t, makeReference(rn, blobName, repb.Compressor_IDENTITY), chunks)
 		localPeer := fmt.Sprintf("localhost:%d", testport.FindFree(t))
@@ -2030,11 +2094,11 @@ func (e *errorReadCloser) Read(p []byte) (int, error) { return 0, e.err }
 func (e *errorReadCloser) Close() error               { return nil }
 
 // verificationCounts returns the current values of the reference verification
-// counter, keyed by outcome.
+// counter, keyed by outcome, summed across error codes.
 func verificationCounts(t *testing.T) map[string]float64 {
 	counts := map[string]float64{}
-	for _, s := range []string{distributed_client.VerificationSuccess, distributed_client.VerificationFailure, distributed_client.VerificationError} {
-		counts[s] = testmetrics.CounterValueForLabels(t, metrics.DistributedCacheReferenceVerificationCount, prometheus.Labels{metrics.VerificationOutcomeLabel: s})
+	for _, v := range testmetrics.CounterValues(t, metrics.DistributedCacheReferenceVerificationCount) {
+		counts[v.Labels[metrics.VerificationOutcomeLabel]] += v.Value
 	}
 	return counts
 }
@@ -2210,7 +2274,7 @@ func TestVerifyingReadCloser(t *testing.T) {
 	// the change in the verification counter, keyed by outcome.
 	run := func(t *testing.T, secondary io.ReadCloser) (gotData []byte, counted map[string]float64) {
 		before := verificationCounts(t)
-		v := distributed_client.NewVerifyingReadCloser(newRC(data), secondary, log.NamedSubLogger(t.Name()), rn, "test-peer")
+		v := distributed_client.NewVerifyingReadCloser(newRC(data), secondary, log.NamedSubLogger(t.Name()), rn, "test-peer", "GR-test")
 		got, err := io.ReadAll(v)
 		require.NoError(t, err)
 		require.NoError(t, v.Close())
@@ -2255,5 +2319,19 @@ func TestVerifyingReadCloser(t *testing.T) {
 		got, counted := run(t, &errorReadCloser{err: errors.New("gcs exploded")})
 		require.Equal(t, data, got)
 		require.Equal(t, map[string]float64{distributed_client.VerificationError: 1}, counted)
+	})
+
+	t.Run("secondary read errors carry their code", func(t *testing.T) {
+		canceledLabels := prometheus.Labels{
+			metrics.GroupID:                  "GR-test",
+			metrics.VerificationOutcomeLabel: distributed_client.VerificationError,
+			metrics.StatusHumanReadableLabel: "Canceled",
+		}
+		before := testmetrics.CounterValueForLabels(t, metrics.DistributedCacheReferenceVerificationCount, canceledLabels)
+		got, counted := run(t, &errorReadCloser{err: status.CanceledError("context canceled")})
+		require.Equal(t, data, got)
+		require.Equal(t, map[string]float64{distributed_client.VerificationError: 1}, counted)
+		after := testmetrics.CounterValueForLabels(t, metrics.DistributedCacheReferenceVerificationCount, canceledLabels)
+		require.Equal(t, before+1, after)
 	})
 }

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1055,14 +1055,18 @@ var (
 	// references received alongside streamed bytes on distributed cache
 	// reads, by outcome: "success" (the dereferenced bytes matched the
 	// streamed bytes through EOF), "failure" (the two streams diverged), or
-	// "error" (verification could not be run or completed).
+	// "error" (verification could not be run or completed). The status label
+	// carries the gRPC code of the error that produced the outcome ("OK" on
+	// success).
 	DistributedCacheReferenceVerificationCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_cache",
 		Name:      "distributed_cache_reference_verification_count",
-		Help:      "Count of reference verifications on distributed cache reads, by outcome.",
+		Help:      "Count of reference verifications on distributed cache reads, by group, outcome, and error code.",
 	}, []string{
+		GroupID,
 		VerificationOutcomeLabel,
+		StatusHumanReadableLabel,
 	})
 
 	// DistributedCacheReferenceWriteVerificationCount counts verifications of


### PR DESCRIPTION
The read-reference verification path can generate spurious `NOT_FOUND` errors due to mis-matched digest metadata (e.g. remote-instance-name). This PR updates the verification check to ignore that and also makes actual digest mismatches not fail the entire request. It also adds a couple of dimensions to the read-reference verification metric to make debugging a little bit easier.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7911