### PR TITLE
bb analyze: return a deterministic path for the same lengths

### DIFF
--- a/cli/analyze/BUILD
+++ b/cli/analyze/BUILD
@@ -21,5 +21,8 @@ go_test(
     name = "analyze_test",
     srcs = ["analyze_test.go"],
     embed = [":analyze"],
-    deps = ["//proto:bazel_query_go_proto"],
+    deps = [
+        "//proto:bazel_query_go_proto",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/cli/analyze/BUILD
+++ b/cli/analyze/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//cli:__subpackages__"])
 
@@ -15,4 +15,11 @@ go_library(
         "//server/util/proto",
         "@org_golang_x_sync//errgroup",
     ],
+)
+
+go_test(
+    name = "analyze_test",
+    srcs = ["analyze_test.go"],
+    embed = [":analyze"],
+    deps = ["//proto:bazel_query_go_proto"],
 )

--- a/cli/analyze/analyze.go
+++ b/cli/analyze/analyze.go
@@ -423,39 +423,36 @@ func (g *DependencyGraph) AffectedTargetCount(name string) int {
 // LongestPath returns the longest dependency path from one node in the graph to
 // any other node.
 func (g *DependencyGraph) LongestPath() []string {
-	longestPathLength := 0
-	var longestPathEnd *string
-
 	length := map[string]int{}
-	pred := map[string]*string{}
+	next := map[string]string{}
+	longestPathLength := 0
+	longestPathStart := ""
+
 	e := g.EdgeSet()
-	for _, m := range g.TopologicalSort() {
-		for n := range e.Incoming[m] {
-			l := length[n] + 1
-			if l > length[m] {
-				length[m] = l
-				n := n
-				pred[m] = &n
-			}
-			if l > longestPathLength {
-				longestPathLength = l
-				m := m
-				longestPathEnd = &m
+	nodes := g.TopologicalSort()
+	for i := len(nodes) - 1; i >= 0; i-- {
+		n := nodes[i]
+		for dep := range e.Outgoing[n] {
+			candidateLength := length[dep] + 1
+			if candidateLength > length[n] ||
+				(candidateLength == length[n] && dep < next[n]) {
+				length[n] = candidateLength
+				next[n] = dep
 			}
 		}
+		if length[n] > longestPathLength ||
+			(length[n] == longestPathLength && n < longestPathStart) {
+			longestPathLength = length[n]
+			longestPathStart = n
+		}
 	}
-	if longestPathEnd == nil {
+	if longestPathStart == "" {
 		return nil
 	}
-	path := []string{*longestPathEnd}
-	for {
-		p := pred[path[len(path)-1]]
-		if p == nil {
-			break
-		}
-		path = append(path, *p)
+	path := make([]string, 0, longestPathLength+1)
+	for n := longestPathStart; n != ""; n = next[n] {
+		path = append(path, n)
 	}
-	reverseSlice(path)
 	return path
 }
 
@@ -564,14 +561,6 @@ func makeSet[T comparable](values []T) map[T]bool {
 		set[v] = true
 	}
 	return set
-}
-
-// reverseSlice reverses the order of the elements in the given slice.
-func reverseSlice[T any](a []T) {
-	for i := 0; i < len(a)/2; i++ {
-		j := len(a) - i - 1
-		a[i], a[j] = a[j], a[i]
-	}
 }
 
 // bufferedChanOf returns a channel pre-populated with the list of values from

--- a/cli/analyze/analyze_test.go
+++ b/cli/analyze/analyze_test.go
@@ -1,10 +1,10 @@
 package analyze
 
 import (
-	"reflect"
 	"testing"
 
 	bqpb "github.com/buildbuddy-io/buildbuddy/proto/bazel_query"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLongestPath_TiesChooseLexicographicallyFirstPath(t *testing.T) {
@@ -19,19 +19,8 @@ func TestLongestPath_TiesChooseLexicographicallyFirstPath(t *testing.T) {
 	}
 	want := []string{"//:a_root", "//:a_left", "//:a_leaf"}
 
-	// Construct equivalent graphs in different orders to ensure that neither
-	// proto result order nor Go map iteration affects which tied path wins.
-	ruleOrders := [][]string{
-		{"//:a_root", "//:a_left", "//:a_right", "//:a_leaf", "//:z_root", "//:z_middle", "//:z_leaf"},
-		{"//:z_leaf", "//:z_middle", "//:z_root", "//:a_leaf", "//:a_right", "//:a_left", "//:a_root"},
-		{"//:a_right", "//:z_root", "//:a_leaf", "//:z_leaf", "//:a_root", "//:z_middle", "//:a_left"},
-	}
-	for _, order := range ruleOrders {
-		graph := dependencyGraph(rulesByName, order)
-		if got := graph.LongestPath(); !reflect.DeepEqual(got, want) {
-			t.Fatalf("LongestPath() = %v, want %v", got, want)
-		}
-	}
+	graph := dependencyGraph(rulesByName)
+	require.Equal(t, want, graph.LongestPath())
 }
 
 func TestLongestPath_TieBreakComparesPathsFromStart(t *testing.T) {
@@ -42,27 +31,22 @@ func TestLongestPath_TieBreakComparesPathsFromStart(t *testing.T) {
 		"//:a_parent": rule("//:a_parent", "//:leaf"),
 		"//:leaf":     rule("//:leaf"),
 	}
-	graph := dependencyGraph(rulesByName, []string{
-		"//:a_root", "//:z_parent", "//:b_root", "//:a_parent", "//:leaf",
-	})
+	graph := dependencyGraph(rulesByName)
 	want := []string{"//:a_root", "//:z_parent", "//:leaf"}
 
-	if got := graph.LongestPath(); !reflect.DeepEqual(got, want) {
-		t.Fatalf("LongestPath() = %v, want %v", got, want)
-	}
+	require.Equal(t, want, graph.LongestPath())
 }
 
 func rule(name string, inputs ...string) *bqpb.Rule {
 	return &bqpb.Rule{Name: &name, RuleInput: inputs}
 }
 
-func dependencyGraph(rulesByName map[string]*bqpb.Rule, ruleOrder []string) *DependencyGraph {
+func dependencyGraph(rulesByName map[string]*bqpb.Rule) *DependencyGraph {
 	g := &DependencyGraph{
 		Rules:  make(map[string]*bqpb.Rule, len(rulesByName)),
 		DepsOn: make(map[string][]*bqpb.Rule),
 	}
-	for _, name := range ruleOrder {
-		r := rulesByName[name]
+	for name, r := range rulesByName {
 		g.Rules[name] = r
 		for _, input := range r.RuleInput {
 			g.DepsOn[input] = append(g.DepsOn[input], r)

--- a/cli/analyze/analyze_test.go
+++ b/cli/analyze/analyze_test.go
@@ -1,0 +1,72 @@
+package analyze
+
+import (
+	"reflect"
+	"testing"
+
+	bqpb "github.com/buildbuddy-io/buildbuddy/proto/bazel_query"
+)
+
+func TestLongestPath_TiesChooseLexicographicallyFirstPath(t *testing.T) {
+	rulesByName := map[string]*bqpb.Rule{
+		"//:a_root":   rule("//:a_root", "//:a_left", "//:a_right"),
+		"//:a_left":   rule("//:a_left", "//:a_leaf"),
+		"//:a_right":  rule("//:a_right", "//:a_leaf"),
+		"//:a_leaf":   rule("//:a_leaf"),
+		"//:z_root":   rule("//:z_root", "//:z_middle"),
+		"//:z_middle": rule("//:z_middle", "//:z_leaf"),
+		"//:z_leaf":   rule("//:z_leaf"),
+	}
+	want := []string{"//:a_root", "//:a_left", "//:a_leaf"}
+
+	// Construct equivalent graphs in different orders to ensure that neither
+	// proto result order nor Go map iteration affects which tied path wins.
+	ruleOrders := [][]string{
+		{"//:a_root", "//:a_left", "//:a_right", "//:a_leaf", "//:z_root", "//:z_middle", "//:z_leaf"},
+		{"//:z_leaf", "//:z_middle", "//:z_root", "//:a_leaf", "//:a_right", "//:a_left", "//:a_root"},
+		{"//:a_right", "//:z_root", "//:a_leaf", "//:z_leaf", "//:a_root", "//:z_middle", "//:a_left"},
+	}
+	for _, order := range ruleOrders {
+		graph := dependencyGraph(rulesByName, order)
+		if got := graph.LongestPath(); !reflect.DeepEqual(got, want) {
+			t.Fatalf("LongestPath() = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestLongestPath_TieBreakComparesPathsFromStart(t *testing.T) {
+	rulesByName := map[string]*bqpb.Rule{
+		"//:a_root":   rule("//:a_root", "//:z_parent"),
+		"//:z_parent": rule("//:z_parent", "//:leaf"),
+		"//:b_root":   rule("//:b_root", "//:a_parent"),
+		"//:a_parent": rule("//:a_parent", "//:leaf"),
+		"//:leaf":     rule("//:leaf"),
+	}
+	graph := dependencyGraph(rulesByName, []string{
+		"//:a_root", "//:z_parent", "//:b_root", "//:a_parent", "//:leaf",
+	})
+	want := []string{"//:a_root", "//:z_parent", "//:leaf"}
+
+	if got := graph.LongestPath(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("LongestPath() = %v, want %v", got, want)
+	}
+}
+
+func rule(name string, inputs ...string) *bqpb.Rule {
+	return &bqpb.Rule{Name: &name, RuleInput: inputs}
+}
+
+func dependencyGraph(rulesByName map[string]*bqpb.Rule, ruleOrder []string) *DependencyGraph {
+	g := &DependencyGraph{
+		Rules:  make(map[string]*bqpb.Rule, len(rulesByName)),
+		DepsOn: make(map[string][]*bqpb.Rule),
+	}
+	for _, name := range ruleOrder {
+		r := rulesByName[name]
+		g.Rules[name] = r
+		for _, input := range r.RuleInput {
+			g.DepsOn[input] = append(g.DepsOn[input], r)
+		}
+	}
+	return g
+}


### PR DESCRIPTION
Previously if you had multiple paths with the same length, which on was
returned was "random". Now we return whichever one is first
alphabetically so that it's stable.
