### PR TITLE
Deflake `//enterprise/server/test/integration/remote_execution:remote_execution_test`

### DIFF
--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -1733,12 +1733,16 @@ func TestBazelRemoteBuildWithChunkedGeneratedInputAfterChunkSizeIncrease(t *test
 	bumpPort := lis.Addr().(*net.TCPAddr).Port
 
 	const largeOutputSize = 3 * 1024 * 1024
+	largeOutputMarker := uuid.NewString()
+	largeOutput := append([]byte(largeOutputMarker), make([]byte, largeOutputSize-len(largeOutputMarker))...)
+	largeOutputZeroKiB := (largeOutputSize - len(largeOutputMarker)) / 1024
+	largeOutputZeroRemainder := (largeOutputSize - len(largeOutputMarker)) % 1024
 	ws := testbazel.MakeTempModule(t, map[string]string{
 		"BUILD": fmt.Sprintf(`
 genrule(
     name = "producer",
     outs = ["large.bin"],
-    cmd_bash = "dd if=/dev/zero of=$@ bs=1024 count=%d 2>/dev/null && { printf 'GET /bump HTTP/1.0\r\n\r\n' >&3; cat <&3 >/dev/null; } 3<>/dev/tcp/127.0.0.1/%d",
+    cmd_bash = "{ printf '%%s' '%s'; dd if=/dev/zero bs=1024 count=%d 2>/dev/null; dd if=/dev/zero bs=%d count=1 2>/dev/null; } > $@ && { printf 'GET /bump HTTP/1.0\r\n\r\n' >&3; cat <&3 >/dev/null; } 3<>/dev/tcp/127.0.0.1/%d",
     exec_properties = {
         "OSFamily": "%s",
         "Arch": "%s",
@@ -1755,7 +1759,7 @@ genrule(
         "Arch": "%s",
     },
 )
-`, largeOutputSize/1024, bumpPort, runtime.GOOS, runtime.GOARCH, runtime.GOOS, runtime.GOARCH),
+`, largeOutputMarker, largeOutputZeroKiB, largeOutputZeroRemainder, bumpPort, runtime.GOOS, runtime.GOARCH, runtime.GOOS, runtime.GOARCH),
 	})
 
 	buildFlags := func(target string) []string {
@@ -1786,7 +1790,7 @@ genrule(
 		require.Fail(t, "producer did not bump chunk size")
 	}
 
-	largeDigest, err := digest.Compute(bytes.NewReader(make([]byte, largeOutputSize)), repb.DigestFunction_SHA256)
+	largeDigest, err := digest.Compute(bytes.NewReader(largeOutput), repb.DigestFunction_SHA256)
 	require.NoError(t, err)
 	casClient := rbe.GetContentAddressableStorageClient()
 	cacheCtx := metadata.AppendToOutgoingContext(ctx, "x-buildbuddy-api-key", rbe.APIKey1)


### PR DESCRIPTION
## Summary
- Make `TestBazelRemoteBuildWithChunkedGeneratedInputAfterChunkSizeIncrease` generate a per-run unique large output blob instead of a fixed all-zero payload.
- Keep the output size at 3 MiB so it still exercises old chunked upload params after the chunk-size bump.

## Diagnosis
The failing assertion sees `FindMissingBlobs` return no missing digests for `bbd05cf6097ac9b1f89ea29d2542c1b7b67ee46848393895f5a9e43fa1f621e5`, which is the SHA-256 of 3 MiB of zero bytes. In this integration test the Redis-backed CAS is test-local, so this is unlikely to be an arbitrary external cache hit.

The important issue is that the fixed all-zero payload makes the final assertion ambiguous: any normal whole-blob upload of that common digest during the test attempt (for example if Bazel rewinds and re-executes the producer after the chunk-size bump, when 3 MiB is no longer chunk-upload eligible) will make the later chunked `FindMissingBlobs` call return an empty missing set. Using a per-run unique payload removes that fixed-digest collision while preserving the intended chunked-output scenario; if the current run re-uploads the producer output whole, the final assertion will still catch it for that run-specific digest.

## Testing
- `bazel test --config=race --bes_backend= --runs_per_test=5 --jobs=5 --test_output=errors --test_sharding_strategy=disabled --test_filter=TestBazelRemoteBuildWithChunkedGeneratedInputAfterChunkSizeIncrease //enterprise/server/test/integration/remote_execution:remote_execution_test`