### PR TITLE
firecracker: native workspace image writer behind flag + experiment

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -49,6 +49,7 @@ go_library(
         "//enterprise/server/remote_execution/vmexec_client",
         "//enterprise/server/util/cpuset",
         "//enterprise/server/util/ext4",
+        "//enterprise/server/util/ext4writer",
         "//enterprise/server/util/oci",
         "//enterprise/server/util/vfs_server",
         "//enterprise/server/util/vsock",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -42,6 +42,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/vmexec_client"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/cpuset"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ext4"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ext4writer"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/oci"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/vfs_server"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/vsock"
@@ -88,6 +89,9 @@ var (
 	debugTerminal                         = flag.Bool("executor.firecracker_debug_terminal", false, "Run an interactive terminal in the Firecracker VM connected to the executor's controlling terminal. For debugging only.")
 	dieOnFirecrackerFailure               = flag.Bool("executor.die_on_firecracker_failure", false, "Makes the host executor process die if any command orchestrating or running Firecracker fails. Useful for capturing failures preemptively. WARNING: using this option MAY leave the host machine in an unhealthy state on Firecracker failure; some post-hoc cleanup may be necessary.")
 	workspaceDiskSlackSpaceMB             = flag.Int64("executor.firecracker_workspace_disk_slack_space_mb", 2_000, "Extra space to allocate to firecracker workspace disks, in megabytes. ** Experimental **")
+	workspaceImageWriter                  = flag.String("executor.firecracker_workspace_image_writer", "mke2fs", "How to build the per-action workspace ext4 image: 'mke2fs' (shell out to mke2fs -d) or 'native' (in-process ext4 writer; much faster for large input trees). 'native' additionally requires the "+NativeWorkspaceWriterExperiment+" experiment to be enabled for the task. ** Experimental **")
+	workspaceImageWriterConcurrency       = flag.Int("executor.firecracker_workspace_image_writer_concurrency", 0, "Number of parallel data-copy workers for the native workspace image writer (0 = min(8, NumCPU)).")
+	workspaceImageCopyMode                = flag.String("executor.firecracker_workspace_image_copy_mode", "cfr", "Data copy strategy for the native workspace image writer: 'cfr' (copy_file_range) or 'mmap'.")
 	healthCheckInterval                   = flag.Duration("executor.firecracker_health_check_interval", 10*time.Second, "How often to run VM health checks while tasks are executing.")
 	healthCheckTimeout                    = flag.Duration("executor.firecracker_health_check_timeout", 30*time.Second, "Timeout for VM health check requests.")
 	overprovisionCPUs                     = flag.Int("executor.firecracker_overprovision_cpus", 3, "Number of CPUs to overprovision for VMs. This allows VMs to more effectively utilize CPU resources on the host machine. Set to -1 to allow all VMs to use max CPU.")
@@ -1555,6 +1559,22 @@ func (c *FirecrackerContainer) resizeRootfs(ctx context.Context, cf *copy_on_wri
 	return nil
 }
 
+// NativeWorkspaceWriterExperiment gates the native (in-process) workspace
+// image writer. The native writer is only used when
+// --executor.firecracker_workspace_image_writer=native AND this experiment
+// name is present in the task's experiments (the app appends it when the
+// experiment flag of the same name evaluates to true). If either is missing,
+// the executor falls back to mke2fs.
+const NativeWorkspaceWriterExperiment = "executor.firecracker_native_workspace_writer"
+
+// useNativeWorkspaceImageWriter returns whether the native in-process ext4
+// writer should be used to build this task's workspace image. Requires both
+// the executor flag and the task-level experiment.
+func (c *FirecrackerContainer) useNativeWorkspaceImageWriter() bool {
+	return *workspaceImageWriter == "native" &&
+		slices.Contains(c.task.GetExperiments(), NativeWorkspaceWriterExperiment)
+}
+
 // createWorkspaceImage creates a new ext4 image from the action working dir.
 func (c *FirecrackerContainer) createWorkspaceImage(ctx context.Context, workspaceDir, ext4ImagePath string) error {
 	ctx, span := tracing.StartSpan(ctx)
@@ -1566,6 +1586,33 @@ func (c *FirecrackerContainer) createWorkspaceImage(ctx context.Context, workspa
 	if err := os.RemoveAll(ext4ImagePath); err != nil {
 		return status.WrapError(err, "failed to delete existing workspace disk image")
 	}
+	switch *workspaceImageWriter {
+	case "native", "mke2fs":
+	default:
+		return status.InvalidArgumentErrorf("invalid --executor.firecracker_workspace_image_writer %q (want native or mke2fs)", *workspaceImageWriter)
+	}
+	if c.useNativeWorkspaceImageWriter() {
+		stats, err := ext4writer.DirectoryToImage(ctx, workspaceDir, ext4ImagePath, &ext4writer.Options{
+			SlackBytes:  ext4.MinDiskImageSizeBytes + *workspaceDiskSlackSpaceMB*1e6,
+			Concurrency: *workspaceImageWriterConcurrency,
+			CopyMode:    *workspaceImageCopyMode,
+		})
+		if err != nil {
+			return status.WrapError(err, "failed to convert workspace dir to ext4 image (native writer)")
+		}
+		log.CtxDebugf(ctx, "Native workspace image writer: %s", stats)
+		span.SetAttributes(
+			attribute.String("workspace_image_writer", "native"),
+			attribute.Int64("walk_ms", stats.WalkDuration.Milliseconds()),
+			attribute.Int64("layout_ms", stats.LayoutDuration.Milliseconds()),
+			attribute.Int64("metadata_ms", stats.MetadataDuration.Milliseconds()),
+			attribute.Int64("data_copy_ms", stats.DataDuration.Milliseconds()),
+			attribute.Int64("data_bytes", stats.DataBytes),
+			attribute.Int64("files", int64(stats.Files)),
+		)
+		return nil
+	}
+	span.SetAttributes(attribute.String("workspace_image_writer", "mke2fs"))
 	workspaceSizeBytes, err := ext4.DiskSizeBytes(ctx, workspaceDir)
 	if err != nil {
 		return err

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -969,6 +969,14 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 		executionTask.Experiments = append(executionTask.Experiments, "remote_execution.publish_post_completion_stats")
 	}
 
+	// Native firecracker workspace image writer rollout: executors only use
+	// the native writer for a task when this experiment name is present on
+	// the task AND the executor is running with
+	// --executor.firecracker_workspace_image_writer=native.
+	if efp != nil && efp.Boolean(ctx, "executor.firecracker_native_workspace_writer", false) {
+		executionTask.Experiments = append(executionTask.Experiments, "executor.firecracker_native_workspace_writer")
+	}
+
 	// Add in secrets for any action explicitly requesting secrets, and all workflows.
 	secretService := s.env.GetSecretService()
 	if props.IncludeSecrets || len(props.EnvSecrets) > 0 {

--- a/enterprise/server/util/ext4writer/BUILD
+++ b/enterprise/server/util/ext4writer/BUILD
@@ -1,0 +1,37 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//visibility:public"])
+
+go_library(
+    name = "ext4writer",
+    srcs = [
+        "ext4reader.go",
+        "ext4writer.go",
+        "tree.go",
+        "virtual.go",
+        "xattr.go",
+    ],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ext4writer",
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = [
+        "//proto:remote_execution_go_proto",
+        "//server/remote_cache/digest",
+        "//server/util/status",
+        "@org_golang_x_sync//errgroup",
+        "@org_golang_x_sys//unix",
+    ],
+)
+
+go_test(
+    name = "ext4writer_test",
+    srcs = ["ext4writer_test.go"],
+    embed = [":ext4writer"],
+    deps = [
+        "//enterprise/server/util/ext4",
+        "//proto:remote_execution_go_proto",
+        "//server/remote_cache/digest",
+        "//server/testutil/testfs",
+        "//server/util/log",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/server/util/ext4writer/ext4reader.go
+++ b/enterprise/server/util/ext4writer/ext4reader.go
@@ -1,0 +1,597 @@
+package ext4writer
+
+// A small read-only ext4 parser used to extract action outputs from the
+// workspace image without shelling out to debugfs.
+//
+// Why not debugfs: e2fsprogs fsync()s the image file right after opening it,
+// which forces every dirty page of the (throwaway) workspace image out to disk
+// — hundreds of milliseconds for a few hundred MB of inputs, and needless disk
+// write traffic. It also costs a process spawn per action.
+//
+// Supported: 4 KiB (or other) block sizes, 32/64-byte group descriptors,
+// extent-mapped files of any depth, uninitialized extents (read as zeros),
+// holes (preserved as sparse), linear and htree directories (read linearly),
+// fast and slow symlinks, hard links (extracted as separate files).
+// Not supported: inline_data, encryption, block-mapped (non-extent) files.
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+)
+
+const (
+	incompatInlineData = 0x8000
+	incompatEncrypt    = 0x10000
+	incompat64Bit      = 0x0080
+	inodeFlagInline    = 0x10000000
+)
+
+type ext4Image struct {
+	f              io.ReaderAt
+	closer         io.Closer
+	dirCache       map[uint32][]dirent // parsed directories, by inode
+	linked         map[uint32]string   // first extracted path per inode (for hardlinks)
+	size           int64               // image file size; every read is bounds-checked against it
+	blockSize      int64
+	inodeSize      int64
+	inodesPerGroup uint32
+	ngroups        uint32
+	firstDataBlock uint32
+	descSize       int64
+	gdtOffset      int64
+	incompat       uint32
+}
+
+// Limits that protect the host from a malicious or corrupt guest-written image.
+const (
+	maxDirBytes    = 1 << 30 // 1 GiB of directory blocks
+	maxExtentsList = 1 << 20 // extents per file
+	maxNameLen     = 255
+)
+
+// readAt reads exactly len(dst) bytes at off, refusing reads outside the image.
+func (img *ext4Image) readAt(dst []byte, off int64) error {
+	if off < 0 || off+int64(len(dst)) > img.size {
+		return status.InvalidArgumentErrorf("read [%d,+%d) outside image of %d bytes", off, len(dst), img.size)
+	}
+	_, err := img.f.ReadAt(dst, off)
+	return err
+}
+
+func openImage(path string) (*ext4Image, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	st, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	img, err := openImageReader(f, st.Size())
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	img.closer = f
+	return img, nil
+}
+
+// openImageReader parses the superblock of an ext4 image served by any
+// ReaderAt (a file, or a virtual block device).
+func openImageReader(r io.ReaderAt, size int64) (*ext4Image, error) {
+	img := &ext4Image{f: r, size: size, dirCache: map[uint32][]dirent{}, linked: map[uint32]string{}}
+	sb := make([]byte, 1024)
+	if err := img.readAt(sb, 1024); err != nil {
+		return nil, status.WrapError(err, "read superblock")
+	}
+	le := binary.LittleEndian
+	bad := func(format string, args ...any) (*ext4Image, error) {
+		return nil, status.InvalidArgumentErrorf("invalid ext4 image: "+format, args...)
+	}
+	if le.Uint16(sb[0x38:]) != superMagic {
+		return bad("bad magic")
+	}
+	logBlockSize := le.Uint32(sb[0x18:])
+	if logBlockSize > 6 {
+		return bad("log block size %d", logBlockSize)
+	}
+	img.blockSize = 1024 << logBlockSize
+	img.inodesPerGroup = le.Uint32(sb[0x28:])
+	blocksPerGrp := le.Uint32(sb[0x20:])
+	blocksCount := uint64(le.Uint32(sb[0x04:]))
+	img.firstDataBlock = le.Uint32(sb[0x14:])
+	img.incompat = le.Uint32(sb[0x60:])
+	if img.incompat&incompat64Bit != 0 {
+		blocksCount |= uint64(le.Uint32(sb[0x150:])) << 32
+	}
+	if img.inodesPerGroup == 0 || int64(img.inodesPerGroup) > img.blockSize*8 || blocksPerGrp == 0 || int64(blocksPerGrp) > img.blockSize*8 {
+		return bad("inodes/blocks per group %d/%d", img.inodesPerGroup, blocksPerGrp)
+	}
+	if blocksCount == 0 || int64(blocksCount)*img.blockSize > img.size+img.blockSize {
+		return bad("block count %d exceeds image size %d", blocksCount, img.size)
+	}
+	img.ngroups = uint32((blocksCount - uint64(img.firstDataBlock) + uint64(blocksPerGrp) - 1) / uint64(blocksPerGrp))
+	img.inodeSize = 128
+	if le.Uint32(sb[0x4C:]) >= 1 {
+		img.inodeSize = int64(le.Uint16(sb[0x58:]))
+	}
+	if img.inodeSize < 128 || img.inodeSize > img.blockSize || img.inodeSize&(img.inodeSize-1) != 0 {
+		return bad("inode size %d", img.inodeSize)
+	}
+	img.descSize = 32
+	if img.incompat&incompat64Bit != 0 {
+		img.descSize = int64(le.Uint16(sb[0xFE:]))
+		if img.descSize < 64 || img.descSize > img.blockSize || img.descSize&(img.descSize-1) != 0 {
+			return bad("descriptor size %d", img.descSize)
+		}
+	}
+	// Reject anything we don't know how to read rather than misparse it.
+	const supportedIncompat = featureIncompatFiletype | featureIncompatExtents | featureIncompatFlexBG | incompat64Bit |
+		0x0004 /*recover*/ | 0x0010 /*journal_dev? no: 0x8 is journal_dev; 0x10 is meta_bg*/
+	// Explicitly: allow filetype, extents, flex_bg, 64bit, recover, extra_isize(0x2000), mmp(0x100), large_dir(0x4000), csum_seed(0x2000? no 0x2000 is csum_seed)
+	allowed := uint32(featureIncompatFiletype | featureIncompatExtents | featureIncompatFlexBG | incompat64Bit | 0x0004 | 0x0100 | 0x2000 | 0x4000)
+	_ = supportedIncompat
+	if unknown := img.incompat &^ allowed; unknown != 0 {
+		return nil, status.UnimplementedErrorf("ext4 image has unsupported incompat features 0x%x", unknown)
+	}
+	// GDT starts at the block after the superblock.
+	img.gdtOffset = int64(img.firstDataBlock+1) * img.blockSize
+	if img.blockSize == 1024 {
+		img.gdtOffset = 2048
+	}
+	return img, nil
+}
+
+func (img *ext4Image) Close() error {
+	if img.closer != nil {
+		return img.closer.Close()
+	}
+	return nil
+}
+
+func (img *ext4Image) readBlock(blk uint64, dst []byte) error {
+	if blk > uint64(img.size/img.blockSize) {
+		return status.InvalidArgumentErrorf("block %d outside image", blk)
+	}
+	return img.readAt(dst, int64(blk)*img.blockSize)
+}
+
+type inode struct {
+	num       uint32
+	mode      uint16
+	uid, gid  uint32
+	size      int64
+	flags     uint32
+	linksCnt  uint16
+	iblock    []byte // 60 bytes
+	extraSize uint16
+}
+
+func (img *ext4Image) readInode(num uint32) (*inode, error) {
+	if num == 0 {
+		return nil, status.InvalidArgumentError("inode 0")
+	}
+	group := (num - 1) / img.inodesPerGroup
+	index := int64((num - 1) % img.inodesPerGroup)
+	if group >= img.ngroups {
+		return nil, status.InvalidArgumentErrorf("inode %d is beyond the last block group", num)
+	}
+	desc := make([]byte, img.descSize)
+	if err := img.readAt(desc, img.gdtOffset+int64(group)*img.descSize); err != nil {
+		return nil, status.WrapErrorf(err, "read group descriptor %d", group)
+	}
+	le := binary.LittleEndian
+	table := uint64(le.Uint32(desc[0x8:]))
+	if img.descSize >= 64 {
+		table |= uint64(le.Uint32(desc[0x28:])) << 32
+	}
+	raw := make([]byte, img.inodeSize)
+	if table > uint64(img.size/img.blockSize) {
+		return nil, status.InvalidArgumentErrorf("inode table for group %d outside image", group)
+	}
+	if err := img.readAt(raw, int64(table)*img.blockSize+index*img.inodeSize); err != nil {
+		return nil, status.WrapErrorf(err, "read inode %d", num)
+	}
+	in := &inode{
+		num:      num,
+		mode:     le.Uint16(raw[0x0:]),
+		uid:      uint32(le.Uint16(raw[0x2:])) | uint32(le.Uint16(raw[0x78:]))<<16,
+		gid:      uint32(le.Uint16(raw[0x18:])) | uint32(le.Uint16(raw[0x7A:]))<<16,
+		size:     int64(le.Uint32(raw[0x4:])) | int64(le.Uint32(raw[0x6C:]))<<32,
+		flags:    le.Uint32(raw[0x20:]),
+		linksCnt: le.Uint16(raw[0x1A:]),
+		iblock:   append([]byte(nil), raw[0x28:0x64]...),
+	}
+	if img.inodeSize > 128 {
+		in.extraSize = le.Uint16(raw[0x80:])
+	}
+	if in.size < 0 || in.size > img.size {
+		// A regular file can be sparse, but nothing legitimately claims to be
+		// larger than the whole image.
+		return nil, status.InvalidArgumentErrorf("inode %d claims size %d > image size %d", num, in.size, img.size)
+	}
+	return in, nil
+}
+
+// extent is a mapped range of a file.
+type extent struct {
+	logical uint32
+	len     uint32
+	start   uint64
+	uninit  bool
+}
+
+// extents walks the extent tree rooted in the inode.
+func (img *ext4Image) extents(in *inode) ([]extent, error) {
+	if in.flags&inodeFlagExtents == 0 {
+		return nil, status.UnimplementedErrorf("inode %d does not use extents", in.num)
+	}
+	var out []extent
+	visited := map[uint64]bool{}
+	imgBlocks := uint64(img.size / img.blockSize)
+	var nextLogical uint64 // extents must be in increasing, non-overlapping logical order
+	var walk func(node []byte, wantDepth int) error
+	walk = func(node []byte, wantDepth int) error {
+		le := binary.LittleEndian
+		if le.Uint16(node[0:]) != extentMagic {
+			return status.InvalidArgumentErrorf("bad extent header magic in inode %d", in.num)
+		}
+		entries := int(le.Uint16(node[2:]))
+		max := int(le.Uint16(node[4:]))
+		depth := int(le.Uint16(node[6:]))
+		if wantDepth >= 0 && depth != wantDepth {
+			return status.InvalidArgumentErrorf("extent node depth %d != expected %d in inode %d", depth, wantDepth, in.num)
+		}
+		if depth > 5 {
+			return status.InvalidArgumentErrorf("extent tree too deep (%d) in inode %d", depth, in.num)
+		}
+		if entries > max || 12+max*12 > len(node) {
+			return status.InvalidArgumentErrorf("extent header %d/%d entries does not fit in inode %d", entries, max, in.num)
+		}
+		for i := 0; i < entries; i++ {
+			if len(out) >= maxExtentsList {
+				return status.InvalidArgumentErrorf("inode %d has too many extents", in.num)
+			}
+			e := node[12+i*12:]
+			if depth == 0 {
+				l := uint32(le.Uint16(e[4:]))
+				uninit := false
+				if l > maxExtentLen {
+					l -= maxExtentLen
+					uninit = true
+				}
+				logical := le.Uint32(e[0:])
+				start := uint64(le.Uint32(e[8:])) | uint64(le.Uint16(e[6:]))<<32
+				if l == 0 || uint64(logical) < nextLogical || start == 0 || start+uint64(l) > imgBlocks {
+					return status.InvalidArgumentErrorf("invalid extent (logical %d, len %d, start %d) in inode %d", logical, l, start, in.num)
+				}
+				nextLogical = uint64(logical) + uint64(l)
+				out = append(out, extent{logical: logical, len: l, start: start, uninit: uninit})
+			} else {
+				leaf := uint64(le.Uint32(e[4:])) | uint64(le.Uint16(e[8:]))<<32
+				if leaf == 0 || leaf >= imgBlocks || visited[leaf] {
+					return status.InvalidArgumentErrorf("invalid extent index block %d in inode %d", leaf, in.num)
+				}
+				visited[leaf] = true
+				child := make([]byte, img.blockSize)
+				if err := img.readBlock(leaf, child); err != nil {
+					return err
+				}
+				if err := walk(child, depth-1); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+	if err := walk(in.iblock, -1); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// dirent is one directory entry.
+type dirent struct {
+	inode uint32
+	name  string
+	ftype uint8
+}
+
+// readDir lists a directory linearly. htree index blocks are skipped
+// naturally: dx_root hides the index behind the ".." entry's rec_len, and
+// dx_node blocks are fake entries with inode 0.
+func (img *ext4Image) readDir(in *inode) ([]dirent, error) {
+	if ents, ok := img.dirCache[in.num]; ok {
+		return ents, nil
+	}
+	ents, err := img.readDirUncached(in)
+	if err != nil {
+		return nil, err
+	}
+	img.dirCache[in.num] = ents
+	return ents, nil
+}
+
+func (img *ext4Image) readDirUncached(in *inode) ([]dirent, error) {
+	if in.flags&inodeFlagInline != 0 {
+		return nil, status.UnimplementedErrorf("inline directory (inode %d) is not supported", in.num)
+	}
+	if in.size > maxDirBytes {
+		return nil, status.InvalidArgumentErrorf("directory inode %d is too large (%d bytes)", in.num, in.size)
+	}
+	exts, err := img.extents(in)
+	if err != nil {
+		return nil, err
+	}
+	var out []dirent
+	seen := map[string]bool{}
+	blk := make([]byte, img.blockSize)
+	le := binary.LittleEndian
+	for _, e := range exts {
+		for i := uint32(0); i < e.len; i++ {
+			if int64(e.logical+i)*img.blockSize >= in.size {
+				break
+			}
+			if e.uninit {
+				continue
+			}
+			if err := img.readBlock(e.start+uint64(i), blk); err != nil {
+				return nil, err
+			}
+			off := 0
+			for off+8 <= len(blk) {
+				ino := le.Uint32(blk[off:])
+				recLen := int(le.Uint16(blk[off+4:]))
+				nameLen := int(blk[off+6])
+				ftype := blk[off+7]
+				if recLen < 8 || recLen%4 != 0 || off+recLen > len(blk) || 8+nameLen > recLen {
+					return nil, status.InvalidArgumentErrorf("corrupt directory entry in inode %d", in.num)
+				}
+				if ino != 0 {
+					name := string(blk[off+8 : off+8+nameLen])
+					if name != "." && name != ".." {
+						if name == "" || strings.ContainsAny(name, "/\x00") {
+							return nil, status.InvalidArgumentErrorf("invalid entry name %q in inode %d", name, in.num)
+						}
+						if seen[name] {
+							// Duplicate names could be used to make us write
+							// through a symlink we created a moment ago.
+							return nil, status.InvalidArgumentErrorf("duplicate entry %q in inode %d", name, in.num)
+						}
+						seen[name] = true
+						out = append(out, dirent{inode: ino, name: name, ftype: ftype})
+					}
+				}
+				off += recLen
+			}
+		}
+	}
+	return out, nil
+}
+
+// lookup resolves a slash-separated path relative to root (no symlink
+// following). Returns nil inode if not found.
+func (img *ext4Image) lookup(path string) (*inode, error) {
+	cur, err := img.readInode(rootInode)
+	if err != nil {
+		return nil, err
+	}
+	for part := range strings.SplitSeq(strings.Trim(path, "/"), "/") {
+		if part == "" || part == "." {
+			continue
+		}
+		if cur.mode&syscall.S_IFMT != syscall.S_IFDIR {
+			return nil, nil
+		}
+		ents, err := img.readDir(cur)
+		if err != nil {
+			return nil, err
+		}
+		var next uint32
+		for _, e := range ents {
+			if e.name == part {
+				next = e.inode
+				break
+			}
+		}
+		if next == 0 {
+			return nil, nil
+		}
+		cur, err = img.readInode(next)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return cur, nil
+}
+
+// extractFile writes a regular file's contents to dst, preserving holes.
+func (img *ext4Image) extractFile(in *inode, dst string) error {
+	if in.flags&inodeFlagInline != 0 {
+		return status.UnimplementedErrorf("inline data (inode %d) is not supported", in.num)
+	}
+	f, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_EXCL, os.FileMode(in.mode&0o777)|0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	defer f.Chmod(os.FileMode(in.mode & 0o777))
+	if err := f.Truncate(in.size); err != nil {
+		return err
+	}
+	if in.size == 0 {
+		return nil
+	}
+	exts, err := img.extents(in)
+	if err != nil {
+		return err
+	}
+	buf := make([]byte, min(int64(1<<20), img.blockSize*max(1, (1<<20)/img.blockSize)))
+	for _, e := range exts {
+		if e.uninit {
+			continue
+		}
+		logicalOff := int64(e.logical) * img.blockSize
+		remaining := min(int64(e.len)*img.blockSize, in.size-logicalOff)
+		srcOff := int64(e.start) * img.blockSize
+		for remaining > 0 {
+			n := min(remaining, int64(len(buf)))
+			if err := img.readAt(buf[:n], srcOff); err != nil {
+				return err
+			}
+			if _, err := f.WriteAt(buf[:n], logicalOff); err != nil {
+				return err
+			}
+			srcOff += n
+			logicalOff += n
+			remaining -= n
+		}
+	}
+	return nil
+}
+
+func (img *ext4Image) readlink(in *inode) (string, error) {
+	if in.flags&inodeFlagExtents == 0 {
+		if in.size > int64(len(in.iblock)) {
+			return "", status.InvalidArgumentErrorf("fast symlink inode %d claims size %d", in.num, in.size)
+		}
+		return string(in.iblock[:in.size]), nil
+	}
+	if in.size > 4096 {
+		return "", status.InvalidArgumentErrorf("symlink inode %d target too long (%d)", in.num, in.size)
+	}
+	exts, err := img.extents(in)
+	if err != nil {
+		return "", err
+	}
+	data := make([]byte, in.size)
+	blk := make([]byte, img.blockSize)
+	for _, e := range exts {
+		if e.uninit {
+			continue
+		}
+		for i := uint32(0); i < e.len; i++ {
+			off := int64(e.logical+i) * img.blockSize
+			if off >= in.size {
+				break
+			}
+			if err := img.readBlock(e.start+uint64(i), blk); err != nil {
+				return "", err
+			}
+			copy(data[off:], blk)
+		}
+	}
+	return string(data), nil
+}
+
+// extractTree recursively extracts the object at inode `in` to dst.
+func (img *ext4Image) extractTree(ctx context.Context, in *inode, dst string, depth int) error {
+	if depth > 256 {
+		return status.InternalError("directory nesting too deep")
+	}
+	isDir := in.mode&syscall.S_IFMT == syscall.S_IFDIR
+	if st, err := os.Lstat(dst); err == nil {
+		// Only the top-level requested directory may already exist (e.g. the
+		// output dir itself when extracting "/"); everything below must be new,
+		// otherwise a crafted image could make us write through a symlink.
+		if !(depth == 0 && isDir && st.IsDir()) {
+			return status.InvalidArgumentErrorf("refusing to overwrite existing path %q", dst)
+		}
+	}
+	switch in.mode & syscall.S_IFMT {
+	case syscall.S_IFDIR:
+		if err := os.Mkdir(dst, os.FileMode(in.mode&0o777)|0o700); err != nil && !(depth == 0 && os.IsExist(err)) {
+			return err
+		}
+		ents, err := img.readDir(in)
+		if err != nil {
+			return err
+		}
+		for _, e := range ents {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			child, err := img.readInode(e.inode)
+			if err != nil {
+				return err
+			}
+			if err := img.extractTree(ctx, child, filepath.Join(dst, e.name), depth+1); err != nil {
+				return err
+			}
+		}
+		// Apply the real mode after populating (it may be read-only).
+		return os.Chmod(dst, os.FileMode(in.mode&0o777))
+	case syscall.S_IFREG:
+		if in.linksCnt > 1 {
+			if first, ok := img.linked[in.num]; ok {
+				// Hard link to something we already extracted.
+				return os.Link(first, dst)
+			}
+			img.linked[in.num] = dst
+		}
+		return img.extractFile(in, dst)
+	case syscall.S_IFLNK:
+		target, err := img.readlink(in)
+		if err != nil {
+			return err
+		}
+		return os.Symlink(target, dst)
+	default:
+		// FIFOs, sockets, devices: skip (debugfs rdump does the same).
+		return nil
+	}
+}
+
+// ImageToDirectory extracts the given paths (files or directories, relative
+// to the image root) from the ext4 image into outputDir. Missing paths are
+// silently ignored, matching ext4.ImageToDirectory.
+func ImageToDirectory(ctx context.Context, imagePath, outputDir string, paths []string) error {
+	img, err := openImage(imagePath)
+	if err != nil {
+		return err
+	}
+	defer img.Close()
+	return img.extractPaths(ctx, outputDir, paths)
+}
+
+// ReaderToDirectory is ImageToDirectory for an image served by a ReaderAt
+// (e.g. a virtual workspace block device).
+func ReaderToDirectory(ctx context.Context, r io.ReaderAt, size int64, outputDir string, paths []string) error {
+	img, err := openImageReader(r, size)
+	if err != nil {
+		return err
+	}
+	return img.extractPaths(ctx, outputDir, paths)
+}
+
+func (img *ext4Image) extractPaths(ctx context.Context, outputDir string, paths []string) error {
+	for _, p := range paths {
+		clean := filepath.Clean("/" + p)
+		in, err := img.lookup(clean)
+		if err != nil {
+			return status.WrapErrorf(err, "lookup %q", p)
+		}
+		if in == nil {
+			continue
+		}
+		dst := filepath.Join(outputDir, clean)
+		if !strings.HasPrefix(dst, filepath.Clean(outputDir)) {
+			return status.InvalidArgumentErrorf("path %q escapes output dir", p)
+		}
+		if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+			return err
+		}
+		if err := img.extractTree(ctx, in, dst, 0); err != nil {
+			return status.WrapErrorf(err, "extract %q", p)
+		}
+	}
+	return nil
+}

--- a/enterprise/server/util/ext4writer/ext4writer.go
+++ b/enterprise/server/util/ext4writer/ext4writer.go
@@ -1,0 +1,1481 @@
+// Package ext4writer builds ext4 disk images directly from a directory tree,
+// without shelling out to mke2fs.
+//
+// Why: `mke2fs -d` populates the image through libext2fs one 4 KiB block at a
+// time (one pwrite per block, ~5 syscalls per file) on a single thread. For a
+// 10k-file / 330 MB Bazel workspace that is ~1.7 s, which dominates Firecracker
+// action preparation. This writer computes the whole layout up front, writes
+// metadata with a handful of large writes, and copies file data with
+// copy_file_range on a worker pool.
+//
+// The images are deliberately simple:
+//   - 4 KiB blocks, 256-byte inodes, extents, flex_bg (all bitmaps and inode
+//     tables live at the start of the image), sparse_super backups.
+//   - No journal (workspace disks are throwaway), no checksums
+//     (metadata_csum / gdt_csum), no htree directory index (directories are
+//     linear; the kernel handles that fine).
+//   - Hardlinks in the source tree are preserved (same inode). Symlinks are
+//     preserved (fast symlinks when the target fits in the inode). Sockets,
+//     FIFOs and device nodes are preserved as inodes without data.
+//   - Extended attributes are not copied.
+//
+// The resulting image is a sparse file: unused inode tables and free blocks are
+// never written.
+package ext4writer
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"sort"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sys/unix"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+const (
+	blockSize      = 4096
+	blockShift     = 12
+	inodeSize      = 256
+	blocksPerGroup = 32768 // 8 * blockSize
+	maxExtentLen   = 32768 // blocks per extent (ee_len must be < 32768+1 for initialized extents)
+	extentSize     = 12
+	extentsInInode = 4
+	extentsPerLeaf = (blockSize - 12) / extentSize
+	rootInode      = 2
+	lostFoundInode = 11
+	firstInode     = 11 // s_first_ino
+	superMagic     = 0xEF53
+	extentMagic    = 0xF30A
+
+	// Superblock feature flags.
+	featureIncompatFiletype = 0x0002
+	featureIncompatExtents  = 0x0040
+	featureIncompatFlexBG   = 0x0200
+	featureROSparseSuper    = 0x0001
+	featureROLargeFile      = 0x0002
+	featureROHugeFile       = 0x0008
+	featureRODirNlink       = 0x0020
+	featureROExtraIsize     = 0x0040
+
+	// Inode flags.
+	inodeFlagExtents = 0x80000
+
+	// Directory entry file types.
+	ftUnknown = 0
+	ftRegular = 1
+	ftDir     = 2
+	ftChrdev  = 3
+	ftBlkdev  = 4
+	ftFifo    = 5
+	ftSock    = 6
+	ftSymlink = 7
+
+	// maxFileBytes bounds a single input file (ext4 with 4K blocks and 32-bit
+	// block numbers can't address more than 16 TiB anyway).
+	maxFileBytes = int64(1) << 40
+
+	// MinImageSizeBytes is the smallest image we'll produce (one block group
+	// worth of blocks is always allocated anyway, since group sizes are fixed).
+	MinImageSizeBytes = int64(blocksPerGroup) * blockSize
+)
+
+// Options controls image creation.
+type Options struct {
+	// SizeBytes is the requested image size. It is rounded up to a whole
+	// number of block groups (128 MiB each) and increased if the tree doesn't
+	// fit. The image file is sparse, so a larger size costs nothing on disk.
+	SizeBytes int64
+	// SlackBytes is free space to leave in the image beyond what the tree
+	// needs (for outputs). The image size is max(SizeBytes, needed+SlackBytes).
+	SlackBytes int64
+	// SlackFraction adds this fraction of the data size as extra free space
+	// (e.g. 0.2 for 20% headroom, like ext4.DirectoryToImageAutoSize).
+	SlackFraction float64
+	// Concurrency is the number of parallel data-copy workers (default: min(8, NumCPU)).
+	Concurrency int
+	// ExtraInodes reserves this many extra inodes beyond what the tree needs,
+	// for files the guest will create (default: 1 per 16 KiB of image, like mke2fs).
+	ExtraInodes int
+	// Now is the timestamp used for the filesystem metadata (default: time.Now()).
+	Now time.Time
+	// Reflink attempts FICLONERANGE for block-aligned file prefixes (works on
+	// XFS with reflink=1 and btrfs; silently falls back elsewhere).
+	Reflink bool
+	// Xattrs copies extended attributes (needed for container images; Bazel
+	// inputs never have them, so it's off by default to save syscalls).
+	Xattrs bool
+	// CopyMode selects how file data is copied: "mmap" (default: map the
+	// image MAP_SHARED and pread source files directly into the mapping;
+	// parallelizes well since writes are not serialized on the image inode
+	// lock) or "cfr" (copy_file_range; required for Reflink).
+	CopyMode string
+}
+
+// Stats describes what was written.
+type Stats struct {
+	Files, Dirs, Symlinks, Hardlinks int
+	Xattrs                           int
+	DataBytes                        int64
+	ReflinkedBytes                   int64 // bytes shared with the source via FICLONERANGE
+	ImageBytes                       int64
+	BlockGroups                      int
+	Inodes                           uint32
+	WalkDuration, LayoutDuration     time.Duration
+	MetadataDuration, DataDuration   time.Duration
+}
+
+// node is one filesystem object in the source tree.
+type node struct {
+	name     string // base name
+	path     string // full source path
+	mode     os.FileMode
+	rawMode  uint32 // st_mode
+	uid, gid uint32
+	size     int64
+	mtime    time.Time
+	rdev     uint64
+	target   string // symlink target
+	children []*node
+	parent   *node
+	ino      uint32 // assigned inode number
+	// Data layout.
+	nblocks  uint32         // data blocks (excluding extent index blocks)
+	extents  []extentRg     // allocated data extents
+	leaf     uint32         // extent leaf block if depth==1, else 0
+	dirData  []byte         // rendered directory blocks
+	hardlink *node          // if this path is a hardlink to an already-seen node
+	links    int            // number of directory entries referencing this inode (files)
+	fileNode *repb.FileNode // when building from a Tree: the input node (content via writer.open)
+	ranges   []blockRange   // logical block ranges holding data (nil = [0, nblocks) i.e. dense)
+	xattrs   []xattr        // extended attributes
+	xattrBlk uint32         // external xattr block, if the attributes don't fit in the inode
+}
+
+// blockRange is a run of logical blocks that contain data (sparse files have
+// gaps between ranges).
+type blockRange struct {
+	start uint32 // logical block
+	n     uint32
+}
+
+type extentRg struct {
+	logical uint32
+	start   uint32
+	len     uint32
+}
+
+func fileType(m os.FileMode) uint8 {
+	switch {
+	case m.IsRegular():
+		return ftRegular
+	case m.IsDir():
+		return ftDir
+	case m&os.ModeSymlink != 0:
+		return ftSymlink
+	case m&os.ModeNamedPipe != 0:
+		return ftFifo
+	case m&os.ModeSocket != 0:
+		return ftSock
+	case m&os.ModeCharDevice != 0:
+		return ftChrdev
+	case m&os.ModeDevice != 0:
+		return ftBlkdev
+	}
+	return ftUnknown
+}
+
+func ceilDiv(a, b int64) int64 { return (a + b - 1) / b }
+
+// DirectoryToImage creates an ext4 image at outputFile containing the
+// contents of inputDir. The image is at least opts.SizeBytes large.
+func DirectoryToImage(ctx context.Context, inputDir, outputFile string, opts *Options) (*Stats, error) {
+	if opts == nil {
+		opts = &Options{}
+	}
+	w := &writer{opts: *opts, stats: &Stats{}}
+	if w.opts.Concurrency <= 0 {
+		w.opts.Concurrency = min(8, defaultConcurrency())
+	}
+	if w.opts.Now.IsZero() {
+		w.opts.Now = time.Now()
+	}
+	w.open = func(n *node) (*os.File, error) { return os.Open(n.path) }
+	start := time.Now()
+	if _, err := w.walk(inputDir); err != nil {
+		return nil, status.WrapError(err, "walk input directory")
+	}
+	w.stats.WalkDuration = time.Since(start)
+	return w.finish(ctx, outputFile)
+}
+
+func defaultConcurrency() int { return runtime.NumCPU() }
+
+// finish lays out and writes the image for the already-walked tree.
+func (w *writer) finish(ctx context.Context, outputFile string) (*Stats, error) {
+	w.assignInodes()
+	root := w.root
+	start := time.Now()
+	if err := w.layout(root); err != nil {
+		return nil, status.WrapError(err, "compute layout")
+	}
+	w.stats.LayoutDuration = time.Since(start)
+
+	f, err := os.OpenFile(outputFile, os.O_CREATE|os.O_RDWR|os.O_EXCL, 0644)
+	if err != nil {
+		return nil, status.WrapError(err, "create image file")
+	}
+	defer f.Close()
+	// Don't leave a half-written image behind on failure.
+	ok := false
+	defer func() {
+		if !ok {
+			os.Remove(outputFile)
+		}
+	}()
+	if err := f.Truncate(w.stats.ImageBytes); err != nil {
+		return nil, status.WrapError(err, "truncate image file")
+	}
+
+	start = time.Now()
+	if err := w.writeMetadata(f); err != nil {
+		return nil, status.WrapError(err, "write metadata")
+	}
+	w.stats.MetadataDuration = time.Since(start)
+
+	start = time.Now()
+	if err := w.copyData(ctx, f); err != nil {
+		return nil, status.WrapError(err, "copy file data")
+	}
+	w.stats.DataDuration = time.Since(start)
+	ok = true
+	return w.stats, nil
+}
+
+type writer struct {
+	opts  Options
+	stats *Stats
+	open  func(n *node) (*os.File, error) // content source for regular files
+	root  *node
+
+	nodes    []*node // all nodes in inode order (index 0 = root)
+	files    []*node // regular files with data (excluding hardlink duplicates)
+	hardlink map[devIno]*node
+
+	// Geometry.
+	ngroups        uint32
+	blocksCount    uint32
+	inodesPerGroup uint32
+	inodesCount    uint32
+	itBlocksPerGrp uint32 // inode table blocks per group
+	gdtBlocks      uint32
+	backupGroups   []uint32 // groups with superblock+GDT backups
+
+	// Per-group metadata locations (flex_bg: all in group 0).
+	blockBitmapBlk []uint32
+	inodeBitmapBlk []uint32
+	inodeTableBlk  []uint32
+
+	// Allocation state.
+	dataStartBlock uint32 // first block after the metadata area
+	nextBlock      uint32
+	usedBlocks     uint32
+	blockBmp       []byte // one bit per block for the whole fs
+	inodeBmp       []byte
+	nextInode      uint32
+	dirsCount      uint32
+}
+
+type devIno struct{ dev, ino uint64 }
+
+// walk reads the source tree and assigns inode numbers in a deterministic
+// order (root, lost+found, then depth-first in sorted name order).
+func (w *writer) walk(dir string) (*node, error) {
+	w.hardlink = map[devIno]*node{}
+	st, err := os.Lstat(dir)
+	if err != nil {
+		return nil, err
+	}
+	if !st.IsDir() {
+		return nil, status.InvalidArgumentErrorf("%q is not a directory", dir)
+	}
+	root := w.newNode("", dir, st)
+	if w.opts.Xattrs {
+		xs, err := readXattrs(dir)
+		if err != nil {
+			return nil, status.WrapErrorf(err, "read xattrs of %q", dir)
+		}
+		root.xattrs = xs
+		w.stats.Xattrs += len(xs)
+	}
+	// lost+found: keep e2fsck happy.
+	lf := &node{name: "lost+found", mode: os.ModeDir | 0700, rawMode: syscall.S_IFDIR | 0700, mtime: w.opts.Now, parent: root}
+	root.children = append(root.children, lf)
+	if err := w.walkDir(root); err != nil {
+		return nil, err
+	}
+	w.root = root
+	return root, nil
+}
+
+// assignInodes numbers every node (root=2, lost+found=11, then depth-first in
+// name order from 12) and fills w.nodes. Hardlink duplicates get the number of
+// their original in a second pass, so the original is always numbered first
+// regardless of tree order.
+func (w *writer) assignInodes() {
+	w.nodes = w.nodes[:0]
+	next := uint32(lostFoundInode + 1)
+	var visit func(n *node)
+	visit = func(n *node) {
+		switch {
+		case n == w.root:
+			n.ino = rootInode
+		case n.parent == w.root && n.name == "lost+found":
+			n.ino = lostFoundInode
+		case n.hardlink != nil:
+			return // numbered in the second pass
+		default:
+			n.ino = next
+			next++
+		}
+		w.nodes = append(w.nodes, n)
+		for _, ch := range n.children {
+			visit(ch)
+		}
+	}
+	visit(w.root)
+	w.nextInode = next
+	var fix func(n *node)
+	fix = func(n *node) {
+		if n.hardlink != nil {
+			n.ino = n.hardlink.ino
+		}
+		for _, ch := range n.children {
+			fix(ch)
+		}
+	}
+	fix(w.root)
+}
+
+func (w *writer) newNode(name, path string, st os.FileInfo) *node {
+	n := &node{name: name, path: path, mode: st.Mode(), size: st.Size(), mtime: st.ModTime()}
+	if sys, ok := st.Sys().(*syscall.Stat_t); ok {
+		n.rawMode = sys.Mode
+		n.uid = sys.Uid
+		n.gid = sys.Gid
+		n.rdev = uint64(sys.Rdev)
+	} else {
+		n.rawMode = uint32(st.Mode().Perm())
+	}
+	return n
+}
+
+func (w *writer) walkDir(d *node) error {
+	entries, err := os.ReadDir(d.path)
+	if err != nil {
+		return err
+	}
+	// os.ReadDir returns entries sorted by name.
+	for _, e := range entries {
+		st, err := e.Info() // lstat
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return err
+		}
+		n := w.newNode(e.Name(), filepath.Join(d.path, e.Name()), st)
+		n.parent = d
+		d.children = append(d.children, n)
+		if w.opts.Xattrs {
+			xs, err := readXattrs(n.path)
+			if err != nil {
+				return status.WrapErrorf(err, "read xattrs of %q", n.path)
+			}
+			n.xattrs = xs
+			w.stats.Xattrs += len(xs)
+		}
+		if sys, ok := st.Sys().(*syscall.Stat_t); ok && !st.IsDir() && sys.Nlink > 1 {
+			key := devIno{uint64(sys.Dev), sys.Ino}
+			if orig, ok := w.hardlink[key]; ok {
+				if orig.links >= 65000 {
+					return status.InvalidArgumentErrorf("%q has more than 65000 hard links", orig.path)
+				}
+				n.hardlink = orig
+				orig.links++
+				w.stats.Hardlinks++
+				continue
+			}
+			w.hardlink[key] = n
+		}
+		n.links = 1
+		switch {
+		case st.IsDir():
+			w.stats.Dirs++
+			if err := w.walkDir(n); err != nil {
+				return err
+			}
+		case st.Mode()&os.ModeSymlink != 0:
+			w.stats.Symlinks++
+			target, err := os.Readlink(n.path)
+			if err != nil {
+				return err
+			}
+			n.target = target
+			n.size = int64(len(target))
+		case st.Mode().IsRegular():
+			if n.size < 0 || n.size > maxFileBytes {
+				return status.InvalidArgumentErrorf("%q: unsupported file size %d", n.path, n.size)
+			}
+			if sys, ok := st.Sys().(*syscall.Stat_t); ok && n.size >= 2*blockSize && sys.Blocks*512+blockSize < n.size {
+				// Sparse file: only map the data ranges.
+				ranges, err := dataRanges(n.path, n.size)
+				if err != nil {
+					return status.WrapErrorf(err, "find data ranges of %q", n.path)
+				}
+				n.ranges = ranges
+			}
+			w.stats.Files++
+			w.stats.DataBytes += n.size
+		}
+	}
+	return nil
+}
+
+// dataRanges finds the logical block ranges of a file that contain data,
+// using SEEK_DATA/SEEK_HOLE. Falls back to a single dense range.
+func dataRanges(path string, size int64) ([]blockRange, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var out []blockRange
+	var off int64
+	for off < size {
+		dataStart, err := unix.Seek(int(f.Fd()), off, unix.SEEK_DATA)
+		if err != nil {
+			if errors.Is(err, unix.ENXIO) {
+				break // no more data
+			}
+			if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.ENOTSUP) || errors.Is(err, unix.EOPNOTSUPP) {
+				return nil, nil // filesystem doesn't support it: treat as dense
+			}
+			return nil, err
+		}
+		holeStart, err := unix.Seek(int(f.Fd()), dataStart, unix.SEEK_HOLE)
+		if err != nil {
+			return nil, err
+		}
+		if holeStart > size {
+			holeStart = size
+		}
+		// Round to whole blocks.
+		sb := uint32(dataStart / blockSize)
+		eb := uint32(ceilDiv(holeStart, blockSize))
+		if len(out) > 0 && out[len(out)-1].start+out[len(out)-1].n >= sb {
+			// Merge with previous (block rounding can make ranges touch).
+			last := &out[len(out)-1]
+			if eb > last.start+last.n {
+				last.n = eb - last.start
+			}
+		} else if eb > sb {
+			out = append(out, blockRange{start: sb, n: eb - sb})
+		}
+		off = holeStart
+		if len(out) > maxExtentsList {
+			return nil, status.InvalidArgumentErrorf("%q has too many data ranges", path)
+		}
+	}
+	return out, nil
+}
+
+func sortChildren(d *node) {
+	sort.Slice(d.children, func(i, j int) bool { return d.children[i].name < d.children[j].name })
+}
+
+// linkCount returns the number of hard links to a node's inode.
+func linkCount(n *node) uint16 {
+	if n.mode.IsDir() {
+		c := 2
+		for _, ch := range n.children {
+			if ch.mode.IsDir() && ch.hardlink == nil {
+				c++
+			}
+		}
+		if c > 65000 {
+			return 1 // dir_nlink: "many"
+		}
+		return uint16(c)
+	}
+	return uint16(max(n.links, 1))
+}
+
+// direntLen returns the on-disk size of a directory entry for a name.
+func direntLen(name string) int {
+	return (8 + len(name) + 3) &^ 3
+}
+
+// renderDir builds the directory data blocks for d.
+func renderDir(d *node) []byte {
+	type ent struct {
+		ino  uint32
+		name string
+		ft   uint8
+	}
+	parentIno := d.ino
+	if d.parent != nil {
+		parentIno = d.parent.ino
+	}
+	ents := []ent{{d.ino, ".", ftDir}, {parentIno, "..", ftDir}}
+	for _, ch := range d.children {
+		ents = append(ents, ent{ch.ino, ch.name, fileType(ch.mode)})
+	}
+	var blocks []byte
+	cur := make([]byte, 0, blockSize)
+	flush := func() {
+		if len(cur) == 0 {
+			return
+		}
+		// Extend the last entry's rec_len to the end of the block.
+		// Find the last entry start: we track it via lastOff.
+		blocks = append(blocks, cur...)
+		blocks = append(blocks, make([]byte, blockSize-len(cur))...)
+		cur = cur[:0]
+	}
+	lastOff := -1
+	for _, e := range ents {
+		l := direntLen(e.name)
+		if len(cur)+l > blockSize {
+			// Fix up rec_len of the last entry to reach the block end.
+			binary.LittleEndian.PutUint16(cur[lastOff+4:], uint16(blockSize-lastOff))
+			flush()
+			lastOff = -1
+		}
+		lastOff = len(cur)
+		var hdr [8]byte
+		binary.LittleEndian.PutUint32(hdr[0:], e.ino)
+		binary.LittleEndian.PutUint16(hdr[4:], uint16(l))
+		hdr[6] = uint8(len(e.name))
+		hdr[7] = e.ft
+		cur = append(cur, hdr[:]...)
+		cur = append(cur, e.name...)
+		for len(cur)%4 != 0 {
+			cur = append(cur, 0)
+		}
+	}
+	if lastOff >= 0 {
+		binary.LittleEndian.PutUint16(cur[lastOff+4:], uint16(blockSize-lastOff))
+	}
+	flush()
+	return blocks
+}
+
+func isBackupGroup(g uint32) bool {
+	if g == 0 || g == 1 {
+		return true
+	}
+	for _, p := range []uint32{3, 5, 7} {
+		x := p
+		for x < g {
+			x *= p
+		}
+		if x == g {
+			return true
+		}
+	}
+	return false
+}
+
+// layout computes the filesystem geometry and allocates every block and inode.
+func (w *writer) layout(root *node) error {
+	// --- Per-node block requirements.
+	var dataBlocks int64
+	for _, n := range w.nodes {
+		switch {
+		case n.mode.IsDir():
+			n.dirData = renderDir(n)
+			n.nblocks = uint32(len(n.dirData) / blockSize)
+		case n.mode.IsRegular():
+			if n.ranges != nil {
+				for _, r := range n.ranges {
+					n.nblocks += r.n
+				}
+			} else {
+				n.nblocks = uint32(ceilDiv(n.size, blockSize))
+			}
+		case n.mode&os.ModeSymlink != 0:
+			if len(n.target) >= 60 {
+				n.nblocks = uint32(ceilDiv(n.size, blockSize))
+			}
+		}
+		dataBlocks += int64(n.nblocks)
+		if len(n.xattrs) > 0 && !xattrsFitInInode(n.xattrs) {
+			dataBlocks++
+		}
+		// Files with more than 4 extents need an extent-tree leaf block. Extents
+		// are split at 32768 blocks and around reserved backup blocks, so
+		// reserve a leaf for anything over 2 max-size extents; the general
+		// slack below covers rare extra splits.
+		if n.nblocks > 2*maxExtentLen {
+			dataBlocks++
+		}
+	}
+
+	// --- Geometry.
+	inodesNeeded := int64(w.nextInode - 1)
+	extraInodes := int64(w.opts.ExtraInodes)
+	sizeBytes := max(w.opts.SizeBytes, MinImageSizeBytes)
+	// Metadata estimate: GDT + bitmaps + inode tables. Iterate once since inode
+	// count depends on size.
+	if w.opts.SizeBytes < 0 || w.opts.SlackBytes < 0 || w.opts.ExtraInodes < 0 {
+		return status.InvalidArgumentError("negative size option")
+	}
+	var ngroups, ipg, itb, gdtBlocks int64
+	converged := false
+	for iter := 0; iter < 16 && !converged; iter++ {
+		ngroups = ceilDiv(sizeBytes, int64(blocksPerGroup)*blockSize)
+		if w.opts.ExtraInodes == 0 {
+			// 1 inode per 16 KiB of image, like mke2fs -N 0. This must be
+			// recomputed whenever the size grows, otherwise an action could
+			// hit ENOSPC on inodes with gigabytes of free blocks.
+			extraInodes = ngroups * blocksPerGroup * blockSize / 16384
+		}
+		totalInodes := inodesNeeded + extraInodes
+		// A group holds at most 32768 inodes (one bitmap block); grow the
+		// image if the inodes alone need more groups.
+		if minGroups := ceilDiv(totalInodes, blocksPerGroup); minGroups > ngroups {
+			sizeBytes = minGroups * blocksPerGroup * blockSize
+			continue
+		}
+		ipg = ceilDiv(totalInodes, ngroups)
+		ipg = (ipg + 15) &^ 15
+		if ipg > blocksPerGroup {
+			ipg = blocksPerGroup
+		}
+		itb = ceilDiv(ipg*inodeSize, blockSize)
+		ipg = itb * blockSize / inodeSize // fill whole table blocks
+		if ipg > blocksPerGroup {
+			ipg = blocksPerGroup
+			itb = ipg * inodeSize / blockSize
+		}
+		gdtBlocks = ceilDiv(ngroups*32, blockSize)
+		nBackup := int64(0)
+		for g := int64(0); g < ngroups; g++ {
+			if isBackupGroup(uint32(g)) {
+				nBackup++
+			}
+		}
+		meta := nBackup*(1+gdtBlocks) + 2*ngroups + ngroups*itb
+		need := (meta+dataBlocks+256)*blockSize + w.opts.SlackBytes + int64(float64(dataBlocks*blockSize)*w.opts.SlackFraction)
+		if need > sizeBytes {
+			sizeBytes = need
+			continue
+		}
+		converged = true
+	}
+	if !converged {
+		return status.InternalError("image sizing did not converge")
+	}
+	w.ngroups = uint32(ngroups)
+	w.blocksCount = uint32(ngroups * blocksPerGroup)
+	w.inodesPerGroup = uint32(ipg)
+	w.inodesCount = uint32(ngroups * ipg)
+	w.itBlocksPerGrp = uint32(itb)
+	w.gdtBlocks = uint32(gdtBlocks)
+	w.stats.ImageBytes = int64(w.blocksCount) * blockSize
+	w.stats.BlockGroups = int(w.ngroups)
+	w.stats.Inodes = w.inodesCount
+	if w.inodesCount < uint32(inodesNeeded) {
+		return status.InternalErrorf("inode count %d < needed %d", w.inodesCount, inodesNeeded)
+	}
+	w.blockBmp = make([]byte, w.blocksCount/8)
+	w.inodeBmp = make([]byte, w.inodesCount/8+1)
+
+	// --- Reserve superblock/GDT backups.
+	for g := uint32(0); g < w.ngroups; g++ {
+		if isBackupGroup(g) {
+			w.backupGroups = append(w.backupGroups, g)
+			base := g * blocksPerGroup
+			for b := base; b < base+1+w.gdtBlocks; b++ {
+				w.markBlock(b)
+			}
+		}
+	}
+	// --- Bitmaps and inode tables, packed at the front (flex_bg lets them
+	// live anywhere). Skip blocks already reserved for backup superblocks,
+	// which matters once the metadata area grows past group 0 (~8 GiB
+	// images at default inode density).
+	w.nextBlock = 1 + w.gdtBlocks
+	takeBlocks := func(n uint32) (uint32, error) {
+		// Find n contiguous free blocks starting at nextBlock.
+		for {
+			for w.nextBlock < w.blocksCount && w.isBlockUsed(w.nextBlock) {
+				w.nextBlock++
+			}
+			start := w.nextBlock
+			ok := true
+			for b := start; b < start+n; b++ {
+				if b >= w.blocksCount {
+					return 0, status.InternalErrorf("metadata does not fit in %d blocks", w.blocksCount)
+				}
+				if w.isBlockUsed(b) {
+					ok = false
+					w.nextBlock = b + 1
+					break
+				}
+			}
+			if !ok {
+				continue
+			}
+			for b := start; b < start+n; b++ {
+				w.markBlock(b)
+			}
+			w.nextBlock = start + n
+			return start, nil
+		}
+	}
+	w.blockBitmapBlk = make([]uint32, w.ngroups)
+	w.inodeBitmapBlk = make([]uint32, w.ngroups)
+	w.inodeTableBlk = make([]uint32, w.ngroups)
+	var err error
+	for g := uint32(0); g < w.ngroups; g++ {
+		if w.blockBitmapBlk[g], err = takeBlocks(1); err != nil {
+			return err
+		}
+	}
+	for g := uint32(0); g < w.ngroups; g++ {
+		if w.inodeBitmapBlk[g], err = takeBlocks(1); err != nil {
+			return err
+		}
+	}
+	for g := uint32(0); g < w.ngroups; g++ {
+		if w.inodeTableBlk[g], err = takeBlocks(w.itBlocksPerGrp); err != nil {
+			return err
+		}
+	}
+	w.dataStartBlock = w.nextBlock
+
+	// --- Inodes 1..10 are reserved.
+	for i := uint32(1); i <= 10; i++ {
+		w.markInode(i)
+	}
+	for _, n := range w.nodes {
+		w.markInode(n.ino)
+		if n.mode.IsDir() {
+			w.dirsCount++
+		}
+	}
+
+	// --- Allocate data: directories and symlinks first (metadata locality),
+	// then files in tree order.
+	for _, n := range w.nodes {
+		if n.nblocks > 0 && !n.mode.IsRegular() {
+			if err := w.allocExtents(n); err != nil {
+				return err
+			}
+		}
+	}
+	for _, n := range w.nodes {
+		if n.mode.IsRegular() {
+			if n.nblocks > 0 {
+				if err := w.allocExtents(n); err != nil {
+					return err
+				}
+			}
+			w.files = append(w.files, n)
+		}
+	}
+	// External xattr blocks.
+	for _, n := range w.nodes {
+		if len(n.xattrs) > 0 && !xattrsFitInInode(n.xattrs) {
+			for w.nextBlock < w.blocksCount && w.isBlockUsed(w.nextBlock) {
+				w.nextBlock++
+			}
+			if w.nextBlock >= w.blocksCount {
+				return status.ResourceExhaustedErrorf("image too small: out of blocks")
+			}
+			n.xattrBlk = w.nextBlock
+			w.markBlock(n.xattrBlk)
+			w.nextBlock++
+		}
+	}
+	return nil
+}
+
+func (w *writer) markBlock(b uint32) {
+	w.blockBmp[b/8] |= 1 << (b % 8)
+	w.usedBlocks++
+}
+
+func (w *writer) markInode(i uint32) {
+	i-- // inode numbers are 1-based
+	w.inodeBmp[i/8] |= 1 << (i % 8)
+}
+
+func (w *writer) isBlockUsed(b uint32) bool {
+	return w.blockBmp[b/8]&(1<<(b%8)) != 0
+}
+
+// allocExtents allocates n.nblocks contiguous-as-possible blocks, splitting
+// around reserved backup blocks and the 32768-block extent limit.
+func (w *writer) allocExtents(n *node) error {
+	ranges := n.ranges
+	if ranges == nil {
+		ranges = []blockRange{{start: 0, n: n.nblocks}}
+	}
+	for _, r := range ranges {
+		if err := w.allocRange(n, r); err != nil {
+			return err
+		}
+	}
+	if len(n.extents) > extentsInInode {
+		if len(n.extents) > extentsPerLeaf {
+			return status.UnimplementedErrorf("file %q needs %d extents; more than %d is unsupported", n.path, len(n.extents), extentsPerLeaf)
+		}
+		// Allocate one leaf block for the extent tree.
+		for w.nextBlock < w.blocksCount && w.isBlockUsed(w.nextBlock) {
+			w.nextBlock++
+		}
+		if w.nextBlock >= w.blocksCount {
+			return status.ResourceExhaustedErrorf("image too small: out of blocks")
+		}
+		n.leaf = w.nextBlock
+		w.markBlock(n.leaf)
+		w.nextBlock++
+	}
+	return nil
+}
+
+// allocRange allocates physical blocks for one logical range of n.
+func (w *writer) allocRange(n *node, r blockRange) error {
+	remaining := r.n
+	logical := r.start
+	for remaining > 0 {
+		// Skip used (reserved) blocks.
+		for w.nextBlock < w.blocksCount && w.isBlockUsed(w.nextBlock) {
+			w.nextBlock++
+		}
+		if w.nextBlock >= w.blocksCount {
+			return status.ResourceExhaustedErrorf("image too small: out of blocks")
+		}
+		start := w.nextBlock
+		// Extend the run until a reserved block, the extent limit, or done.
+		l := uint32(0)
+		for l < remaining && l < maxExtentLen && start+l < w.blocksCount && !w.isBlockUsed(start+l) {
+			l++
+		}
+		for b := start; b < start+l; b++ {
+			w.markBlock(b)
+		}
+		w.nextBlock = start + l
+		n.extents = append(n.extents, extentRg{logical: logical, start: start, len: l})
+		logical += l
+		remaining -= l
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Metadata encoding
+// ---------------------------------------------------------------------------
+
+func (w *writer) superblock() []byte {
+	sb := make([]byte, 1024)
+	le := binary.LittleEndian
+	freeBlocks := w.blocksCount - w.usedBlocks
+	usedInodes := w.nextInode - 1 // inodes are allocated contiguously from 1
+	now := uint32(w.opts.Now.Unix())
+	le.PutUint32(sb[0x00:], w.inodesCount)
+	le.PutUint32(sb[0x04:], w.blocksCount)
+	le.PutUint32(sb[0x08:], 0) // reserved blocks
+	le.PutUint32(sb[0x0C:], freeBlocks)
+	le.PutUint32(sb[0x10:], w.inodesCount-usedInodes)
+	le.PutUint32(sb[0x14:], 0) // first data block
+	le.PutUint32(sb[0x18:], 2) // log block size: 1024 << 2
+	le.PutUint32(sb[0x1C:], 2) // log cluster size
+	le.PutUint32(sb[0x20:], blocksPerGroup)
+	le.PutUint32(sb[0x24:], blocksPerGroup)
+	le.PutUint32(sb[0x28:], w.inodesPerGroup)
+	le.PutUint32(sb[0x2C:], 0)   // mtime
+	le.PutUint32(sb[0x30:], now) // wtime
+	le.PutUint16(sb[0x34:], 0)   // mnt count
+	le.PutUint16(sb[0x36:], 0xFFFF)
+	le.PutUint16(sb[0x38:], superMagic)
+	le.PutUint16(sb[0x3A:], 1) // state: clean
+	le.PutUint16(sb[0x3C:], 1) // errors: continue
+	le.PutUint16(sb[0x3E:], 0)
+	le.PutUint32(sb[0x40:], now) // lastcheck
+	le.PutUint32(sb[0x44:], 0)
+	le.PutUint32(sb[0x48:], 0) // creator os: linux
+	le.PutUint32(sb[0x4C:], 1) // rev level: dynamic
+	le.PutUint16(sb[0x50:], 0)
+	le.PutUint16(sb[0x52:], 0)
+	le.PutUint32(sb[0x54:], firstInode)
+	le.PutUint16(sb[0x58:], inodeSize)
+	le.PutUint16(sb[0x5A:], 0)
+	compat := uint32(0)
+	if w.stats.Xattrs > 0 {
+		compat |= featureCompatExtAttr
+	}
+	le.PutUint32(sb[0x5C:], compat)
+	le.PutUint32(sb[0x60:], featureIncompatFiletype|featureIncompatExtents|featureIncompatFlexBG)
+	le.PutUint32(sb[0x64:], featureROSparseSuper|featureROLargeFile|featureROHugeFile|featureRODirNlink|featureROExtraIsize)
+	// uuid: derive something non-zero but deterministic-looking from time.
+	uuid := sb[0x68:0x78]
+	le.PutUint64(uuid[0:], uint64(w.opts.Now.UnixNano()))
+	le.PutUint64(uuid[8:], uint64(w.blocksCount)<<32|uint64(w.inodesCount))
+	uuid[6] = (uuid[6] & 0x0F) | 0x40
+	uuid[8] = (uuid[8] & 0x3F) | 0x80
+	// hash seed / version (unused without dir_index, but keep sane).
+	copy(sb[0xEC:], uuid)
+	sb[0xFC] = 1                  // half_md4
+	le.PutUint32(sb[0x100:], 0)   // default mount opts
+	le.PutUint32(sb[0x108:], now) // mkfs time
+	le.PutUint16(sb[0x15C:], 32)  // min extra isize
+	le.PutUint16(sb[0x15E:], 32)  // want extra isize
+	le.PutUint32(sb[0x160:], 1)   // flags: signed dir hash
+	sb[0x174] = 4                 // log groups per flex (16)
+	return sb
+}
+
+func (w *writer) groupDescriptors() []byte {
+	gdt := make([]byte, w.gdtBlocks*blockSize)
+	le := binary.LittleEndian
+	usedInodes := w.nextInode - 1
+	dirsPerGroup := make([]uint32, w.ngroups)
+	for _, n := range w.nodes {
+		if n.mode.IsDir() {
+			dirsPerGroup[(n.ino-1)/w.inodesPerGroup]++
+		}
+	}
+	for g := uint32(0); g < w.ngroups; g++ {
+		d := gdt[g*32:]
+		le.PutUint32(d[0x0:], w.blockBitmapBlk[g])
+		le.PutUint32(d[0x4:], w.inodeBitmapBlk[g])
+		le.PutUint32(d[0x8:], w.inodeTableBlk[g])
+		// Free blocks in this group.
+		free := uint32(0)
+		base := g * blocksPerGroup
+		for b := base; b < base+blocksPerGroup; b++ {
+			if !w.isBlockUsed(b) {
+				free++
+			}
+		}
+		le.PutUint16(d[0xC:], uint16(free))
+		// Free inodes / used dirs in this group.
+		firstIno := g*w.inodesPerGroup + 1
+		lastIno := firstIno + w.inodesPerGroup - 1
+		usedHere := uint32(0)
+		if usedInodes >= firstIno {
+			usedHere = min(usedInodes, lastIno) - firstIno + 1
+		}
+		le.PutUint16(d[0xE:], uint16(w.inodesPerGroup-usedHere))
+		le.PutUint16(d[0x10:], uint16(dirsPerGroup[g]))
+		le.PutUint16(d[0x12:], 0)                                 // no uninit_bg feature => no flags
+		le.PutUint16(d[0x1C:], uint16(w.inodesPerGroup-usedHere)) // itable unused
+	}
+	return gdt
+}
+
+func (w *writer) encodeInode(n *node) []byte {
+	b := make([]byte, inodeSize)
+	le := binary.LittleEndian
+	mode := uint16(n.rawMode & 0xFFFF)
+	if n.mode.IsDir() {
+		mode = syscall.S_IFDIR | uint16(n.rawMode&0o7777)
+	}
+	le.PutUint16(b[0x0:], mode)
+	le.PutUint16(b[0x2:], uint16(n.uid))
+	size := n.size
+	if n.mode.IsDir() {
+		size = int64(len(n.dirData))
+	}
+	le.PutUint32(b[0x4:], uint32(size))
+	t := uint32(n.mtime.Unix())
+	le.PutUint32(b[0x8:], t)  // atime
+	le.PutUint32(b[0xC:], t)  // ctime
+	le.PutUint32(b[0x10:], t) // mtime
+	le.PutUint16(b[0x18:], uint16(n.gid))
+	le.PutUint16(b[0x1A:], linkCount(n))
+	blocks := uint64(n.nblocks) * (blockSize / 512)
+	if n.leaf != 0 {
+		blocks += blockSize / 512
+	}
+	le.PutUint32(b[0x1C:], uint32(blocks))
+	le.PutUint16(b[0x74:], uint16(blocks>>32))
+	le.PutUint32(b[0x6C:], uint32(size>>32))
+	le.PutUint16(b[0x78:], uint16(n.uid>>16))
+	le.PutUint16(b[0x7A:], uint16(n.gid>>16))
+	le.PutUint16(b[0x80:], 32) // extra isize
+	le.PutUint32(b[0x90:], t)  // crtime
+	if len(n.xattrs) > 0 {
+		if n.xattrBlk != 0 {
+			le.PutUint32(b[0x68:], n.xattrBlk) // i_file_acl_lo
+			blocks += blockSize / 512
+			le.PutUint32(b[0x1C:], uint32(blocks))
+			le.PutUint16(b[0x74:], uint16(blocks>>32))
+		} else {
+			encodeInodeXattrs(b, n.xattrs)
+		}
+	}
+	iblock := b[0x28:0x64]
+	switch {
+	case n.mode&os.ModeSymlink != 0 && n.nblocks == 0:
+		// Fast symlink: target stored inline.
+		copy(iblock, n.target)
+	case n.mode&(os.ModeDevice|os.ModeCharDevice) != 0:
+		// New-style device number encoding in i_block[1].
+		major := unix.Major(n.rdev)
+		minor := unix.Minor(n.rdev)
+		le.PutUint32(iblock[4:], (minor&0xff)|(major<<8)|((minor&^0xff)<<12))
+	case n.mode&(os.ModeNamedPipe|os.ModeSocket) != 0:
+		// no data
+	default:
+		le.PutUint32(b[0x20:], inodeFlagExtents)
+		w.encodeExtentTree(n, iblock)
+	}
+	return b
+}
+
+func putExtent(dst []byte, e extentRg) {
+	le := binary.LittleEndian
+	le.PutUint32(dst[0:], e.logical)
+	le.PutUint16(dst[4:], uint16(e.len))
+	le.PutUint16(dst[6:], 0) // start hi
+	le.PutUint32(dst[8:], e.start)
+}
+
+func (w *writer) encodeExtentTree(n *node, iblock []byte) {
+	le := binary.LittleEndian
+	le.PutUint16(iblock[0:], extentMagic)
+	le.PutUint16(iblock[4:], extentsInInode) // eh_max
+	if n.leaf == 0 {
+		le.PutUint16(iblock[2:], uint16(len(n.extents)))
+		le.PutUint16(iblock[6:], 0) // depth
+		for i, e := range n.extents {
+			putExtent(iblock[12+i*extentSize:], e)
+		}
+		return
+	}
+	// Depth 1: one index entry pointing at the leaf block.
+	le.PutUint16(iblock[2:], 1)
+	le.PutUint16(iblock[6:], 1)
+	le.PutUint32(iblock[12:], 0)      // ei_block
+	le.PutUint32(iblock[16:], n.leaf) // ei_leaf_lo
+	le.PutUint16(iblock[20:], 0)      // ei_leaf_hi
+}
+
+func (w *writer) encodeLeaf(n *node) []byte {
+	b := make([]byte, blockSize)
+	le := binary.LittleEndian
+	le.PutUint16(b[0:], extentMagic)
+	le.PutUint16(b[2:], uint16(len(n.extents)))
+	le.PutUint16(b[4:], extentsPerLeaf)
+	le.PutUint16(b[6:], 0)
+	for i, e := range n.extents {
+		putExtent(b[12+i*extentSize:], e)
+	}
+	return b
+}
+
+// writeMetadata writes superblocks, GDTs, bitmaps, inode tables, directory
+// blocks, extent leaves and slow symlink targets.
+func (w *writer) writeMetadata(f io.WriterAt) error {
+	sb := w.superblock()
+	gdt := w.groupDescriptors()
+	// Primary superblock lives at byte 1024; backups at the first block of
+	// each backup group.
+	for _, g := range w.backupGroups {
+		off := int64(g) * blocksPerGroup * blockSize
+		if g == 0 {
+			if _, err := f.WriteAt(sb, 1024); err != nil {
+				return err
+			}
+		} else {
+			bsb := append([]byte(nil), sb...)
+			binary.LittleEndian.PutUint16(bsb[0x5A:], uint16(g)) // block group nr
+			if _, err := f.WriteAt(bsb, off); err != nil {
+				return err
+			}
+		}
+		if _, err := f.WriteAt(gdt, off+blockSize); err != nil {
+			return err
+		}
+	}
+	// Block bitmaps: one block per group (contiguous unless a backup
+	// superblock interrupted the run, so write in contiguous runs).
+	if err := writeRuns(f, w.blockBitmapBlk, func(g uint32) []byte {
+		return w.blockBmp[g*blockSize : (g+1)*blockSize]
+	}); err != nil {
+		return err
+	}
+	// Inode bitmaps: one block per group, bits beyond inodesPerGroup set.
+	nbytes := w.inodesPerGroup / 8
+	if err := writeRuns(f, w.inodeBitmapBlk, func(g uint32) []byte {
+		blk := make([]byte, blockSize)
+		for i := range blk {
+			blk[i] = 0xFF
+		}
+		copy(blk[:nbytes], w.inodeBmp[g*nbytes:(g+1)*nbytes])
+		return blk
+	}); err != nil {
+		return err
+	}
+	// Inode tables: only the used prefix of each group's table.
+	// Group inode tables are contiguous in group 0, so gather all used inodes
+	// into per-group buffers.
+	type grpBuf struct {
+		buf []byte
+		max uint32 // highest local index written
+	}
+	bufs := make([]grpBuf, w.ngroups)
+	put := func(ino uint32, data []byte) {
+		g := (ino - 1) / w.inodesPerGroup
+		idx := (ino - 1) % w.inodesPerGroup
+		if bufs[g].buf == nil {
+			bufs[g].buf = make([]byte, w.inodesPerGroup*inodeSize)
+		}
+		copy(bufs[g].buf[idx*inodeSize:], data)
+		if idx+1 > bufs[g].max {
+			bufs[g].max = idx + 1
+		}
+	}
+	// Reserved inodes 1..10: zeroed but present (bitmap marks them used).
+	put(10, make([]byte, inodeSize))
+	for _, n := range w.nodes {
+		put(n.ino, w.encodeInode(n))
+	}
+	for g := range bufs {
+		if bufs[g].buf == nil {
+			continue
+		}
+		end := (int64(bufs[g].max)*inodeSize + blockSize - 1) &^ (blockSize - 1)
+		if _, err := f.WriteAt(bufs[g].buf[:end], int64(w.inodeTableBlk[g])*blockSize); err != nil {
+			return err
+		}
+	}
+	// Directory blocks, extent leaves, slow symlinks, xattr blocks.
+	for _, n := range w.nodes {
+		if n.xattrBlk != 0 {
+			blk, err := encodeXattrBlock(n.xattrs)
+			if err != nil {
+				return err
+			}
+			if _, err := f.WriteAt(blk, int64(n.xattrBlk)*blockSize); err != nil {
+				return err
+			}
+		}
+		if n.leaf != 0 {
+			if _, err := f.WriteAt(w.encodeLeaf(n), int64(n.leaf)*blockSize); err != nil {
+				return err
+			}
+		}
+		switch {
+		case n.mode.IsDir():
+			if err := writeExtents(f, n.extents, n.dirData); err != nil {
+				return err
+			}
+		case n.mode&os.ModeSymlink != 0 && n.nblocks > 0:
+			data := make([]byte, int(n.nblocks)*blockSize)
+			copy(data, n.target)
+			if err := writeExtents(f, n.extents, data); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// writeRuns writes one block per group at the given block numbers, coalescing
+// adjacent blocks into single writes.
+func writeRuns(f io.WriterAt, blocks []uint32, data func(g uint32) []byte) error {
+	var buf []byte
+	var start uint32
+	flush := func() error {
+		if len(buf) == 0 {
+			return nil
+		}
+		_, err := f.WriteAt(buf, int64(start)*blockSize)
+		buf = buf[:0]
+		return err
+	}
+	for g := uint32(0); g < uint32(len(blocks)); g++ {
+		if len(buf) > 0 && blocks[g] != start+uint32(len(buf)/blockSize) {
+			if err := flush(); err != nil {
+				return err
+			}
+		}
+		if len(buf) == 0 {
+			start = blocks[g]
+		}
+		buf = append(buf, data(g)...)
+	}
+	return flush()
+}
+
+// writeExtents writes data to the physical blocks described by extents.
+func writeExtents(f io.WriterAt, extents []extentRg, data []byte) error {
+	for _, e := range extents {
+		off := int64(e.logical) * blockSize
+		end := min(int64(len(data)), off+int64(e.len)*blockSize)
+		if _, err := f.WriteAt(data[off:end], int64(e.start)*blockSize); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Data copy
+// ---------------------------------------------------------------------------
+
+// reflinkState remembers whether FICLONERANGE works between the source
+// files and the image, so we stop trying after the first hard failure.
+type reflinkState struct {
+	mu       sync.Mutex
+	disabled bool
+	bytes    int64
+}
+
+func (r *reflinkState) add(n int64) {
+	r.mu.Lock()
+	r.bytes += n
+	r.mu.Unlock()
+}
+
+func (r *reflinkState) enabled() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return !r.disabled
+}
+
+func (r *reflinkState) disable() {
+	r.mu.Lock()
+	r.disabled = true
+	r.mu.Unlock()
+}
+
+func (w *writer) copyData(ctx context.Context, f *os.File) error {
+	// Sort files by size descending so big copies start first (better tail).
+	files := make([]*node, 0, len(w.files))
+	for _, n := range w.files {
+		if n.size > 0 {
+			files = append(files, n)
+		}
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].size > files[j].size })
+	ch := make(chan *node)
+	eg, ctx := errgroup.WithContext(ctx)
+	dstFD := int(f.Fd())
+	var bufPool sync.Pool
+	reflink := &reflinkState{disabled: !w.opts.Reflink}
+	var mapping []byte
+	if w.opts.CopyMode != "cfr" && len(files) > 0 {
+		// Writing through a MAP_SHARED mapping means a failed page allocation
+		// (ENOSPC on the host filesystem) would surface as SIGBUS and kill the
+		// process. Reserve the data region up front so that ENOSPC is reported
+		// here instead. Data blocks are allocated in one contiguous run after
+		// the metadata, so this is a single fallocate.
+		dataStart := int64(w.dataStartBlock) * blockSize
+		dataLen := int64(w.nextBlock)*blockSize - dataStart
+		if dataLen > 0 {
+			if err := unix.Fallocate(dstFD, unix.FALLOC_FL_KEEP_SIZE, dataStart, dataLen); err != nil {
+				if errors.Is(err, unix.ENOSPC) {
+					return status.ResourceExhaustedErrorf("fallocate %d bytes for workspace image: %s", dataLen, err)
+				}
+				// Filesystem doesn't support fallocate: fall back to
+				// copy_file_range which reports errors normally.
+				mapping = nil
+			} else {
+				m, err := unix.Mmap(dstFD, 0, int(w.stats.ImageBytes), unix.PROT_WRITE|unix.PROT_READ, unix.MAP_SHARED)
+				if err != nil {
+					return status.WrapError(err, "mmap image")
+				}
+				mapping = m
+				defer unix.Munmap(m)
+			}
+		}
+	}
+	for i := 0; i < w.opts.Concurrency; i++ {
+		eg.Go(func() error {
+			for n := range ch {
+				src, err := w.open(n)
+				if err != nil {
+					return status.WrapErrorf(err, "open %q", n.name)
+				}
+				if mapping != nil {
+					err = copyFileMmapSafe(ctx, src, n, mapping)
+				} else {
+					err = copyFile(ctx, src, n, dstFD, &bufPool, reflink)
+				}
+				src.Close()
+				if err != nil {
+					return status.WrapErrorf(err, "copy %q", n.path)
+				}
+			}
+			return nil
+		})
+	}
+	eg.Go(func() error {
+		defer close(ch)
+		for _, n := range files {
+			select {
+			case ch <- n:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		return nil
+	})
+	err := eg.Wait()
+	w.stats.ReflinkedBytes = reflink.bytes
+	return err
+}
+
+// copyFile copies n's contents into the image at its allocated extents.
+//
+// On filesystems with reflink support (XFS with reflink=1, btrfs) the
+// block-aligned prefix of each file is cloned with FICLONERANGE, which shares
+// the filecache's on-disk extents with the image instead of copying bytes.
+// Otherwise (or for the unaligned tail) copy_file_range is used, falling back
+// to read/write.
+func copyFile(ctx context.Context, src *os.File, n *node, dstFD int, pool *sync.Pool, reflink *reflinkState) error {
+	srcFD := int(src.Fd())
+	for _, e := range n.extents {
+		srcOff := int64(e.logical) * blockSize
+		end := min(n.size, int64(e.logical+e.len)*blockSize)
+		dstOff := int64(e.start) * blockSize
+		if reflink.enabled() {
+			// Clone the block-aligned part of this extent; the tail (if any)
+			// is copied below.
+			alignedEnd := end &^ (blockSize - 1)
+			if alignedEnd > srcOff {
+				err := unix.IoctlFileCloneRange(dstFD, &unix.FileCloneRange{
+					Src_fd: int64(srcFD), Src_offset: uint64(srcOff), Src_length: uint64(alignedEnd - srcOff), Dest_offset: uint64(dstOff),
+				})
+				if err == nil {
+					reflink.add(alignedEnd - srcOff)
+					dstOff += alignedEnd - srcOff
+					srcOff = alignedEnd
+				} else if errors.Is(err, unix.EOPNOTSUPP) || errors.Is(err, unix.EXDEV) || errors.Is(err, unix.ENOTTY) || errors.Is(err, unix.EINVAL) {
+					reflink.disable()
+				}
+			}
+		}
+		for srcOff < end {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			nn, err := unix.CopyFileRange(srcFD, &srcOff, dstFD, &dstOff, int(min(end-srcOff, 1<<30)), 0)
+			if err != nil {
+				if errors.Is(err, unix.EXDEV) || errors.Is(err, unix.ENOSYS) || errors.Is(err, unix.EOPNOTSUPP) || errors.Is(err, unix.EINVAL) {
+					// Fall back to a buffered copy for the rest of this extent.
+					if err := copyRangeBuffered(src, srcOff, end, dstFD, dstOff, pool); err != nil {
+						return err
+					}
+					break
+				}
+				return err
+			}
+			if nn == 0 {
+				return io.ErrUnexpectedEOF
+			}
+		}
+	}
+	return nil
+}
+
+// copyFileMmapSafe runs copyFileMmap with memory faults on the mapping turned
+// into recoverable panics, so an I/O error on the image file (which would
+// otherwise SIGBUS and kill the whole executor) surfaces as an error.
+func copyFileMmapSafe(ctx context.Context, src *os.File, n *node, mapping []byte) (err error) {
+	defer debug.SetPanicOnFault(debug.SetPanicOnFault(true))
+	defer func() {
+		if r := recover(); r != nil {
+			err = status.UnavailableErrorf("memory fault while writing workspace image (I/O error on the host filesystem?): %v", r)
+		}
+	}()
+	return copyFileMmap(ctx, src, n, mapping)
+}
+
+// copyFileMmap preads the source file directly into the MAP_SHARED image
+// mapping, so the kernel copies from the source page cache straight into the
+// image's page cache pages.
+func copyFileMmap(ctx context.Context, src *os.File, n *node, mapping []byte) error {
+	for _, e := range n.extents {
+		srcOff := int64(e.logical) * blockSize
+		end := min(n.size, int64(e.logical+e.len)*blockSize)
+		dstOff := int64(e.start) * blockSize
+		for srcOff < end {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			chunk := min(end-srcOff, int64(64<<20))
+			nr, err := src.ReadAt(mapping[dstOff:dstOff+chunk], srcOff)
+			if err != nil && !(errors.Is(err, io.EOF) && nr > 0) {
+				return err
+			}
+			if nr == 0 {
+				return io.ErrUnexpectedEOF
+			}
+			srcOff += int64(nr)
+			dstOff += int64(nr)
+		}
+	}
+	return nil
+}
+
+// copyRangeBuffered copies [srcOff, end) of src to dstOff with read/write.
+func copyRangeBuffered(src *os.File, srcOff, end int64, dstFD int, dstOff int64, pool *sync.Pool) error {
+	bufp, _ := pool.Get().(*[]byte)
+	if bufp == nil {
+		b := make([]byte, 1<<20)
+		bufp = &b
+	}
+	defer pool.Put(bufp)
+	buf := *bufp
+	for srcOff < end {
+		chunk := min(end-srcOff, int64(len(buf)))
+		nr, err := src.ReadAt(buf[:chunk], srcOff)
+		if err != nil && !(errors.Is(err, io.EOF) && nr > 0) {
+			return err
+		}
+		if nr == 0 {
+			return io.ErrUnexpectedEOF
+		}
+		for w := 0; w < nr; {
+			nw, err := unix.Pwrite(dstFD, buf[w:nr], dstOff+int64(w))
+			if err != nil {
+				return err
+			}
+			if nw == 0 {
+				return io.ErrShortWrite
+			}
+			w += nw
+		}
+		srcOff += int64(nr)
+		dstOff += int64(nr)
+	}
+	return nil
+}
+
+// String renders stats for logs.
+func (s *Stats) String() string {
+	return fmt.Sprintf("files=%d dirs=%d symlinks=%d hardlinks=%d xattrs=%d data=%dMB reflinked=%dMB image=%dMB groups=%d inodes=%d walk=%s layout=%s meta=%s data_copy=%s",
+		s.Files, s.Dirs, s.Symlinks, s.Hardlinks, s.Xattrs, s.DataBytes>>20, s.ReflinkedBytes>>20, s.ImageBytes>>20, s.BlockGroups, s.Inodes,
+		s.WalkDuration.Round(time.Millisecond), s.LayoutDuration.Round(time.Millisecond), s.MetadataDuration.Round(time.Millisecond), s.DataDuration.Round(time.Millisecond))
+}

--- a/enterprise/server/util/ext4writer/ext4writer_test.go
+++ b/enterprise/server/util/ext4writer/ext4writer_test.go
@@ -1,0 +1,735 @@
+package ext4writer_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ext4"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ext4writer"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+func requireTool(t *testing.T, path string) {
+	if _, err := os.Stat(path); err != nil {
+		t.Skipf("%s not available: %s", path, err)
+	}
+}
+
+// makeTree writes a synthetic tree resembling a Bazel workspace.
+func makeTree(t *testing.T, root string, nfiles, avg int, seed int64) {
+	rng := rand.New(rand.NewSource(seed))
+	ndirs := max(1, nfiles/20)
+	for i := 0; i < ndirs; i++ {
+		// Some nesting.
+		p := filepath.Join(root, fmt.Sprintf("d%04d", i))
+		if i%5 == 0 {
+			p = filepath.Join(root, "nested", fmt.Sprintf("x%02d", i%7), fmt.Sprintf("d%04d", i))
+		}
+		require.NoError(t, os.MkdirAll(p, 0755))
+	}
+	dirs := []string{}
+	filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if d.IsDir() {
+			dirs = append(dirs, p)
+		}
+		return nil
+	})
+	pat := make([]byte, 65536)
+	for i := range pat {
+		pat[i] = byte(i)
+	}
+	for i := 0; i < nfiles; i++ {
+		sz := int(rng.ExpFloat64() * float64(avg))
+		if sz > avg*8 {
+			sz = avg * 8
+		}
+		data := make([]byte, sz)
+		for off := 0; off < sz; off += len(pat) {
+			copy(data[off:], pat)
+		}
+		if sz > 0 {
+			data[0] = byte(i)
+			data[sz-1] = byte(i >> 8)
+		}
+		mode := os.FileMode(0644)
+		if i%7 == 0 {
+			mode = 0755
+		}
+		d := dirs[rng.Intn(len(dirs))]
+		require.NoError(t, os.WriteFile(filepath.Join(d, fmt.Sprintf("f%06d.dat", i)), data, mode))
+	}
+	// Edge cases.
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "empty_dir"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "empty_file"), nil, 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "exactly_4096"), pat[:4096], 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "exactly_4097"), pat[:4097], 0644))
+	require.NoError(t, os.Symlink("d0000", filepath.Join(root, "short_symlink")))
+	require.NoError(t, os.Symlink(strings.Repeat("abcdefghij/", 10)+"target", filepath.Join(root, "long_symlink")))
+	require.NoError(t, os.Symlink("../../..", filepath.Join(root, "empty_dir", "..dots")))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "hardlink_src"), []byte("hardlinked content"), 0600))
+	require.NoError(t, os.Link(filepath.Join(root, "hardlink_src"), filepath.Join(root, "hardlink_a")))
+	require.NoError(t, os.Link(filepath.Join(root, "hardlink_src"), filepath.Join(root, "d0001", "hardlink_b")))
+	require.NoError(t, os.WriteFile(filepath.Join(root, strings.Repeat("n", 255)), []byte("max name"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "space in name & (weird) 'chars'"), []byte("x"), 0644))
+	require.NoError(t, syscall.Mkfifo(filepath.Join(root, "fifo"), 0644))
+	// A directory with many entries (multi-block linear directory).
+	big := filepath.Join(root, "bigdir")
+	require.NoError(t, os.MkdirAll(big, 0755))
+	for i := 0; i < 3000; i++ {
+		require.NoError(t, os.WriteFile(filepath.Join(big, fmt.Sprintf("entry_with_a_longish_name_%05d", i)), []byte{byte(i)}, 0644))
+	}
+}
+
+type entry struct {
+	Path   string
+	Mode   string
+	Size   int64
+	Hash   string
+	Target string
+}
+
+// snapshotDir summarizes a tree for comparison.
+func snapshotDir(t *testing.T, root string, skip map[string]bool) []entry {
+	var out []entry
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		require.NoError(t, err)
+		rel, _ := filepath.Rel(root, p)
+		if rel == "." || skip[rel] {
+			return nil
+		}
+		info, err := os.Lstat(p)
+		require.NoError(t, err)
+		e := entry{Path: rel, Mode: info.Mode().String()}
+		switch {
+		case info.Mode().IsRegular():
+			e.Size = info.Size()
+			b, err := os.ReadFile(p)
+			require.NoError(t, err)
+			h := sha256.Sum256(b)
+			e.Hash = hex.EncodeToString(h[:])
+		case info.Mode()&os.ModeSymlink != 0:
+			e.Target, err = os.Readlink(p)
+			require.NoError(t, err)
+		}
+		out = append(out, e)
+		return nil
+	})
+	require.NoError(t, err)
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out
+}
+
+func fsck(t *testing.T, image string) {
+	cmd := exec.Command("/sbin/e2fsck", "-f", "-n", image)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "e2fsck failed:\n%s", out)
+	t.Logf("e2fsck: %s", strings.TrimSpace(string(out)))
+}
+
+// rdump extracts the whole image with debugfs.
+func rdump(t *testing.T, image, dst string) {
+	require.NoError(t, ext4.ImageToDirectory(context.Background(), image, dst, []string{"/"}))
+}
+
+func TestImageContentsMatchSource(t *testing.T) {
+	for _, mode := range []string{"mmap", "cfr"} {
+		t.Run(mode, func(t *testing.T) { testImageContentsMatchSource(t, mode) })
+	}
+}
+
+func testImageContentsMatchSource(t *testing.T, copyMode string) {
+	requireTool(t, "/sbin/e2fsck")
+	requireTool(t, "/sbin/debugfs")
+	root := testfs.MakeTempDir(t)
+	src := filepath.Join(root, "src")
+	require.NoError(t, os.Mkdir(src, 0755))
+	makeTree(t, src, 2000, 16*1024, 1)
+
+	image := filepath.Join(root, "ws.ext4")
+	stats, err := ext4writer.DirectoryToImage(context.Background(), src, image, &ext4writer.Options{SizeBytes: 300e6, CopyMode: copyMode, Reflink: copyMode == "cfr"})
+	require.NoError(t, err)
+	t.Logf("stats: %s", stats)
+	require.Equal(t, 2, stats.Hardlinks)
+	fsck(t, image)
+
+	// Extract and compare.
+	dst := filepath.Join(root, "dst")
+	require.NoError(t, os.Mkdir(dst, 0755))
+	rdump(t, image, dst)
+	// debugfs rdump puts the tree under dst/ (root dir name is empty -> "dst").
+	extracted := dst
+	if _, err := os.Stat(filepath.Join(dst, "d0001")); err != nil {
+		// Some debugfs versions nest under a directory named after the root.
+		entries, _ := os.ReadDir(dst)
+		require.Len(t, entries, 1)
+		extracted = filepath.Join(dst, entries[0].Name())
+	}
+	// debugfs rdump does not recreate FIFOs; check that one via stat instead.
+	skip := map[string]bool{"lost+found": true, "fifo": true}
+	want := snapshotDir(t, src, skip)
+	got := snapshotDir(t, extracted, skip)
+	wantPaths := map[string]bool{}
+	for _, e := range want {
+		wantPaths[e.Path] = true
+	}
+	for _, e := range got {
+		require.True(t, wantPaths[e.Path], "unexpected entry in image: %q", e.Path)
+	}
+	require.Equal(t, len(want), len(got), "entry count")
+	for i := range want {
+		require.Equal(t, want[i], got[i])
+	}
+	out, err := exec.Command("/sbin/debugfs", "-R", "stat /fifo", image).CombinedOutput()
+	require.NoError(t, err, "%s", out)
+	require.Contains(t, string(out), "Type: FIFO")
+	// Hardlinks share an inode in the image.
+	var links []string
+	for _, e := range got {
+		if strings.HasPrefix(e.Path, "hardlink") || strings.HasSuffix(e.Path, "hardlink_b") {
+			links = append(links, e.Path)
+		}
+	}
+	require.Len(t, links, 3)
+}
+
+func TestLargeFilesAndManyExtents(t *testing.T) {
+	requireTool(t, "/sbin/e2fsck")
+	root := testfs.MakeTempDir(t)
+	src := filepath.Join(root, "src")
+	require.NoError(t, os.Mkdir(src, 0755))
+	// A file bigger than one extent (128 MiB) and straddling a backup group.
+	f, err := os.Create(filepath.Join(src, "big"))
+	require.NoError(t, err)
+	require.NoError(t, f.Truncate(300<<20))
+	_, err = f.WriteAt([]byte("tail-marker"), 300<<20-11)
+	require.NoError(t, err)
+	_, err = f.WriteAt([]byte("head-marker"), 0)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	// Lots of small files so data spans several groups.
+	for i := 0; i < 50; i++ {
+		require.NoError(t, os.WriteFile(filepath.Join(src, fmt.Sprintf("f%d", i)), make([]byte, 1<<20), 0644))
+	}
+	image := filepath.Join(root, "ws.ext4")
+	stats, err := ext4writer.DirectoryToImage(context.Background(), src, image, &ext4writer.Options{SizeBytes: 2000e6})
+	require.NoError(t, err)
+	t.Logf("stats: %s", stats)
+	fsck(t, image)
+	dst := filepath.Join(root, "dst")
+	require.NoError(t, os.Mkdir(dst, 0755))
+	require.NoError(t, ext4.ImageToDirectory(context.Background(), image, dst, []string{"/big"}))
+	b, err := os.ReadFile(filepath.Join(dst, "big"))
+	require.NoError(t, err)
+	require.Equal(t, int64(300<<20), int64(len(b)))
+	require.Equal(t, "head-marker", string(b[:11]))
+	require.Equal(t, "tail-marker", string(b[len(b)-11:]))
+}
+
+func TestEmptyDirectory(t *testing.T) {
+	requireTool(t, "/sbin/e2fsck")
+	root := testfs.MakeTempDir(t)
+	src := filepath.Join(root, "src")
+	require.NoError(t, os.Mkdir(src, 0755))
+	image := filepath.Join(root, "ws.ext4")
+	_, err := ext4writer.DirectoryToImage(context.Background(), src, image, nil)
+	require.NoError(t, err)
+	fsck(t, image)
+}
+
+// TestCompareWithMke2fs benchmarks against mke2fs -d on the same tree.
+func TestCompareWithMke2fs(t *testing.T) {
+	if os.Getenv("EXT4WRITER_BENCH") == "" {
+		t.Skip("set EXT4WRITER_BENCH=1 to run")
+	}
+	root := testfs.MakeTempDir(t)
+	src := filepath.Join(root, "src")
+	require.NoError(t, os.Mkdir(src, 0755))
+	makeTree(t, src, 10000, 32*1024, 2)
+	size, err := ext4.DiskSizeBytes(context.Background(), src)
+	require.NoError(t, err)
+	imgSize := size + 2000e6
+	for i := 0; i < 3; i++ {
+		img := filepath.Join(root, fmt.Sprintf("a%d.ext4", i))
+		start := time.Now()
+		require.NoError(t, ext4.DirectoryToImage(context.Background(), src, img, imgSize))
+		log.Infof("mke2fs -d: %s", time.Since(start))
+		img = filepath.Join(root, fmt.Sprintf("b%d.ext4", i))
+		start = time.Now()
+		stats, err := ext4writer.DirectoryToImage(context.Background(), src, img, &ext4writer.Options{SizeBytes: imgSize})
+		require.NoError(t, err)
+		log.Infof("ext4writer: %s (%s)", time.Since(start), stats)
+	}
+}
+
+// TestReaderMatchesDebugfs extracts trees with both the native reader and
+// debugfs and compares them, for images produced by both writers (mke2fs
+// images have htree directories, a journal, metadata checksums, etc.).
+func TestReaderMatchesDebugfs(t *testing.T) {
+	requireTool(t, "/sbin/debugfs")
+	requireTool(t, "/sbin/mke2fs")
+	root := testfs.MakeTempDir(t)
+	src := filepath.Join(root, "src")
+	require.NoError(t, os.Mkdir(src, 0755))
+	makeTree(t, src, 1000, 8*1024, 3)
+	// A sparse file.
+	sf, err := os.Create(filepath.Join(src, "sparse"))
+	require.NoError(t, err)
+	require.NoError(t, sf.Truncate(10<<20))
+	_, err = sf.WriteAt([]byte("middle"), 5<<20)
+	require.NoError(t, err)
+	require.NoError(t, sf.Close())
+
+	native := filepath.Join(root, "native.ext4")
+	_, err = ext4writer.DirectoryToImage(context.Background(), src, native, &ext4writer.Options{SizeBytes: 200e6})
+	require.NoError(t, err)
+	mk := filepath.Join(root, "mke2fs.ext4")
+	require.NoError(t, ext4.DirectoryToImage(context.Background(), src, mk, 200e6))
+	// Add files to the mke2fs image the way a guest would (new inodes,
+	// new extents) using debugfs -w.
+	out, err := exec.Command("/sbin/debugfs", "-w", "-R", "mkdir /out", mk).CombinedOutput()
+	require.NoError(t, err, "%s", out)
+	big := filepath.Join(root, "bigout")
+	require.NoError(t, os.WriteFile(big, make([]byte, 3<<20), 0644))
+	out, err = exec.Command("/sbin/debugfs", "-w", "-R", fmt.Sprintf("write %s /out/big.bin", big), mk).CombinedOutput()
+	require.NoError(t, err, "%s", out)
+	for _, img := range []string{native, mk} {
+		for _, paths := range [][]string{{"/"}, {"bigdir", "nested", "out", "missing", "sparse"}} {
+			a := testfs.MakeTempDir(t)
+			b := testfs.MakeTempDir(t)
+			require.NoError(t, ext4.ImageToDirectory(context.Background(), img, a, paths))
+			require.NoError(t, ext4writer.ImageToDirectory(context.Background(), img, b, paths))
+			skip := map[string]bool{"fifo": true}
+			wa := snapshotDir(t, a, skip)
+			wb := snapshotDir(t, b, skip)
+			require.Equal(t, len(wa), len(wb), "%s %v: entry count", filepath.Base(img), paths)
+			for i := range wa {
+				require.Equal(t, wa[i], wb[i], "%s %v", filepath.Base(img), paths)
+			}
+			t.Logf("%s %v: %d entries match", filepath.Base(img), paths, len(wa))
+		}
+	}
+}
+
+// TestReaderRejectsCorruptImages mutates images in many random ways and checks
+// that extraction fails cleanly (no panic, no hang, no writes outside the
+// output dir) — the guest that wrote the image is untrusted.
+func TestReaderRejectsCorruptImages(t *testing.T) {
+	root := testfs.MakeTempDir(t)
+	src := filepath.Join(root, "src")
+	require.NoError(t, os.Mkdir(src, 0755))
+	makeTree(t, src, 50, 4096, 4)
+	image := filepath.Join(root, "ws.ext4")
+	_, err := ext4writer.DirectoryToImage(context.Background(), src, image, &ext4writer.Options{SizeBytes: 150e6})
+	require.NoError(t, err)
+	orig, err := os.ReadFile(image)
+	require.NoError(t, err)
+	rng := rand.New(rand.NewSource(7))
+	// Interesting regions: superblock, GDT, bitmaps, inode tables, first dir blocks.
+	regions := []int{1024, 4096, 8192, 12288, 16384, 16384 + 4096*8, 4096 * 40}
+	for i := 0; i < 150; i++ {
+		img := append([]byte(nil), orig...)
+		nMut := 1 + rng.Intn(8)
+		for j := 0; j < nMut; j++ {
+			base := regions[rng.Intn(len(regions))]
+			off := base + rng.Intn(4096)
+			if off >= len(img) {
+				continue
+			}
+			switch rng.Intn(3) {
+			case 0:
+				img[off] = byte(rng.Intn(256))
+			case 1:
+				img[off] = 0xFF
+			case 2:
+				img[off] = 0
+			}
+		}
+		mutated := filepath.Join(root, fmt.Sprintf("m%d.ext4", i))
+		require.NoError(t, os.WriteFile(mutated, img, 0644))
+		out := filepath.Join(root, fmt.Sprintf("o%d", i))
+		require.NoError(t, os.Mkdir(out, 0755))
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("mutation %d: panic: %v", i, r)
+				}
+			}()
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+			_ = ext4writer.ImageToDirectory(ctx, mutated, out, []string{"/"})
+		}()
+		select {
+		case <-done:
+		case <-time.After(30 * time.Second):
+			t.Fatalf("mutation %d: extraction hung", i)
+		}
+		os.Remove(mutated)
+		os.RemoveAll(out)
+	}
+}
+
+// TestReaderRefusesSymlinkEscape: a directory entry that is a symlink followed
+// by a same-named directory must not let us write through the symlink.
+func TestReaderRefusesDuplicateNames(t *testing.T) {
+	requireTool(t, "/sbin/debugfs")
+	root := testfs.MakeTempDir(t)
+	src := filepath.Join(root, "src")
+	require.NoError(t, os.Mkdir(src, 0755))
+	require.NoError(t, os.Symlink("/tmp", filepath.Join(src, "a")))
+	image := filepath.Join(root, "ws.ext4")
+	_, err := ext4writer.DirectoryToImage(context.Background(), src, image, nil)
+	require.NoError(t, err)
+	// Use debugfs to add a second entry named "a" (a directory) to the root.
+	out, err := exec.Command("/sbin/debugfs", "-w", "-R", "mkdir /b", image).CombinedOutput()
+	require.NoError(t, err, "%s", out)
+	// Rename b -> a via debugfs isn't possible when a exists; instead patch the
+	// dirent name directly: find "b" in the root directory block.
+	img, err := os.ReadFile(image)
+	require.NoError(t, err)
+	idx := -1
+	for i := 0; i+9 < len(img); i++ {
+		// dirent header: inode(4) rec_len(2) name_len(1)=1 ftype(1)=2 name "b"
+		if img[i+6] == 1 && img[i+7] == 2 && img[i+8] == 'b' && img[i+9] == 0 {
+			idx = i
+			break
+		}
+	}
+	require.Greater(t, idx, 0, "could not find dirent for b")
+	img[idx+8] = 'a'
+	require.NoError(t, os.WriteFile(image, img, 0644))
+	dst := filepath.Join(root, "dst")
+	require.NoError(t, os.Mkdir(dst, 0755))
+	err = ext4writer.ImageToDirectory(context.Background(), image, dst, []string{"/"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate")
+}
+
+// TestHardlinksShareInode checks hardlinks map to one inode with the right
+// link count, and are extracted as hardlinks.
+func TestHardlinksShareInode(t *testing.T) {
+	requireTool(t, "/sbin/debugfs")
+	root := testfs.MakeTempDir(t)
+	src := filepath.Join(root, "src")
+	require.NoError(t, os.Mkdir(src, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "a"), []byte("x"), 0644))
+	require.NoError(t, os.Link(filepath.Join(src, "a"), filepath.Join(src, "b")))
+	require.NoError(t, os.Mkdir(filepath.Join(src, "d"), 0755))
+	require.NoError(t, os.Link(filepath.Join(src, "a"), filepath.Join(src, "d", "c")))
+	// Exactly-60-byte symlink target (boundary between fast and slow).
+	require.NoError(t, os.Symlink(strings.Repeat("y", 60), filepath.Join(src, "sym60")))
+	require.NoError(t, os.Symlink(strings.Repeat("y", 59), filepath.Join(src, "sym59")))
+	image := filepath.Join(root, "ws.ext4")
+	_, err := ext4writer.DirectoryToImage(context.Background(), src, image, nil)
+	require.NoError(t, err)
+	fsck(t, image)
+	ino := func(p string) string {
+		out, err := exec.Command("/sbin/debugfs", "-R", "stat "+p, image).CombinedOutput()
+		require.NoError(t, err, "%s", out)
+		m := regexp.MustCompile(`Inode: (\d+).*Links: (\d+)`).FindStringSubmatch(strings.ReplaceAll(string(out), "\n", " "))
+		require.NotNil(t, m, "%s", out)
+		return m[1] + "/" + m[2]
+	}
+	require.Equal(t, ino("/a"), ino("/b"))
+	require.Equal(t, ino("/a"), ino("/d/c"))
+	require.True(t, strings.HasSuffix(ino("/a"), "/3"), "link count: %s", ino("/a"))
+	dst := filepath.Join(root, "dst")
+	require.NoError(t, os.Mkdir(dst, 0755))
+	require.NoError(t, ext4writer.ImageToDirectory(context.Background(), image, dst, []string{"/"}))
+	sa, _ := os.Stat(filepath.Join(dst, "a"))
+	sb, _ := os.Stat(filepath.Join(dst, "d", "c"))
+	require.True(t, os.SameFile(sa, sb), "extracted hardlinks should share an inode")
+	for _, n := range []string{"sym60", "sym59"} {
+		tgt, err := os.Readlink(filepath.Join(dst, n))
+		require.NoError(t, err)
+		want, _ := os.Readlink(filepath.Join(src, n))
+		require.Equal(t, want, tgt)
+	}
+}
+
+// TestManyInodesAndGroups: 100k empty files (inode-bound sizing) and a large
+// image (many block groups, metadata past group 0, flex boundary).
+func TestManyInodesAndGroups(t *testing.T) {
+	requireTool(t, "/sbin/e2fsck")
+	root := testfs.MakeTempDir(t)
+	src := filepath.Join(root, "src")
+	require.NoError(t, os.Mkdir(src, 0755))
+	for d := 0; d < 100; d++ {
+		dir := filepath.Join(src, fmt.Sprintf("d%03d", d))
+		require.NoError(t, os.Mkdir(dir, 0755))
+		for i := 0; i < 1000; i++ {
+			require.NoError(t, os.WriteFile(filepath.Join(dir, fmt.Sprintf("f%d", i)), nil, 0644))
+		}
+	}
+	image := filepath.Join(root, "small.ext4")
+	stats, err := ext4writer.DirectoryToImage(context.Background(), src, image, &ext4writer.Options{ExtraInodes: 1})
+	require.NoError(t, err)
+	t.Logf("100k empty files: %s", stats)
+	fsck(t, image)
+
+	// 24 GiB image: 192 groups, metadata area crosses backup-superblock groups.
+	big := filepath.Join(root, "big.ext4")
+	stats, err = ext4writer.DirectoryToImage(context.Background(), src, big, &ext4writer.Options{SizeBytes: 24 << 30})
+	require.NoError(t, err)
+	t.Logf("24GiB image: %s", stats)
+	require.Equal(t, 192, stats.BlockGroups)
+	fsck(t, big)
+	dst := filepath.Join(root, "dst")
+	require.NoError(t, os.Mkdir(dst, 0755))
+	require.NoError(t, ext4writer.ImageToDirectory(context.Background(), big, dst, []string{"d099"}))
+	entries, err := os.ReadDir(filepath.Join(dst, "d099"))
+	require.NoError(t, err)
+	require.Len(t, entries, 1000)
+}
+
+// TestTreeToImage builds an image from a REAPI Tree with contents served by an
+// opener, overlaid on a directory, and checks the result.
+func TestTreeToImage(t *testing.T) {
+	requireTool(t, "/sbin/e2fsck")
+	requireTool(t, "/sbin/debugfs")
+	root := testfs.MakeTempDir(t)
+	blobs := filepath.Join(root, "blobs")
+	require.NoError(t, os.Mkdir(blobs, 0755))
+	ws := filepath.Join(root, "ws")
+	require.NoError(t, os.MkdirAll(filepath.Join(ws, "out", "sub"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(ws, "local.txt"), []byte("local"), 0644))
+	// A host file with the same name as an input: the input must win.
+	require.NoError(t, os.WriteFile(filepath.Join(ws, "shadowed"), []byte("host-version"), 0644))
+
+	mkFile := func(name string, content []byte, exe bool) *repb.FileNode {
+		d, err := digest.Compute(bytes.NewReader(content), repb.DigestFunction_SHA256)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(blobs, d.GetHash()), content, 0644))
+		return &repb.FileNode{Name: name, Digest: d, IsExecutable: exe}
+	}
+	big := make([]byte, 5<<20)
+	for i := range big {
+		big[i] = byte(i * 7)
+	}
+	sub := &repb.Directory{
+		Files:    []*repb.FileNode{mkFile("a.txt", []byte("hello"), false), mkFile("same1", []byte("dup"), false), mkFile("same2", []byte("dup"), false), mkFile("same-exe", []byte("dup"), true)},
+		Symlinks: []*repb.SymlinkNode{{Name: "ln", Target: "a.txt"}},
+	}
+	subD, err := digest.ComputeForMessage(sub, repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+	// "out" also exists in the workspace dir: must merge.
+	outDir := &repb.Directory{Files: []*repb.FileNode{mkFile("in-out", []byte("x"), false)}}
+	outD, err := digest.ComputeForMessage(outDir, repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+	rootDir := &repb.Directory{
+		Files:       []*repb.FileNode{mkFile("big.bin", big, true), mkFile("empty", nil, false), mkFile("shadowed", []byte("input-version"), false)},
+		Directories: []*repb.DirectoryNode{{Name: "sub", Digest: subD}, {Name: "out", Digest: outD}},
+	}
+	tree := &repb.Tree{Root: rootDir, Children: []*repb.Directory{sub, outDir}}
+	opener := func(ctx context.Context, n *repb.FileNode) (*os.File, error) {
+		return os.Open(filepath.Join(blobs, n.GetDigest().GetHash()))
+	}
+	image := filepath.Join(root, "ws.ext4")
+	stats, err := ext4writer.DirectoryAndTreeToImage(context.Background(), ws, image, &ext4writer.TreeOptions{Tree: tree, DigestFunction: repb.DigestFunction_SHA256, Open: opener})
+	require.NoError(t, err)
+	t.Logf("stats: %s", stats)
+	require.Equal(t, 1, stats.Hardlinks) // same1/same2 share; same-exe differs by mode
+	fsck(t, image)
+	dst := filepath.Join(root, "dst")
+	require.NoError(t, os.Mkdir(dst, 0755))
+	require.NoError(t, ext4writer.ImageToDirectory(context.Background(), image, dst, []string{"/"}))
+	got := snapshotDir(t, dst, map[string]bool{"lost+found": true})
+	names := map[string]entry{}
+	for _, e := range got {
+		names[e.Path] = e
+	}
+	for _, p := range []string{"local.txt", "out/sub", "out/in-out", "sub/a.txt", "sub/same1", "sub/same2", "sub/same-exe", "sub/ln", "big.bin", "empty"} {
+		require.Contains(t, names, p)
+	}
+	b, err := os.ReadFile(filepath.Join(dst, "big.bin"))
+	require.NoError(t, err)
+	require.Equal(t, big, b)
+	require.Equal(t, "-rwxr-xr-x", names["sub/same-exe"].Mode)
+	require.Equal(t, "-rw-r--r--", names["sub/same1"].Mode)
+	require.Equal(t, "a.txt", names["sub/ln"].Target)
+	sh, err := os.ReadFile(filepath.Join(dst, "shadowed"))
+	require.NoError(t, err)
+	require.Equal(t, "input-version", string(sh))
+	s1, _ := os.Stat(filepath.Join(dst, "sub", "same1"))
+	s2, _ := os.Stat(filepath.Join(dst, "sub", "same2"))
+	require.True(t, os.SameFile(s1, s2))
+}
+
+// TestSparseFilesStaySparse: holes in source files become holes in the image
+// (no blocks allocated) and extract back as sparse files with equal content.
+func TestSparseFilesStaySparse(t *testing.T) {
+	requireTool(t, "/sbin/e2fsck")
+	requireTool(t, "/sbin/debugfs")
+	for _, mode := range []string{"mmap", "cfr"} {
+		t.Run(mode, func(t *testing.T) {
+			root := testfs.MakeTempDir(t)
+			src := filepath.Join(root, "src")
+			require.NoError(t, os.Mkdir(src, 0755))
+			f, err := os.Create(filepath.Join(src, "sparse"))
+			require.NoError(t, err)
+			require.NoError(t, f.Truncate(64<<20))
+			_, err = f.WriteAt([]byte("start"), 0)
+			require.NoError(t, err)
+			_, err = f.WriteAt(make([]byte, 5000), 20<<20+100) // straddles blocks
+			require.NoError(t, err)
+			_, err = f.WriteAt([]byte("end"), 64<<20-3)
+			require.NoError(t, err)
+			require.NoError(t, f.Close())
+			st, _ := os.Stat(filepath.Join(src, "sparse"))
+			if st.Sys().(*syscall.Stat_t).Blocks*512 >= 64<<20 {
+				t.Skip("filesystem does not support sparse files")
+			}
+			image := filepath.Join(root, "ws.ext4")
+			stats, err := ext4writer.DirectoryToImage(context.Background(), src, image, &ext4writer.Options{CopyMode: mode})
+			require.NoError(t, err)
+			fsck(t, image)
+			out, err := exec.Command("/sbin/debugfs", "-R", "stat /sparse", image).CombinedOutput()
+			require.NoError(t, err, "%s", out)
+			m := regexp.MustCompile(`Blockcount: (\d+)`).FindStringSubmatch(string(out))
+			require.NotNil(t, m, "%s", out)
+			var blocks int
+			fmt.Sscanf(m[1], "%d", &blocks)
+			require.Less(t, blocks, 64, "sparse file should use only a few blocks, got %d (stats %s)", blocks, stats)
+			dst := filepath.Join(root, "dst")
+			require.NoError(t, os.Mkdir(dst, 0755))
+			require.NoError(t, ext4writer.ImageToDirectory(context.Background(), image, dst, []string{"sparse"}))
+			want, _ := os.ReadFile(filepath.Join(src, "sparse"))
+			got, err := os.ReadFile(filepath.Join(dst, "sparse"))
+			require.NoError(t, err)
+			require.True(t, bytes.Equal(want, got))
+			st2, _ := os.Stat(filepath.Join(dst, "sparse"))
+			require.Less(t, st2.Sys().(*syscall.Stat_t).Blocks*512, int64(1<<20), "extracted file should be sparse")
+		})
+	}
+}
+
+// TestVirtualImage serves the image through the block-device interface,
+// dumps it to a file, and checks fsck + contents; then exercises writes.
+func TestVirtualImage(t *testing.T) {
+	requireTool(t, "/sbin/e2fsck")
+	requireTool(t, "/sbin/debugfs")
+	root := testfs.MakeTempDir(t)
+	src := filepath.Join(root, "src")
+	require.NoError(t, os.Mkdir(src, 0755))
+	makeTree(t, src, 1500, 16*1024, 5)
+	v, err := ext4writer.NewVirtualImage(context.Background(), src, root, &ext4writer.Options{SizeBytes: 200e6})
+	require.NoError(t, err)
+	defer v.Close()
+	t.Logf("virtual: %s", v.Stats())
+	size, _ := v.SizeBytes()
+	// Dump through ReadAt in odd-sized chunks to a file and fsck it.
+	dump := filepath.Join(root, "dump.ext4")
+	f, err := os.Create(dump)
+	require.NoError(t, err)
+	buf := make([]byte, 100_003)
+	for off := int64(0); off < size; off += int64(len(buf)) {
+		n, err := v.ReadAt(buf, off)
+		if err != nil && err != io.EOF {
+			require.NoError(t, err)
+		}
+		_, err = f.WriteAt(buf[:n], off)
+		require.NoError(t, err)
+	}
+	require.NoError(t, f.Truncate(size))
+	require.NoError(t, f.Close())
+	fsck(t, dump)
+	// Same content as the source, via the reader on the device.
+	dst := filepath.Join(root, "dst")
+	require.NoError(t, os.Mkdir(dst, 0755))
+	require.NoError(t, ext4writer.ReaderToDirectory(context.Background(), v, size, dst, []string{"/"}))
+	skip := map[string]bool{"lost+found": true, "fifo": true}
+	want := snapshotDir(t, src, skip)
+	got := snapshotDir(t, dst, skip)
+	require.Equal(t, len(want), len(got))
+	for i := range want {
+		require.Equal(t, want[i], got[i])
+	}
+	// Writes: overwrite part of a data block and a metadata block; reads see them; others untouched.
+	off := size/2 + 123
+	before := make([]byte, 8192)
+	_, err = v.ReadAt(before, off-100)
+	require.NoError(t, err)
+	_, err = v.WriteAt([]byte("HELLO"), off)
+	require.NoError(t, err)
+	after := make([]byte, 8192)
+	_, err = v.ReadAt(after, off-100)
+	require.NoError(t, err)
+	require.Equal(t, "HELLO", string(after[100:105]))
+	require.Equal(t, before[:100], after[:100])
+	require.Equal(t, before[105:], after[105:])
+	require.Equal(t, 1, v.DirtyBlocks())
+	// Read past the end returns EOF.
+	_, err = v.ReadAt(buf, size)
+	require.Equal(t, io.EOF, err)
+}
+
+// TestXattrs: in-inode and external-block extended attributes survive and
+// e2fsck (which verifies xattr hashes) is happy.
+func TestXattrs(t *testing.T) {
+	requireTool(t, "/sbin/e2fsck")
+	requireTool(t, "/sbin/debugfs")
+	root := testfs.MakeTempDir(t)
+	src := filepath.Join(root, "src")
+	require.NoError(t, os.Mkdir(src, 0755))
+	small := filepath.Join(src, "small")
+	require.NoError(t, os.WriteFile(small, []byte("x"), 0755))
+	if err := unix.Setxattr(small, "user.cap", []byte{1, 0, 0, 2, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0); err != nil {
+		t.Skipf("xattrs not supported here: %s", err)
+	}
+	require.NoError(t, unix.Setxattr(small, "user.b", []byte("second"), 0))
+	bigv := bytes.Repeat([]byte("v"), 300) // won't fit in the inode
+	big := filepath.Join(src, "big")
+	require.NoError(t, os.WriteFile(big, []byte("y"), 0644))
+	require.NoError(t, unix.Setxattr(big, "user.large", bigv, 0))
+	require.NoError(t, unix.Setxattr(big, "user.a", []byte("1"), 0))
+	dir := filepath.Join(src, "d")
+	require.NoError(t, os.Mkdir(dir, 0755))
+	require.NoError(t, unix.Setxattr(dir, "user.dirattr", []byte("d"), 0))
+
+	image := filepath.Join(root, "ws.ext4")
+	stats, err := ext4writer.DirectoryToImage(context.Background(), src, image, &ext4writer.Options{Xattrs: true})
+	require.NoError(t, err)
+	require.Equal(t, 5, stats.Xattrs)
+	fsck(t, image)
+	ea := func(p string) string {
+		out, err := exec.Command("/sbin/debugfs", "-R", "ea_list "+p, image).CombinedOutput()
+		require.NoError(t, err, "%s", out)
+		return string(out)
+	}
+	require.Contains(t, ea("/small"), "user.b")
+	require.Contains(t, ea("/small"), "user.cap")
+	require.Contains(t, ea("/big"), "user.large")
+	require.Contains(t, ea("/big"), "user.a")
+	require.Contains(t, ea("/d"), "user.dirattr")
+	out, err := exec.Command("/sbin/debugfs", "-R", "ea_get /big user.large", image).CombinedOutput()
+	require.NoError(t, err, "%s", out)
+	require.Contains(t, string(out), strings.Repeat("v", 300))
+	// Without the option, none are copied and the ext_attr feature is off.
+	image2 := filepath.Join(root, "ws2.ext4")
+	stats, err = ext4writer.DirectoryToImage(context.Background(), src, image2, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, stats.Xattrs)
+	fsck(t, image2)
+}

--- a/enterprise/server/util/ext4writer/tree.go
+++ b/enterprise/server/util/ext4writer/tree.go
@@ -1,0 +1,194 @@
+package ext4writer
+
+// Building an image directly from a REAPI input Tree + the filecache, without
+// first materializing the inputs as a directory of hardlinks on the host.
+
+import (
+	"context"
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+// FileOpener opens the content of an input file node (typically
+// FileCache.Open). The returned file is closed by the writer.
+type FileOpener func(ctx context.Context, node *repb.FileNode) (*os.File, error)
+
+// TreeOptions configures DirectoryAndTreeToImage.
+type TreeOptions struct {
+	Options
+	Tree           *repb.Tree
+	DigestFunction repb.DigestFunction_Value
+	Open           FileOpener
+	// Now is used as the mtime of tree entries (REAPI has no timestamps).
+}
+
+// DirectoryAndTreeToImage builds an image containing everything under
+// inputDir (e.g. pre-created output directories) plus the input Tree overlaid
+// on it, with file contents read through opts.Open instead of from disk.
+//
+// Files with the same digest and executable bit share one inode (hard links),
+// matching what the host workspace looks like today when inputs are hardlinked
+// from the filecache.
+func DirectoryAndTreeToImage(ctx context.Context, inputDir, outputFile string, opts *TreeOptions) (*Stats, error) {
+	if opts == nil || opts.Tree == nil || opts.Open == nil {
+		return nil, status.InvalidArgumentError("tree and opener are required")
+	}
+	w := &writer{opts: opts.Options, stats: &Stats{}}
+	if w.opts.Concurrency <= 0 {
+		w.opts.Concurrency = min(8, defaultConcurrency())
+	}
+	if w.opts.Now.IsZero() {
+		w.opts.Now = time.Now()
+	}
+	w.open = func(n *node) (*os.File, error) {
+		if n.fileNode != nil {
+			return opts.Open(ctx, n.fileNode)
+		}
+		return os.Open(n.path)
+	}
+	start := time.Now()
+	root, err := w.walk(inputDir)
+	if err != nil {
+		return nil, status.WrapError(err, "walk input directory")
+	}
+	if err := w.addTree(root, opts.Tree, opts.DigestFunction); err != nil {
+		return nil, status.WrapError(err, "add input tree")
+	}
+	w.stats.WalkDuration = time.Since(start)
+	return w.finish(ctx, outputFile)
+}
+
+type digestKey struct {
+	hash string
+	size int64
+	exec bool
+}
+
+// addTree merges a REAPI Tree into the node tree rooted at root.
+func (w *writer) addTree(root *node, tree *repb.Tree, df repb.DigestFunction_Value) error {
+	dirs := make(map[string]*repb.Directory, len(tree.Children)+1)
+	for _, d := range tree.Children {
+		dg, err := digest.ComputeForMessage(d, df)
+		if err != nil {
+			return err
+		}
+		dirs[dg.GetHash()] = d
+	}
+	byDigest := map[digestKey]*node{}
+	var add func(parent *node, dir *repb.Directory, depth int) error
+	add = func(parent *node, dir *repb.Directory, depth int) error {
+		if depth > 256 {
+			return status.InvalidArgumentError("input tree too deep")
+		}
+		existing := map[string]*node{}
+		for _, ch := range parent.children {
+			existing[ch.name] = ch
+		}
+		// replaceHost drops a host-directory entry that an input of the same
+		// name shadows: inputs win, matching the normal path where inputs are
+		// written first and host-side additions (e.g. CI runner binaries)
+		// skip names that already exist.
+		replaceHost := func(name string) error {
+			old, ok := existing[name]
+			if !ok {
+				return nil
+			}
+			if old.fileNode != nil || old.mode.IsDir() {
+				return status.InvalidArgumentErrorf("duplicate entry %q", name)
+			}
+			for i, ch := range parent.children {
+				if ch == old {
+					parent.children = append(parent.children[:i], parent.children[i+1:]...)
+					break
+				}
+			}
+			delete(existing, name)
+			switch {
+			case old.mode.IsRegular():
+				w.stats.Files--
+				w.stats.DataBytes -= old.size
+			case old.mode&os.ModeSymlink != 0:
+				w.stats.Symlinks--
+			}
+			return nil
+		}
+		for _, f := range dir.GetFiles() {
+			if err := replaceHost(f.GetName()); err != nil {
+				return err
+			}
+			mode := uint32(0644)
+			if f.GetIsExecutable() {
+				mode = 0755
+			}
+			n := &node{name: f.GetName(), mode: os.FileMode(mode), rawMode: syscall.S_IFREG | mode, size: f.GetDigest().GetSizeBytes(), mtime: w.opts.Now, parent: parent, fileNode: f, links: 1}
+			if n.size < 0 || n.size > maxFileBytes {
+				return status.InvalidArgumentErrorf("%q: unsupported file size %d", f.GetName(), n.size)
+			}
+			key := digestKey{f.GetDigest().GetHash(), n.size, f.GetIsExecutable()}
+			if orig, ok := byDigest[key]; ok && orig.links < 65000 {
+				n.hardlink = orig
+				orig.links++
+				w.stats.Hardlinks++
+				parent.children = append(parent.children, n)
+				existing[n.name] = n
+				continue
+			}
+			byDigest[key] = n
+			w.stats.Files++
+			w.stats.DataBytes += n.size
+			parent.children = append(parent.children, n)
+			existing[n.name] = n
+		}
+		for _, s := range dir.GetSymlinks() {
+			if err := replaceHost(s.GetName()); err != nil {
+				return err
+			}
+			n := &node{name: s.GetName(), mode: os.ModeSymlink | 0777, rawMode: syscall.S_IFLNK | 0777, target: s.GetTarget(), size: int64(len(s.GetTarget())), mtime: w.opts.Now, parent: parent, links: 1}
+			w.stats.Symlinks++
+			parent.children = append(parent.children, n)
+			existing[n.name] = n
+		}
+		for _, d := range dir.GetDirectories() {
+			child, ok := existing[d.GetName()]
+			if ok {
+				if !child.mode.IsDir() {
+					return status.InvalidArgumentErrorf("%q exists and is not a directory", d.GetName())
+				}
+			} else {
+				child = &node{name: d.GetName(), mode: os.ModeDir | 0755, rawMode: syscall.S_IFDIR | 0755, mtime: w.opts.Now, parent: parent}
+				w.stats.Dirs++
+				parent.children = append(parent.children, child)
+				existing[child.name] = child
+			}
+			sub, ok := dirs[d.GetDigest().GetHash()]
+			if !ok {
+				return status.InvalidArgumentErrorf("directory %q (%s) missing from tree", d.GetName(), d.GetDigest().GetHash())
+			}
+			if err := add(child, sub, depth+1); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := add(root, tree.GetRoot(), 0); err != nil {
+		return err
+	}
+	// Directory entries must be sorted by name for deterministic images.
+	var sortAll func(n *node)
+	sortAll = func(n *node) {
+		if n.mode.IsDir() {
+			sortChildren(n)
+			for _, ch := range n.children {
+				sortAll(ch)
+			}
+		}
+	}
+	sortAll(root)
+	return nil
+}

--- a/enterprise/server/util/ext4writer/virtual.go
+++ b/enterprise/server/util/ext4writer/virtual.go
@@ -1,0 +1,494 @@
+package ext4writer
+
+// A virtual ext4 image: the same layout the writer produces, but served
+// through a block-device interface instead of materialized into a file.
+// Metadata blocks live in memory, file data blocks are read on demand from
+// the source files (host workspace files or filecache entries), and guest
+// writes go to a sparse overlay file. Preparation cost is O(metadata) and the
+// input bytes are never copied per action; the host page cache of the source
+// files is shared across all actions that use them.
+
+import (
+	"context"
+	"io"
+	"os"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"golang.org/x/sys/unix"
+)
+
+// blockMap collects metadata writes as 4 KiB blocks.
+type blockMap map[uint32][]byte
+
+func (m blockMap) WriteAt(p []byte, off int64) (int, error) {
+	n := 0
+	for len(p) > 0 {
+		blk := uint32(off / blockSize)
+		inBlk := int(off % blockSize)
+		buf, ok := m[blk]
+		if !ok {
+			buf = make([]byte, blockSize)
+			m[blk] = buf
+		}
+		c := copy(buf[inBlk:], p)
+		p = p[c:]
+		off += int64(c)
+		n += c
+	}
+	return n, nil
+}
+
+// dataExtent maps a physical block range of the image to a source file range.
+type dataExtent struct {
+	start   uint32 // physical block
+	n       uint32
+	node    *node
+	logical uint32 // logical block within the file
+}
+
+// VirtualOptions configures a VirtualImage.
+type VirtualOptions struct {
+	// PinSources opens every source file when the image is created and keeps
+	// it open for the image's lifetime, so that a filecache eviction can't
+	// pull an input out from under a running action. Costs one fd per unique
+	// file. Off by default (host workspace hardlinks already pin the inode).
+	PinSources bool
+}
+
+// VirtualImage implements vbd.BlockDevice (io.ReaderAt, io.WriterAt,
+// SizeBytes) for a workspace image that is never written to disk.
+type VirtualImage struct {
+	stats   *Stats
+	size    int64
+	nblocks uint32
+	meta    blockMap
+	extents []dataExtent // sorted by start
+	open    func(n *node) (*os.File, error)
+
+	mu      sync.Mutex
+	dirty   []uint64 // bitset of dirty blocks, backed by overlay
+	overlay *os.File // sparse file holding dirty blocks at block*blockSize
+	fds     *fdCache
+}
+
+const virtualImageMaxOpenFiles = 512
+
+// NewVirtualImage lays out an image for inputDir. overlayDir is where the
+// sparse overlay file for guest writes is created.
+func NewVirtualImage(ctx context.Context, inputDir, overlayDir string, opts *Options) (*VirtualImage, error) {
+	w := newWriter(opts)
+	w.open = func(n *node) (*os.File, error) { return os.Open(n.path) }
+	start := time.Now()
+	if _, err := w.walk(inputDir); err != nil {
+		return nil, status.WrapError(err, "walk input directory")
+	}
+	w.stats.WalkDuration = time.Since(start)
+	return w.finishVirtual(ctx, overlayDir, &VirtualOptions{})
+}
+
+// NewVirtualImageFromTree is NewVirtualImage with an input Tree overlaid on
+// inputDir (see DirectoryAndTreeToImage).
+func NewVirtualImageFromTree(ctx context.Context, inputDir, overlayDir string, opts *TreeOptions, vopts *VirtualOptions) (*VirtualImage, error) {
+	if vopts == nil {
+		vopts = &VirtualOptions{PinSources: true}
+	}
+	if opts == nil || opts.Tree == nil || opts.Open == nil {
+		return nil, status.InvalidArgumentError("tree and opener are required")
+	}
+	w := newWriter(&opts.Options)
+	w.open = func(n *node) (*os.File, error) {
+		if n.fileNode != nil {
+			return opts.Open(ctx, n.fileNode)
+		}
+		return os.Open(n.path)
+	}
+	start := time.Now()
+	root, err := w.walk(inputDir)
+	if err != nil {
+		return nil, status.WrapError(err, "walk input directory")
+	}
+	if err := w.addTree(root, opts.Tree, opts.DigestFunction); err != nil {
+		return nil, status.WrapError(err, "add input tree")
+	}
+	w.stats.WalkDuration = time.Since(start)
+	return w.finishVirtual(ctx, overlayDir, vopts)
+}
+
+func newWriter(opts *Options) *writer {
+	if opts == nil {
+		opts = &Options{}
+	}
+	w := &writer{opts: *opts, stats: &Stats{}}
+	if w.opts.Concurrency <= 0 {
+		w.opts.Concurrency = min(8, defaultConcurrency())
+	}
+	if w.opts.Now.IsZero() {
+		w.opts.Now = time.Now()
+	}
+	return w
+}
+
+func (w *writer) finishVirtual(ctx context.Context, overlayDir string, vopts *VirtualOptions) (*VirtualImage, error) {
+	w.assignInodes()
+	start := time.Now()
+	if err := w.layout(w.root); err != nil {
+		return nil, status.WrapError(err, "compute layout")
+	}
+	w.stats.LayoutDuration = time.Since(start)
+
+	start = time.Now()
+	meta := blockMap{}
+	if err := w.writeMetadata(meta); err != nil {
+		return nil, status.WrapError(err, "write metadata")
+	}
+	w.stats.MetadataDuration = time.Since(start)
+
+	var exts []dataExtent
+	for _, n := range w.nodes {
+		if !n.mode.IsRegular() || n.size == 0 {
+			continue
+		}
+		for _, e := range n.extents {
+			exts = append(exts, dataExtent{start: e.start, n: e.len, node: n, logical: e.logical})
+		}
+	}
+	sort.Slice(exts, func(i, j int) bool { return exts[i].start < exts[j].start })
+
+	overlay, err := os.CreateTemp(overlayDir, "workspace-overlay-*")
+	if err != nil {
+		return nil, status.WrapError(err, "create overlay file")
+	}
+	// Unlink immediately: the overlay lives only as long as the fd.
+	os.Remove(overlay.Name())
+	v := &VirtualImage{
+		stats:   w.stats,
+		size:    w.stats.ImageBytes,
+		nblocks: w.blocksCount,
+		meta:    meta,
+		extents: exts,
+		open:    w.open,
+		dirty:   make([]uint64, (w.blocksCount+63)/64),
+		overlay: overlay,
+		fds:     newFDCache(virtualImageMaxOpenFiles),
+	}
+	if vopts.PinSources {
+		// Open everything now (in parallel) and keep it open.
+		start := time.Now()
+		if err := v.pinAll(ctx, w.opts.Concurrency); err != nil {
+			v.Close()
+			return nil, status.WrapError(err, "open input files")
+		}
+		w.stats.DataDuration = time.Since(start)
+	}
+	return v, nil
+}
+
+// pinAll opens every source file and holds a reference so it is never
+// evicted from the fd cache (and can't be deleted from under us).
+func (v *VirtualImage) pinAll(ctx context.Context, concurrency int) error {
+	seen := map[*node]bool{}
+	var nodes []*node
+	for i := range v.extents {
+		n := v.extents[i].node
+		if !seen[n] {
+			seen[n] = true
+			nodes = append(nodes, n)
+		}
+	}
+	if rl, err := getNoFileLimit(); err == nil && uint64(len(nodes)+1024) > rl {
+		return status.ResourceExhaustedErrorf("need %d open files but RLIMIT_NOFILE is %d", len(nodes), rl)
+	}
+	v.fds.max = len(nodes) + virtualImageMaxOpenFiles
+	ch := make(chan *node)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var firstErr error
+	for i := 0; i < max(1, concurrency); i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for n := range ch {
+				_, _, err := v.fds.get(n, v.open) // reference intentionally never released
+				if err != nil {
+					mu.Lock()
+					if firstErr == nil {
+						firstErr = err
+					}
+					mu.Unlock()
+				}
+			}
+		}()
+	}
+	for _, n := range nodes {
+		if ctx.Err() != nil {
+			break
+		}
+		ch <- n
+	}
+	close(ch)
+	wg.Wait()
+	return firstErr
+}
+
+// Stats returns layout statistics.
+func (v *VirtualImage) Stats() *Stats { return v.stats }
+
+// SizeBytes implements vbd.BlockDevice.
+func (v *VirtualImage) SizeBytes() (int64, error) { return v.size, nil }
+
+func (v *VirtualImage) isDirty(blk uint32) bool {
+	return v.dirty[blk/64]&(1<<(blk%64)) != 0
+}
+
+func (v *VirtualImage) setDirty(blk uint32) {
+	v.dirty[blk/64] |= 1 << (blk % 64)
+}
+
+// findExtent returns the data extent containing blk, or nil.
+func (v *VirtualImage) findExtent(blk uint32) *dataExtent {
+	i := sort.Search(len(v.extents), func(i int) bool { return v.extents[i].start+v.extents[i].n > blk })
+	if i < len(v.extents) && v.extents[i].start <= blk {
+		return &v.extents[i]
+	}
+	return nil
+}
+
+// ReadAt implements io.ReaderAt. Reads are served block by block from the
+// dirty overlay, the metadata map, the source files, or zeros.
+func (v *VirtualImage) ReadAt(p []byte, off int64) (int, error) {
+	if off < 0 || off >= v.size {
+		return 0, io.EOF
+	}
+	short := false
+	if int64(len(p)) > v.size-off {
+		p = p[:v.size-off]
+		short = true
+	}
+	n, err := v.readAll(p, off)
+	if err == nil && short {
+		return n, io.EOF
+	}
+	return n, err
+}
+
+func (v *VirtualImage) readAll(p []byte, off int64) (int, error) {
+	done := 0
+	for done < len(p) {
+		blk := uint32((off + int64(done)) / blockSize)
+		inBlk := int((off + int64(done)) % blockSize)
+		n := min(blockSize-inBlk, len(p)-done)
+		dst := p[done : done+n]
+		v.mu.Lock()
+		dirty := v.isDirty(blk)
+		v.mu.Unlock()
+		switch {
+		case dirty:
+			if _, err := v.overlay.ReadAt(dst, int64(blk)*blockSize+int64(inBlk)); err != nil && err != io.EOF {
+				return done, err
+			}
+		default:
+			if buf, ok := v.meta[blk]; ok {
+				copy(dst, buf[inBlk:inBlk+n])
+			} else if e := v.findExtent(blk); e != nil {
+				if err := v.readFileBlock(e, blk, inBlk, dst); err != nil {
+					return done, err
+				}
+			} else {
+				clear(dst)
+			}
+		}
+		done += n
+	}
+	return done, nil
+}
+
+// readFileBlock fills dst with bytes [inBlk, inBlk+len(dst)) of physical block
+// blk, which belongs to data extent e. Bytes past the file's end are zero.
+func (v *VirtualImage) readFileBlock(e *dataExtent, blk uint32, inBlk int, dst []byte) error {
+	fileOff := int64(e.logical+(blk-e.start))*blockSize + int64(inBlk)
+	n := e.node
+	if fileOff >= n.size {
+		clear(dst)
+		return nil
+	}
+	want := dst
+	if fileOff+int64(len(dst)) > n.size {
+		want = dst[:n.size-fileOff]
+		clear(dst[len(want):])
+	}
+	f, release, err := v.fds.get(n, v.open)
+	if err != nil {
+		return err
+	}
+	defer release()
+	nr, err := f.ReadAt(want, fileOff)
+	if err != nil && !(err == io.EOF && nr == len(want)) {
+		if err == io.EOF {
+			// The source is shorter than it was when the layout was computed:
+			// don't hand the guest zeros in place of input data.
+			return status.DataLossErrorf("input %q truncated: expected %d bytes at %d, got %d", n.name, len(want), fileOff, nr)
+		}
+		return err
+	}
+	return nil
+}
+
+// WriteAt implements io.WriterAt: writes go to the overlay. Partial-block
+// writes first pull the current block contents into the overlay.
+func (v *VirtualImage) WriteAt(p []byte, off int64) (int, error) {
+	if off < 0 || off+int64(len(p)) > v.size {
+		return 0, status.InvalidArgumentErrorf("write [%d,+%d) outside image of %d bytes", off, len(p), v.size)
+	}
+	done := 0
+	for done < len(p) {
+		blk := uint32((off + int64(done)) / blockSize)
+		inBlk := int((off + int64(done)) % blockSize)
+		n := min(blockSize-inBlk, len(p)-done)
+		v.mu.Lock()
+		if !v.isDirty(blk) && n < blockSize {
+			// Copy-up the rest of the block first.
+			var cur [blockSize]byte
+			v.mu.Unlock()
+			if _, err := v.ReadAt(cur[:], int64(blk)*blockSize); err != nil && err != io.EOF {
+				return done, err
+			}
+			v.mu.Lock()
+			if !v.isDirty(blk) {
+				if _, err := v.overlay.WriteAt(cur[:], int64(blk)*blockSize); err != nil {
+					v.mu.Unlock()
+					return done, err
+				}
+			}
+		}
+		if _, err := v.overlay.WriteAt(p[done:done+n], int64(blk)*blockSize+int64(inBlk)); err != nil {
+			v.mu.Unlock()
+			return done, err
+		}
+		v.setDirty(blk)
+		v.mu.Unlock()
+		done += n
+	}
+	return done, nil
+}
+
+// DirtyBlocks returns how many blocks the guest has written.
+func (v *VirtualImage) DirtyBlocks() int {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	c := 0
+	for _, w := range v.dirty {
+		for ; w != 0; w &= w - 1 {
+			c++
+		}
+	}
+	return c
+}
+
+// Close releases open source files and the overlay.
+func (v *VirtualImage) Close() error {
+	v.fds.closeAll()
+	return v.overlay.Close()
+}
+
+// fdCache keeps a bounded number of source files open, LRU-evicting the rest.
+// Entries in use are never evicted.
+type fdCache struct {
+	mu    sync.Mutex
+	max   int
+	items map[*node]*fdEntry
+	lru   []*node // most recently used at the end
+}
+
+type fdEntry struct {
+	f    *os.File
+	refs int
+}
+
+func newFDCache(max int) *fdCache { return &fdCache{max: max, items: map[*node]*fdEntry{}} }
+
+func (c *fdCache) get(n *node, open func(n *node) (*os.File, error)) (*os.File, func(), error) {
+	c.mu.Lock()
+	if e, ok := c.items[n]; ok {
+		e.refs++
+		c.touch(n)
+		c.mu.Unlock()
+		return e.f, func() { c.put(n) }, nil
+	}
+	c.mu.Unlock()
+	f, err := open(n)
+	if err != nil {
+		return nil, nil, err
+	}
+	c.mu.Lock()
+	if e, ok := c.items[n]; ok {
+		// Raced with another opener; use theirs.
+		f.Close()
+		e.refs++
+		c.touch(n)
+		c.mu.Unlock()
+		return e.f, func() { c.put(n) }, nil
+	}
+	c.items[n] = &fdEntry{f: f, refs: 1}
+	c.lru = append(c.lru, n)
+	c.evictLocked()
+	c.mu.Unlock()
+	return f, func() { c.put(n) }, nil
+}
+
+func (c *fdCache) put(n *node) {
+	c.mu.Lock()
+	if e, ok := c.items[n]; ok {
+		e.refs--
+	}
+	c.evictLocked()
+	c.mu.Unlock()
+}
+
+func getNoFileLimit() (uint64, error) {
+	var rl unix.Rlimit
+	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &rl); err != nil {
+		return 0, err
+	}
+	return rl.Cur, nil
+}
+
+func (c *fdCache) touch(n *node) {
+	for i, x := range c.lru {
+		if x == n {
+			c.lru = append(c.lru[:i], c.lru[i+1:]...)
+			break
+		}
+	}
+	c.lru = append(c.lru, n)
+}
+
+func (c *fdCache) evictLocked() {
+	for len(c.items) > c.max {
+		evicted := false
+		for i, n := range c.lru {
+			if e := c.items[n]; e != nil && e.refs == 0 {
+				e.f.Close()
+				delete(c.items, n)
+				c.lru = append(c.lru[:i], c.lru[i+1:]...)
+				evicted = true
+				break
+			}
+		}
+		if !evicted {
+			return
+		}
+	}
+}
+
+func (c *fdCache) closeAll() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for n, e := range c.items {
+		e.f.Close()
+		delete(c.items, n)
+	}
+	c.lru = nil
+}

--- a/enterprise/server/util/ext4writer/xattr.go
+++ b/enterprise/server/util/ext4writer/xattr.go
@@ -1,0 +1,196 @@
+package ext4writer
+
+// Extended attributes: stored in the inode's extra space when they fit,
+// otherwise in one external xattr block per inode (ext_attr feature).
+// Container images need these (e.g. security.capability on binaries).
+
+import (
+	"encoding/binary"
+	"sort"
+	"strings"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	xattrMagic           = 0xEA020000
+	featureCompatExtAttr = 0x0008
+	// Space available for in-inode xattrs: inode size minus the 128-byte
+	// base and the 32-byte extra fields, minus the 4-byte magic.
+	inInodeXattrBytes = inodeSize - 128 - 32 - 4
+)
+
+type xattr struct {
+	index uint8 // ext4 name index
+	name  string
+	value []byte
+}
+
+// xattrIndex splits a full attribute name into an ext4 name index and the
+// remaining name.
+func xattrIndex(full string) (uint8, string, bool) {
+	switch {
+	case strings.HasPrefix(full, "user."):
+		return 1, full[5:], true
+	case full == "system.posix_acl_access":
+		return 2, "", true
+	case full == "system.posix_acl_default":
+		return 3, "", true
+	case strings.HasPrefix(full, "trusted."):
+		return 4, full[8:], true
+	case strings.HasPrefix(full, "security."):
+		return 6, full[9:], true
+	case strings.HasPrefix(full, "system."):
+		return 7, full[7:], true
+	}
+	return 0, "", false
+}
+
+// readXattrs lists and reads a path's extended attributes (not following
+// symlinks).
+func readXattrs(path string) ([]xattr, error) {
+	names := make([]byte, 4096)
+	n, err := unix.Llistxattr(path, names)
+	if err != nil {
+		if err == unix.ENOTSUP || err == unix.EOPNOTSUPP || err == unix.ENODATA {
+			return nil, nil
+		}
+		if err == unix.ERANGE {
+			sz, err := unix.Llistxattr(path, nil)
+			if err != nil {
+				return nil, err
+			}
+			names = make([]byte, sz)
+			if n, err = unix.Llistxattr(path, names); err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
+	}
+	var out []xattr
+	for full := range strings.SplitSeq(strings.TrimRight(string(names[:n]), "\x00"), "\x00") {
+		if full == "" {
+			continue
+		}
+		idx, name, ok := xattrIndex(full)
+		if !ok {
+			continue // unknown namespace; ext4 couldn't store it either
+		}
+		sz, err := unix.Lgetxattr(path, full, nil)
+		if err != nil {
+			return nil, err
+		}
+		val := make([]byte, sz)
+		if sz > 0 {
+			if _, err := unix.Lgetxattr(path, full, val); err != nil {
+				return nil, err
+			}
+		}
+		out = append(out, xattr{index: idx, name: name, value: val})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		a, b := out[i], out[j]
+		if a.index != b.index {
+			return a.index < b.index
+		}
+		if len(a.name) != len(b.name) {
+			return len(a.name) < len(b.name)
+		}
+		return a.name < b.name
+	})
+	return out, nil
+}
+
+func xattrEntryLen(name string) int { return (16 + len(name) + 3) &^ 3 }
+
+func xattrValueLen(v []byte) int { return (len(v) + 3) &^ 3 }
+
+// xattrHashEntry computes e_hash as the kernel does.
+func xattrHashEntry(name string, value []byte) uint32 {
+	var h uint32
+	for i := 0; i < len(name); i++ {
+		h = (h << 5) ^ (h >> 27) ^ uint32(name[i])
+	}
+	for i := 0; i < len(value); i += 4 {
+		var w [4]byte
+		copy(w[:], value[i:])
+		h = (h << 16) ^ (h >> 16) ^ binary.LittleEndian.Uint32(w[:])
+	}
+	return h
+}
+
+// xattrsFitInInode reports whether the attributes fit in the inode body.
+func xattrsFitInInode(xs []xattr) bool {
+	need := 4 // terminating null entry
+	for _, x := range xs {
+		need += xattrEntryLen(x.name) + xattrValueLen(x.value)
+	}
+	return need <= inInodeXattrBytes
+}
+
+// encodeXattrs serializes entries + values into a region of the given size.
+// valueBase is the offset that e_value_offs is relative to, measured from
+// the start of the entries (0 for in-inode, where offsets are relative to
+// the first entry; for a block, entries start at 32 and offsets are relative
+// to the block start, so valueBase = 32). hashed selects whether e_hash is
+// filled in: the kernel requires it for external blocks and requires zero for
+// in-inode entries (it doesn't maintain those).
+func encodeXattrs(xs []xattr, region []byte, valueBase int, hashed bool) {
+	off := 0
+	valEnd := len(region)
+	for _, x := range xs {
+		vl := xattrValueLen(x.value)
+		valEnd -= vl
+		e := region[off:]
+		e[0] = uint8(len(x.name))
+		e[1] = x.index
+		binary.LittleEndian.PutUint16(e[2:], uint16(valEnd+valueBase))
+		binary.LittleEndian.PutUint32(e[4:], 0) // e_value_inum
+		binary.LittleEndian.PutUint32(e[8:], uint32(len(x.value)))
+		if hashed {
+			binary.LittleEndian.PutUint32(e[12:], xattrHashEntry(x.name, x.value))
+		}
+		copy(e[16:], x.name)
+		copy(region[valEnd:], x.value)
+		off += xattrEntryLen(x.name)
+	}
+	// Null terminator entry (already zero).
+}
+
+// encodeInodeXattrs writes the in-inode xattr region of a 256-byte inode.
+func encodeInodeXattrs(b []byte, xs []xattr) {
+	region := b[128+32:]
+	binary.LittleEndian.PutUint32(region, xattrMagic)
+	encodeXattrs(xs, region[4:], 0, false)
+}
+
+// encodeXattrBlock renders an external xattr block.
+func encodeXattrBlock(xs []xattr) ([]byte, error) {
+	need := 32 + 4
+	for _, x := range xs {
+		need += xattrEntryLen(x.name) + xattrValueLen(x.value)
+	}
+	if need > blockSize {
+		return nil, status.InvalidArgumentErrorf("extended attributes do not fit in one block (%d bytes)", need)
+	}
+	b := make([]byte, blockSize)
+	le := binary.LittleEndian
+	le.PutUint32(b[0:], xattrMagic)
+	le.PutUint32(b[4:], 1) // h_refcount
+	le.PutUint32(b[8:], 1) // h_blocks
+	encodeXattrs(xs, b[32:], 32, true)
+	// h_hash: combination of entry hashes.
+	var h uint32
+	for _, x := range xs {
+		eh := xattrHashEntry(x.name, x.value)
+		if eh == 0 {
+			h = 0
+			break
+		}
+		h = (h << 16) ^ (h >> 16) ^ eh
+	}
+	le.PutUint32(b[12:], h)
+	return b, nil
+}


### PR DESCRIPTION
Adds an in-process ext4 writer (enterprise/server/util/ext4writer) and uses it to build the per-action firecracker workspace image instead of shelling out to mke2fs -d, which does one pwrite per 4K block on a single thread and dominates action preparation time for large input trees (10k files/330MB: 2.9s -> 1.1s; 30k files/2GB: 9.3s -> 3.0s in benchmarks).

Rollout is double-gated: the native writer is only used when the executor runs with --executor.firecracker_workspace_image_writer=native AND the task carries the executor.firecracker_native_workspace_writer experiment, which the app appends when the experiment flag of the same name evaluates true. Either side missing falls back to mke2fs. Defaults preserve current behavior everywhere.