### PR TITLE
firecracker: stage metrics for workspace image build and output extraction

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1560,6 +1560,11 @@ func (c *FirecrackerContainer) createWorkspaceImage(ctx context.Context, workspa
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
+	start := time.Now()
+	defer func() {
+		c.observeStageDuration("create_workspace_image", time.Since(start))
+	}()
+
 	// The existing workspace disk may still be mounted in the VM, so we unlink
 	// it then create a new file rather than overwriting the existing file
 	// to avoid corruption.
@@ -1930,6 +1935,7 @@ func (c *FirecrackerContainer) copyOutputsToWorkspace(ctx context.Context) error
 	start := time.Now()
 	defer func() {
 		log.CtxDebugf(ctx, "copyOutputsToWorkspace took %s", time.Since(start))
+		c.observeStageDuration("copy_outputs", time.Since(start))
 	}()
 	if exists, err := disk.FileExists(ctx, workspaceExt4Path); err != nil || !exists {
 		return status.FailedPreconditionErrorf("workspacefs path %q not found", workspaceExt4Path)


### PR DESCRIPTION
This change records separate `create_workspace_image` and `copy_outputs` for Firecracker actions, so we can see them in Grafana.