### PR TITLE
Record the user who created an organization API key in the DB

### DIFF
--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -746,8 +746,8 @@ func (d *AuthDB) createAPIKey(ctx context.Context, db interfaces.DB, ak tables.A
 		value = ""
 	}
 
-	// This insert bypasses gorm's BeforeCreate hook, so set the timestamps
-	// ourselves.
+	// Because this insert invokes Exec() directly, it bypasses gorm's
+	// BeforeCreate hook, so we need to set the timestamps explicitly.
 	nowUsec := d.clock.Now().UnixMicro()
 	ak.CreatedAtUsec = nowUsec
 	ak.UpdatedAtUsec = nowUsec

--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -745,6 +745,16 @@ func (d *AuthDB) createAPIKey(ctx context.Context, db interfaces.DB, ak tables.A
 		encryptedValue = ek
 		value = ""
 	}
+
+	// This insert bypasses gorm's BeforeCreate hook, so set the timestamps
+	// ourselves.
+	nowUsec := d.clock.Now().UnixMicro()
+	ak.CreatedAtUsec = nowUsec
+	ak.UpdatedAtUsec = nowUsec
+	if u, err := d.env.GetAuthenticator().AuthenticatedUser(ctx); err == nil {
+		ak.CreatedByUserID = u.GetUserID()
+	}
+
 	err = db.NewQuery(ctx, "authdb_create_api_key").Raw(`
 		INSERT INTO "APIKeys" (
 			api_key_id,
@@ -758,8 +768,11 @@ func (d *AuthDB) createAPIKey(ctx context.Context, db interfaces.DB, ak tables.A
 			label,
 			visible_to_developers,
 			impersonation,
-			expiry_usec
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			expiry_usec,
+			created_at_usec,
+			updated_at_usec,
+			created_by_user_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		pk,
 		ak.UserID,
 		ak.GroupID,
@@ -772,6 +785,9 @@ func (d *AuthDB) createAPIKey(ctx context.Context, db interfaces.DB, ak tables.A
 		ak.VisibleToDevelopers,
 		ak.Impersonation,
 		ak.ExpiryUsec,
+		ak.CreatedAtUsec,
+		ak.UpdatedAtUsec,
+		ak.CreatedByUserID,
 	).Exec().Error
 	if err != nil {
 		return nil, err

--- a/enterprise/server/backends/authdb/authdb_test.go
+++ b/enterprise/server/backends/authdb/authdb_test.go
@@ -912,6 +912,52 @@ func createRandomAPIKeys(t *testing.T, ctx context.Context, env environment.Env)
 	return allKeys
 }
 
+func TestAPIKeyCreationMetadata(t *testing.T) {
+	ctx := context.Background()
+	env := setupEnv(t)
+	flags.Set(t, "app.create_group_per_user", true)
+	flags.Set(t, "app.no_default_user_group", true)
+	fakeClock := clockwork.NewFakeClock()
+	env.SetClock(fakeClock)
+	adb, err := authdb.NewAuthDB(env, env.GetDBHandle())
+	require.NoError(t, err)
+
+	users := enterprise_testauth.CreateRandomGroups(t, env)
+	// Get a random admin user.
+	var admin *tables.User
+	for _, u := range users {
+		if u.Groups[0].HasCapability(cappb.Capability_ORG_ADMIN) {
+			admin = u
+			break
+		}
+	}
+	require.NotNil(t, admin, "expected at least one admin user")
+	groupID := admin.Groups[0].Group.GroupID
+	auth := env.GetAuthenticator().(*testauth.TestAuthenticator)
+	adminCtx, err := auth.WithAuthenticatedUser(ctx, admin.UserID)
+	require.NoError(t, err)
+
+	created, err := adb.CreateAPIKey(adminCtx, groupID, "test key", nil, 0, false /*=visibleToDevelopers*/)
+	require.NoError(t, err)
+	require.Equal(t, admin.UserID, created.CreatedByUserID)
+	require.Equal(t, fakeClock.Now().UnixMicro(), created.CreatedAtUsec)
+
+	// The metadata should have been persisted, not just set on the returned
+	// key.
+	keys, err := adb.GetAPIKeys(adminCtx, groupID)
+	require.NoError(t, err)
+	var fetched *tables.APIKey
+	for _, k := range keys {
+		if k.APIKeyID == created.APIKeyID {
+			fetched = k
+			break
+		}
+	}
+	require.NotNil(t, fetched, "created key not returned by GetAPIKeys")
+	require.Equal(t, admin.UserID, fetched.CreatedByUserID)
+	require.Equal(t, fakeClock.Now().UnixMicro(), fetched.CreatedAtUsec)
+}
+
 func setupEnv(t *testing.T) *testenv.TestEnv {
 	flags.Set(t, "app.user_owned_keys_enabled", true)
 	env := enterprise_testenv.New(t)

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -491,6 +491,10 @@ type APIKey struct {
 	Impersonation bool `gorm:"not null;default:0"`
 	// If set, the API key is not considered to be valid after this time.
 	ExpiryUsec int64 `gorm:"not null;default:0"`
+	// The ID of the user who created this API key, if it was created by an
+	// authenticated user. Keys created by the server or by an
+	// API-key-authenticated caller do not have this field set.
+	CreatedByUserID string `gorm:"default:''"`
 }
 
 func (k *APIKey) TableName() string {


### PR DESCRIPTION
Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/8184