### PR TITLE
Make `GetApiKeys` return API key creation details to org admins

### DIFF
--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -745,6 +745,16 @@ func (d *AuthDB) createAPIKey(ctx context.Context, db interfaces.DB, ak tables.A
 		encryptedValue = ek
 		value = ""
 	}
+
+	// This insert bypasses gorm's BeforeCreate hook, so set the timestamps
+	// ourselves.
+	nowUsec := d.clock.Now().UnixMicro()
+	ak.CreatedAtUsec = nowUsec
+	ak.UpdatedAtUsec = nowUsec
+	if u, err := d.env.GetAuthenticator().AuthenticatedUser(ctx); err == nil {
+		ak.CreatedByUserID = u.GetUserID()
+	}
+
 	err = db.NewQuery(ctx, "authdb_create_api_key").Raw(`
 		INSERT INTO "APIKeys" (
 			api_key_id,
@@ -758,8 +768,11 @@ func (d *AuthDB) createAPIKey(ctx context.Context, db interfaces.DB, ak tables.A
 			label,
 			visible_to_developers,
 			impersonation,
-			expiry_usec
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			expiry_usec,
+			created_at_usec,
+			updated_at_usec,
+			created_by_user_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		pk,
 		ak.UserID,
 		ak.GroupID,
@@ -772,6 +785,9 @@ func (d *AuthDB) createAPIKey(ctx context.Context, db interfaces.DB, ak tables.A
 		ak.VisibleToDevelopers,
 		ak.Impersonation,
 		ak.ExpiryUsec,
+		ak.CreatedAtUsec,
+		ak.UpdatedAtUsec,
+		ak.CreatedByUserID,
 	).Exec().Error
 	if err != nil {
 		return nil, err

--- a/enterprise/server/backends/authdb/authdb_test.go
+++ b/enterprise/server/backends/authdb/authdb_test.go
@@ -912,6 +912,52 @@ func createRandomAPIKeys(t *testing.T, ctx context.Context, env environment.Env)
 	return allKeys
 }
 
+func TestAPIKeyCreationMetadata(t *testing.T) {
+	ctx := context.Background()
+	env := setupEnv(t)
+	flags.Set(t, "app.create_group_per_user", true)
+	flags.Set(t, "app.no_default_user_group", true)
+	fakeClock := clockwork.NewFakeClock()
+	env.SetClock(fakeClock)
+	adb, err := authdb.NewAuthDB(env, env.GetDBHandle())
+	require.NoError(t, err)
+
+	users := enterprise_testauth.CreateRandomGroups(t, env)
+	// Get a random admin user.
+	var admin *tables.User
+	for _, u := range users {
+		if u.Groups[0].HasCapability(cappb.Capability_ORG_ADMIN) {
+			admin = u
+			break
+		}
+	}
+	require.NotNil(t, admin, "expected at least one admin user")
+	groupID := admin.Groups[0].Group.GroupID
+	auth := env.GetAuthenticator().(*testauth.TestAuthenticator)
+	adminCtx, err := auth.WithAuthenticatedUser(ctx, admin.UserID)
+	require.NoError(t, err)
+
+	created, err := adb.CreateAPIKey(adminCtx, groupID, "test key", nil, 0, false /*=visibleToDevelopers*/)
+	require.NoError(t, err)
+	require.Equal(t, admin.UserID, created.CreatedByUserID)
+	require.Equal(t, fakeClock.Now().UnixMicro(), created.CreatedAtUsec)
+
+	// The metadata should have been persisted, not just set on the returned
+	// key.
+	keys, err := adb.GetAPIKeys(adminCtx, groupID)
+	require.NoError(t, err)
+	var fetched *tables.APIKey
+	for _, k := range keys {
+		if k.APIKeyID == created.APIKeyID {
+			fetched = k
+			break
+		}
+	}
+	require.NotNil(t, fetched, "created key not returned by GetAPIKeys")
+	require.Equal(t, admin.UserID, fetched.CreatedByUserID)
+	require.Equal(t, fakeClock.Now().UnixMicro(), fetched.CreatedAtUsec)
+}
+
 func setupEnv(t *testing.T) *testenv.TestEnv {
 	flags.Set(t, "app.user_owned_keys_enabled", true)
 	env := enterprise_testenv.New(t)

--- a/enterprise/server/backends/authdb/authdb_test.go
+++ b/enterprise/server/backends/authdb/authdb_test.go
@@ -958,6 +958,70 @@ func TestAPIKeyCreationMetadata(t *testing.T) {
 	require.Equal(t, fakeClock.Now().UnixMicro(), fetched.CreatedAtUsec)
 }
 
+func TestGetApiKeysCreationMetadata(t *testing.T) {
+	ctx := context.Background()
+	env := setupEnv(t)
+	flags.Set(t, "app.create_group_per_user", true)
+	flags.Set(t, "app.no_default_user_group", true)
+	fakeClock := clockwork.NewFakeClock()
+	env.SetClock(fakeClock)
+	adb, err := authdb.NewAuthDB(env, env.GetDBHandle())
+	require.NoError(t, err)
+
+	// Find a group that has both an admin and a non-admin member.
+	users := enterprise_testauth.CreateRandomGroups(t, env)
+	var admin, dev *tables.User
+	for _, u := range users {
+		if !u.Groups[0].HasCapability(cappb.Capability_ORG_ADMIN) {
+			dev = u
+			break
+		}
+	}
+	require.NotNil(t, dev, "expected at least one non-admin user")
+	groupID := dev.Groups[0].Group.GroupID
+	for _, u := range users {
+		if u.Groups[0].Group.GroupID == groupID && u.Groups[0].HasCapability(cappb.Capability_ORG_ADMIN) {
+			admin = u
+			break
+		}
+	}
+	require.NotNil(t, admin, "expected group %s to have an admin", groupID)
+
+	auth := env.GetAuthenticator().(*testauth.TestAuthenticator)
+	adminCtx, err := auth.WithAuthenticatedUser(ctx, admin.UserID)
+	require.NoError(t, err)
+	devCtx, err := auth.WithAuthenticatedUser(ctx, dev.UserID)
+	require.NoError(t, err)
+
+	created, err := adb.CreateAPIKey(adminCtx, groupID, "test key", nil, 0, true /*=visibleToDevelopers*/)
+	require.NoError(t, err)
+
+	getKey := func(reqCtx context.Context) *akpb.ApiKey {
+		rsp, err := env.GetBuildBuddyServer().GetApiKeys(reqCtx, &akpb.GetApiKeysRequest{
+			RequestContext: &ctxpb.RequestContext{GroupId: groupID},
+		})
+		require.NoError(t, err)
+		for _, k := range rsp.GetApiKey() {
+			if k.GetId() == created.APIKeyID {
+				return k
+			}
+		}
+		require.FailNow(t, "created key not returned by GetApiKeys")
+		return nil
+	}
+
+	// Admins should see the creation metadata.
+	k := getKey(adminCtx)
+	require.Equal(t, fakeClock.Now().UnixMicro(), k.GetCreatedAtUsec())
+	require.Equal(t, admin.UserID, k.GetCreatedByUser().GetUserId().GetId())
+	require.Equal(t, admin.FirstName+" "+admin.LastName, k.GetCreatedByUser().GetName().GetFull())
+
+	// Non-admins should see the key, but not who created it or when.
+	k = getKey(devCtx)
+	require.Zero(t, k.GetCreatedAtUsec())
+	require.Nil(t, k.GetCreatedByUser())
+}
+
 func setupEnv(t *testing.T) *testenv.TestEnv {
 	flags.Set(t, "app.user_owned_keys_enabled", true)
 	env := enterprise_testenv.New(t)

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -55,6 +55,7 @@ proto_library(
     deps = [
         ":capability_proto",
         ":context_proto",
+        ":user_id_proto",
         "@com_google_protobuf//:duration_proto",
     ],
 )
@@ -1043,6 +1044,7 @@ go_proto_library(
     deps = [
         ":capability_go_proto",
         ":context_go_proto",
+        ":user_id_go_proto",
     ],
 )
 
@@ -1989,6 +1991,7 @@ ts_proto_library(
         ":capability_ts_proto",
         ":context_ts_proto",
         ":duration_ts_proto",
+        ":user_id_ts_proto",
     ],
 )
 

--- a/proto/api_key.proto
+++ b/proto/api_key.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 import "proto/capability.proto";
 import "proto/context.proto";
+import "proto/user_id.proto";
 import "google/protobuf/duration.proto";
 
 package api_key;
@@ -34,6 +35,14 @@ message ApiKey {
   // Optional certificate corresponding to this API key, if
   // requested.
   Certificate certificate = 8;
+
+  // The time at which this API key was created. Identifies an org member, so
+  // it is only returned to org admins.
+  int64 created_at_usec = 9;
+
+  // The user who created this API key, if known. Identifies an org member, so
+  // it is only returned to org admins.
+  user_id.DisplayUser created_by_user = 10;
 }
 
 message Certificate {

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1006,26 +1006,59 @@ func (s *BuildBuddyServer) UpdateUserListMembership(ctx context.Context, request
 	return &ulpb.UpdateUserListMembershipResponse{}, nil
 }
 
+// toDisplayUser looks up display information for the given user. It returns nil
+// if the user can't be looked up.
+func (s *BuildBuddyServer) toDisplayUser(ctx context.Context, userID string) *uidpb.DisplayUser {
+	udb := s.env.GetUserDB()
+	if udb == nil || userID == "" {
+		return nil
+	}
+	u, err := udb.GetUserByIDWithoutAuthCheck(ctx, userID, &interfaces.GetUserOpts{})
+	if err != nil {
+		log.CtxWarningf(ctx, "Could not look up user %q: %s", userID, err)
+		return nil
+	}
+	return u.ToProto()
+}
+
+// isOrgAdmin returns whether the authenticated user is an admin of the given
+// group.
+func (s *BuildBuddyServer) isOrgAdmin(ctx context.Context, groupID string) bool {
+	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
+	if err != nil {
+		return false
+	}
+	return authutil.AuthorizeOrgAdmin(u, groupID) == nil
+}
+
 func (s *BuildBuddyServer) GetApiKeys(ctx context.Context, req *akpb.GetApiKeysRequest) (*akpb.GetApiKeysResponse, error) {
 	authDB := s.env.GetAuthDB()
 	if authDB == nil {
 		return nil, status.UnimplementedError("Not Implemented")
 	}
-	tableKeys, err := authDB.GetAPIKeys(ctx, req.GetRequestContext().GetGroupId())
+	groupID := req.GetRequestContext().GetGroupId()
+	tableKeys, err := authDB.GetAPIKeys(ctx, groupID)
 	if err != nil {
 		return nil, err
 	}
+	// Creation metadata names an org member, so only return it to org admins.
+	includeCreationMetadata := s.isOrgAdmin(ctx, groupID)
 	rsp := &akpb.GetApiKeysResponse{
 		ApiKey: make([]*akpb.ApiKey, 0, len(tableKeys)),
 	}
 	for _, k := range tableKeys {
 		// API Key value must be retrieved via GetAPIKey API.
-		rsp.ApiKey = append(rsp.ApiKey, &akpb.ApiKey{
+		key := &akpb.ApiKey{
 			Id:                  k.APIKeyID,
 			Label:               k.Label,
 			Capability:          capabilities.FromInt(k.Capabilities),
 			VisibleToDevelopers: k.VisibleToDevelopers,
-		})
+		}
+		if includeCreationMetadata {
+			key.CreatedAtUsec = k.CreatedAtUsec
+			key.CreatedByUser = s.toDisplayUser(ctx, k.CreatedByUserID)
+		}
+		rsp.ApiKey = append(rsp.ApiKey, key)
 	}
 	return rsp, nil
 }

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -491,6 +491,10 @@ type APIKey struct {
 	Impersonation bool `gorm:"not null;default:0"`
 	// If set, the API key is not considered to be valid after this time.
 	ExpiryUsec int64 `gorm:"not null;default:0"`
+	// The ID of the user who created this API key, if it was created by an
+	// authenticated user. Keys created by the server or by an
+	// API-key-authenticated caller do not have this field set.
+	CreatedByUserID string `gorm:"default:''"`
 }
 
 func (k *APIKey) TableName() string {


### PR DESCRIPTION
Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/8184