### PR TITLE
Deflake `//cli/cmd/bb:bb_test`

### DIFF
--- a/cli/cmd/bb/BUILD
+++ b/cli/cmd/bb/BUILD
@@ -123,6 +123,7 @@ go_binary(
 
 go_test(
     name = "bb_test",
+    size = "small",
     srcs = ["bb_test.go"],
     data = [":bb"],
     embed = [":bb_lib"],

--- a/cli/cmd/bb/bb_test.go
+++ b/cli/cmd/bb/bb_test.go
@@ -16,9 +16,6 @@ import (
 var bbRunfilePath string
 
 func TestStartupDoesNotQueryTerminal(t *testing.T) {
-	// No explicit deadline here: cold-starting the CLI binary can take
-	// several seconds on loaded machines, so rely on the test timeout to
-	// catch hangs. t.Context() kills the subprocess on cleanup.
 	// version --cli exits without starting Bazel, but it still imports the CLI
 	// command registry and the UI package, covering package-level initialization.
 	cmd := exec.CommandContext(t.Context(), testfs.RunfilePath(t, bbRunfilePath), "version", "--cli")

--- a/cli/cmd/bb/bb_test.go
+++ b/cli/cmd/bb/bb_test.go
@@ -34,8 +34,11 @@ func TestStartupDoesNotQueryTerminal(t *testing.T) {
 	}()
 
 	err = cmd.Wait()
-	_ = f.Close()
+	// The slave fd was closed in the parent by pty.Start, so the master
+	// read returns EIO once the child exits; drain it fully before closing
+	// so late output isn't discarded.
 	<-readDone
+	_ = f.Close()
 	require.NoError(t, err, "output: %q", output.String())
 	require.NotContains(t, output.String(), "\x1b]11;?", "queried terminal background color")
 	require.NotContains(t, output.String(), "\x1b[6n", "queried cursor position")

--- a/cli/cmd/bb/bb_test.go
+++ b/cli/cmd/bb/bb_test.go
@@ -18,8 +18,21 @@ import (
 var bbRunfilePath string
 
 func TestStartupDoesNotQueryTerminal(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 4*time.Second)
-	defer cancel()
+	// The regression this test guards against (terminal queries during
+	// startup) is detected by inspecting the output bytes below, not by
+	// timing: a binary that probes the terminal emits the query escape
+	// sequences whether or not it also stalls waiting for a reply. Avoid a
+	// short wall-clock deadline here; on heavily loaded CI machines just
+	// exec-ing the CLI binary can take several seconds, which made this
+	// test flaky. Instead, allow the subprocess to run until shortly
+	// before the test itself times out, so a true hang still fails with
+	// useful output instead of tripping the bazel test timeout.
+	ctx := t.Context()
+	if deadline, ok := t.Deadline(); ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithDeadline(ctx, deadline.Add(-10*time.Second))
+		defer cancel()
+	}
 
 	// version --cli exits without starting Bazel, but it still imports the CLI
 	// command registry and the UI package, covering package-level initialization.

--- a/cli/cmd/bb/bb_test.go
+++ b/cli/cmd/bb/bb_test.go
@@ -2,13 +2,11 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/creack/pty"
@@ -18,21 +16,12 @@ import (
 var bbRunfilePath string
 
 func TestStartupDoesNotQueryTerminal(t *testing.T) {
-	// A regressed binary is detected by the output assertions below, not by
-	// timing. Don't use a short wall-clock deadline: cold-starting the CLI
-	// binary alone can take several seconds on loaded CI machines, which
-	// made this test flaky. Cap the subprocess just short of the test
-	// deadline so a true hang still fails with useful output.
-	ctx := t.Context()
-	if deadline, ok := t.Deadline(); ok {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithDeadline(ctx, deadline.Add(-10*time.Second))
-		defer cancel()
-	}
-
+	// No explicit deadline here: cold-starting the CLI binary can take
+	// several seconds on loaded machines, so rely on the test timeout to
+	// catch hangs. t.Context() kills the subprocess on cleanup.
 	// version --cli exits without starting Bazel, but it still imports the CLI
 	// command registry and the UI package, covering package-level initialization.
-	cmd := exec.CommandContext(ctx, testfs.RunfilePath(t, bbRunfilePath), "version", "--cli")
+	cmd := exec.CommandContext(t.Context(), testfs.RunfilePath(t, bbRunfilePath), "version", "--cli")
 	cmd.Env = append(envWithout("CI", "TERM"), "TERM=xterm-256color")
 	f, err := pty.Start(cmd)
 	require.NoError(t, err)
@@ -47,7 +36,6 @@ func TestStartupDoesNotQueryTerminal(t *testing.T) {
 	err = cmd.Wait()
 	_ = f.Close()
 	<-readDone
-	require.NoError(t, ctx.Err(), "bb startup timed out; output: %q", output.String())
 	require.NoError(t, err, "output: %q", output.String())
 	require.NotContains(t, output.String(), "\x1b]11;?", "queried terminal background color")
 	require.NotContains(t, output.String(), "\x1b[6n", "queried cursor position")

--- a/cli/cmd/bb/bb_test.go
+++ b/cli/cmd/bb/bb_test.go
@@ -18,15 +18,11 @@ import (
 var bbRunfilePath string
 
 func TestStartupDoesNotQueryTerminal(t *testing.T) {
-	// The regression this test guards against (terminal queries during
-	// startup) is detected by inspecting the output bytes below, not by
-	// timing: a binary that probes the terminal emits the query escape
-	// sequences whether or not it also stalls waiting for a reply. Avoid a
-	// short wall-clock deadline here; on heavily loaded CI machines just
-	// exec-ing the CLI binary can take several seconds, which made this
-	// test flaky. Instead, allow the subprocess to run until shortly
-	// before the test itself times out, so a true hang still fails with
-	// useful output instead of tripping the bazel test timeout.
+	// A regressed binary is detected by the output assertions below, not by
+	// timing. Don't use a short wall-clock deadline: cold-starting the CLI
+	// binary alone can take several seconds on loaded CI machines, which
+	// made this test flaky. Cap the subprocess just short of the test
+	// deadline so a true hang still fails with useful output.
 	ctx := t.Context()
 	if deadline, ok := t.Deadline(); ok {
 		var cancel context.CancelFunc


### PR DESCRIPTION
## Problem

`//cli/cmd/bb:bb_test` flakes with:

```
Error: Received unexpected error: context deadline exceeded
Messages: bb startup timed out; output: ""
--- FAIL: TestStartupDoesNotQueryTerminal (4.00s)
```

The test gave the `bb version --cli` subprocess a hard-coded 4-second deadline (chosen in #12776 to be below Bubble Tea v1's 5s terminal-probe stall). On loaded CI machines, cold-starting the ~78MB CLI binary can exceed 4s on its own, so the child gets killed before printing anything — hence `output: ""`.

## Fix

The regression is detected by the output assertions, not by timing: a binary that probes the terminal emits the OSC 11 / CSI 6n query bytes regardless of how long it runs. So drop the custom deadline entirely and rely on the test timeout to catch hangs (`t.Context()` still kills the subprocess on cleanup). Also mark the test `size = "small"` — it runs in ~1s and bazel was already warning the size was too big — so a true hang fails within 60s.

## Verification

With this change, this test passes with `--runs_per_test=1000`: https://app.buildbuddy.io/invocation/b6dd8154-da68-4cf6-bb51-b84b4e606079