### PR TITLE
ociruntime: make seccomp_additional_syscalls override default deny rules

### DIFF
--- a/enterprise/server/remote_execution/containers/ociruntime/seccomp/seccomp.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/seccomp/seccomp.go
@@ -1,10 +1,11 @@
 package seccomp
 
 import (
-	_ "embed"
 	"encoding/json"
 	"fmt"
 	"slices"
+
+	_ "embed"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -14,21 +15,40 @@ var defaultProfileJSON []byte
 
 // New constructs a seccomp profile from the embedded default and appends an
 // allow rule for any additional syscalls configured by the executor operator.
+// The configured names are removed from the default rules so that the appended
+// allow rule is the only rule matching them.
 func New(additionalSyscalls []string) (*specs.LinuxSeccomp, error) {
 	profile := &specs.LinuxSeccomp{}
 	if err := json.Unmarshal(defaultProfileJSON, profile); err != nil {
 		return nil, fmt.Errorf("parse seccomp profile: %w", err)
 	}
-
-	if len(additionalSyscalls) > 0 {
-		names := slices.Clone(additionalSyscalls)
-		slices.Sort(names)
-		names = slices.Compact(names)
-		profile.Syscalls = append(profile.Syscalls, specs.LinuxSyscall{
-			Names:  names,
-			Action: specs.ActAllow,
-		})
+	if len(additionalSyscalls) == 0 {
+		return profile, nil
 	}
 
+	names := slices.Clone(additionalSyscalls)
+	slices.Sort(names)
+	names = slices.Compact(names)
+
+	// Remove the configured names from the default rules. Runtimes resolve
+	// conflicting rules for the same syscall in unspecified ways, so leaving a
+	// default rule in place would make the outcome unpredictable. In
+	// particular, crun keeps whichever rule for a syscall comes first, which
+	// would make a default deny rule silently win over the appended allow
+	// rule.
+	for i := range profile.Syscalls {
+		rule := &profile.Syscalls[i]
+		rule.Names = slices.DeleteFunc(rule.Names, func(name string) bool {
+			return slices.Contains(names, name)
+		})
+	}
+	profile.Syscalls = slices.DeleteFunc(profile.Syscalls, func(rule specs.LinuxSyscall) bool {
+		return len(rule.Names) == 0
+	})
+
+	profile.Syscalls = append(profile.Syscalls, specs.LinuxSyscall{
+		Names:  names,
+		Action: specs.ActAllow,
+	})
 	return profile, nil
 }

--- a/enterprise/server/remote_execution/containers/ociruntime/seccomp/seccomp_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/seccomp/seccomp_test.go
@@ -60,9 +60,10 @@ func TestNew_AdditionalSyscalls(t *testing.T) {
 
 func TestNew_AdditionalSyscallsOverrideDefaultDenyRules(t *testing.T) {
 	// The default profile has deny rules covering userfaultfd and setns.
-	// (setns appears in both an allow rule and a deny rule because the
-	// cap-based conditions on those rules are dropped when parsing the JSON
-	// into specs.LinuxSeccomp.)
+	// userfaultfd's only matching rule is a deny. setns appears in three
+	// rules: the default allow list, then a cap-conditional allow and a
+	// cap-conditional deny whose conditions are dropped when parsing the JSON
+	// into specs.LinuxSeccomp.
 	defaultProfile, err := New(nil)
 	require.NoError(t, err)
 	for _, name := range []string{"userfaultfd", "setns"} {
@@ -76,10 +77,11 @@ func TestNew_AdditionalSyscallsOverrideDefaultDenyRules(t *testing.T) {
 	}
 
 	// Allow both syscalls. Expect the appended allow rule to become the only
-	// rule matching them. Keeping the default deny rules alongside the allow
-	// rule would leave the outcome to runtime-specific conflict resolution.
-	// crun keeps whichever rule for a syscall comes first, which makes the
-	// default deny rule win.
+	// rule matching them. Keeping the default rules in place would leave the
+	// outcome to runtime-specific conflict resolution. crun keeps whichever
+	// rule for a syscall comes first, so userfaultfd would stay denied.
+	// setns exercises removing a name that appears in several rules,
+	// including allow rules that precede its deny rule.
 	profile, err := New([]string{"userfaultfd", "setns"})
 	require.NoError(t, err)
 	for _, name := range []string{"userfaultfd", "setns"} {

--- a/enterprise/server/remote_execution/containers/ociruntime/seccomp/seccomp_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/seccomp/seccomp_test.go
@@ -2,12 +2,14 @@ package seccomp
 
 import (
 	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func TestNew_Default(t *testing.T) {
@@ -54,4 +56,52 @@ func TestNew_AdditionalSyscalls(t *testing.T) {
 		"io_uring_register",
 		"io_uring_setup",
 	}, additionalSyscalls)
+}
+
+func TestNew_AdditionalSyscallsOverrideDefaultDenyRules(t *testing.T) {
+	// The default profile has deny rules covering userfaultfd and setns.
+	// (setns appears in both an allow rule and a deny rule because the
+	// cap-based conditions on those rules are dropped when parsing the JSON
+	// into specs.LinuxSeccomp.)
+	defaultProfile, err := New(nil)
+	require.NoError(t, err)
+	for _, name := range []string{"userfaultfd", "setns"} {
+		denyRules := 0
+		for _, rule := range defaultProfile.Syscalls {
+			if slices.Contains(rule.Names, name) && rule.Action == specs.ActErrno {
+				denyRules++
+			}
+		}
+		require.GreaterOrEqual(t, denyRules, 1, "expected a default deny rule for %q", name)
+	}
+
+	// Allow both syscalls. Expect the appended allow rule to become the only
+	// rule matching them. Keeping the default deny rules alongside the allow
+	// rule would leave the outcome to runtime-specific conflict resolution.
+	// crun keeps whichever rule for a syscall comes first, which makes the
+	// default deny rule win.
+	profile, err := New([]string{"userfaultfd", "setns"})
+	require.NoError(t, err)
+	for _, name := range []string{"userfaultfd", "setns"} {
+		var matchingRules []specs.LinuxSyscall
+		for _, rule := range profile.Syscalls {
+			if slices.Contains(rule.Names, name) {
+				matchingRules = append(matchingRules, rule)
+			}
+		}
+		require.Len(t, matchingRules, 1, "expected exactly one rule for %q", name)
+		assert.Equal(t, specs.ActAllow, matchingRules[0].Action)
+		assert.Empty(t, matchingRules[0].Args)
+	}
+
+	// Expect syscalls that share a default rule with the configured names to
+	// remain denied. The default rule denying userfaultfd also denies
+	// vmsplice.
+	var vmspliceActions []specs.LinuxSeccompAction
+	for _, rule := range profile.Syscalls {
+		if slices.Contains(rule.Names, "vmsplice") {
+			vmspliceActions = append(vmspliceActions, rule.Action)
+		}
+	}
+	assert.Equal(t, []specs.LinuxSeccompAction{specs.ActErrno}, vmspliceActions)
 }


### PR DESCRIPTION
Follow-up to #13112. Appending the allow rule left the default profile's rules for the same syscalls in place. crun keeps whichever rule for a syscall comes first, so for syscalls that the default profile explicitly denies (such as userfaultfd and vmsplice), the default deny rule silently won and the setting had no effect. Only syscalls entirely absent from the default profile could actually be enabled.

Remove the configured names from the default rules before appending the allow rule, so that the allow rule is the only rule matching them regardless of how the runtime resolves conflicting rules.