### PR TITLE
Support on-demand VFS input mode

### DIFF
--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -427,6 +427,12 @@ type FileSystemLayout struct {
 	RemoteInstanceName string
 	DigestFunction     repb.DigestFunction_Value
 	Inputs             *repb.Tree
+	InputFetcher       InputFetcher
+}
+
+// InputFetcher ensures that an input file is available in the local file cache.
+type InputFetcher interface {
+	Fetch(ctx context.Context, node *repb.FileNode) error
 }
 
 // CommandContainer provides an execution environment for commands.

--- a/enterprise/server/remote_execution/runner/BUILD
+++ b/enterprise/server/remote_execution/runner/BUILD
@@ -91,6 +91,7 @@ go_test(
         "//enterprise/server/tasksize",
         "//enterprise/server/util/oci",
         "//proto:remote_execution_go_proto",
+        "//proto:runner_go_proto",
         "//proto:scheduler_go_proto",
         "//proto:worker_go_proto",
         "//server/interfaces",

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -1292,8 +1292,9 @@ func (p *pool) newRunner(ctx context.Context, key *rnpb.RunnerKey, props *platfo
 	if err != nil {
 		return nil, err
 	}
+	useVFS := props.EnableVFS && platform.ContainerType(props.WorkloadIsolationType) != platform.FirecrackerContainerType
 	var vfsInputMode workspace.VFSInputMode
-	if props.EnableVFS {
+	if useVFS {
 		vfsInputMode = workspace.VFSInputMode(props.VFSInputMode)
 	}
 	wsOpts := &workspace.Opts{
@@ -1301,7 +1302,7 @@ func (p *pool) newRunner(ctx context.Context, key *rnpb.RunnerKey, props *platfo
 		CleanInputs:     props.CleanWorkspaceInputs,
 		CaseInsensitive: p.caseInsensitiveFS,
 		UseOverlayfs:    useOverlayfs,
-		UseVFS:          props.EnableVFS && platform.ContainerType(props.WorkloadIsolationType) != platform.FirecrackerContainerType,
+		UseVFS:          useVFS,
 		VFSInputMode:    vfsInputMode,
 	}
 	ws, err := workspace.New(p.env, p.buildRoot, wsOpts)

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -1293,9 +1293,9 @@ func (p *pool) newRunner(ctx context.Context, key *rnpb.RunnerKey, props *platfo
 		return nil, err
 	}
 	useVFS := props.EnableVFS && platform.ContainerType(props.WorkloadIsolationType) != platform.FirecrackerContainerType
-	var vfsInputMode workspace.VFSInputMode
+	var prefetchInputs workspace.PrefetchInputsMode
 	if useVFS {
-		vfsInputMode = workspace.VFSInputMode(props.VFSInputMode)
+		prefetchInputs = workspace.PrefetchInputsMode(props.PrefetchInputs)
 	}
 	wsOpts := &workspace.Opts{
 		Preserve:        props.PreserveWorkspace,
@@ -1303,7 +1303,7 @@ func (p *pool) newRunner(ctx context.Context, key *rnpb.RunnerKey, props *platfo
 		CaseInsensitive: p.caseInsensitiveFS,
 		UseOverlayfs:    useOverlayfs,
 		UseVFS:          useVFS,
-		VFSInputMode:    vfsInputMode,
+		PrefetchInputs:  prefetchInputs,
 	}
 	ws, err := workspace.New(p.env, p.buildRoot, wsOpts)
 	if err != nil {

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -1293,9 +1293,9 @@ func (p *pool) newRunner(ctx context.Context, key *rnpb.RunnerKey, props *platfo
 		return nil, err
 	}
 	useVFS := props.EnableVFS && platform.ContainerType(props.WorkloadIsolationType) != platform.FirecrackerContainerType
-	var prefetchInputs workspace.PrefetchInputsMode
+	var vfsPrefetchMode workspace.VFSPrefetchMode
 	if useVFS {
-		prefetchInputs = workspace.PrefetchInputsMode(props.PrefetchInputs)
+		vfsPrefetchMode = workspace.VFSPrefetchMode(props.VFSPrefetchMode)
 	}
 	wsOpts := &workspace.Opts{
 		Preserve:        props.PreserveWorkspace,
@@ -1303,7 +1303,7 @@ func (p *pool) newRunner(ctx context.Context, key *rnpb.RunnerKey, props *platfo
 		CaseInsensitive: p.caseInsensitiveFS,
 		UseOverlayfs:    useOverlayfs,
 		UseVFS:          useVFS,
-		PrefetchInputs:  prefetchInputs,
+		VFSPrefetchMode: vfsPrefetchMode,
 	}
 	ws, err := workspace.New(p.env, p.buildRoot, wsOpts)
 	if err != nil {

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -1292,12 +1292,17 @@ func (p *pool) newRunner(ctx context.Context, key *rnpb.RunnerKey, props *platfo
 	if err != nil {
 		return nil, err
 	}
+	var vfsInputMode workspace.VFSInputMode
+	if props.EnableVFS {
+		vfsInputMode = workspace.VFSInputMode(props.VFSInputMode)
+	}
 	wsOpts := &workspace.Opts{
 		Preserve:        props.PreserveWorkspace,
 		CleanInputs:     props.CleanWorkspaceInputs,
 		CaseInsensitive: p.caseInsensitiveFS,
 		UseOverlayfs:    useOverlayfs,
 		UseVFS:          props.EnableVFS && platform.ContainerType(props.WorkloadIsolationType) != platform.FirecrackerContainerType,
+		VFSInputMode:    vfsInputMode,
 	}
 	ws, err := workspace.New(p.env, p.buildRoot, wsOpts)
 	if err != nil {

--- a/enterprise/server/remote_execution/runner/runner_test.go
+++ b/enterprise/server/remote_execution/runner/runner_test.go
@@ -628,7 +628,7 @@ func TestNewRunner_FirecrackerDoesNotConfigureVFSWorkspace(t *testing.T) {
 	}
 	props := &platform.Properties{
 		EnableVFS:             true,
-		PrefetchInputs:        platform.PrefetchInputsAll,
+		VFSPrefetchMode:       platform.VFSPrefetchModeAll,
 		WorkloadIsolationType: string(platform.FirecrackerContainerType),
 	}
 	r, err := p.newRunner(t.Context(), &rnpb.RunnerKey{Platform: &repb.Platform{}}, props, newTask())
@@ -638,7 +638,7 @@ func TestNewRunner_FirecrackerDoesNotConfigureVFSWorkspace(t *testing.T) {
 	})
 
 	require.False(t, r.Workspace.Opts.UseVFS)
-	require.Empty(t, r.Workspace.Opts.PrefetchInputs)
+	require.Empty(t, r.Workspace.Opts.VFSPrefetchMode)
 }
 
 // Returns containers that only consume disk resources when paused (like firecracker).

--- a/enterprise/server/remote_execution/runner/runner_test.go
+++ b/enterprise/server/remote_execution/runner/runner_test.go
@@ -42,6 +42,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rnpb "github.com/buildbuddy-io/buildbuddy/proto/runner"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
 	wkpb "github.com/buildbuddy-io/buildbuddy/proto/worker"
 )
@@ -614,6 +615,30 @@ type providerFunc func(ctx context.Context, args *container.Init) (container.Com
 
 func (f providerFunc) New(ctx context.Context, args *container.Init) (container.CommandContainer, error) {
 	return f(ctx, args)
+}
+
+func TestNewRunner_FirecrackerDoesNotConfigureVFSWorkspace(t *testing.T) {
+	env := newTestEnv(t)
+	p := &pool{
+		env:       env,
+		buildRoot: testfs.MakeTempDir(t),
+		overrideProvider: providerFunc(func(ctx context.Context, args *container.Init) (container.CommandContainer, error) {
+			return bare.NewBareCommandContainer(&bare.Opts{}), nil
+		}),
+	}
+	props := &platform.Properties{
+		EnableVFS:             true,
+		VFSInputMode:          platform.VFSInputModePrefetch,
+		WorkloadIsolationType: string(platform.FirecrackerContainerType),
+	}
+	r, err := p.newRunner(t.Context(), &rnpb.RunnerKey{Platform: &repb.Platform{}}, props, newTask())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, r.Remove(context.Background()))
+	})
+
+	require.False(t, r.Workspace.Opts.UseVFS)
+	require.Empty(t, r.Workspace.Opts.VFSInputMode)
 }
 
 // Returns containers that only consume disk resources when paused (like firecracker).

--- a/enterprise/server/remote_execution/runner/runner_test.go
+++ b/enterprise/server/remote_execution/runner/runner_test.go
@@ -628,7 +628,7 @@ func TestNewRunner_FirecrackerDoesNotConfigureVFSWorkspace(t *testing.T) {
 	}
 	props := &platform.Properties{
 		EnableVFS:             true,
-		VFSInputMode:          platform.VFSInputModePrefetch,
+		PrefetchInputs:        platform.PrefetchInputsAll,
 		WorkloadIsolationType: string(platform.FirecrackerContainerType),
 	}
 	r, err := p.newRunner(t.Context(), &rnpb.RunnerKey{Platform: &repb.Platform{}}, props, newTask())
@@ -638,7 +638,7 @@ func TestNewRunner_FirecrackerDoesNotConfigureVFSWorkspace(t *testing.T) {
 	})
 
 	require.False(t, r.Workspace.Opts.UseVFS)
-	require.Empty(t, r.Workspace.Opts.VFSInputMode)
+	require.Empty(t, r.Workspace.Opts.PrefetchInputs)
 }
 
 // Returns containers that only consume disk resources when paused (like firecracker).

--- a/enterprise/server/remote_execution/workspace/BUILD
+++ b/enterprise/server/remote_execution/workspace/BUILD
@@ -52,6 +52,7 @@ go_test(
     deps = [
         ":workspace",
         "//enterprise/server/remote_execution/container",
+        "//enterprise/server/remote_execution/filecache",
         "//proto:remote_execution_go_proto",
         "//server/remote_cache/cachetools",
         "//server/testutil/testcache",

--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -428,7 +428,7 @@ func (ws *Workspace) AddCLI(ctx context.Context) error {
 		return status.UnimplementedErrorf("CLI binary not embedded")
 	}
 	// Don't add CLI if the workspace is backed by FUSE.
-	if ws.vfs != nil || ws.Opts.VFSInputMode != "" {
+	if ws.vfs != nil {
 		return status.UnimplementedErrorf("AddCLI not supported on VFS")
 	}
 	destPath := path.Join(ws.Path(), ci_runner_util.CLIBinaryName)
@@ -447,7 +447,7 @@ func (ws *Workspace) AddCLI(ctx context.Context) error {
 // already exist.
 func (ws *Workspace) AddCIRunner(ctx context.Context) error {
 	// Don't add CI runner if the workspace is backed by FUSE.
-	if ws.vfs != nil || ws.Opts.VFSInputMode != "" {
+	if ws.vfs != nil {
 		return status.UnimplementedErrorf("AddCIRunner not supported on VFS")
 	}
 	destPath := path.Join(ws.Path(), ci_runner_util.ExecutableName)

--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -99,11 +99,11 @@ type Workspace struct {
 	treeFetcher *dirtools.TreeFetcher
 }
 
-type PrefetchInputsMode string
+type VFSPrefetchMode string
 
 const (
-	PrefetchInputsAll  PrefetchInputsMode = platform.PrefetchInputsAll
-	PrefetchInputsNone PrefetchInputsMode = platform.PrefetchInputsNone
+	VFSPrefetchModeAll  VFSPrefetchMode = platform.VFSPrefetchModeAll
+	VFSPrefetchModeNone VFSPrefetchMode = platform.VFSPrefetchModeNone
 )
 
 type Opts struct {
@@ -120,14 +120,14 @@ type Opts struct {
 	// UseVFS specifies whether the workspace should use a FUSE virtual file
 	// system to serve CAS artifacts and scratch files.
 	UseVFS bool
-	// PrefetchInputs controls whether VFS inputs are prefetched.
-	PrefetchInputs PrefetchInputsMode
+	// VFSPrefetchMode controls whether VFS inputs are prefetched.
+	VFSPrefetchMode VFSPrefetchMode
 }
 
 // New creates a new workspace directly under the given parent directory.
 func New(env environment.Env, parentDir string, opts *Opts) (*Workspace, error) {
-	if opts.PrefetchInputs != "" && opts.PrefetchInputs != PrefetchInputsAll && opts.PrefetchInputs != PrefetchInputsNone {
-		return nil, status.InvalidArgumentErrorf("invalid prefetch inputs mode %q", opts.PrefetchInputs)
+	if opts.VFSPrefetchMode != "" && opts.VFSPrefetchMode != VFSPrefetchModeAll && opts.VFSPrefetchMode != VFSPrefetchModeNone {
+		return nil, status.InvalidArgumentErrorf("invalid VFS prefetch mode %q", opts.VFSPrefetchMode)
 	}
 	dirPerms := fs.FileMode(0777)
 	var rootDir string
@@ -333,9 +333,9 @@ func (ws *Workspace) DownloadInputs(ctx context.Context, layout *container.FileS
 		}
 	}
 
-	prefetchInputs := ws.Opts.PrefetchInputs
-	usesVFS := ws.vfs != nil || prefetchInputs != ""
-	if prefetchInputs == PrefetchInputsNone {
+	vfsPrefetchMode := ws.Opts.VFSPrefetchMode
+	usesVFS := ws.vfs != nil || vfsPrefetchMode != ""
+	if vfsPrefetchMode == VFSPrefetchModeNone {
 		layout.InputFetcher = nil
 		ws.treeFetcher = nil
 		if ws.vfs != nil {
@@ -682,7 +682,7 @@ func (ws *Workspace) TaskFinished() (*dirtools.TransferInfo, error) {
 	tf := ws.treeFetcher
 	ws.mu.Unlock()
 	if tf == nil {
-		if ws.Opts.PrefetchInputs == PrefetchInputsNone {
+		if ws.Opts.VFSPrefetchMode == VFSPrefetchModeNone {
 			return &dirtools.TransferInfo{}, nil
 		}
 		return nil, status.FailedPreconditionError("tree fetcher not set")

--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -99,11 +99,11 @@ type Workspace struct {
 	treeFetcher *dirtools.TreeFetcher
 }
 
-type VFSInputMode string
+type PrefetchInputsMode string
 
 const (
-	VFSInputModePrefetch VFSInputMode = platform.VFSInputModePrefetch
-	VFSInputModeDemand   VFSInputMode = platform.VFSInputModeDemand
+	PrefetchInputsAll  PrefetchInputsMode = platform.PrefetchInputsAll
+	PrefetchInputsNone PrefetchInputsMode = platform.PrefetchInputsNone
 )
 
 type Opts struct {
@@ -120,14 +120,14 @@ type Opts struct {
 	// UseVFS specifies whether the workspace should use a FUSE virtual file
 	// system to serve CAS artifacts and scratch files.
 	UseVFS bool
-	// VFSInputMode controls how inputs are prepared when VFS is enabled.
-	VFSInputMode VFSInputMode
+	// PrefetchInputs controls whether VFS inputs are prefetched.
+	PrefetchInputs PrefetchInputsMode
 }
 
 // New creates a new workspace directly under the given parent directory.
 func New(env environment.Env, parentDir string, opts *Opts) (*Workspace, error) {
-	if opts.VFSInputMode != "" && opts.VFSInputMode != VFSInputModePrefetch && opts.VFSInputMode != VFSInputModeDemand {
-		return nil, status.InvalidArgumentErrorf("invalid VFS input mode %q", opts.VFSInputMode)
+	if opts.PrefetchInputs != "" && opts.PrefetchInputs != PrefetchInputsAll && opts.PrefetchInputs != PrefetchInputsNone {
+		return nil, status.InvalidArgumentErrorf("invalid prefetch inputs mode %q", opts.PrefetchInputs)
 	}
 	dirPerms := fs.FileMode(0777)
 	var rootDir string
@@ -333,9 +333,9 @@ func (ws *Workspace) DownloadInputs(ctx context.Context, layout *container.FileS
 		}
 	}
 
-	inputMode := ws.Opts.VFSInputMode
-	usesVFS := ws.vfs != nil || inputMode != ""
-	if inputMode == VFSInputModeDemand {
+	prefetchInputs := ws.Opts.PrefetchInputs
+	usesVFS := ws.vfs != nil || prefetchInputs != ""
+	if prefetchInputs == PrefetchInputsNone {
 		layout.InputFetcher = nil
 		ws.treeFetcher = nil
 		if ws.vfs != nil {
@@ -682,7 +682,7 @@ func (ws *Workspace) TaskFinished() (*dirtools.TransferInfo, error) {
 	tf := ws.treeFetcher
 	ws.mu.Unlock()
 	if tf == nil {
-		if ws.Opts.VFSInputMode == VFSInputModeDemand {
+		if ws.Opts.PrefetchInputs == PrefetchInputsNone {
 			return &dirtools.TransferInfo{}, nil
 		}
 		return nil, status.FailedPreconditionError("tree fetcher not set")

--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -99,6 +99,13 @@ type Workspace struct {
 	treeFetcher *dirtools.TreeFetcher
 }
 
+type VFSInputMode string
+
+const (
+	VFSInputModePrefetch VFSInputMode = platform.VFSInputModePrefetch
+	VFSInputModeDemand   VFSInputMode = platform.VFSInputModeDemand
+)
+
 type Opts struct {
 	// Preserve specifies whether to preserve all files in the workspace except
 	// for output paths.
@@ -113,10 +120,15 @@ type Opts struct {
 	// UseVFS specifies whether the workspace should use a FUSE virtual file
 	// system to serve CAS artifacts and scratch files.
 	UseVFS bool
+	// VFSInputMode controls how inputs are prepared when VFS is enabled.
+	VFSInputMode VFSInputMode
 }
 
 // New creates a new workspace directly under the given parent directory.
 func New(env environment.Env, parentDir string, opts *Opts) (*Workspace, error) {
+	if opts.VFSInputMode != "" && opts.VFSInputMode != VFSInputModePrefetch && opts.VFSInputMode != VFSInputModeDemand {
+		return nil, status.InvalidArgumentErrorf("invalid VFS input mode %q", opts.VFSInputMode)
+	}
 	dirPerms := fs.FileMode(0777)
 	var rootDir string
 	maxAttempts := 10
@@ -251,12 +263,12 @@ func (ws *Workspace) CreateOutputDirs() error {
 	return ws.dirHelper.CreateOutputDirs()
 }
 
-func (ws *Workspace) prepareVFS(ctx context.Context, layout *container.FileSystemLayout) error {
+func (ws *Workspace) prepareVFS(ctx context.Context, layout *container.FileSystemLayout, inputFetcher container.InputFetcher) error {
 	if ws.vfs == nil {
 		return status.FailedPreconditionError("vfs cannot be null if vfsServer is set")
 	}
 
-	invalidatedInodes, err := ws.vfsServer.Prepare(ctx, layout, ws.treeFetcher)
+	invalidatedInodes, err := ws.vfsServer.Prepare(ctx, layout, inputFetcher)
 	if err != nil {
 		return err
 	}
@@ -321,8 +333,21 @@ func (ws *Workspace) DownloadInputs(ctx context.Context, layout *container.FileS
 		}
 	}
 
+	inputMode := ws.Opts.VFSInputMode
+	usesVFS := ws.vfs != nil || inputMode != ""
+	if inputMode == VFSInputModeDemand {
+		layout.InputFetcher = nil
+		ws.treeFetcher = nil
+		if ws.vfs != nil {
+			if err := ws.prepareVFS(ctx, layout, nil); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
 	opts := &dirtools.DownloadTreeOpts{CaseInsensitive: ws.Opts.CaseInsensitive}
-	if ws.vfs == nil {
+	if !usesVFS {
 		opts.RootDir = ws.inputRoot()
 	}
 	opts.ChunkedInputFiles = slices.Contains(ws.task.GetExperiments(), "executor.download_inputs_chunked")
@@ -336,6 +361,9 @@ func (ws *Workspace) DownloadInputs(ctx context.Context, layout *container.FileS
 		return status.WrapErrorf(err, "could not create tree fetcher")
 	}
 	ws.treeFetcher = tf
+	if usesVFS {
+		layout.InputFetcher = tf
+	}
 
 	// Start fetching inputs.
 	inputsState, err := tf.Start()
@@ -345,9 +373,11 @@ func (ws *Workspace) DownloadInputs(ctx context.Context, layout *container.FileS
 
 	// Inform VFS about the layout of the input tree and give it access to the
 	// running tree fetcher.
-	if ws.vfs != nil {
-		if err := ws.prepareVFS(ctx, layout); err != nil {
-			return err
+	if usesVFS {
+		if ws.vfs != nil {
+			if err := ws.prepareVFS(ctx, layout, tf); err != nil {
+				return err
+			}
 		}
 	} else {
 		// If we're not using FUSE, wait for the input tree to be fully downloaded.
@@ -359,6 +389,10 @@ func (ws *Workspace) DownloadInputs(ctx context.Context, layout *container.FileS
 		span.SetAttributes(attribute.Int64("file_count", txInfo.FileCount))
 		span.SetAttributes(attribute.Int64("bytes_transferred", txInfo.BytesTransferred))
 		log.CtxDebugf(ctx, "DownloadTree linked %d files in %s, downloaded %d bytes in %s [%2.2f MB/sec]", txInfo.LinkCount, txInfo.LinkDuration, txInfo.BytesTransferred, txInfo.TransferDuration, mbps)
+	}
+
+	if usesVFS {
+		return nil
 	}
 
 	// Now that the input tree is setup, remove any unwanted inputs.
@@ -394,7 +428,7 @@ func (ws *Workspace) AddCLI(ctx context.Context) error {
 		return status.UnimplementedErrorf("CLI binary not embedded")
 	}
 	// Don't add CLI if the workspace is backed by FUSE.
-	if ws.vfs != nil {
+	if ws.vfs != nil || ws.Opts.VFSInputMode != "" {
 		return status.UnimplementedErrorf("AddCLI not supported on VFS")
 	}
 	destPath := path.Join(ws.Path(), ci_runner_util.CLIBinaryName)
@@ -413,7 +447,7 @@ func (ws *Workspace) AddCLI(ctx context.Context) error {
 // already exist.
 func (ws *Workspace) AddCIRunner(ctx context.Context) error {
 	// Don't add CI runner if the workspace is backed by FUSE.
-	if ws.vfs != nil {
+	if ws.vfs != nil || ws.Opts.VFSInputMode != "" {
 		return status.UnimplementedErrorf("AddCIRunner not supported on VFS")
 	}
 	destPath := path.Join(ws.Path(), ci_runner_util.ExecutableName)
@@ -648,6 +682,9 @@ func (ws *Workspace) TaskFinished() (*dirtools.TransferInfo, error) {
 	tf := ws.treeFetcher
 	ws.mu.Unlock()
 	if tf == nil {
+		if ws.Opts.VFSInputMode == VFSInputModeDemand {
+			return &dirtools.TransferInfo{}, nil
+		}
 		return nil, status.FailedPreconditionError("tree fetcher not set")
 	}
 	// TODO(vadim): cancel unfinished transfers instead of waiting for them

--- a/enterprise/server/remote_execution/workspace/workspace_test.go
+++ b/enterprise/server/remote_execution/workspace/workspace_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/workspace"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testcache"
@@ -605,4 +606,70 @@ func TestDownloadInputs_WorkingDirectoryNestedMissing(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, status.IsFailedPreconditionError(err), "expected FailedPrecondition, got: %v", err)
 	assert.Contains(t, err.Error(), "a/b")
+}
+
+func TestDownloadInputs_VFSInputModes(t *testing.T) {
+	for _, testCase := range []struct {
+		name             string
+		mode             workspace.VFSInputMode
+		wantInputFetcher bool
+		wantCached       bool
+		wantMaterialized bool
+	}{
+		{
+			name:             "materialized_without_vfs",
+			wantCached:       true,
+			wantMaterialized: true,
+		},
+		{
+			name:             "prefetch",
+			mode:             workspace.VFSInputModePrefetch,
+			wantInputFetcher: true,
+			wantCached:       true,
+		},
+		{
+			name: "demand",
+			mode: workspace.VFSInputModeDemand,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := t.Context()
+			te := testenv.GetTestEnv(t)
+			_, runServer, lis := testenv.RegisterLocalGRPCServer(t, te)
+			testcache.Setup(t, te, lis)
+			go runServer()
+
+			fc, err := filecache.NewFileCache(testfs.MakeTempDir(t), 1e9, false)
+			require.NoError(t, err)
+			fc.WaitForDirectoryScanToComplete()
+			te.SetFileCache(fc)
+
+			inputDigest, err := cachetools.UploadBlob(ctx, te.GetByteStreamClient(), "", repb.DigestFunction_SHA256, strings.NewReader("input"))
+			require.NoError(t, err)
+			inputNode := &repb.FileNode{Name: "input.txt", Digest: inputDigest}
+			layout := &container.FileSystemLayout{
+				DigestFunction: repb.DigestFunction_SHA256,
+				Inputs: &repb.Tree{Root: &repb.Directory{
+					Files: []*repb.FileNode{inputNode},
+				}},
+			}
+
+			ws, err := workspace.New(te, testfs.MakeTempDir(t), &workspace.Opts{VFSInputMode: testCase.mode})
+			require.NoError(t, err)
+			ws.SetTask(ctx, &repb.ExecutionTask{})
+			require.NoError(t, ws.DownloadInputs(ctx, layout))
+			_, err = ws.TaskFinished()
+			require.NoError(t, err)
+
+			require.Equal(t, testCase.wantInputFetcher, layout.InputFetcher != nil)
+			require.Equal(t, testCase.wantCached, fc.ContainsFile(ctx, inputNode))
+			contents, err := os.ReadFile(filepath.Join(ws.Path(), inputNode.GetName()))
+			if testCase.wantMaterialized {
+				require.NoError(t, err)
+				require.Equal(t, "input", string(contents))
+			} else {
+				require.ErrorIs(t, err, os.ErrNotExist)
+			}
+		})
+	}
 }

--- a/enterprise/server/remote_execution/workspace/workspace_test.go
+++ b/enterprise/server/remote_execution/workspace/workspace_test.go
@@ -608,10 +608,10 @@ func TestDownloadInputs_WorkingDirectoryNestedMissing(t *testing.T) {
 	assert.Contains(t, err.Error(), "a/b")
 }
 
-func TestDownloadInputs_VFSInputModes(t *testing.T) {
+func TestDownloadInputs_PrefetchInputs(t *testing.T) {
 	for _, testCase := range []struct {
 		name             string
-		mode             workspace.VFSInputMode
+		mode             workspace.PrefetchInputsMode
 		wantInputFetcher bool
 		wantCached       bool
 		wantMaterialized bool
@@ -622,14 +622,14 @@ func TestDownloadInputs_VFSInputModes(t *testing.T) {
 			wantMaterialized: true,
 		},
 		{
-			name:             "prefetch",
-			mode:             workspace.VFSInputModePrefetch,
+			name:             "all",
+			mode:             workspace.PrefetchInputsAll,
 			wantInputFetcher: true,
 			wantCached:       true,
 		},
 		{
-			name: "demand",
-			mode: workspace.VFSInputModeDemand,
+			name: "none",
+			mode: workspace.PrefetchInputsNone,
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -654,7 +654,7 @@ func TestDownloadInputs_VFSInputModes(t *testing.T) {
 				}},
 			}
 
-			ws, err := workspace.New(te, testfs.MakeTempDir(t), &workspace.Opts{VFSInputMode: testCase.mode})
+			ws, err := workspace.New(te, testfs.MakeTempDir(t), &workspace.Opts{PrefetchInputs: testCase.mode})
 			require.NoError(t, err)
 			ws.SetTask(ctx, &repb.ExecutionTask{})
 			require.NoError(t, ws.DownloadInputs(ctx, layout))

--- a/enterprise/server/remote_execution/workspace/workspace_test.go
+++ b/enterprise/server/remote_execution/workspace/workspace_test.go
@@ -608,10 +608,10 @@ func TestDownloadInputs_WorkingDirectoryNestedMissing(t *testing.T) {
 	assert.Contains(t, err.Error(), "a/b")
 }
 
-func TestDownloadInputs_PrefetchInputs(t *testing.T) {
+func TestDownloadInputs_VFSPrefetchMode(t *testing.T) {
 	for _, testCase := range []struct {
 		name             string
-		mode             workspace.PrefetchInputsMode
+		mode             workspace.VFSPrefetchMode
 		wantInputFetcher bool
 		wantCached       bool
 		wantMaterialized bool
@@ -623,13 +623,13 @@ func TestDownloadInputs_PrefetchInputs(t *testing.T) {
 		},
 		{
 			name:             "all",
-			mode:             workspace.PrefetchInputsAll,
+			mode:             workspace.VFSPrefetchModeAll,
 			wantInputFetcher: true,
 			wantCached:       true,
 		},
 		{
 			name: "none",
-			mode: workspace.PrefetchInputsNone,
+			mode: workspace.VFSPrefetchModeNone,
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -654,7 +654,7 @@ func TestDownloadInputs_PrefetchInputs(t *testing.T) {
 				}},
 			}
 
-			ws, err := workspace.New(te, testfs.MakeTempDir(t), &workspace.Opts{PrefetchInputs: testCase.mode})
+			ws, err := workspace.New(te, testfs.MakeTempDir(t), &workspace.Opts{VFSPrefetchMode: testCase.mode})
 			require.NoError(t, err)
 			ws.SetTask(ctx, &repb.ExecutionTask{})
 			require.NoError(t, ws.DownloadInputs(ctx, layout))

--- a/enterprise/server/util/vfs_server/BUILD
+++ b/enterprise/server/util/vfs_server/BUILD
@@ -19,7 +19,6 @@ go_library(
             "//enterprise/server/util/vfscommon",
             "//proto:remote_execution_go_proto",
             "//proto:vfs_go_proto",
-            "//server/cache/dirtools",
             "//server/environment",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
@@ -52,7 +51,6 @@ go_library(
             "//enterprise/server/util/vfscommon",
             "//proto:remote_execution_go_proto",
             "//proto:vfs_go_proto",
-            "//server/cache/dirtools",
             "//server/environment",
         ],
         "//conditions:default": [],

--- a/enterprise/server/util/vfs_server/BUILD
+++ b/enterprise/server/util/vfs_server/BUILD
@@ -74,6 +74,7 @@ go_test(
         "//proto:vfs_go_proto",
         "//server/cache/dirtools",
         "//server/environment",
+        "//server/interfaces",
         "//server/remote_cache/byte_stream_server",
         "//server/remote_cache/content_addressable_storage_server",
         "//server/remote_cache/digest",

--- a/enterprise/server/util/vfs_server/vfs_server.go
+++ b/enterprise/server/util/vfs_server/vfs_server.go
@@ -996,6 +996,13 @@ func (p *Server) openCASFile(ctx context.Context, node *fsNode) (*os.File, error
 	if err := inputFetcher.Fetch(ctx, node.fileNode); err != nil {
 		return nil, err
 	}
+	f, err := p.env.GetFileCache().Open(ctx, node.fileNode)
+	if err == nil {
+		return f, nil
+	}
+	if err := inputFetcher.Fetch(ctx, node.fileNode); err != nil {
+		return nil, err
+	}
 	return p.env.GetFileCache().Open(ctx, node.fileNode)
 }
 

--- a/enterprise/server/util/vfs_server/vfs_server.go
+++ b/enterprise/server/util/vfs_server/vfs_server.go
@@ -378,7 +378,7 @@ type Server struct {
 	nodes              map[uint64]*fsNode
 	internalTaskCtx    context.Context
 	root               *fsNode
-	treeFetcher        *dirtools.TreeFetcher
+	inputFetcher       container.InputFetcher
 	remoteInstanceName string
 	fileHandles        map[uint64]*fileHandle
 
@@ -603,13 +603,17 @@ func (p *Server) ComputeStats() *repb.VfsStats {
 		}
 	}
 	walkNode(p.root)
+	inputFetcher := p.inputFetcher
 	p.mu.Unlock()
+	if statsProvider, ok := inputFetcher.(interface{ UpdateIOStats(*repb.VfsStats) }); ok {
+		statsProvider.UpdateIOStats(stats)
+	}
 
 	return stats
 }
 
 // Prepare is used to inform the VFS server about files that can be lazily loaded on the first open attempt.
-func (p *Server) Prepare(ctx context.Context, layout *container.FileSystemLayout, treeFetcher *dirtools.TreeFetcher) (*vfscommon.InodeInvalidations, error) {
+func (p *Server) Prepare(ctx context.Context, layout *container.FileSystemLayout, inputFetcher container.InputFetcher) (*vfscommon.InodeInvalidations, error) {
 	p.mu.Lock()
 	p.casFileCount = 0
 	p.casFileSizeBytes = 0
@@ -624,7 +628,10 @@ func (p *Server) Prepare(ctx context.Context, layout *container.FileSystemLayout
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.treeFetcher = treeFetcher
+	if inputFetcher == nil {
+		inputFetcher = newCASFetcher(p.env, layout.RemoteInstanceName, layout.DigestFunction)
+	}
+	p.inputFetcher = inputFetcher
 	p.internalTaskCtx = ctx
 	return invalidatedInodes, nil
 }
@@ -892,7 +899,6 @@ type casFetcher struct {
 	fetchStart        time.Time
 	fetchesInProgress int
 
-	fileCacheHits     int
 	downloadCount     int
 	downloadDuration  time.Duration
 	downloadSizeBytes int64
@@ -906,11 +912,11 @@ func newCASFetcher(env environment.Env, remoteInstanceName string, digestFunctio
 	}
 }
 
-func (cf *casFetcher) downloadToFileCache(ctx context.Context, node *fsNode) error {
+func (cf *casFetcher) downloadToFileCache(ctx context.Context, node *repb.FileNode) error {
 	bsClient := cf.env.GetByteStreamClient()
-	rn := digest.NewCASResourceName(node.fileNode.GetDigest(), cf.remoteInstanceName, cf.digestFunction)
+	rn := digest.NewCASResourceName(node.GetDigest(), cf.remoteInstanceName, cf.digestFunction)
 	rn.SetCompressor(repb.Compressor_ZSTD)
-	w, err := cf.env.GetFileCache().Writer(ctx, node.fileNode, cf.digestFunction)
+	w, err := cf.env.GetFileCache().Writer(ctx, node, cf.digestFunction)
 	if err != nil {
 		return err
 	}
@@ -927,7 +933,7 @@ func (cf *casFetcher) downloadToFileCache(ctx context.Context, node *fsNode) err
 	return nil
 }
 
-func (cf *casFetcher) dedupeDownloadToFileCache(ctx context.Context, node *fsNode) error {
+func (cf *casFetcher) dedupeDownloadToFileCache(ctx context.Context, node *repb.FileNode) error {
 	cf.mu.Lock()
 	cf.fetchesInProgress++
 	// Don't include concurrent downloads in total fetch time.
@@ -947,35 +953,29 @@ func (cf *casFetcher) dedupeDownloadToFileCache(ctx context.Context, node *fsNod
 		cf.mu.Unlock()
 	}()
 
-	dedupeKey := groupIDStringFromContext(ctx) + "-" + node.fileNode.GetDigest().GetHash()
+	dedupeKey := groupIDStringFromContext(ctx) + "-" + node.GetDigest().GetHash()
 	_, _, err := downloadDeduper.Do(ctx, dedupeKey, func(ctx context.Context) (struct{}, error) {
 		return struct{}{}, cf.downloadToFileCache(ctx, node)
 	})
 	return err
 }
 
-func (cf *casFetcher) Open(ctx context.Context, node *fsNode) (*os.File, error) {
-	// If we can open the file directly from the file cache then use that.
-	if f, err := cf.env.GetFileCache().Open(ctx, node.fileNode); err == nil {
-		cf.mu.Lock()
-		cf.fileCacheHits++
-		cf.mu.Unlock()
-		return f, nil
+func (cf *casFetcher) Fetch(ctx context.Context, node *repb.FileNode) error {
+	if cf.env.GetFileCache().ContainsFile(ctx, node) {
+		return nil
 	}
 
 	if err := cf.dedupeDownloadToFileCache(ctx, node); err != nil {
-		return nil, err
+		return err
 	}
 
 	cf.mu.Lock()
 	// N.B. in case of deduping, the download will be counted in the stats of
 	// all deduped actions.
 	cf.downloadCount++
-	cf.downloadSizeBytes += node.fileNode.GetDigest().GetSizeBytes()
+	cf.downloadSizeBytes += node.GetDigest().GetSizeBytes()
 	cf.mu.Unlock()
-
-	// CAS downloads put the CAS artifacts directly into the file cache.
-	return cf.env.GetFileCache().Open(ctx, node.fileNode)
+	return nil
 }
 
 func (cf *casFetcher) UpdateIOStats(stats *repb.VfsStats) {
@@ -984,6 +984,19 @@ func (cf *casFetcher) UpdateIOStats(stats *repb.VfsStats) {
 	stats.FileDownloadSizeBytes = cf.downloadSizeBytes
 	stats.FileDownloadCount = int64(cf.downloadCount)
 	stats.FileDownloadDurationUsec = cf.downloadDuration.Microseconds()
+}
+
+func (p *Server) openCASFile(ctx context.Context, node *fsNode) (*os.File, error) {
+	p.mu.Lock()
+	inputFetcher := p.inputFetcher
+	p.mu.Unlock()
+	if inputFetcher == nil {
+		return nil, status.FailedPreconditionError("no input fetcher is configured")
+	}
+	if err := inputFetcher.Fetch(ctx, node.fileNode); err != nil {
+		return nil, err
+	}
+	return p.env.GetFileCache().Open(ctx, node.fileNode)
 }
 
 func (p *Server) Mknod(ctx context.Context, request *vfspb.MknodRequest) (*vfspb.MknodResponse, error) {
@@ -1080,21 +1093,9 @@ func (p *Server) Open(ctx context.Context, request *vfspb.OpenRequest) (*vfspb.O
 		}
 		openedFile = f
 	} else if node.fileNode != nil {
-		p.mu.Lock()
-		tf := p.treeFetcher
-		p.mu.Unlock()
-		if tf == nil {
-			log.CtxWarningf(p.taskCtx(), "Open %d could not open file because tree fetcher is not set", request.GetId())
-			return nil, syscallErrStatus(syscall.EIO)
-		}
-		err = tf.Fetch(p.taskCtx(), node.fileNode)
+		f, err := p.openCASFile(p.taskCtx(), node)
 		if err != nil {
-			log.CtxWarningf(p.taskCtx(), "Open %q could not fetch file from cache: %s", node.Path(), err)
-			return nil, err
-		}
-		f, err := p.env.GetFileCache().Open(p.taskCtx(), node.fileNode)
-		if err != nil {
-			log.CtxWarningf(p.taskCtx(), "Open %q could not open file from file cache: %s", node.Path(), err)
+			log.CtxWarningf(p.taskCtx(), "Open %q could not fetch file from CAS: %s", node.Path(), err)
 			return nil, err
 		}
 		openedFile = f

--- a/enterprise/server/util/vfs_server/vfs_server_test.go
+++ b/enterprise/server/util/vfs_server/vfs_server_test.go
@@ -3,7 +3,9 @@ package vfs_server_test
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"runtime"
+	"sync"
 	"syscall"
 	"testing"
 
@@ -13,6 +15,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/vfscommon"
 	"github.com/buildbuddy-io/buildbuddy/server/cache/dirtools"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/byte_stream_server"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/content_addressable_storage_server"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
@@ -178,6 +181,21 @@ func prepare(t *testing.T, env environment.Env, server *vfs_server.Server, tree 
 	require.NoError(t, err)
 }
 
+type evictingFileCache struct {
+	interfaces.FileCache
+	once sync.Once
+}
+
+func (fc *evictingFileCache) ContainsFile(ctx context.Context, node *repb.FileNode) bool {
+	contains := fc.FileCache.ContainsFile(ctx, node)
+	if contains {
+		fc.once.Do(func() {
+			fc.FileCache.DeleteFile(ctx, node)
+		})
+	}
+	return contains
+}
+
 func TestCASFileFetchedOnDemand(t *testing.T) {
 	ctx, env, server, _ := newServerWithEnv(t)
 	d := setFile(t, env, ctx, "", "only fetched after open")
@@ -199,6 +217,28 @@ func TestCASFileFetchedOnDemand(t *testing.T) {
 	require.EqualValues(t, 1, stats.GetCasFilesAccessedCount())
 	require.EqualValues(t, 1, stats.GetFileDownloadCount())
 	require.Equal(t, d.GetSizeBytes(), stats.GetFileDownloadSizeBytes())
+}
+
+func TestCASFileRefetchedIfEvictedBeforeOpen(t *testing.T) {
+	ctx, env, server, _ := newServerWithEnv(t)
+	contents := "refetched after eviction"
+	d := setFile(t, env, ctx, "", contents)
+	fileNode := &repb.FileNode{Name: "input.txt", Digest: d}
+
+	tmpPath := filepath.Join(testfs.MakeTempDir(t), "input.txt")
+	require.NoError(t, os.WriteFile(tmpPath, []byte(contents), 0644))
+	require.NoError(t, env.GetFileCache().AddFile(ctx, fileNode, tmpPath))
+	env.SetFileCache(&evictingFileCache{FileCache: env.GetFileCache()})
+
+	_, err := server.Prepare(ctx, &container.FileSystemLayout{
+		DigestFunction: repb.DigestFunction_SHA256,
+		Inputs: &repb.Tree{Root: &repb.Directory{
+			Files: []*repb.FileNode{fileNode},
+		}},
+	}, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, contents, readFromVFS(t, server, "input.txt"))
 }
 
 func TestGetLayout(t *testing.T) {

--- a/enterprise/server/util/vfs_server/vfs_server_test.go
+++ b/enterprise/server/util/vfs_server/vfs_server_test.go
@@ -178,6 +178,29 @@ func prepare(t *testing.T, env environment.Env, server *vfs_server.Server, tree 
 	require.NoError(t, err)
 }
 
+func TestCASFileFetchedOnDemand(t *testing.T) {
+	ctx, env, server, _ := newServerWithEnv(t)
+	d := setFile(t, env, ctx, "", "only fetched after open")
+	fileNode := &repb.FileNode{Name: "input.txt", Digest: d}
+	layout := &container.FileSystemLayout{
+		DigestFunction: repb.DigestFunction_SHA256,
+		Inputs: &repb.Tree{Root: &repb.Directory{
+			Files: []*repb.FileNode{fileNode},
+		}},
+	}
+
+	_, err := server.Prepare(ctx, layout, nil)
+	require.NoError(t, err)
+	require.False(t, env.GetFileCache().ContainsFile(ctx, fileNode))
+
+	require.Equal(t, "only fetched after open", readFromVFS(t, server, "input.txt"))
+	require.True(t, env.GetFileCache().ContainsFile(ctx, fileNode))
+	stats := server.ComputeStats()
+	require.EqualValues(t, 1, stats.GetCasFilesAccessedCount())
+	require.EqualValues(t, 1, stats.GetFileDownloadCount())
+	require.Equal(t, d.GetSizeBytes(), stats.GetFileDownloadSizeBytes())
+}
+
 func TestGetLayout(t *testing.T) {
 	server, env := newServer(t)
 	ctx := context.Background()

--- a/enterprise/server/util/vfs_server/vfs_server_unsupported.go
+++ b/enterprise/server/util/vfs_server/vfs_server_unsupported.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/vfscommon"
-	"github.com/buildbuddy-io/buildbuddy/server/cache/dirtools"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -26,7 +25,7 @@ func New(env environment.Env, workspacePath string) (*Server, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (p *Server) Prepare(ctx context.Context, layout *container.FileSystemLayout, treeFetcher *dirtools.TreeFetcher) (*vfscommon.InodeInvalidations, error) {
+func (p *Server) Prepare(ctx context.Context, layout *container.FileSystemLayout, inputFetcher container.InputFetcher) (*vfscommon.InodeInvalidations, error) {
 	return nil, fmt.Errorf("Prepare not implemented")
 }
 

--- a/server/util/platform/platform.go
+++ b/server/util/platform/platform.go
@@ -89,7 +89,7 @@ const (
 	persistentWorkerProtocolPropertyName     = "persistentWorkerProtocol"
 	WorkflowIDPropertyName                   = "workflow-id"
 	WorkloadIsolationPropertyName            = "workload-isolation-type"
-	VFSInputModePropertyName                 = "vfs-input-mode"
+	PrefetchInputsPropertyName               = "prefetch-inputs"
 	initDockerdPropertyName                  = "init-dockerd"
 	enableDockerdTCPPropertyName             = "enable-dockerd-tcp"
 	enableVFSPropertyName                    = "enable-vfs"
@@ -188,8 +188,8 @@ const (
 )
 
 const (
-	VFSInputModePrefetch = "prefetch"
-	VFSInputModeDemand   = "demand"
+	PrefetchInputsAll  = "all"
+	PrefetchInputsNone = "none"
 )
 
 // KnownContainerTypes are all the types that are currently supported, or were
@@ -285,7 +285,7 @@ type Properties struct {
 	TransientErrorExitCodes []int
 
 	EnableVFS      bool
-	VFSInputMode   string
+	PrefetchInputs string
 	IncludeSecrets bool
 	// EnvSecrets is a list of specific secret names to inject as env vars.
 	// Takes precedence over IncludeSecrets for targeted injection.
@@ -453,11 +453,11 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 	isolationType := stringProp(m, WorkloadIsolationPropertyName, "")
 
 	vfsEnabled := boolProp(m, enableVFSPropertyName, false)
-	vfsInputMode := stringProp(m, VFSInputModePropertyName, VFSInputModePrefetch)
-	switch vfsInputMode {
-	case VFSInputModePrefetch, VFSInputModeDemand:
+	prefetchInputs := stringProp(m, PrefetchInputsPropertyName, PrefetchInputsAll)
+	switch prefetchInputs {
+	case PrefetchInputsAll, PrefetchInputsNone:
 	default:
-		return nil, status.InvalidArgumentErrorf("%s is not a valid value for the %q platform property", vfsInputMode, VFSInputModePropertyName)
+		return nil, status.InvalidArgumentErrorf("%s is not a valid value for the %q platform property", prefetchInputs, PrefetchInputsPropertyName)
 	}
 	// Runner recycling is not yet supported in combination with VFS workspaces.
 	// Firecracker VFS performance is not good enough yet to be enabled.
@@ -588,7 +588,7 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 		TerminationGracePeriod:    terminationGracePeriod,
 		RunnerRecyclingMaxWait:    runnerRecyclingMaxWait,
 		EnableVFS:                 vfsEnabled,
-		VFSInputMode:              vfsInputMode,
+		PrefetchInputs:            prefetchInputs,
 		IncludeSecrets:            boolProp(m, IncludeSecretsPropertyName, false),
 		EnvSecrets:                stringListProp(m, EnvSecretsPropertyName),
 		PreserveWorkspace:         boolProp(m, PreserveWorkspacePropertyName, false),

--- a/server/util/platform/platform.go
+++ b/server/util/platform/platform.go
@@ -89,7 +89,7 @@ const (
 	persistentWorkerProtocolPropertyName     = "persistentWorkerProtocol"
 	WorkflowIDPropertyName                   = "workflow-id"
 	WorkloadIsolationPropertyName            = "workload-isolation-type"
-	PrefetchInputsPropertyName               = "prefetch-inputs"
+	VFSPrefetchModePropertyName              = "vfs-prefetch-mode"
 	initDockerdPropertyName                  = "init-dockerd"
 	enableDockerdTCPPropertyName             = "enable-dockerd-tcp"
 	enableVFSPropertyName                    = "enable-vfs"
@@ -188,8 +188,8 @@ const (
 )
 
 const (
-	PrefetchInputsAll  = "all"
-	PrefetchInputsNone = "none"
+	VFSPrefetchModeAll  = "all"
+	VFSPrefetchModeNone = "none"
 )
 
 // KnownContainerTypes are all the types that are currently supported, or were
@@ -284,9 +284,9 @@ type Properties struct {
 	// they can be retried automatically by the client.
 	TransientErrorExitCodes []int
 
-	EnableVFS      bool
-	PrefetchInputs string
-	IncludeSecrets bool
+	EnableVFS       bool
+	VFSPrefetchMode string
+	IncludeSecrets  bool
 	// EnvSecrets is a list of specific secret names to inject as env vars.
 	// Takes precedence over IncludeSecrets for targeted injection.
 	EnvSecrets []string
@@ -453,11 +453,11 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 	isolationType := stringProp(m, WorkloadIsolationPropertyName, "")
 
 	vfsEnabled := boolProp(m, enableVFSPropertyName, false)
-	prefetchInputs := stringProp(m, PrefetchInputsPropertyName, PrefetchInputsAll)
-	switch prefetchInputs {
-	case PrefetchInputsAll, PrefetchInputsNone:
+	vfsPrefetchMode := stringProp(m, VFSPrefetchModePropertyName, VFSPrefetchModeAll)
+	switch vfsPrefetchMode {
+	case VFSPrefetchModeAll, VFSPrefetchModeNone:
 	default:
-		return nil, status.InvalidArgumentErrorf("%s is not a valid value for the %q platform property", prefetchInputs, PrefetchInputsPropertyName)
+		return nil, status.InvalidArgumentErrorf("%s is not a valid value for the %q platform property", vfsPrefetchMode, VFSPrefetchModePropertyName)
 	}
 	// Runner recycling is not yet supported in combination with VFS workspaces.
 	// Firecracker VFS performance is not good enough yet to be enabled.
@@ -588,7 +588,7 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 		TerminationGracePeriod:    terminationGracePeriod,
 		RunnerRecyclingMaxWait:    runnerRecyclingMaxWait,
 		EnableVFS:                 vfsEnabled,
-		PrefetchInputs:            prefetchInputs,
+		VFSPrefetchMode:           vfsPrefetchMode,
 		IncludeSecrets:            boolProp(m, IncludeSecretsPropertyName, false),
 		EnvSecrets:                stringListProp(m, EnvSecretsPropertyName),
 		PreserveWorkspace:         boolProp(m, PreserveWorkspacePropertyName, false),

--- a/server/util/platform/platform.go
+++ b/server/util/platform/platform.go
@@ -89,6 +89,7 @@ const (
 	persistentWorkerProtocolPropertyName     = "persistentWorkerProtocol"
 	WorkflowIDPropertyName                   = "workflow-id"
 	WorkloadIsolationPropertyName            = "workload-isolation-type"
+	VFSInputModePropertyName                 = "vfs-input-mode"
 	initDockerdPropertyName                  = "init-dockerd"
 	enableDockerdTCPPropertyName             = "enable-dockerd-tcp"
 	enableVFSPropertyName                    = "enable-vfs"
@@ -186,6 +187,11 @@ const (
 // If you add a container type, also add it to KnownContainerTypes
 )
 
+const (
+	VFSInputModePrefetch = "prefetch"
+	VFSInputModeDemand   = "demand"
+)
+
 // KnownContainerTypes are all the types that are currently supported, or were
 // previously supported.
 var KnownContainerTypes []ContainerType = []ContainerType{BareContainerType, PodmanContainerType, DockerContainerType, FirecrackerContainerType, OCIContainerType, SandboxContainerType}
@@ -279,6 +285,7 @@ type Properties struct {
 	TransientErrorExitCodes []int
 
 	EnableVFS      bool
+	VFSInputMode   string
 	IncludeSecrets bool
 	// EnvSecrets is a list of specific secret names to inject as env vars.
 	// Takes precedence over IncludeSecrets for targeted injection.
@@ -446,6 +453,12 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 	isolationType := stringProp(m, WorkloadIsolationPropertyName, "")
 
 	vfsEnabled := boolProp(m, enableVFSPropertyName, false)
+	vfsInputMode := stringProp(m, VFSInputModePropertyName, VFSInputModePrefetch)
+	switch vfsInputMode {
+	case VFSInputModePrefetch, VFSInputModeDemand:
+	default:
+		return nil, status.InvalidArgumentErrorf("%s is not a valid value for the %q platform property", vfsInputMode, VFSInputModePropertyName)
+	}
 	// Runner recycling is not yet supported in combination with VFS workspaces.
 	// Firecracker VFS performance is not good enough yet to be enabled.
 	if ContainerType(isolationType) == FirecrackerContainerType {
@@ -575,6 +588,7 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 		TerminationGracePeriod:    terminationGracePeriod,
 		RunnerRecyclingMaxWait:    runnerRecyclingMaxWait,
 		EnableVFS:                 vfsEnabled,
+		VFSInputMode:              vfsInputMode,
 		IncludeSecrets:            boolProp(m, IncludeSecretsPropertyName, false),
 		EnvSecrets:                stringListProp(m, EnvSecretsPropertyName),
 		PreserveWorkspace:         boolProp(m, PreserveWorkspacePropertyName, false),

--- a/server/util/platform/platform_test.go
+++ b/server/util/platform/platform_test.go
@@ -67,6 +67,57 @@ func TestParse_Arch(t *testing.T) {
 	assert.Equal(t, "amd64", platformProps.Arch)
 }
 
+func TestParse_VFSInputMode(t *testing.T) {
+	for _, testCase := range []struct {
+		name          string
+		value         string
+		expectedValue string
+		wantError     bool
+	}{
+		{
+			name:          "default",
+			expectedValue: VFSInputModePrefetch,
+		},
+		{
+			name:      "materialize",
+			value:     "materialize",
+			wantError: true,
+		},
+		{
+			name:          "prefetch",
+			value:         VFSInputModePrefetch,
+			expectedValue: VFSInputModePrefetch,
+		},
+		{
+			name:          "demand",
+			value:         VFSInputModeDemand,
+			expectedValue: VFSInputModeDemand,
+		},
+		{
+			name:      "invalid",
+			value:     "invalid",
+			wantError: true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			platformProto := &repb.Platform{}
+			if testCase.value != "" {
+				platformProto.Properties = append(platformProto.Properties, &repb.Platform_Property{
+					Name:  VFSInputModePropertyName,
+					Value: testCase.value,
+				})
+			}
+			properties, err := ParseProperties(&repb.ExecutionTask{Command: &repb.Command{Platform: platformProto}})
+			if testCase.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, testCase.expectedValue, properties.VFSInputMode)
+		})
+	}
+}
+
 func TestParse_Pool(t *testing.T) {
 	for _, testCase := range []struct {
 		rawValue      string

--- a/server/util/platform/platform_test.go
+++ b/server/util/platform/platform_test.go
@@ -67,7 +67,7 @@ func TestParse_Arch(t *testing.T) {
 	assert.Equal(t, "amd64", platformProps.Arch)
 }
 
-func TestParse_VFSInputMode(t *testing.T) {
+func TestParse_PrefetchInputs(t *testing.T) {
 	for _, testCase := range []struct {
 		name          string
 		value         string
@@ -76,22 +76,22 @@ func TestParse_VFSInputMode(t *testing.T) {
 	}{
 		{
 			name:          "default",
-			expectedValue: VFSInputModePrefetch,
+			expectedValue: PrefetchInputsAll,
 		},
 		{
-			name:      "materialize",
-			value:     "materialize",
+			name:      "prefetch",
+			value:     "prefetch",
 			wantError: true,
 		},
 		{
-			name:          "prefetch",
-			value:         VFSInputModePrefetch,
-			expectedValue: VFSInputModePrefetch,
+			name:          "all",
+			value:         PrefetchInputsAll,
+			expectedValue: PrefetchInputsAll,
 		},
 		{
-			name:          "demand",
-			value:         VFSInputModeDemand,
-			expectedValue: VFSInputModeDemand,
+			name:          "none",
+			value:         PrefetchInputsNone,
+			expectedValue: PrefetchInputsNone,
 		},
 		{
 			name:      "invalid",
@@ -103,7 +103,7 @@ func TestParse_VFSInputMode(t *testing.T) {
 			platformProto := &repb.Platform{}
 			if testCase.value != "" {
 				platformProto.Properties = append(platformProto.Properties, &repb.Platform_Property{
-					Name:  VFSInputModePropertyName,
+					Name:  PrefetchInputsPropertyName,
 					Value: testCase.value,
 				})
 			}
@@ -113,7 +113,7 @@ func TestParse_VFSInputMode(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, testCase.expectedValue, properties.VFSInputMode)
+			require.Equal(t, testCase.expectedValue, properties.PrefetchInputs)
 		})
 	}
 }

--- a/server/util/platform/platform_test.go
+++ b/server/util/platform/platform_test.go
@@ -67,7 +67,7 @@ func TestParse_Arch(t *testing.T) {
 	assert.Equal(t, "amd64", platformProps.Arch)
 }
 
-func TestParse_PrefetchInputs(t *testing.T) {
+func TestParse_VFSPrefetchMode(t *testing.T) {
 	for _, testCase := range []struct {
 		name          string
 		value         string
@@ -76,7 +76,7 @@ func TestParse_PrefetchInputs(t *testing.T) {
 	}{
 		{
 			name:          "default",
-			expectedValue: PrefetchInputsAll,
+			expectedValue: VFSPrefetchModeAll,
 		},
 		{
 			name:      "prefetch",
@@ -85,13 +85,13 @@ func TestParse_PrefetchInputs(t *testing.T) {
 		},
 		{
 			name:          "all",
-			value:         PrefetchInputsAll,
-			expectedValue: PrefetchInputsAll,
+			value:         VFSPrefetchModeAll,
+			expectedValue: VFSPrefetchModeAll,
 		},
 		{
 			name:          "none",
-			value:         PrefetchInputsNone,
-			expectedValue: PrefetchInputsNone,
+			value:         VFSPrefetchModeNone,
+			expectedValue: VFSPrefetchModeNone,
 		},
 		{
 			name:      "invalid",
@@ -103,7 +103,7 @@ func TestParse_PrefetchInputs(t *testing.T) {
 			platformProto := &repb.Platform{}
 			if testCase.value != "" {
 				platformProto.Properties = append(platformProto.Properties, &repb.Platform_Property{
-					Name:  PrefetchInputsPropertyName,
+					Name:  VFSPrefetchModePropertyName,
 					Value: testCase.value,
 				})
 			}
@@ -113,7 +113,7 @@ func TestParse_PrefetchInputs(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, testCase.expectedValue, properties.PrefetchInputs)
+			require.Equal(t, testCase.expectedValue, properties.VFSPrefetchMode)
 		})
 	}
 }


### PR DESCRIPTION
Add a platform property `vfs-input-mode` that can be set to either `prefetch` or `demand`. This allows for demand based file loading in the VFS (which I plan to use in firecracker in a subsequent CL).