### PR TITLE
[CLI] Add boilerplate for new bb agent command

### DIFF
--- a/cli/agent/BUILD
+++ b/cli/agent/BUILD
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//cli:__subpackages__"])
+
+go_library(
+    name = "agent",
+    srcs = ["agent.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/agent",
+    deps = [
+        "//cli/agent/agentflags",
+        "//cli/arg",
+        "//cli/log",
+    ],
+)
+
+go_test(
+    name = "agent_test",
+    srcs = ["agent_test.go"],
+    embed = [":agent"],
+    deps = [
+        "//cli/agent/agentflags",
+        "//cli/login",
+        "//cli/util/agent/agentutil",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/cli/agent/agent.go
+++ b/cli/agent/agent.go
@@ -1,0 +1,70 @@
+package agent
+
+import (
+	"errors"
+	"flag"
+	"slices"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/agent/agentflags"
+	"github.com/buildbuddy-io/buildbuddy/cli/arg"
+	"github.com/buildbuddy-io/buildbuddy/cli/log"
+)
+
+const usage = `
+usage: bb agent <subcommand> [args]
+
+Runs an AI coding agent to analyze data.
+`
+
+// subcommand is a `bb agent` subcommand.
+type subcommand struct {
+	name  string
+	usage string
+	flags *flag.FlagSet
+	// HandleAgent parses flags before calling handler, so handler receives only the positional args.
+	handler func(args []string) (int, error)
+}
+
+var (
+	subcommands = []*subcommand{}
+)
+
+// Mirror the common agent flags onto every subcommand's flag set, so that each
+// subcommand only declares the flags that are unique to it.
+func init() {
+	for _, s := range subcommands {
+		agentflags.RegisterSharedFlags(s.flags)
+	}
+}
+
+func HandleAgent(args []string) (int, error) {
+	s, rest := findSubcommand(args)
+	if s == nil {
+		log.Warn("Unknown subcommand")
+		log.Print(usage)
+		return 1, nil
+	}
+	if err := arg.ParseFlagSet(s.flags, rest); err != nil {
+		if !errors.Is(err, flag.ErrHelp) {
+			log.Printf("Failed to parse flags: %s", err)
+		}
+		log.Print(s.usage)
+		return 1, nil
+	}
+
+	// The flags are parsed above, so s.handler receives only the positional args.
+	return s.handler(s.flags.Args())
+}
+
+// findSubcommand returns the first arg naming a subcommand, along with the
+// args with that name removed.
+func findSubcommand(args []string) (*subcommand, []string) {
+	for i, a := range args {
+		for _, s := range subcommands {
+			if s.name == a {
+				return s, slices.Concat(args[:i], args[i+1:])
+			}
+		}
+	}
+	return nil, nil
+}

--- a/cli/agent/agent_test.go
+++ b/cli/agent/agent_test.go
@@ -1,0 +1,199 @@
+package agent
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/agent/agentflags"
+	"github.com/buildbuddy-io/buildbuddy/cli/login"
+	"github.com/buildbuddy-io/buildbuddy/cli/util/agent/agentutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetSharedFlags restores every shared agent flag to its default value.
+//
+// RegisterSharedFlags aliases the same flag.Value into every subcommand's flag
+// set, so parsing any of them mutates package-level state. Without a reset,
+// values set by one test case would leak into the next and make assertions
+// order-dependent. Iterating the flag set covers flags added later for free.
+func resetSharedFlags(t *testing.T) {
+	t.Helper()
+	agentflags.SharedAgentFlags.VisitAll(func(f *flag.Flag) {
+		require.NoError(t, f.Value.Set(f.DefValue), "reset --%s to its default", f.Name)
+	})
+}
+
+// installTestSubcommand replaces the registered subcommands with a single fake
+// one for the duration of the test, and returns a pointer to the positional
+// args that its handler received.
+//
+// The shared agent flags are reset both before and after the test, so that the
+// test neither inherits values from an earlier one nor leaks its own.
+func installTestSubcommand(t *testing.T) *[]string {
+	t.Helper()
+
+	resetSharedFlags(t)
+
+	var handlerArgs []string
+	flags := flag.NewFlagSet("test-subcommand", flag.ContinueOnError)
+	agentflags.RegisterSharedFlags(flags)
+
+	previousSubcommands := subcommands
+	subcommands = []*subcommand{{
+		name:  "test-subcommand",
+		usage: "usage: bb agent test-subcommand",
+		flags: flags,
+		handler: func(args []string) (int, error) {
+			handlerArgs = args
+			return 0, nil
+		},
+	}}
+	t.Cleanup(func() {
+		subcommands = previousSubcommands
+		resetSharedFlags(t)
+	})
+	return &handlerArgs
+}
+
+func TestHandleAgent_Parsing(t *testing.T) {
+	defaultAgent := agentutil.Claude
+	for _, test := range []struct {
+		name                   string
+		args                   []string
+		expectedPositionalArgs []string
+		expectedModel          string
+		expectedAgent          string
+		expectedEffort         string
+		expectedAPITarget      string
+	}{
+		{
+			name:                   "No flags specified, defaults applied",
+			args:                   []string{"test-subcommand", "invocation-id"},
+			expectedPositionalArgs: []string{"invocation-id"},
+			expectedModel:          "",
+			expectedAgent:          defaultAgent,
+			expectedEffort:         "",
+			expectedAPITarget:      login.DefaultApiTarget,
+		},
+		// bbrc expansion puts options ahead of the subcommand name.
+		{
+			name:                   "Flags specified before subcommand",
+			args:                   []string{"--model=from-bbrc", "test-subcommand", "invocation-id"},
+			expectedPositionalArgs: []string{"invocation-id"},
+			expectedModel:          "from-bbrc",
+			expectedAgent:          defaultAgent,
+			expectedEffort:         "",
+			expectedAPITarget:      login.DefaultApiTarget,
+		},
+		{
+			name:                   "Multiple flags before subcommand",
+			args:                   []string{"--model=from-bbrc", "--agent=codex", "test-subcommand", "invocation-id"},
+			expectedPositionalArgs: []string{"invocation-id"},
+			expectedModel:          "from-bbrc",
+			expectedAgent:          agentutil.Codex,
+			expectedEffort:         "",
+			expectedAPITarget:      login.DefaultApiTarget,
+		},
+		{
+			name:                   "Flags specified before and after subcommand",
+			args:                   []string{"--model=from-bbrc", "test-subcommand", "--agent=codex", "invocation-id"},
+			expectedPositionalArgs: []string{"invocation-id"},
+			expectedModel:          "from-bbrc",
+			expectedAgent:          agentutil.Codex,
+			expectedEffort:         "",
+			expectedAPITarget:      login.DefaultApiTarget,
+		},
+		{
+			// The subcommand is found by name rather than by taking the first
+			// non-option arg, which would pick up an option's value here.
+			name:                   "Space-separated flag before subcommand",
+			args:                   []string{"--model", "from-bbrc", "test-subcommand", "invocation-id"},
+			expectedPositionalArgs: []string{"invocation-id"},
+			expectedModel:          "from-bbrc",
+			expectedAgent:          defaultAgent,
+			expectedEffort:         "",
+			expectedAPITarget:      login.DefaultApiTarget,
+		},
+		{
+			name:                   "All shared flags specified",
+			args:                   []string{"test-subcommand", "--model=from-bbrc", "--agent=codex", "--effort=high", "--target=grpcs://example.invalid", "invocation-id"},
+			expectedPositionalArgs: []string{"invocation-id"},
+			expectedModel:          "from-bbrc",
+			expectedAgent:          agentutil.Codex,
+			expectedEffort:         "high",
+			expectedAPITarget:      "grpcs://example.invalid",
+		},
+		{
+			name:                   "MultiplePositionalArgs",
+			args:                   []string{"--model=from-bbrc", "test-subcommand", "first", "second"},
+			expectedPositionalArgs: []string{"first", "second"},
+			expectedModel:          "from-bbrc",
+			expectedAgent:          defaultAgent,
+			expectedEffort:         "",
+			expectedAPITarget:      login.DefaultApiTarget,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			handlerArgs := installTestSubcommand(t)
+
+			exitCode, err := HandleAgent(test.args)
+
+			require.NoError(t, err)
+			assert.Equal(t, 0, exitCode)
+			assert.Equal(t, test.expectedPositionalArgs, *handlerArgs)
+			assert.Equal(t, test.expectedModel, *agentflags.Model)
+			assert.Equal(t, test.expectedAgent, *agentflags.Agent)
+			assert.Equal(t, test.expectedEffort, *agentflags.Effort)
+			assert.Equal(t, test.expectedAPITarget, *agentflags.APITarget)
+		})
+	}
+}
+
+func TestFindSubcommand(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		args         []string
+		expectedName string
+		expectedRest []string
+	}{
+		{
+			name:         "Subcommand first",
+			args:         []string{"test-subcommand", "invocation-id"},
+			expectedName: "test-subcommand",
+			expectedRest: []string{"invocation-id"},
+		},
+		{
+			name:         "Flags specified before subcommand",
+			args:         []string{"--model=from-bbrc", "test-subcommand", "invocation-id"},
+			expectedName: "test-subcommand",
+			expectedRest: []string{"--model=from-bbrc", "invocation-id"},
+		},
+		{
+			name:         "Flags specified after subcommand",
+			args:         []string{"test-subcommand", "--model=from-bbrc"},
+			expectedName: "test-subcommand",
+			expectedRest: []string{"--model=from-bbrc"},
+		},
+		{
+			name:         "Unknown subcommand",
+			args:         []string{"--model=from-bbrc", "frobnicate"},
+			expectedName: "",
+			expectedRest: nil,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			installTestSubcommand(t)
+
+			s, rest := findSubcommand(test.args)
+
+			if test.expectedName == "" {
+				assert.Nil(t, s)
+				return
+			}
+			require.NotNil(t, s)
+			assert.Equal(t, test.expectedName, s.name)
+			assert.Equal(t, test.expectedRest, rest)
+		})
+	}
+}

--- a/cli/agent/agentflags/BUILD
+++ b/cli/agent/agentflags/BUILD
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = ["//cli:__subpackages__"])
+
+go_library(
+    name = "agentflags",
+    srcs = ["agentflags.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/agent/agentflags",
+    deps = [
+        "//cli/login",
+        "//cli/util/agent/agentutil",
+    ],
+)

--- a/cli/agent/agentflags/agentflags.go
+++ b/cli/agent/agentflags/agentflags.go
@@ -1,0 +1,27 @@
+// Package agentflags declares the flags that are shared by all `bb agent`
+// subcommands.
+package agentflags
+
+import (
+	"flag"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/login"
+	"github.com/buildbuddy-io/buildbuddy/cli/util/agent/agentutil"
+)
+
+var (
+	SharedAgentFlags = flag.NewFlagSet("agent", flag.ContinueOnError)
+	Agent            = SharedAgentFlags.String("agent", agentutil.Claude, "The agent to use.")
+	Model            = SharedAgentFlags.String("model", "", "The agent model to use (Ex. gpt-5.4 or claude-opus-4-8). Defaults to the selected agent's default.")
+	Effort           = SharedAgentFlags.String("effort", "", "The agent reasoning effort to use. Defaults to the selected agent's default.")
+	APITarget        = SharedAgentFlags.String("target", login.DefaultApiTarget, "The API target to use.")
+	HTTPTarget       = SharedAgentFlags.String("url", login.DefaultHTTPTarget, "The BuildBuddy web URL to use.")
+)
+
+// RegisterSharedFlags adds the shared agent flags onto the given flagset so that the shared
+// flags can be parsed as part of the flagset for the subcommand.
+func RegisterSharedFlags(fs *flag.FlagSet) {
+	SharedAgentFlags.VisitAll(func(f *flag.Flag) {
+		fs.Var(f.Value, f.Name, f.Usage)
+	})
+}

--- a/cli/cli_command/register/BUILD
+++ b/cli/cli_command/register/BUILD
@@ -9,6 +9,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cli/add",
+        "//cli/agent",
+        "//cli/agent/agentflags",
         "//cli/analyze",
         "//cli/ask",
         "//cli/box",

--- a/cli/cli_command/register/register.go
+++ b/cli/cli_command/register/register.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/add"
+	"github.com/buildbuddy-io/buildbuddy/cli/agent"
+	"github.com/buildbuddy-io/buildbuddy/cli/agent/agentflags"
 	"github.com/buildbuddy-io/buildbuddy/cli/analyze"
 	"github.com/buildbuddy-io/buildbuddy/cli/ask"
 	"github.com/buildbuddy-io/buildbuddy/cli/box"
@@ -47,6 +49,12 @@ func register() {
 			Help:    "Adds a dependency to your WORKSPACE file.",
 			Handler: add.HandleAdd,
 			Flags:   add.Flags,
+		},
+		{
+			Name:    "agent",
+			Help:    "Runs an AI coding agent to analyze data.",
+			Handler: agent.HandleAgent,
+			Flags:   agentflags.SharedAgentFlags,
 		},
 		{
 			Name:    "analyze",

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -982,6 +982,21 @@ func (p *Parser) parseBBRCConfig(phase string, tokens []string) ([]arguments.Arg
 	if err != nil {
 		return nil, err
 	}
+	// Reject positional arguments (i.e. arguments that are not options prefixed with `--`).
+	// TODO: This will reject specifying options for CLI subcommands (Ex. `agent analyze-profile`).
+	// Expand the parser to support that.
+	if cli_command.GetCommand(phase) != nil {
+		for _, arg := range args {
+			positional, ok := arg.(*arguments.PositionalArgument)
+			if !ok {
+				continue
+			}
+			return nil, fmt.Errorf(
+				"positional argument %q is not allowed in the %q section of a .bbrc file",
+				positional.GetValue(), phase,
+			)
+		}
+	}
 	// Validate that all options in the config are CLI flags.
 	// Bazel options are not allowed in bbrc files.
 	for _, classified := range parsed.Classify(args) {

--- a/cli/parser/parser_test.go
+++ b/cli/parser/parser_test.go
@@ -239,6 +239,71 @@ func TestParseBBRCFiles_RejectsInvalidStartupOptions(t *testing.T) {
 	}
 }
 
+func TestParseBBRCFiles_RejectsSubcommands(t *testing.T) {
+	agentFlags := flag.NewFlagSet("agent", flag.ContinueOnError)
+	agentFlags.String("model", "", "")
+
+	previousCommandsByName := cli_command.CommandsByName
+	cli_command.CommandsByName = map[string]*cli_command.Command{
+		"agent": {Name: "agent", Flags: agentFlags},
+	}
+	t.Cleanup(func() {
+		cli_command.CommandsByName = previousCommandsByName
+	})
+
+	for _, test := range []struct {
+		name     string
+		contents string
+	}{
+		{
+			name:     "rejects subcommands",
+			contents: "agent analyze-profile --model=claude-opus-5\n",
+		},
+		{
+			name:     "rejects subcommands after options",
+			contents: "agent --model=claude-opus-5 analyze-profile\n",
+		},
+		{
+			name:     "rejects named configs with subcommands",
+			contents: "agent:fast analyze-profile --model=claude-opus-5\n",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ws := testfs.MakeTempDir(t)
+			testfs.WriteAllFileContents(t, ws, map[string]string{".bbrc": test.contents})
+
+			p, err := GetBBParserForCommand("agent")
+			require.NoError(t, err)
+			_, _, err = p.ParseBBRCFiles(ws, filepath.Join(ws, ".bbrc"))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestParseBBRCFiles_AllowsSpaceSeparatedOptionValue(t *testing.T) {
+	agentFlags := flag.NewFlagSet("agent", flag.ContinueOnError)
+	agentFlags.String("model", "", "")
+
+	previousCommandsByName := cli_command.CommandsByName
+	cli_command.CommandsByName = map[string]*cli_command.Command{
+		"agent": {Name: "agent", Flags: agentFlags},
+	}
+	t.Cleanup(func() {
+		cli_command.CommandsByName = previousCommandsByName
+	})
+
+	ws := testfs.MakeTempDir(t)
+	testfs.WriteAllFileContents(t, ws, map[string]string{
+		".bbrc": "agent --model claude-opus-5\n",
+	})
+
+	p, err := GetBBParserForCommand("agent")
+	require.NoError(t, err)
+	_, defaultConfig, err := p.ParseBBRCFiles(ws, filepath.Join(ws, ".bbrc"))
+	require.NoError(t, err)
+	require.Equal(t, []string{"--model", "claude-opus-5"}, arguments.FormatAll(defaultConfig.ByPhase["agent"]))
+}
+
 func TestConsumeBBRCFileOptions(t *testing.T) {
 	p, err := GetParser()
 	require.NoError(t, err)
@@ -454,6 +519,69 @@ run:second --second_flag
 	expanded, err := bbrc.ExpandConfigs(args, namedConfigs, defaultConfig)
 	require.NoError(t, err)
 	require.Equal(t, []string{"run", "--first_flag", "--second_flag", "//:target"}, expanded.Format())
+}
+
+func TestParseBBRCFiles_CommandWithSubcommands(t *testing.T) {
+	previousCommandsByName := cli_command.CommandsByName
+	cli_command.CommandsByName = map[string]*cli_command.Command{
+		"agent": {Name: "agent"},
+	}
+	t.Cleanup(func() {
+		cli_command.CommandsByName = previousCommandsByName
+	})
+
+	ws := testfs.MakeTempDir(t)
+	testfs.WriteAllFileContents(t, ws, map[string]string{
+		".bbrc": `
+agent --model=claude-opus-5
+agent:fast --effort=low
+`,
+	})
+
+	p := NewParser(
+		[]*options.Definition{
+			bbrc.NewConfigOptionDefinition("agent"),
+			options.NewDefinition("model", options.WithRequiresValue(), options.WithSupportFor("agent")),
+			options.NewDefinition("effort", options.WithRequiresValue(), options.WithSupportFor("agent")),
+		},
+		[]string{"agent"},
+		nil,
+	)
+	namedConfigs, defaultConfig, err := p.ParseBBRCFiles(ws, filepath.Join(ws, ".bbrc"))
+	require.NoError(t, err)
+
+	// The `agent` flags should be applied to all subcommands.
+	for _, subcommand := range []string{"subcommand-1", "subcommand-2"} {
+		t.Run(subcommand, func(t *testing.T) {
+			args, err := p.ParseArgs([]string{"agent", subcommand, "invocation-id"})
+			require.NoError(t, err)
+			expanded, err := bbrc.ExpandConfigs(args, namedConfigs, defaultConfig)
+			require.NoError(t, err)
+			assert.Equal(t, []string{
+				"agent",
+				"--model=claude-opus-5",
+				subcommand,
+				"invocation-id",
+			}, expanded.Format())
+		})
+	}
+
+	// Unlike the default section, whose options are inserted after the command
+	// name, a named config expands in place, wherever --bb_config appeared. So
+	// options can land on either side of the subcommand name.
+	t.Run("NamedConfig", func(t *testing.T) {
+		args, err := p.ParseArgs([]string{"agent", "analyze-profile", "--bb_config=fast", "invocation-id"})
+		require.NoError(t, err)
+		expanded, err := bbrc.ExpandConfigs(args, namedConfigs, defaultConfig)
+		require.NoError(t, err)
+		assert.Equal(t, []string{
+			"agent",
+			"--model=claude-opus-5",
+			"analyze-profile",
+			"--effort=low",
+			"invocation-id",
+		}, expanded.Format())
+	})
 }
 
 func TestParseBazelrc_Simple(t *testing.T) {


### PR DESCRIPTION
Based off [this feedback](https://github.com/buildbuddy-io/buildbuddy/pull/13081#discussion_r3882784215)

Support specifying flags that apply to all subcommands 