### PR TITLE
gateway: Implementation of a "relay" service.

### DIFF
--- a/enterprise/gateway/cmd/gateway/gateway.go
+++ b/enterprise/gateway/cmd/gateway/gateway.go
@@ -119,7 +119,7 @@ func main() {
 }
 
 func startGRPCServers(env *real_environment.RealEnv) error {
-	gw, err := server.New(env)
+	gw, err := server.New(env, server.DNSService())
 	if err != nil {
 		return err
 	}

--- a/enterprise/gateway/relay/BUILD
+++ b/enterprise/gateway/relay/BUILD
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "relay",
+    srcs = ["relay.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/gateway/relay",
+    deps = [
+        "//enterprise/gateway/server",
+        "//server/util/flag",
+        "//server/util/log",
+        "//server/util/relaywire",
+        "//server/util/status",
+    ],
+)
+
+go_test(
+    name = "relay_test",
+    srcs = [
+        "relay_e2e_test.go",
+        "relay_test.go",
+    ],
+    embed = [":relay"],
+    deps = [
+        "//enterprise/gateway/server",
+        "//enterprise/gateway/testgateway",
+        "//server/testutil/testauth",
+        "//server/util/relaywire",
+        "//server/util/status",
+        "//server/util/testing/flags",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/gateway/relay/relay.go
+++ b/enterprise/gateway/relay/relay.go
@@ -48,25 +48,35 @@ func (relayService) Start(hub *server.HubNetwork) (io.Closer, error) {
 	if err != nil {
 		return nil, err
 	}
-	go serveRelay(ln, hub.NetworkKey)
+	go serveRelay(ln, hub)
 	return ln, nil
 }
 
 // serveRelay accepts relay handshakes on the hub listener until it is closed.
-func serveRelay(ln net.Listener, networkKey string) {
+func serveRelay(ln net.Listener, hub *server.HubNetwork) {
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
 			return // stack or listener closed
 		}
-		go handleRelayConn(conn, networkKey)
+		go handleRelayConn(conn, hub)
 	}
 }
 
-func handleRelayConn(conn net.Conn, networkKey string) {
+func handleRelayConn(conn net.Conn, hub *server.HubNetwork) {
 	defer conn.Close()
+	networkKey := hub.NetworkKey
 
 	srcAddr, _ := netip.ParseAddrPort(conn.RemoteAddr().String())
+
+	// Get the context for the client so we can kill the relay connection if the client goes away.
+	peerCtx, ok := hub.PeerContext(srcAddr.Addr())
+	if !ok {
+		return // peer already removed
+	}
+	// Make sure we clean up the connection if the client disappears from the gateway.
+	stopClosingConn := context.AfterFunc(peerCtx, func() { conn.Close() })
+	defer stopClosingConn()
 
 	req, err := relaywire.ReadRequest(conn)
 	if err != nil {
@@ -84,7 +94,7 @@ func handleRelayConn(conn net.Conn, networkKey string) {
 	}
 
 	start := time.Now()
-	ctx, cancel := context.WithTimeout(context.Background(), *relayDialTimeout)
+	ctx, cancel := context.WithTimeout(peerCtx, *relayDialTimeout)
 	defer cancel()
 	var dialer net.Dialer
 	upstream, err := dialer.DialContext(ctx, "tcp", target)
@@ -95,6 +105,9 @@ func handleRelayConn(conn net.Conn, networkKey string) {
 		return
 	}
 	defer upstream.Close()
+	// Make sure we clean up the relayed connection if the gateway client disappears.
+	stopClosingUpstream := context.AfterFunc(peerCtx, func() { upstream.Close() })
+	defer stopClosingUpstream()
 
 	resolved := upstream.RemoteAddr().String()
 	if err := relaywire.Accept(conn, resolved); err != nil {
@@ -114,9 +127,12 @@ func handleRelayConn(conn net.Conn, networkKey string) {
 // error for the client.
 func refusalForDialError(err error, target string) error {
 	var dnsErr *net.DNSError
+	isDNS := errors.As(err, &dnsErr)
 	switch {
-	case errors.As(err, &dnsErr):
+	case isDNS && dnsErr.IsNotFound:
 		return status.NotFoundErrorf("%q does not resolve at the gateway: %s", dnsErr.Name, dnsErr.Err)
+	case isDNS && errors.Is(err, context.DeadlineExceeded):
+		return status.DeadlineExceededErrorf("resolving %q at the gateway timed out after %s", dnsErr.Name, *relayDialTimeout)
 	case errors.Is(err, context.DeadlineExceeded):
 		return status.DeadlineExceededErrorf("dialing %s from the gateway timed out after %s", target, *relayDialTimeout)
 	default:
@@ -128,35 +144,42 @@ func refusalForDialError(err error, target string) error {
 type closeWriter interface{ CloseWrite() error }
 
 // splice copies bytes in both directions until both halves are done, and
-// returns the number of bytes sent to and received from upstream.
+// returns the number of bytes sent to and received from upstream. A clean EOF
+// on one side is propagated as a half-close so the other side can finish
+// what it was sending.
 func splice(client, upstream net.Conn) (sent, received int64) {
 	var toUpstream, fromUpstream atomic.Int64
 	done := make(chan struct{}, 2)
 
 	go func() {
-		n, _ := io.Copy(upstream, client)
+		n, err := io.Copy(upstream, client)
 		toUpstream.Store(n)
-		if cw, ok := upstream.(closeWriter); ok {
-			cw.CloseWrite()
-		} else {
-			upstream.Close()
-		}
+		closeAfterCopy(upstream, err)
 		done <- struct{}{}
 	}()
 	go func() {
-		n, _ := io.Copy(client, upstream)
+		n, err := io.Copy(client, upstream)
 		fromUpstream.Store(n)
-		if cw, ok := client.(closeWriter); ok {
-			cw.CloseWrite()
-		} else {
-			client.Close()
-		}
+		closeAfterCopy(client, err)
 		done <- struct{}{}
 	}()
 
 	<-done
 	<-done
 	return toUpstream.Load(), fromUpstream.Load()
+}
+
+// closeAfterCopy ends the write side of dst once a copy into it has finished:
+// a half-close if the copy ended cleanly (err == nil), a full close if it
+// failed.
+func closeAfterCopy(dst net.Conn, err error) {
+	if err == nil {
+		if cw, ok := dst.(closeWriter); ok {
+			cw.CloseWrite()
+			return
+		}
+	}
+	dst.Close()
 }
 
 // relayTargetAllowed reports whether host is covered by the configured suffix

--- a/enterprise/gateway/relay/relay.go
+++ b/enterprise/gateway/relay/relay.go
@@ -1,0 +1,181 @@
+// Package relay implements a gateway hub service that allows connections to
+// destinations that the gateway itself can reach, such as internal k8s
+// resources.
+//
+// The client requests a relay connection either by name or by IP. If the
+// client sends a name, the gateway uses its own resolver to resolve the IP.
+// This allows the client to resolve IPs for DNS entries that are internal
+// to the cluster.
+//
+// The relay listens on the hub IP and speaks the protocol implemented in the
+// relaywire package. The client opens a connection, sends the relay request
+// proto inline, the relay service attempts to open the connection and sends a
+// proto response back to the client. If the connection is successful, the
+// connection then switches to shuffling raw bytes between the client and the
+// destination.
+package relay
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/netip"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/server"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/relaywire"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+)
+
+var (
+	relayAllowedTargetSuffixes = flag.Slice("gateway.relay.allowed_target_suffixes", []string{}, "DNS suffixes the relay may connect to, e.g. 'svc.cluster.local'. Empty means any target.")
+	relayDialTimeout           = flag.Duration("gateway.relay.dial_timeout", 10*time.Second, "Timeout for the gateway's outbound dial on behalf of a relay client.")
+)
+
+// New returns the egress relay hub service.
+func New() server.HubService { return relayService{} }
+
+type relayService struct{}
+
+func (relayService) Start(hub *server.HubNetwork) (io.Closer, error) {
+	ln, err := hub.ListenTCP(relaywire.DefaultPort)
+	if err != nil {
+		return nil, err
+	}
+	go serveRelay(ln, hub.NetworkKey)
+	return ln, nil
+}
+
+// serveRelay accepts relay handshakes on the hub listener until it is closed.
+func serveRelay(ln net.Listener, networkKey string) {
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			return // stack or listener closed
+		}
+		go handleRelayConn(conn, networkKey)
+	}
+}
+
+func handleRelayConn(conn net.Conn, networkKey string) {
+	defer conn.Close()
+
+	srcAddr, _ := netip.ParseAddrPort(conn.RemoteAddr().String())
+
+	req, err := relaywire.ReadRequest(conn)
+	if err != nil {
+		log.Warningf("relay[%s]: handshake with %s failed: %s", networkKey, srcAddr.Addr(), err)
+		return
+	}
+	target := net.JoinHostPort(req.GetHost(), strconv.Itoa(int(req.GetPort())))
+
+	if !relayTargetAllowed(req.GetHost()) {
+		log.Warningf("relay[%s]: src=%s target=%s is not in the allowed suffix list",
+			networkKey, srcAddr.Addr(), target)
+		relaywire.Refuse(conn, status.PermissionDeniedErrorf(
+			"target %q is not in this gateway's allowed suffix list", req.GetHost()))
+		return
+	}
+
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), *relayDialTimeout)
+	defer cancel()
+	var dialer net.Dialer
+	upstream, err := dialer.DialContext(ctx, "tcp", target)
+	if err != nil {
+		log.Warningf("relay[%s]: src=%s target=%s dial failed after %s: %s",
+			networkKey, srcAddr.Addr(), target, time.Since(start).Round(time.Millisecond), err)
+		relaywire.Refuse(conn, refusalForDialError(err, target))
+		return
+	}
+	defer upstream.Close()
+
+	resolved := upstream.RemoteAddr().String()
+	if err := relaywire.Accept(conn, resolved); err != nil {
+		return
+	}
+
+	log.Infof("relay[%s]: OPEN src=%s target=%s resolved=%s",
+		networkKey, srcAddr.Addr(), target, resolved)
+
+	sent, received := splice(conn, upstream)
+	log.Infof("relay[%s]: CLOSE src=%s target=%s resolved=%s sent=%d received=%d duration=%s",
+		networkKey, srcAddr.Addr(), target, resolved, sent, received,
+		time.Since(start).Round(time.Millisecond))
+}
+
+// refusalForDialError turns the gateway's failed outbound dial into a status
+// error for the client.
+func refusalForDialError(err error, target string) error {
+	var dnsErr *net.DNSError
+	switch {
+	case errors.As(err, &dnsErr):
+		return status.NotFoundErrorf("%q does not resolve at the gateway: %s", dnsErr.Name, dnsErr.Err)
+	case errors.Is(err, context.DeadlineExceeded):
+		return status.DeadlineExceededErrorf("dialing %s from the gateway timed out after %s", target, *relayDialTimeout)
+	default:
+		return status.UnavailableErrorf("dialing %s from the gateway: %s", target, err)
+	}
+}
+
+// closeWriter is implemented by both *net.TCPConn and gVisor's *gonet.TCPConn.
+type closeWriter interface{ CloseWrite() error }
+
+// splice copies bytes in both directions until both halves are done, and
+// returns the number of bytes sent to and received from upstream.
+func splice(client, upstream net.Conn) (sent, received int64) {
+	var toUpstream, fromUpstream atomic.Int64
+	done := make(chan struct{}, 2)
+
+	go func() {
+		n, _ := io.Copy(upstream, client)
+		toUpstream.Store(n)
+		if cw, ok := upstream.(closeWriter); ok {
+			cw.CloseWrite()
+		} else {
+			upstream.Close()
+		}
+		done <- struct{}{}
+	}()
+	go func() {
+		n, _ := io.Copy(client, upstream)
+		fromUpstream.Store(n)
+		if cw, ok := client.(closeWriter); ok {
+			cw.CloseWrite()
+		} else {
+			client.Close()
+		}
+		done <- struct{}{}
+	}()
+
+	<-done
+	<-done
+	return toUpstream.Load(), fromUpstream.Load()
+}
+
+// relayTargetAllowed reports whether host is covered by the configured suffix
+// allowlist. An exact match counts, as does any name ending in ".<suffix>";
+// "foo.evil-cluster.local" must not match the suffix "cluster.local".
+func relayTargetAllowed(host string) bool {
+	suffixes := *relayAllowedTargetSuffixes
+	if len(suffixes) == 0 {
+		return true
+	}
+	h := strings.ToLower(strings.TrimSuffix(host, "."))
+	for _, s := range suffixes {
+		s = strings.ToLower(strings.TrimSuffix(strings.TrimPrefix(s, "."), "."))
+		if s == "" {
+			continue
+		}
+		if h == s || strings.HasSuffix(h, "."+s) {
+			return true
+		}
+	}
+	return false
+}

--- a/enterprise/gateway/relay/relay_e2e_test.go
+++ b/enterprise/gateway/relay/relay_e2e_test.go
@@ -1,0 +1,153 @@
+package relay_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/relay"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/server"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/testgateway"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
+	"github.com/buildbuddy-io/buildbuddy/server/util/relaywire"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/stretchr/testify/require"
+)
+
+// setupRelayGateway creates a gateway running the relay service.
+func setupRelayGateway(t testing.TB, ta *testauth.TestAuthenticator) *server.Gateway {
+	t.Helper()
+	return testgateway.Setup(t, ta, relay.New())
+}
+
+// startEchoServer starts a TCP server on localhost that echoes what it reads
+// and then half-closes, standing in for a production service the gateway can
+// reach. It returns its port.
+func startEchoServer(t testing.TB) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				// io.Copy returns when the client half-closes, which is what
+				// makes this a half-close test and not just an echo test.
+				io.Copy(conn, conn)
+			}()
+		}
+	}()
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+// dialRelay opens a connection to the network's relay through the tunnel and
+// performs the relay handshake for target.
+func dialRelay(t testing.TB, peer testgateway.Peer, target string, port int) (net.Conn, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	conn, err := peer.Net.DialContext(ctx, "tcp", fmt.Sprintf("[%s]:%d", peer.GatewayIP, relaywire.DefaultPort))
+	require.NoError(t, err, "dialing the relay listener on the hub")
+	if err := relaywire.Connect(conn, target, port); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return conn, nil
+}
+
+func TestRelay_ConnectByName(t *testing.T) {
+	echoPort := startEchoServer(t)
+
+	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
+	gw := setupRelayGateway(t, ta)
+	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
+	require.NoError(t, err)
+
+	peer := testgateway.RegisterAndConnect(t, gw, ctx, "net1", "")
+
+	// "localhost" exercises the fact that the *gateway* resolves the name: the
+	// peer's gVisor stack has no idea what localhost is.
+	conn, err := dialRelay(t, peer, "localhost", echoPort)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	const want = "hello through the relay"
+	_, err = io.WriteString(conn, want)
+	require.NoError(t, err)
+
+	// Half-close and read to EOF. If CloseWrite is not propagated across both
+	// relay hops, the echo server never sees EOF and this read hangs.
+	require.NoError(t, conn.(interface{ CloseWrite() error }).CloseWrite())
+	conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+	got, err := io.ReadAll(conn)
+	require.NoError(t, err)
+	require.Equal(t, want, string(got))
+}
+
+func TestRelay_NotComposedMeansNoListener(t *testing.T) {
+	// A gateway that does not compose the relay (the customer-facing shape)
+	// must not have a relay listener at all.
+	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
+	gw := testgateway.Setup(t, ta, server.DNSService())
+	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
+	require.NoError(t, err)
+
+	peer := testgateway.RegisterAndConnect(t, gw, ctx, "net1", "")
+
+	dialCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+	conn, err := peer.Net.DialContext(dialCtx, "tcp", fmt.Sprintf("[%s]:%d", peer.GatewayIP, relaywire.DefaultPort))
+	if err == nil {
+		conn.Close()
+		t.Fatal("expected no relay listener on a gateway that does not compose the relay")
+	}
+}
+
+func TestRelay_TargetSuffixNotAllowed(t *testing.T) {
+	flags.Set(t, "gateway.relay.allowed_target_suffixes", []string{"svc.cluster.local"})
+	echoPort := startEchoServer(t)
+
+	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
+	gw := setupRelayGateway(t, ta)
+	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
+	require.NoError(t, err)
+
+	peer := testgateway.RegisterAndConnect(t, gw, ctx, "net1", "")
+
+	_, err = dialRelay(t, peer, "localhost", echoPort)
+	require.Error(t, err)
+	require.True(t, status.IsPermissionDeniedError(err), "got %v", err)
+	// The refusal names the target, so the developer knows what was judged
+	// without reading gateway logs.
+	require.Contains(t, status.Message(err), `"localhost"`)
+}
+
+func TestRelay_TargetRefusesConnection(t *testing.T) {
+	// Bind and immediately close, so the port is (almost certainly) closed.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	deadPort := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
+	gw := setupRelayGateway(t, ta)
+	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
+	require.NoError(t, err)
+
+	peer := testgateway.RegisterAndConnect(t, gw, ctx, "net1", "")
+
+	_, err = dialRelay(t, peer, "localhost", deadPort)
+	require.Error(t, err)
+	require.True(t, status.IsUnavailableError(err), "got %v", err)
+	require.Contains(t, status.Message(err), "refused", "the gateway's dial error reaches the client verbatim")
+}

--- a/enterprise/gateway/relay/relay_e2e_test.go
+++ b/enterprise/gateway/relay/relay_e2e_test.go
@@ -94,6 +94,55 @@ func TestRelay_ConnectByName(t *testing.T) {
 	require.Equal(t, want, string(got))
 }
 
+func TestRelay_PeerRemovalClosesConnection(t *testing.T) {
+	// A client that vanishes (laptop asleep, network gone) never closes its
+	// relay connection, and the gVisor side of the relay has no keepalive, so
+	// the gateway removing the peer is the only signal the relay gets. Stand
+	// in an upstream that never sends and never closes on its own: without
+	// that signal, the relay would hold this connection open forever.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+	upstreamDone := make(chan error, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			upstreamDone <- err
+			return
+		}
+		defer c.Close()
+		_, err = c.Read(make([]byte, 1))
+		upstreamDone <- err
+	}()
+
+	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
+	gw := setupRelayGateway(t, ta)
+	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
+	require.NoError(t, err)
+
+	peer := testgateway.RegisterAndConnect(t, gw, ctx, "net1", "")
+
+	conn, err := dialRelay(t, peer, "localhost", ln.Addr().(*net.TCPAddr).Port)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	select {
+	case err := <-upstreamDone:
+		t.Fatalf("upstream connection ended before the peer was removed: %v", err)
+	default:
+	}
+
+	// Drop the peer without closing the relay connection.
+	peer.Disconnect()
+
+	select {
+	case err := <-upstreamDone:
+		require.ErrorIs(t, err, io.EOF, "the relay should close its upstream connection")
+	case <-time.After(30 * time.Second):
+		t.Fatal("upstream connection was not closed after the peer was removed")
+	}
+}
+
 func TestRelay_NotComposedMeansNoListener(t *testing.T) {
 	// A gateway that does not compose the relay (the customer-facing shape)
 	// must not have a relay listener at all.

--- a/enterprise/gateway/relay/relay_test.go
+++ b/enterprise/gateway/relay/relay_test.go
@@ -1,11 +1,128 @@
 package relay
 
 import (
+	"context"
+	"errors"
+	"io"
+	"net"
 	"testing"
+	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRefusalForDialError(t *testing.T) {
+	const host = "db.svc.cluster.local"
+	const target = host + ":5432"
+	for _, tc := range []struct {
+		name    string
+		err     error
+		wantIs  func(error) bool
+		wantMsg string
+	}{
+		{
+			name:    "no such host is NotFound",
+			err:     &net.DNSError{Err: "no such host", Name: host, IsNotFound: true},
+			wantIs:  status.IsNotFoundError,
+			wantMsg: `"` + host + `" does not resolve`,
+		},
+		{
+			// The dial deadline expiring during resolution is what the Go
+			// resolver reports when DNS is down or slow; it must not read as
+			// a bad name.
+			name:    "resolver timeout is DeadlineExceeded",
+			err:     &net.DNSError{Err: "i/o timeout", Name: host, IsTimeout: true, UnwrapErr: context.DeadlineExceeded},
+			wantIs:  status.IsDeadlineExceededError,
+			wantMsg: "resolving",
+		},
+		{
+			name:    "resolver failure is Unavailable",
+			err:     &net.DNSError{Err: "server misbehaving", Name: host, IsTemporary: true},
+			wantIs:  status.IsUnavailableError,
+			wantMsg: "server misbehaving",
+		},
+		{
+			name:    "connect timeout is DeadlineExceeded",
+			err:     &net.OpError{Op: "dial", Net: "tcp", Err: context.DeadlineExceeded},
+			wantIs:  status.IsDeadlineExceededError,
+			wantMsg: "dialing " + target,
+		},
+		{
+			name:    "connection refused is Unavailable",
+			err:     &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connect: connection refused")},
+			wantIs:  status.IsUnavailableError,
+			wantMsg: "connection refused",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := refusalForDialError(tc.err, target)
+			require.True(t, tc.wantIs(got), "got %v", got)
+			require.Contains(t, status.Message(got), tc.wantMsg)
+		})
+	}
+}
+
+// tcpPair returns both ends of a loopback TCP connection.
+func tcpPair(t *testing.T) (client, server net.Conn) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+	client, err = net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	server, err = ln.Accept()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		client.Close()
+		server.Close()
+	})
+	return client, server
+}
+
+func TestSplice_ErrorOnOneSideClosesTheOther(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		resetClient bool
+	}{
+		{"client reset closes upstream", true},
+		{"upstream reset closes client", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client, relayClientSide := tcpPair(t)
+			relayUpstreamSide, upstream := tcpPair(t)
+
+			done := make(chan struct{})
+			go func() {
+				splice(relayClientSide, relayUpstreamSide)
+				close(done)
+			}()
+
+			// Reset one side rather than closing it cleanly: with SO_LINGER=0,
+			// Close sends a RST, which the relay's read reports as an error
+			// rather than EOF.
+			broken, survivor := client, upstream
+			if !tc.resetClient {
+				broken, survivor = upstream, client
+			}
+			require.NoError(t, broken.(*net.TCPConn).SetLinger(0))
+			require.NoError(t, broken.Close())
+
+			// The survivor never sends anything and never closes on its own.
+			// Were the relay to merely half-close it, the copy out of it would
+			// block forever and splice would never return.
+			select {
+			case <-done:
+			case <-time.After(10 * time.Second):
+				t.Fatal("splice did not return after one side was reset")
+			}
+			survivor.SetReadDeadline(time.Now().Add(5 * time.Second))
+			_, err := survivor.Read(make([]byte, 1))
+			require.ErrorIs(t, err, io.EOF, "the surviving side should see the relay close its connection")
+		})
+	}
+}
 
 func TestRelayTargetAllowed(t *testing.T) {
 	for _, tc := range []struct {

--- a/enterprise/gateway/relay/relay_test.go
+++ b/enterprise/gateway/relay/relay_test.go
@@ -1,0 +1,32 @@
+package relay
+
+import (
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelayTargetAllowed(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		suffixes []string
+		host     string
+		want     bool
+	}{
+		{"no allowlist permits anything", nil, "anything.example.com", true},
+		{"exact match", []string{"prod.buildbuddy.io"}, "prod.buildbuddy.io", true},
+		{"subdomain match", []string{"prod.buildbuddy.io"}, "sjc-prod-abc.prod.buildbuddy.io", true},
+		{"trailing dot in host", []string{"prod.buildbuddy.io"}, "sjc-prod-abc.prod.buildbuddy.io.", true},
+		{"case insensitive", []string{"prod.buildbuddy.io"}, "SJC-Prod-ABC.Prod.BuildBuddy.io", true},
+		{"leading dot in suffix", []string{".prod.buildbuddy.io"}, "abc.prod.buildbuddy.io", true},
+		{"not a suffix", []string{"prod.buildbuddy.io"}, "evil.example.com", false},
+		{"partial label is not a match", []string{"cluster.local"}, "svc.evil-cluster.local", false},
+		{"suffix of a longer name", []string{"cluster.local"}, "notcluster.local", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			flags.Set(t, "gateway.relay.allowed_target_suffixes", tc.suffixes)
+			require.Equal(t, tc.want, relayTargetAllowed(tc.host))
+		})
+	}
+}

--- a/enterprise/gateway/server/BUILD
+++ b/enterprise/gateway/server/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = [
         "forwardingtun.go",
         "gateway.go",
+        "hub.go",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/gateway/server",
     visibility = ["//visibility:public"],
@@ -47,6 +48,7 @@ go_test(
     ],
     embed = [":server"],
     deps = [
+        "//enterprise/gateway/testgateway",
         "//proto:gateway_go_proto",
         "//server/testutil/testauth",
         "//server/testutil/testenv",
@@ -54,9 +56,6 @@ go_test(
         "//server/util/testing/flags",
         "//server/util/wgkeys",
         "@com_github_stretchr_testify//require",
-        "@com_zx2c4_golang_wireguard//conn",
-        "@com_zx2c4_golang_wireguard//device",
-        "@com_zx2c4_golang_wireguard//tun/netstack",
         "@dev_gvisor_gvisor//pkg/tcpip",
         "@dev_gvisor_gvisor//pkg/tcpip/header",
         "@org_golang_google_grpc//:grpc",

--- a/enterprise/gateway/server/forwardingtun.go
+++ b/enterprise/gateway/server/forwardingtun.go
@@ -16,6 +16,7 @@ package server
 // hub services answer them rather than forwarding (see hub.go).
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/netip"
@@ -116,7 +117,7 @@ func (t *muxTUN) unregisterIP(addr netip.Addr) {
 // startNetworkServices creates a gVisor stack for the network at index and
 // starts each composed hub service on its hub IP. networkKey is used for
 // logging only.
-func (t *muxTUN) startNetworkServices(index int, networkKey string, services []HubService, lookupName func(string) (netip.Addr, bool)) error {
+func (t *muxTUN) startNetworkServices(index int, networkKey string, services []HubService, lookupName func(string) (netip.Addr, bool), peerContext func(netip.Addr) (context.Context, bool)) error {
 	hubIP := networkHubIP(index)
 
 	opts := stack.Options{
@@ -151,10 +152,11 @@ func (t *muxTUN) startNetworkServices(index int, networkKey string, services []H
 	ns.notifyHandle = ep.AddNotify(ns)
 
 	hub := &HubNetwork{
-		IP:         hubIP,
-		NetworkKey: networkKey,
-		LookupName: lookupName,
-		stack:      s,
+		IP:          hubIP,
+		NetworkKey:  networkKey,
+		LookupName:  lookupName,
+		PeerContext: peerContext,
+		stack:       s,
 	}
 	for _, svc := range services {
 		closer, err := svc.Start(hub)

--- a/enterprise/gateway/server/forwardingtun.go
+++ b/enterprise/gateway/server/forwardingtun.go
@@ -12,22 +12,19 @@ package server
 //  6. WireGuard encrypts, sends UDP to Client B
 //
 // Packets destined for the network's hub IP (fd00:bb:N::1) are injected into
-// that network's private gVisor stack instead, where the DNS server answers
-// them locally rather than forwarding.
+// that network's private gVisor stack instead, where the gateway's composed
+// hub services answer them rather than forwarding (see hub.go).
 
 import (
 	"fmt"
-	"net"
+	"io"
 	"net/netip"
 	"os"
-	"strings"
 	"sync"
 
-	"github.com/miekg/dns"
 	"golang.zx2c4.com/wireguard/tun"
 	"gvisor.dev/gvisor/pkg/buffer"
 	"gvisor.dev/gvisor/pkg/tcpip"
-	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 	"gvisor.dev/gvisor/pkg/tcpip/link/channel"
 	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
@@ -38,13 +35,14 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip/transport/udp"
 )
 
-// netStack is a per-network gVisor stack used for local services (DNS).
+// netStack is a per-network gVisor stack that hosts the hub services.
 type netStack struct {
 	hubIP        netip.Addr
 	ep           *channel.Endpoint
 	stack        *stack.Stack
 	notifyHandle *channel.NotificationHandle
 	outbound     chan *buffer.View // shared with muxTUN
+	services     []io.Closer       // closers of the started hub services
 }
 
 // WriteNotify implements channel.Notification. Called by gVisor when the stack
@@ -77,6 +75,9 @@ func (ns *netStack) injectInbound(pkt []byte) {
 }
 
 func (ns *netStack) close() {
+	for _, c := range ns.services {
+		c.Close()
+	}
 	ns.ep.RemoveNotify(ns.notifyHandle)
 	ns.ep.Close()
 	ns.stack.Close()
@@ -112,9 +113,10 @@ func (t *muxTUN) unregisterIP(addr netip.Addr) {
 	t.ipToNetwork.Delete(addr)
 }
 
-// startNetworkDNS creates a gVisor stack for the network at index and starts
-// a DNS server bound to its hub IP. networkKey is used for logging only.
-func (t *muxTUN) startNetworkDNS(index int, networkKey string, lookup func(string) (netip.Addr, bool)) error {
+// startNetworkServices creates a gVisor stack for the network at index and
+// starts each composed hub service on its hub IP. networkKey is used for
+// logging only.
+func (t *muxTUN) startNetworkServices(index int, networkKey string, services []HubService, lookupName func(string) (netip.Addr, bool)) error {
 	hubIP := networkHubIP(index)
 
 	opts := stack.Options{
@@ -148,18 +150,22 @@ func (t *muxTUN) startNetworkDNS(index int, networkKey string, lookup func(strin
 	}
 	ns.notifyHandle = ep.AddNotify(ns)
 
-	conn, err := gonet.DialUDP(s, &tcpip.FullAddress{
-		NIC:  1,
-		Addr: tcpip.AddrFromSlice(hubIP.AsSlice()),
-		Port: 53,
-	}, nil, ipv6.ProtocolNumber)
-	if err != nil {
-		ns.close()
-		return fmt.Errorf("DNS listen on %s:53: %v", hubIP, err)
+	hub := &HubNetwork{
+		IP:         hubIP,
+		NetworkKey: networkKey,
+		LookupName: lookupName,
+		stack:      s,
 	}
-	go serveDNS(conn, lookup)
+	for _, svc := range services {
+		closer, err := svc.Start(hub)
+		if err != nil {
+			ns.close()
+			return fmt.Errorf("start hub service on %s: %v", hubIP, err)
+		}
+		ns.services = append(ns.services, closer)
+	}
 
-	// Register the hub IP so Write() routes DNS packets into this stack.
+	// Register the hub IP so Write() routes hub-destined packets into this stack.
 	t.ipToNetwork.Store(hubIP, index)
 	t.netStacks.Store(index, ns)
 	return nil
@@ -268,49 +274,4 @@ func (t *muxTUN) Close() error {
 		})
 	})
 	return nil
-}
-
-func serveDNS(conn *gonet.UDPConn, lookup func(string) (netip.Addr, bool)) {
-	buf := make([]byte, 512)
-	for {
-		n, src, err := conn.ReadFrom(buf)
-		if err != nil {
-			return // stack closed
-		}
-		req := new(dns.Msg)
-		if err := req.Unpack(buf[:n]); err != nil {
-			continue
-		}
-		resp := new(dns.Msg)
-		resp.SetReply(req)
-		resp.Authoritative = true
-		for _, q := range req.Question {
-			name := strings.TrimSuffix(q.Name, ".")
-			ip, ok := lookup(name)
-			if !ok {
-				resp.Rcode = dns.RcodeNameError
-				continue
-			}
-			switch q.Qtype {
-			case dns.TypeAAAA:
-				if ip.Is6() {
-					resp.Answer = append(resp.Answer, &dns.AAAA{
-						Hdr:  dns.RR_Header{Name: q.Name, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 60},
-						AAAA: net.IP(ip.AsSlice()),
-					})
-				}
-			case dns.TypeA:
-				if ip.Is4() {
-					a4 := ip.As4()
-					resp.Answer = append(resp.Answer, &dns.A{
-						Hdr: dns.RR_Header{Name: q.Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
-						A:   net.IP(a4[:]),
-					})
-				}
-			}
-		}
-		if b, err := resp.Pack(); err == nil {
-			conn.WriteTo(b, src)
-		}
-	}
 }

--- a/enterprise/gateway/server/forwardingtun_test.go
+++ b/enterprise/gateway/server/forwardingtun_test.go
@@ -101,8 +101,9 @@ func TestMuxTUN_DNSIsolation(t *testing.T) {
 		return netip.Addr{}, false
 	}
 
-	require.NoError(t, tun.startNetworkDNS(0, "net0", net0Lookup))
-	require.NoError(t, tun.startNetworkDNS(1, "net1", net1Lookup))
+	dns := []HubService{DNSService()}
+	require.NoError(t, tun.startNetworkServices(0, "net0", dns, net0Lookup))
+	require.NoError(t, tun.startNetworkServices(1, "net1", dns, net1Lookup))
 
 	// Property 1: cross-network DNS packet dropped by dispatch before reaching
 	// the DNS stack. A net1 peer's packet to net0's hub IP is in a different

--- a/enterprise/gateway/server/forwardingtun_test.go
+++ b/enterprise/gateway/server/forwardingtun_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"net/netip"
 	"testing"
 	"time"
@@ -101,9 +102,11 @@ func TestMuxTUN_DNSIsolation(t *testing.T) {
 		return netip.Addr{}, false
 	}
 
+	noPeerContext := func(netip.Addr) (context.Context, bool) { return nil, false }
+
 	dns := []HubService{DNSService()}
-	require.NoError(t, tun.startNetworkServices(0, "net0", dns, net0Lookup))
-	require.NoError(t, tun.startNetworkServices(1, "net1", dns, net1Lookup))
+	require.NoError(t, tun.startNetworkServices(0, "net0", dns, net0Lookup, noPeerContext))
+	require.NoError(t, tun.startNetworkServices(1, "net1", dns, net1Lookup, noPeerContext))
 
 	// Property 1: cross-network DNS packet dropped by dispatch before reaching
 	// the DNS stack. A net1 peer's packet to net0's hub IP is in a different

--- a/enterprise/gateway/server/gateway.go
+++ b/enterprise/gateway/server/gateway.go
@@ -79,7 +79,8 @@ type Gateway struct {
 	pubKey        string // server's base64 public key
 	networks      map[string]*networkState
 	peers         map[string]*peerInfo // WireGuard public key hex → peer info
-	nextIndex     int                  // monotonically increasing network index
+	hubServices   []HubService
+	nextIndex     int // monotonically increasing network index
 	publicHost    string
 	udpListenPort int
 	done          chan struct{}
@@ -94,7 +95,7 @@ type Gateway struct {
 }
 
 // New creates a Gateway with a single shared WireGuard device.
-func New(env environment.Env) (*Gateway, error) {
+func New(env environment.Env, hubServices ...HubService) (*Gateway, error) {
 	serverPrivKey, err := wgkeys.GeneratePrivateKey()
 	if err != nil {
 		return nil, status.InternalErrorf("generate server private key: %s", err)
@@ -107,6 +108,7 @@ func New(env environment.Env) (*Gateway, error) {
 		tun:           tunDev,
 		networks:      make(map[string]*networkState),
 		peers:         make(map[string]*peerInfo),
+		hubServices:   hubServices,
 		publicHost:    *publicHost,
 		udpListenPort: *udpListenPort,
 		done:          make(chan struct{}),
@@ -589,8 +591,8 @@ func (g *Gateway) getOrCreateNetwork(groupID, networkName string) (*networkState
 		ns.namesMu.Unlock()
 		return addr, ok
 	}
-	if err := g.tun.startNetworkDNS(index, key, nameLookup); err != nil {
-		return nil, status.InternalErrorf("start DNS for network %q: %s", key, err)
+	if err := g.tun.startNetworkServices(index, key, g.hubServices, nameLookup); err != nil {
+		return nil, status.InternalErrorf("start services for network %q: %s", key, err)
 	}
 
 	g.networks[key] = ns

--- a/enterprise/gateway/server/gateway.go
+++ b/enterprise/gateway/server/gateway.go
@@ -48,11 +48,12 @@ var (
 // networkState holds IP allocation and peer name state for one
 // (groupID, networkName) pair.
 type networkState struct {
-	groupID  string                // group that owns this network
-	index    int                   // assigned network index; determines the /48 prefix
-	namesMu  sync.Mutex            // protects names
-	names    map[string]netip.Addr // peer_name → assigned IP
-	nextHost int                   // next host number to assign; starts at 2 (.1 is the hub)
+	groupID  string                   // group that owns this network
+	index    int                      // assigned network index; determines the /48 prefix
+	mu       sync.Mutex               // protects names and peers
+	names    map[string]netip.Addr    // peer_name → assigned IP
+	peers    map[netip.Addr]*peerInfo // assigned IP → peer, for HubNetwork.PeerContext
+	nextHost int                      // next host number to assign; starts at 2 (.1 is the hub)
 }
 
 // peerInfo tracks per-peer state needed for cleanup.
@@ -63,10 +64,15 @@ type peerInfo struct {
 	sessionID    string    // uniquely identifies this connection
 	registeredAt time.Time // used as last-seen baseline if peer never completed a handshake
 
-	// cancel, if set, closes the Connect stream that owns this registration.
-	// removePeerLocked calls it so that a peer removed by another path (e.g.
-	// the stale-peer sweep) doesn't leave its stream dangling.
-	cancel context.CancelFunc
+	// ctx lives as long as the registration.
+	ctx       context.Context
+	cancelCtx context.CancelFunc
+
+	// closeStream, if set, closes the Connect stream that owns this
+	// registration. removePeerLocked calls it so that a peer removed by
+	// another path (e.g. the stale-peer sweep) doesn't leave its stream
+	// dangling.
+	closeStream context.CancelFunc
 }
 
 // Gateway manages a single WireGuard device shared across all groups.
@@ -188,20 +194,20 @@ func (g *Gateway) Register(ctx context.Context, req *gwpb.RegisterRequest) (*gwp
 		// Find an available name: try the requested name first, then append
 		// numeric suffixes until we find a free slot.
 		assignedName = requested
-		ns.namesMu.Lock()
+		ns.mu.Lock()
 		for i := 1; ; i++ {
 			if _, taken := ns.names[assignedName]; !taken {
 				break
 			}
 			assignedName = fmt.Sprintf("%s-%d", requested, i)
 		}
-		ns.namesMu.Unlock()
+		ns.mu.Unlock()
 	}
 
 	// Note: session_id is left empty for Register peers — it is a Connect
 	// concept, and leaving it unset lets List callers distinguish legacy
 	// registrations.
-	assignedIP, err := g.addPeerLocked(ns, clientPubKey.Hex(), assignedName, "" /*=sessionID*/, nil /*=cancel*/)
+	assignedIP, err := g.addPeerLocked(ns, clientPubKey.Hex(), assignedName, "" /*=sessionID*/, nil /*=closeStream*/)
 	if err != nil {
 		return nil, err
 	}
@@ -263,9 +269,9 @@ func (g *Gateway) Connect(req *gwpb.ConnectRequest, stream gwsvcpb.GatewayServic
 		return err
 	}
 	if name != "" {
-		ns.namesMu.Lock()
+		ns.mu.Lock()
 		_, taken := ns.names[name]
-		ns.namesMu.Unlock()
+		ns.mu.Unlock()
 		if taken {
 			g.mu.Unlock()
 			return status.AlreadyExistsErrorf("peer name %q is already in use", name)
@@ -461,7 +467,7 @@ func (g *Gateway) snapshotPeer(groupID, sessionID string) (*gwpb.Peer, error) {
 // WireGuard device, and records the peer. assignedName and sessionID must
 // already be validated (and checked for conflicts) by the caller. Must be
 // called with g.mu held.
-func (g *Gateway) addPeerLocked(ns *networkState, pubKeyHex, assignedName, sessionID string, cancel context.CancelFunc) (netip.Addr, error) {
+func (g *Gateway) addPeerLocked(ns *networkState, pubKeyHex, assignedName, sessionID string, closeStream context.CancelFunc) (netip.Addr, error) {
 	if _, ok := g.peers[pubKeyHex]; ok {
 		return netip.Addr{}, status.AlreadyExistsErrorf("public key %s... is already registered", pubKeyHex[:8])
 	}
@@ -482,19 +488,24 @@ func (g *Gateway) addPeerLocked(ns *networkState, pubKeyHex, assignedName, sessi
 		return netip.Addr{}, status.InternalErrorf("add WireGuard peer: %s", err)
 	}
 
-	if assignedName != "" {
-		ns.namesMu.Lock()
-		ns.names[assignedName] = assignedIP
-		ns.namesMu.Unlock()
-	}
-	g.peers[pubKeyHex] = &peerInfo{
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	info := &peerInfo{
 		ip:           assignedIP,
 		networkState: ns,
 		assignedName: assignedName,
 		sessionID:    sessionID,
 		registeredAt: time.Now(),
-		cancel:       cancel,
+		ctx:          ctx,
+		cancelCtx:    cancelCtx,
+		closeStream:  closeStream,
 	}
+	ns.mu.Lock()
+	if assignedName != "" {
+		ns.names[assignedName] = assignedIP
+	}
+	ns.peers[assignedIP] = info
+	ns.mu.Unlock()
+	g.peers[pubKeyHex] = info
 	g.notifyWatchers()
 	return assignedIP, nil
 }
@@ -582,16 +593,26 @@ func (g *Gateway) getOrCreateNetwork(groupID, networkName string) (*networkState
 		groupID:  groupID,
 		index:    index,
 		names:    make(map[string]netip.Addr),
+		peers:    make(map[netip.Addr]*peerInfo),
 		nextHost: 2,
 	}
 
 	nameLookup := func(name string) (netip.Addr, bool) {
-		ns.namesMu.Lock()
+		ns.mu.Lock()
 		addr, ok := ns.names[name]
-		ns.namesMu.Unlock()
+		ns.mu.Unlock()
 		return addr, ok
 	}
-	if err := g.tun.startNetworkServices(index, key, g.hubServices, nameLookup); err != nil {
+	peerContext := func(ip netip.Addr) (context.Context, bool) {
+		ns.mu.Lock()
+		info, ok := ns.peers[ip]
+		ns.mu.Unlock()
+		if !ok {
+			return nil, false
+		}
+		return info.ctx, true
+	}
+	if err := g.tun.startNetworkServices(index, key, g.hubServices, nameLookup, peerContext); err != nil {
 		return nil, status.InternalErrorf("start services for network %q: %s", key, err)
 	}
 
@@ -676,21 +697,24 @@ func (g *Gateway) lastHandshakeTimes() (map[string]time.Time, error) {
 }
 
 // removePeerLocked removes a peer from the WireGuard device, the TUN, and the
-// DNS name map, and closes the peer's Connect stream if it has one. Must be
-// called with g.mu held.
+// network's name and IP maps, cancels the peer's context, and closes its
+// Connect stream if it has one. Must be called with g.mu held.
 func (g *Gateway) removePeerLocked(pubKeyHex string, info *peerInfo) {
 	if err := g.dev.IpcSet(fmt.Sprintf("public_key=%s\nremove=true\n", pubKeyHex)); err != nil {
 		log.Errorf("Remove WireGuard peer %s...: %s", pubKeyHex[:8], err)
 	}
 	g.tun.unregisterIP(info.ip)
+	ns := info.networkState
+	ns.mu.Lock()
 	if info.assignedName != "" {
-		info.networkState.namesMu.Lock()
-		delete(info.networkState.names, info.assignedName)
-		info.networkState.namesMu.Unlock()
+		delete(ns.names, info.assignedName)
 	}
+	delete(ns.peers, info.ip)
+	ns.mu.Unlock()
 	delete(g.peers, pubKeyHex)
-	if info.cancel != nil {
-		info.cancel()
+	info.cancelCtx()
+	if info.closeStream != nil {
+		info.closeStream()
 	}
 	g.notifyWatchers()
 	log.Infof("Removed peer %s... (ip=%s name=%q session=%s)", pubKeyHex[:8], info.ip, info.assignedName, info.sessionID)

--- a/enterprise/gateway/server/gateway_e2e_test.go
+++ b/enterprise/gateway/server/gateway_e2e_test.go
@@ -1,9 +1,9 @@
-package server
+package server_test
 
 // End-to-end tests that bring up real userspace WireGuard tunnels and verify
 // actual packet flow through the gateway.
 //
-// Each client uses golang.zx2c4.com/wireguard/tun/netstack to run a userspace
+// Each client (brought up by the testgateway package) runs a userspace
 // WireGuard device backed by a gVisor network stack.  The gateway runs on
 // localhost with a real UDP socket, so these tests exercise the full path:
 //
@@ -15,89 +15,15 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"net/netip"
-	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/server"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/testgateway"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
-	"github.com/buildbuddy-io/buildbuddy/server/util/wgkeys"
 	"github.com/stretchr/testify/require"
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/device"
-	"golang.zx2c4.com/wireguard/tun/netstack"
-
-	gwpb "github.com/buildbuddy-io/buildbuddy/proto/gateway"
 )
-
-// tunnelPeer holds the gVisor netstack and assigned tunnel address for a
-// connected WireGuard peer.
-type tunnelPeer struct {
-	net          *netstack.Net
-	addr         netip.Addr
-	assignedName string
-	sessionID    string
-}
-
-// sessionCounter generates unique session IDs for e2e peers: the gateway
-// requires session IDs and enforces their uniqueness within a group.
-var sessionCounter atomic.Int64
-
-// registerAndConnect connects a new peer to the gateway via the streaming
-// Connect RPC and brings up a userspace WireGuard tunnel for it. The
-// registration is leased to the Connect stream, which stays open (and the
-// tunnel up) until the test ends.
-//
-// persistent_keepalive_interval=1 is used so that the first outbound packet
-// triggers an immediate WireGuard handshake rather than waiting for the
-// gateway to initiate one.
-func registerAndConnect(t testing.TB, gw *Gateway, ctx context.Context, networkName, peerName string) tunnelPeer {
-	t.Helper()
-	sessionID := fmt.Sprintf("e2e-session-%d", sessionCounter.Add(1))
-	return registerAndConnectWithSessionID(t, gw, ctx, networkName, peerName, sessionID)
-}
-
-func registerAndConnectWithSessionID(t testing.TB, gw *Gateway, ctx context.Context, networkName, peerName, sessionID string) tunnelPeer {
-	t.Helper()
-	privKey, err := wgkeys.GeneratePrivateKey()
-	require.NoError(t, err)
-
-	resp, _, _ := startConnect(t, gw, ctx, &gwpb.ConnectRequest{
-		NetworkName: networkName,
-		PeerName:    peerName,
-		PublicKey:   privKey.PublicKey().Hex(),
-		SessionId:   sessionID,
-	})
-
-	addr := netip.MustParseAddr(resp.GetAssignedIp())
-	tunDev, tnet, err := netstack.CreateNetTUN(
-		[]netip.Addr{addr},
-		// Use the gateway's hub IP as the DNS resolver so peer names
-		// registered with peer_name are resolvable by name.
-		[]netip.Addr{netip.MustParseAddr(resp.GetGatewayIp())},
-		1420,
-	)
-	require.NoError(t, err)
-
-	logger := &device.Logger{
-		Verbosef: func(format string, args ...any) {},
-		Errorf:   func(format string, args ...any) { t.Logf("wg: "+format, args...) },
-	}
-	dev := device.NewDevice(tunDev, conn.NewDefaultBind(), logger)
-	t.Cleanup(dev.Close)
-
-	ipc := fmt.Sprintf(
-		"private_key=%s\npublic_key=%s\nallowed_ip=%s\nendpoint=%s\npersistent_keepalive_interval=1\n",
-		privKey.Hex(), resp.GetServerPublicKey(), resp.GetNetworkCidr(), resp.GetServerEndpoint(),
-	)
-	require.NoError(t, dev.IpcSet(ipc))
-	require.NoError(t, dev.Up())
-
-	// Peer names are unique under Connect, so the assigned name is always
-	// the requested name.
-	return tunnelPeer{net: tnet, addr: addr, assignedName: peerName, sessionID: sessionID}
-}
 
 // TestEndToEnd_WatchReportsHandshake verifies that a Watch stream reports the
 // watched peer's first completed WireGuard handshake. The fallback poll is
@@ -107,25 +33,25 @@ func registerAndConnectWithSessionID(t testing.TB, gw *Gateway, ctx context.Cont
 func TestEndToEnd_WatchReportsHandshake(t *testing.T) {
 	flags.Set(t, "gateway.watch_fallback_poll_interval", time.Minute)
 	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
-	gw := setupGateway(t, ta)
+	gw := testgateway.Setup(t, ta, server.DNSService())
 
 	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
 	require.NoError(t, err)
 
 	// Watch before the peer exists so the stream observes the full
 	// lifecycle: registration first, then the handshake.
-	sessionID := fmt.Sprintf("e2e-session-%d", sessionCounter.Add(1))
-	stream, cancelWatch, _ := startWatch(t, gw, ctx, sessionID)
+	sessionID := testgateway.NextSessionID()
+	events, cancelWatch, _ := testgateway.StartWatch(t, gw, ctx, sessionID)
 	defer cancelWatch()
 
-	registerAndConnectWithSessionID(t, gw, ctx, "net1", "peer-a", sessionID)
+	testgateway.RegisterAndConnectWithSessionID(t, gw, ctx, "net1", "peer-a", sessionID)
 
 	// The peer's persistent keepalive triggers the handshake; the watch must
 	// eventually report a peer with a handshake time.
 	deadline := time.After(30 * time.Second)
 	for {
 		select {
-		case rsp := <-stream.responses:
+		case rsp := <-events:
 			if rsp.GetPeer() == nil {
 				continue // heartbeat
 			}
@@ -143,16 +69,16 @@ func TestEndToEnd_WatchReportsHandshake(t *testing.T) {
 // can exchange data over the WireGuard tunnel using direct IP addressing.
 func TestEndToEnd_PeersCanCommunicate(t *testing.T) {
 	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
-	gw := setupGateway(t, ta)
+	gw := testgateway.Setup(t, ta, server.DNSService())
 
 	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
 	require.NoError(t, err)
 
-	peerA := registerAndConnect(t, gw, ctx, "net1", "peer-a")
-	peerB := registerAndConnect(t, gw, ctx, "net1", "peer-b")
+	peerA := testgateway.RegisterAndConnect(t, gw, ctx, "net1", "peer-a")
+	peerB := testgateway.RegisterAndConnect(t, gw, ctx, "net1", "peer-b")
 
 	const port = 9999
-	ln, err := peerA.net.ListenTCP(&net.TCPAddr{Port: port})
+	ln, err := peerA.Net.ListenTCP(&net.TCPAddr{Port: port})
 	require.NoError(t, err)
 	t.Cleanup(func() { ln.Close() })
 
@@ -162,7 +88,7 @@ func TestEndToEnd_PeersCanCommunicate(t *testing.T) {
 	// handshake; allow up to 30 s for it to complete.
 	dialCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	connB, err := peerB.net.DialContext(dialCtx, "tcp", fmt.Sprintf("[%s]:%d", peerA.addr, port))
+	connB, err := peerB.Net.DialContext(dialCtx, "tcp", fmt.Sprintf("[%s]:%d", peerA.Addr, port))
 	require.NoError(t, err)
 	defer connB.Close()
 
@@ -185,16 +111,16 @@ func TestEndToEnd_PeersCanCommunicate(t *testing.T) {
 // that name.
 func TestEndToEnd_DNSResolution(t *testing.T) {
 	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
-	gw := setupGateway(t, ta)
+	gw := testgateway.Setup(t, ta, server.DNSService())
 
 	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
 	require.NoError(t, err)
 
-	peerA := registerAndConnect(t, gw, ctx, "net1", "myvm")
-	peerB := registerAndConnect(t, gw, ctx, "net1", "")
+	peerA := testgateway.RegisterAndConnect(t, gw, ctx, "net1", "myvm")
+	peerB := testgateway.RegisterAndConnect(t, gw, ctx, "net1", "")
 
 	const port = 9998
-	ln, err := peerA.net.ListenTCP(&net.TCPAddr{Port: port})
+	ln, err := peerA.Net.ListenTCP(&net.TCPAddr{Port: port})
 	require.NoError(t, err)
 	t.Cleanup(func() { ln.Close() })
 
@@ -205,7 +131,7 @@ func TestEndToEnd_DNSResolution(t *testing.T) {
 	// Dial peer-a by DNS name. The gVisor stack sends a DNS query to the
 	// gateway hub IP (configured as the resolver in CreateNetTUN), which
 	// routes it to serveDNS via injectInbound.
-	connB, err := peerB.net.DialContext(dialCtx, "tcp", fmt.Sprintf("%s:%d", peerA.assignedName, port))
+	connB, err := peerB.Net.DialContext(dialCtx, "tcp", fmt.Sprintf("%s:%d", peerA.AssignedName, port))
 	require.NoError(t, err)
 	defer connB.Close()
 
@@ -236,22 +162,22 @@ func TestEndToEnd_DNSResolution(t *testing.T) {
 //	  --test_arg=-test.run='^$'
 func BenchmarkGatewayThroughput(b *testing.B) {
 	ta := testauth.NewTestAuthenticator(b, testauth.TestUsers("user1", "group1"))
-	gw := setupGateway(b, ta)
+	gw := testgateway.Setup(b, ta, server.DNSService())
 
 	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
 	require.NoError(b, err)
 
-	peerA := registerAndConnect(b, gw, ctx, "net1", "server")
-	peerB := registerAndConnect(b, gw, ctx, "net1", "client")
+	peerA := testgateway.RegisterAndConnect(b, gw, ctx, "net1", "server")
+	peerB := testgateway.RegisterAndConnect(b, gw, ctx, "net1", "client")
 
 	const port = 9997
-	ln, err := peerA.net.ListenTCP(&net.TCPAddr{Port: port})
+	ln, err := peerA.Net.ListenTCP(&net.TCPAddr{Port: port})
 	require.NoError(b, err)
 	b.Cleanup(func() { ln.Close() })
 
 	dialCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	connB, err := peerB.net.DialContext(dialCtx, "tcp", fmt.Sprintf("[%s]:%d", peerA.addr, port))
+	connB, err := peerB.Net.DialContext(dialCtx, "tcp", fmt.Sprintf("[%s]:%d", peerA.Addr, port))
 	require.NoError(b, err)
 	b.Cleanup(func() { connB.Close() })
 

--- a/enterprise/gateway/server/gateway_test.go
+++ b/enterprise/gateway/server/gateway_test.go
@@ -53,7 +53,7 @@ func setupGateway(t testing.TB, ta *testauth.TestAuthenticator) *Gateway {
 	env := testenv.GetTestEnv(t)
 	env.SetAuthenticator(ta)
 
-	gw, err := New(env)
+	gw, err := New(env, DNSService())
 	require.NoError(t, err)
 	t.Cleanup(gw.Close)
 	return gw

--- a/enterprise/gateway/server/hub.go
+++ b/enterprise/gateway/server/hub.go
@@ -5,6 +5,7 @@ package server
 // gateway offers is decided by composition at construction time — see New.
 
 import (
+	"context"
 	"io"
 	"net"
 	"net/netip"
@@ -24,8 +25,13 @@ type HubNetwork struct {
 	IP netip.Addr
 	// NetworkKey identifies the network in logs ("owner/network").
 	NetworkKey string
+
 	// LookupName resolves a peer name registered in this network.
 	LookupName func(name string) (netip.Addr, bool)
+
+	// PeerContext returns a context that is canceled when the peer at ip is
+	// removed from this network.
+	PeerContext func(ip netip.Addr) (ctx context.Context, ok bool)
 
 	stack *stack.Stack
 }

--- a/enterprise/gateway/server/hub.go
+++ b/enterprise/gateway/server/hub.go
@@ -1,0 +1,117 @@
+package server
+
+// Hub services are what a gateway runs on each network's hub IP
+// (fd00:bb:N::1), inside that network's private gVisor stack. Which services a
+// gateway offers is decided by composition at construction time — see New.
+
+import (
+	"io"
+	"net"
+	"net/netip"
+	"strings"
+
+	"github.com/miekg/dns"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv6"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+)
+
+// HubNetwork is one network's hub as seen by a HubService: listeners on the
+// hub IP plus the lookups a service needs to answer for this network.
+type HubNetwork struct {
+	// IP is the hub address the service is reachable on.
+	IP netip.Addr
+	// NetworkKey identifies the network in logs ("owner/network").
+	NetworkKey string
+	// LookupName resolves a peer name registered in this network.
+	LookupName func(name string) (netip.Addr, bool)
+
+	stack *stack.Stack
+}
+
+// ListenTCP opens a TCP listener on the hub IP inside the network's stack.
+func (h *HubNetwork) ListenTCP(port int) (net.Listener, error) {
+	return gonet.ListenTCP(h.stack, tcpip.FullAddress{
+		NIC:  1,
+		Addr: tcpip.AddrFromSlice(h.IP.AsSlice()),
+		Port: uint16(port),
+	}, ipv6.ProtocolNumber)
+}
+
+// ListenUDP opens a UDP socket bound to the hub IP inside the network's stack.
+func (h *HubNetwork) ListenUDP(port int) (net.PacketConn, error) {
+	return gonet.DialUDP(h.stack, &tcpip.FullAddress{
+		NIC:  1,
+		Addr: tcpip.AddrFromSlice(h.IP.AsSlice()),
+		Port: uint16(port),
+	}, nil, ipv6.ProtocolNumber)
+}
+
+// A HubService serves peers on their network's hub IP. Start is called once
+// per network, when the network is created. The returned closer is invoked
+// when the gateway shuts the network down.
+type HubService interface {
+	Start(hub *HubNetwork) (io.Closer, error)
+}
+
+// DNSService returns the hub service that resolves registered peer names
+// (fd00:bb:N::1 port 53). Peers configure the hub as their resolver, so
+// `ssh <peer-name>` works inside the overlay.
+func DNSService() HubService { return dnsService{} }
+
+type dnsService struct{}
+
+func (dnsService) Start(hub *HubNetwork) (io.Closer, error) {
+	conn, err := hub.ListenUDP(53)
+	if err != nil {
+		return nil, err
+	}
+	go serveDNS(conn, hub.LookupName)
+	return conn, nil
+}
+
+func serveDNS(conn net.PacketConn, lookup func(string) (netip.Addr, bool)) {
+	buf := make([]byte, 512)
+	for {
+		n, src, err := conn.ReadFrom(buf)
+		if err != nil {
+			return // stack closed
+		}
+		req := new(dns.Msg)
+		if err := req.Unpack(buf[:n]); err != nil {
+			continue
+		}
+		resp := new(dns.Msg)
+		resp.SetReply(req)
+		resp.Authoritative = true
+		for _, q := range req.Question {
+			name := strings.TrimSuffix(q.Name, ".")
+			ip, ok := lookup(name)
+			if !ok {
+				resp.Rcode = dns.RcodeNameError
+				continue
+			}
+			switch q.Qtype {
+			case dns.TypeAAAA:
+				if ip.Is6() {
+					resp.Answer = append(resp.Answer, &dns.AAAA{
+						Hdr:  dns.RR_Header{Name: q.Name, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 60},
+						AAAA: net.IP(ip.AsSlice()),
+					})
+				}
+			case dns.TypeA:
+				if ip.Is4() {
+					a4 := ip.As4()
+					resp.Answer = append(resp.Answer, &dns.A{
+						Hdr: dns.RR_Header{Name: q.Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+						A:   net.IP(a4[:]),
+					})
+				}
+			}
+		}
+		if b, err := resp.Pack(); err == nil {
+			conn.WriteTo(b, src)
+		}
+	}
+}

--- a/enterprise/gateway/testgateway/BUILD
+++ b/enterprise/gateway/testgateway/BUILD
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "testgateway",
+    testonly = 1,
+    srcs = ["testgateway.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/gateway/testgateway",
+    deps = [
+        "//enterprise/gateway/server",
+        "//proto:gateway_go_proto",
+        "//proto:gateway_service_go_proto",
+        "//server/testutil/testauth",
+        "//server/testutil/testenv",
+        "//server/util/testing/flags",
+        "//server/util/wgkeys",
+        "@com_github_stretchr_testify//require",
+        "@com_zx2c4_golang_wireguard//conn",
+        "@com_zx2c4_golang_wireguard//device",
+        "@com_zx2c4_golang_wireguard//tun/netstack",
+        "@org_golang_google_grpc//:grpc",
+    ],
+)

--- a/enterprise/gateway/testgateway/testgateway.go
+++ b/enterprise/gateway/testgateway/testgateway.go
@@ -1,0 +1,194 @@
+// Package testgateway is a fixture for bringing up and connecting to a gateway instance.
+package testgateway
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/server"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/buildbuddy-io/buildbuddy/server/util/wgkeys"
+	"github.com/stretchr/testify/require"
+	"golang.zx2c4.com/wireguard/conn"
+	"golang.zx2c4.com/wireguard/device"
+	"golang.zx2c4.com/wireguard/tun/netstack"
+	"google.golang.org/grpc"
+
+	gwpb "github.com/buildbuddy-io/buildbuddy/proto/gateway"
+	gwsvcpb "github.com/buildbuddy-io/buildbuddy/proto/gateway_service"
+)
+
+// Setup starts a gateway composing the given hub services on a free UDP port,
+// registered for cleanup with t.
+func Setup(t testing.TB, ta *testauth.TestAuthenticator, services ...server.HubService) *server.Gateway {
+	t.Helper()
+	flags.Set(t, "gateway.udp_listen_port", freeUDPPort(t))
+	flags.Set(t, "gateway.public_host", "127.0.0.1")
+
+	env := testenv.GetTestEnv(t)
+	env.SetAuthenticator(ta)
+
+	gw, err := server.New(env, services...)
+	require.NoError(t, err)
+	t.Cleanup(gw.Close)
+	return gw
+}
+
+func freeUDPPort(t testing.TB) int {
+	t.Helper()
+	l, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.LocalAddr().(*net.UDPAddr).Port
+	l.Close()
+	return port
+}
+
+// Peer is a connected WireGuard client.
+type Peer struct {
+	Net          *netstack.Net
+	Addr         netip.Addr
+	GatewayIP    netip.Addr // the network's hub IP, where hub services listen
+	AssignedName string
+	SessionID    string
+}
+
+// sessionCounter generates unique session IDs for peers.
+var sessionCounter atomic.Int64
+
+// NextSessionID returns a fresh unique session ID.
+func NextSessionID() string {
+	return fmt.Sprintf("e2e-session-%d", sessionCounter.Add(1))
+}
+
+// RegisterAndConnect connects a new peer to the gateway via the streaming
+// Connect RPC and brings up a userspace WireGuard tunnel for it. The
+// registration is leased to the Connect stream, which stays open (and the
+// tunnel up) until the test ends.
+func RegisterAndConnect(t testing.TB, gw *server.Gateway, ctx context.Context, networkName, peerName string) Peer {
+	t.Helper()
+	return RegisterAndConnectWithSessionID(t, gw, ctx, networkName, peerName, NextSessionID())
+}
+
+// RegisterAndConnectWithSessionID is like RegisterAndConnect but allows session ID to be specified by the caller.
+//
+// persistent_keepalive_interval=1 is used so that the first outbound packet
+// triggers an immediate WireGuard handshake rather than waiting for the
+// gateway to initiate one.
+func RegisterAndConnectWithSessionID(t testing.TB, gw *server.Gateway, ctx context.Context, networkName, peerName, sessionID string) Peer {
+	t.Helper()
+	privKey, err := wgkeys.GeneratePrivateKey()
+	require.NoError(t, err)
+
+	resp, _, _ := StartConnect(t, gw, ctx, &gwpb.ConnectRequest{
+		NetworkName: networkName,
+		PeerName:    peerName,
+		PublicKey:   privKey.PublicKey().Hex(),
+		SessionId:   sessionID,
+	})
+
+	addr := netip.MustParseAddr(resp.GetAssignedIp())
+	gatewayIP := netip.MustParseAddr(resp.GetGatewayIp())
+	tunDev, tnet, err := netstack.CreateNetTUN(
+		[]netip.Addr{addr},
+		// Use the gateway's hub IP as the DNS resolver so peer names
+		// registered with peer_name are resolvable by name.
+		[]netip.Addr{gatewayIP},
+		1420,
+	)
+	require.NoError(t, err)
+
+	logger := &device.Logger{
+		Verbosef: func(format string, args ...any) {},
+		Errorf:   func(format string, args ...any) { t.Logf("wg: "+format, args...) },
+	}
+	dev := device.NewDevice(tunDev, conn.NewDefaultBind(), logger)
+	t.Cleanup(dev.Close)
+
+	ipc := fmt.Sprintf(
+		"private_key=%s\npublic_key=%s\nallowed_ip=%s\nendpoint=%s\npersistent_keepalive_interval=1\n",
+		privKey.Hex(), resp.GetServerPublicKey(), resp.GetNetworkCidr(), resp.GetServerEndpoint(),
+	)
+	require.NoError(t, dev.IpcSet(ipc))
+	require.NoError(t, dev.Up())
+
+	// Peer names are unique under Connect, so the assigned name is always
+	// the requested name.
+	return Peer{Net: tnet, Addr: addr, GatewayIP: gatewayIP, AssignedName: peerName, SessionID: sessionID}
+}
+
+// connectStream implements gwsvcpb.GatewayService_ConnectServer. Only Context
+// and Send are used by the Connect handler; the embedded nil grpc.ServerStream
+// panics if anything else is called.
+type connectStream struct {
+	grpc.ServerStream
+	ctx       context.Context
+	responses chan *gwpb.ConnectResponse
+}
+
+func (f *connectStream) Context() context.Context { return f.ctx }
+func (f *connectStream) Send(rsp *gwpb.ConnectResponse) error {
+	f.responses <- rsp
+	return nil
+}
+
+// StartConnect runs gw.Connect on a fake stream in the background and waits
+// for the initial config response. The returned cancel func closes the stream
+// (simulating the client going away); the done channel receives Connect's
+// return value.
+func StartConnect(t testing.TB, gw *server.Gateway, ctx context.Context, req *gwpb.ConnectRequest) (*gwpb.ConnectResponse, context.CancelFunc, chan error) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	stream := &connectStream{ctx: ctx, responses: make(chan *gwpb.ConnectResponse, 1)}
+	done := make(chan error, 1)
+	go func() { done <- gw.Connect(req, stream) }()
+	select {
+	case rsp := <-stream.responses:
+		return rsp, cancel, done
+	case err := <-done:
+		t.Fatalf("Connect returned before sending config: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Connect response")
+	}
+	return nil, nil, nil
+}
+
+// watchStream implements gwsvcpb.GatewayService_WatchServer. Only Context and
+// Send are used by the Watch handler; the embedded nil grpc.ServerStream panics
+// if anything else is called.
+type watchStream struct {
+	grpc.ServerStream
+	ctx       context.Context
+	responses chan *gwpb.WatchResponse
+}
+
+func (f *watchStream) Context() context.Context { return f.ctx }
+func (f *watchStream) Send(rsp *gwpb.WatchResponse) error {
+	f.responses <- rsp
+	return nil
+}
+
+// StartWatch runs gw.Watch for sessionID on a fake stream in the background
+// and returns the channel its responses arrive on. The returned cancel func
+// closes the stream; the done channel receives Watch's return value.
+func StartWatch(t testing.TB, gw *server.Gateway, ctx context.Context, sessionID string) (<-chan *gwpb.WatchResponse, context.CancelFunc, chan error) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	stream := &watchStream{ctx: ctx, responses: make(chan *gwpb.WatchResponse, 16)}
+	done := make(chan error, 1)
+	go func() { done <- gw.Watch(&gwpb.WatchRequest{SessionId: sessionID}, stream) }()
+	return stream.responses, cancel, done
+}
+
+var (
+	_ gwsvcpb.GatewayService_ConnectServer = (*connectStream)(nil)
+	_ gwsvcpb.GatewayService_WatchServer   = (*watchStream)(nil)
+)

--- a/enterprise/gateway/testgateway/testgateway.go
+++ b/enterprise/gateway/testgateway/testgateway.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -57,6 +58,11 @@ type Peer struct {
 	GatewayIP    netip.Addr // the network's hub IP, where hub services listen
 	AssignedName string
 	SessionID    string
+	// Disconnect closes the peer's Connect stream, as if its gRPC connection
+	// had dropped, and returns once the gateway has removed the
+	// registration. The peer's WireGuard device is left running, so from the
+	// gateway's point of view the client simply went dark.
+	Disconnect func()
 }
 
 // sessionCounter generates unique session IDs for peers.
@@ -86,7 +92,7 @@ func RegisterAndConnectWithSessionID(t testing.TB, gw *server.Gateway, ctx conte
 	privKey, err := wgkeys.GeneratePrivateKey()
 	require.NoError(t, err)
 
-	resp, _, _ := StartConnect(t, gw, ctx, &gwpb.ConnectRequest{
+	resp, cancel, done := StartConnect(t, gw, ctx, &gwpb.ConnectRequest{
 		NetworkName: networkName,
 		PeerName:    peerName,
 		PublicKey:   privKey.PublicKey().Hex(),
@@ -120,7 +126,17 @@ func RegisterAndConnectWithSessionID(t testing.TB, gw *server.Gateway, ctx conte
 
 	// Peer names are unique under Connect, so the assigned name is always
 	// the requested name.
-	return Peer{Net: tnet, Addr: addr, GatewayIP: gatewayIP, AssignedName: peerName, SessionID: sessionID}
+	return Peer{
+		Net:          tnet,
+		Addr:         addr,
+		GatewayIP:    gatewayIP,
+		AssignedName: peerName,
+		SessionID:    sessionID,
+		Disconnect: sync.OnceFunc(func() {
+			cancel()
+			<-done
+		}),
+	}
 }
 
 // connectStream implements gwsvcpb.GatewayService_ConnectServer. Only Context

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -291,6 +291,7 @@ proto_library(
     srcs = ["gateway.proto"],
     deps = [
         "@com_google_protobuf//:timestamp_proto",
+        "@googleapis//google/rpc:status_proto",
     ],
 )
 
@@ -298,6 +299,9 @@ go_proto_library(
     name = "gateway_go_proto",
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/gateway",
     proto = ":gateway_proto",
+    deps = [
+        "@org_golang_google_genproto_googleapis_rpc//status",
+    ],
 )
 
 proto_library(

--- a/proto/gateway.proto
+++ b/proto/gateway.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package gateway;
 
 import "google/protobuf/timestamp.proto";
+import "google/rpc/status.proto";
 
 option go_package = "gateway";
 
@@ -147,4 +148,30 @@ message WatchRequest {
 message WatchResponse {
   // The watched peer's current state. Unset in heartbeat messages.
   Peer peer = 1;
+}
+
+// RelayRequest asks the gateway's egress relay to open a TCP connection on
+// the caller's behalf.
+//
+// N.B. This proto is sent as raw bytes to the relay service over the
+// already-established WireGuard tunnel.
+// The server, likewise, sends the response proto as raw bytes before
+// shuttling bytes back and forth for the relayed connection.
+message RelayRequest {
+  // Required. Target host, as a DNS name resolved by the gateway.
+  string host = 1;
+
+  // Required. Target TCP port, 1-65535.
+  int32 port = 2;
+}
+
+// RelayResponse is the relay's one reply to a RelayRequest.
+message RelayResponse {
+  // OK means the connection to the target is open and the stream now carries
+  // its bytes.
+  google.rpc.Status status = 1;
+
+  // The address the target resolved to at the gateway, as host:port. Set on
+  // success, informational.
+  string resolved_address = 2;
 }

--- a/server/util/relaywire/BUILD
+++ b/server/util/relaywire/BUILD
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "relaywire",
+    srcs = ["relaywire.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/relaywire",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto:gateway_go_proto",
+        "@org_golang_google_genproto_googleapis_rpc//status",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//proto",
+    ],
+)
+
+go_test(
+    name = "relaywire_test",
+    srcs = ["relaywire_test.go"],
+    embed = [":relaywire"],
+    deps = [
+        "//proto:gateway_go_proto",
+        "//server/util/status",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/server/util/relaywire/relaywire.go
+++ b/server/util/relaywire/relaywire.go
@@ -1,0 +1,116 @@
+// Package relaywire implements the relay protocol used by the gateway
+// relay service.
+//
+// The client sends a raw RelayRequest proto, the server processes it and sends
+// raw bytes containing a RelayResponse proto. If the relay request is accepted
+// the raw bytes between the client and the destination are shuffled until both
+// ends of the connection are closed.
+package relaywire
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"google.golang.org/grpc/codes"
+	gstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+
+	gwpb "github.com/buildbuddy-io/buildbuddy/proto/gateway"
+	spb "google.golang.org/genproto/googleapis/rpc/status"
+)
+
+// DefaultPort is the TCP port the gateway relay listens on, on each network's
+// hub IP, and tunnel clients dial.
+const DefaultPort = 1081
+
+// maxFrameSize is the maximum size of the relay request proto sent at the
+// beginning of the connection.
+const maxFrameSize = 4 * 1024
+
+// Connect performs the client half of the handshake over an established
+// stream. On success the stream carries the target's bytes. If the relay
+// refuses the request, the returned error is a gRPC status error carrying the
+// relay's code and message, so callers can check it with the status package's
+// Is*Error helpers and read the explanation with status.Message.
+func Connect(rw io.ReadWriter, host string, port int) error {
+	if port <= 0 || port > 0xFFFF {
+		return fmt.Errorf("relaywire: invalid target port %d", port)
+	}
+	if err := writeFrame(rw, &gwpb.RelayRequest{Host: host, Port: int32(port)}); err != nil {
+		return fmt.Errorf("relaywire: write request: %w", err)
+	}
+	resp := &gwpb.RelayResponse{}
+	if err := readFrame(rw, resp); err != nil {
+		return fmt.Errorf("relaywire: read response: %w", err)
+	}
+	// ErrorProto returns nil for codes.OK.
+	return gstatus.ErrorProto(resp.GetStatus())
+}
+
+// ReadRequest performs the server half of the handshake and returns the
+// requested target.
+func ReadRequest(r io.Reader) (*gwpb.RelayRequest, error) {
+	req := &gwpb.RelayRequest{}
+	if err := readFrame(r, req); err != nil {
+		return nil, err
+	}
+	if req.GetHost() == "" {
+		return nil, fmt.Errorf("request has no target host")
+	}
+	if p := req.GetPort(); p <= 0 || p > 0xFFFF {
+		return nil, fmt.Errorf("request has invalid target port %d", p)
+	}
+	return req, nil
+}
+
+// Accept tells the client the connection to the target is open and the stream
+// now carries its bytes. resolvedAddress is the host:port the target name
+// resolved to at the gateway.
+func Accept(w io.Writer, resolvedAddress string) error {
+	return writeFrame(w, &gwpb.RelayResponse{
+		Status:          &spb.Status{Code: int32(codes.OK)},
+		ResolvedAddress: resolvedAddress,
+	})
+}
+
+// Refuse answers the client with the code and message of err, which should be
+// a status error (see server/util/status) explaining the refusal in terms the
+// developer at the far end can act on. An error without a status code is sent
+// as codes.Unknown.
+func Refuse(w io.Writer, err error) {
+	_ = writeFrame(w, &gwpb.RelayResponse{
+		Status: gstatus.Convert(err).Proto(),
+	})
+}
+
+func writeFrame(w io.Writer, m proto.Message) error {
+	b, err := proto.Marshal(m)
+	if err != nil {
+		return err
+	}
+	frame := make([]byte, 4+len(b))
+	binary.BigEndian.PutUint32(frame, uint32(len(b)))
+	copy(frame[4:], b)
+	_, err = w.Write(frame)
+	return err
+}
+
+func readFrame(r io.Reader, m proto.Message) error {
+	var prefix [4]byte
+	if _, err := io.ReadFull(r, prefix[:]); err != nil {
+		return fmt.Errorf("read length prefix: %w", err)
+	}
+	n := binary.BigEndian.Uint32(prefix[:])
+	if n > maxFrameSize {
+		return fmt.Errorf("frame of %d bytes exceeds the %d byte limit (is the other side speaking this protocol?)", n, maxFrameSize)
+	}
+	b := make([]byte, n)
+	if _, err := io.ReadFull(r, b); err != nil {
+		return fmt.Errorf("read frame body: %w", err)
+	}
+	if err := proto.Unmarshal(b, m); err != nil {
+		return fmt.Errorf("unmarshal frame: %w", err)
+	}
+	return nil
+}

--- a/server/util/relaywire/relaywire.go
+++ b/server/util/relaywire/relaywire.go
@@ -13,11 +13,11 @@ import (
 	"io"
 
 	"google.golang.org/grpc/codes"
-	gstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
 	gwpb "github.com/buildbuddy-io/buildbuddy/proto/gateway"
 	spb "google.golang.org/genproto/googleapis/rpc/status"
+	gstatus "google.golang.org/grpc/status"
 )
 
 // DefaultPort is the TCP port the gateway relay listens on, on each network's

--- a/server/util/relaywire/relaywire_test.go
+++ b/server/util/relaywire/relaywire_test.go
@@ -1,0 +1,108 @@
+package relaywire
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/stretchr/testify/require"
+
+	gwpb "github.com/buildbuddy-io/buildbuddy/proto/gateway"
+)
+
+func TestConnect_SuccessThenStreamCarriesBytes(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+
+	gotReq := make(chan *gwpb.RelayRequest, 1)
+	go func() {
+		defer server.Close()
+		req, err := ReadRequest(server)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		gotReq <- req
+		if err := Accept(server, "10.0.0.7:4317"); err != nil {
+			t.Error(err)
+			return
+		}
+		// The handshake framing must end exactly at the response: everything
+		// after it belongs to the target's stream, byte for byte.
+		io.Copy(server, server)
+	}()
+
+	require.NoError(t, Connect(client, "otel.svc.cluster.local", 4317))
+	req := <-gotReq
+	require.Equal(t, "otel.svc.cluster.local", req.GetHost())
+	require.Equal(t, int32(4317), req.GetPort())
+
+	const payload = "spliced bytes"
+	go io.WriteString(client, payload)
+	buf := make([]byte, len(payload))
+	_, err := io.ReadFull(client, buf)
+	require.NoError(t, err)
+	require.Equal(t, payload, string(buf))
+}
+
+func TestConnect_RefusalCarriesTheRelaysExplanation(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+
+	const why = `target "db.prod.internal:5432" is not in the relay's allowed suffix list`
+	go func() {
+		defer server.Close()
+		if _, err := ReadRequest(server); err != nil {
+			t.Error(err)
+			return
+		}
+		Refuse(server, status.PermissionDeniedError(why))
+	}()
+
+	err := Connect(client, "db.prod.internal", 5432)
+	require.Error(t, err)
+	require.True(t, status.IsPermissionDeniedError(err), "got %v", err)
+	require.Equal(t, why, status.Message(err))
+	require.ErrorContains(t, err, why, "the relay's explanation must survive into the error text")
+
+	wrapped := fmt.Errorf("dialing through relay: %w", err)
+	require.True(t, status.IsPermissionDeniedError(wrapped), "callers detect relay verdicts through wrapping")
+}
+
+func TestConnect_RejectsInvalidPortBeforeWriting(t *testing.T) {
+	for _, port := range []int{0, -1, 65536} {
+		// A Write on this pipe would block forever with nobody reading, so
+		// returning at all proves the port was rejected up front.
+		client, _ := net.Pipe()
+		require.Error(t, Connect(client, "host", port), "port %d", port)
+		client.Close()
+	}
+}
+
+func TestReadRequest_RejectsMalformedRequests(t *testing.T) {
+	for name, req := range map[string]*gwpb.RelayRequest{
+		"no host":        {Port: 443},
+		"zero port":      {Host: "h"},
+		"port too large": {Host: "h", Port: 65536},
+	} {
+		var buf bytes.Buffer
+		require.NoError(t, writeFrame(&buf, req))
+		_, err := ReadRequest(&buf)
+		require.Error(t, err, name)
+	}
+}
+
+func TestReadFrame_RefusesOversizedFrames(t *testing.T) {
+	var buf bytes.Buffer
+	var prefix [4]byte
+	binary.BigEndian.PutUint32(prefix[:], maxFrameSize+1)
+	buf.Write(prefix[:])
+
+	_, err := ReadRequest(&buf)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "exceeds")
+}


### PR DESCRIPTION
This hub service allows connected clients to request a relay connection to a target that is reachable by the gateway.

This PR does not yet wire the relay services into the gateway. The relay service will be wired into a separate gateway type.

The relay service implements a basic proto-based protocol for requesting relay services:

 1) The client opens a new connection to the relay service over the already-established Wireguard tunnel.

 2) The client sends `<proto length> <RelayRequest proto bytes>`

 3) The server attempts to establish an outgoing connection and responds with `<proto length><RelayResponse proto bytes>`.
    If the attempt was not succesful, the connection is closed.
    If the attempt was succesfull, the server begins shuffling raw bytes between the client and the destination.