### PR TITLE
Fix flaky TestError in crypter_key_cache_test

### DIFF
--- a/enterprise/server/crypter_key_cache/crypter_key_cache_test.go
+++ b/enterprise/server/crypter_key_cache/crypter_key_cache_test.go
@@ -118,14 +118,23 @@ func TestError(t *testing.T) {
 
 	opts := &crypter_key_cache.Opts{
 		KeyRefreshScanFrequency: 10 * time.Second,
-		KeyErrCacheTime:         5 * time.Second,
+		// Use a long error cache time so that the async clock advancement
+		// below cannot expire the cached error before the second lookup.
+		KeyErrCacheTime: time.Hour,
 	}
 	cache := crypter_key_cache.NewWithOpts(env, refreshFn, clock, opts)
 
-	// Advance the clock asynchronously to keep the retrier moving along.
+	// Advance the clock asynchronously to keep the retrier moving along
+	// during the first lookup.
 	done := make(chan struct{})
-	defer close(done)
+	advancerStopped := make(chan struct{})
+	stopAdvancer := sync.OnceFunc(func() {
+		close(done)
+		<-advancerStopped
+	})
+	defer stopAdvancer()
 	go func() {
+		defer close(advancerStopped)
 		for {
 			select {
 			case <-done:
@@ -139,6 +148,10 @@ func TestError(t *testing.T) {
 	// First call should trigger refresh and cache the error
 	_, err := cache.EncryptionKey(ctx)
 	require.True(t, status.IsUnavailableError(err))
+
+	// Freeze the clock so the cached error cannot expire before the second
+	// lookup below.
+	stopAdvancer()
 	refreshCount.Store(0)
 
 	// Second call within error cache time should return cached error


### PR DESCRIPTION
## Problem

`//enterprise/server/crypter_key_cache:crypter_key_cache_test` is flaky in `TestError`. The test spawns a goroutine that advances the fake clock by 1 fake second every 5ms of real time to drive the retrier during the first `EncryptionKey` call — but the advancer keeps running after that call returns. The cached error only lives 5 fake seconds, so if more than ~25ms of real time elapses between the first and second calls (easy on a loaded CI machine), the error-cache entry expires, the second call triggers another refresh, and the `refreshCount == 0` assertion at line 148 fails.

## Reproduction

Couldn't repro in 100 clean local runs (`--config=race --runs_per_test=100`), but injecting a 50ms sleep between the two calls — simulating a scheduler stall — made it fail **5/5**.

## Fix

- Stop the clock-advancer goroutine deterministically once the first call returns (it's only needed to drive the retrier), so the clock is frozen before the second lookup.
- Bump `KeyErrCacheTime` to an hour so clock advancement during the first call can't expire the entry either.

## Verification

- With the injected 50ms stall: fails 5/5 before, passes 10/10 after.
- Clean: `bazel test --config=race --runs_per_test=100` — 100/100 pass.

(Note: ran locally rather than with `--config=remote` — remote execution was unavailable in my environment due to an UNAUTHENTICATED API key error.)