### PR TITLE
Add macOS and linux arm64 server binaries to release

### DIFF
--- a/.github/workflows/build-linux-arm64-github-release-artifacts.yaml
+++ b/.github/workflows/build-linux-arm64-github-release-artifacts.yaml
@@ -39,6 +39,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          bazelisk build --config=release --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //enterprise/server/cmd/executor:executor
+          bazelisk build \
+            --config=release \
+            --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
+            //enterprise/server/cmd/server:buildbuddy \
+            //enterprise/server/cmd/executor:executor
+          cp bazel-bin/enterprise/server/cmd/**/**/buildbuddy buildbuddy-enterprise-linux-arm64
           cp bazel-bin/enterprise/server/cmd/**/**/executor executor-enterprise-linux-arm64
-          gh release upload ${{ inputs.version_tag }} executor-enterprise-linux-arm64 --clobber
+          gh release upload \
+            ${{ inputs.version_tag }} \
+            buildbuddy-enterprise-linux-arm64 \
+            executor-enterprise-linux-arm64 \
+            --clobber

--- a/.github/workflows/build-mac-m1-github-release-artifacts.yaml
+++ b/.github/workflows/build-mac-m1-github-release-artifacts.yaml
@@ -51,6 +51,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEVELOPER_DIR: /Library/Developer/CommandLineTools
         run: |
-          bazelisk build --config=release-m1 --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //enterprise/server/cmd/executor:executor
+          bazelisk build \
+            --config=release-m1 \
+            --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
+            //enterprise/server/cmd/server:buildbuddy \
+            //enterprise/server/cmd/executor:executor
+          cp bazel-bin/enterprise/server/cmd/**/**/buildbuddy buildbuddy-enterprise-darwin-arm64
           cp bazel-bin/enterprise/server/cmd/**/**/executor executor-enterprise-darwin-arm64
-          gh release upload ${{ inputs.version_tag }} executor-enterprise-darwin-arm64 --clobber
+          gh release upload \
+            ${{ inputs.version_tag }} \
+            buildbuddy-enterprise-darwin-arm64 \
+            executor-enterprise-darwin-arm64 \
+            --clobber

--- a/tools/check_release_assets_uploaded.py
+++ b/tools/check_release_assets_uploaded.py
@@ -8,7 +8,9 @@ import time
 EXPECTED_ASSETS = [
     # enterprise app
     "buildbuddy-enterprise-darwin-amd64",
+    "buildbuddy-enterprise-darwin-arm64",
     "buildbuddy-enterprise-linux-amd64",
+    "buildbuddy-enterprise-linux-arm64",
     # OSS app
     "buildbuddy-darwin-amd64",
     "buildbuddy-linux-amd64",


### PR DESCRIPTION
Fixes https://github.com/buildbuddy-io/buildbuddy/issues/12876
