### PR TITLE
Populate API key `creation_metadata` in `GetAPIKeys` responses sent to org admins

### DIFF
--- a/enterprise/server/backends/authdb/authdb_test.go
+++ b/enterprise/server/backends/authdb/authdb_test.go
@@ -958,6 +958,69 @@ func TestAPIKeyCreationMetadata(t *testing.T) {
 	require.Equal(t, fakeClock.Now().UnixMicro(), fetched.CreatedAtUsec)
 }
 
+func TestGetApiKeysCreationMetadata(t *testing.T) {
+	ctx := t.Context()
+	env := setupEnv(t)
+	flags.Set(t, "app.create_group_per_user", true)
+	flags.Set(t, "app.no_default_user_group", true)
+	fakeClock := clockwork.NewFakeClock()
+	env.SetClock(fakeClock)
+	adb, err := authdb.NewAuthDB(env, env.GetDBHandle())
+	require.NoError(t, err)
+
+	// Find a group that has both an admin and a non-admin member.
+	users := enterprise_testauth.CreateRandomGroups(t, env)
+	var admin, dev *tables.User
+	for _, u := range users {
+		if !u.Groups[0].HasCapability(cappb.Capability_ORG_ADMIN) {
+			dev = u
+			break
+		}
+	}
+	require.NotNil(t, dev, "expected at least one non-admin user")
+	groupID := dev.Groups[0].Group.GroupID
+	for _, u := range users {
+		if u.Groups[0].Group.GroupID == groupID && u.Groups[0].HasCapability(cappb.Capability_ORG_ADMIN) {
+			admin = u
+			break
+		}
+	}
+	require.NotNil(t, admin, "expected group %s to have an admin", groupID)
+
+	auth := env.GetAuthenticator().(*testauth.TestAuthenticator)
+	adminCtx, err := auth.WithAuthenticatedUser(ctx, admin.UserID)
+	require.NoError(t, err)
+	devCtx, err := auth.WithAuthenticatedUser(ctx, dev.UserID)
+	require.NoError(t, err)
+
+	created, err := adb.CreateAPIKey(adminCtx, groupID, "test key", nil, 0, true /*=visibleToDevelopers*/)
+	require.NoError(t, err)
+
+	getKey := func(reqCtx context.Context) *akpb.ApiKey {
+		rsp, err := env.GetBuildBuddyServer().GetApiKeys(reqCtx, &akpb.GetApiKeysRequest{
+			RequestContext: &ctxpb.RequestContext{GroupId: groupID},
+		})
+		require.NoError(t, err)
+		for _, k := range rsp.GetApiKey() {
+			if k.GetId() == created.APIKeyID {
+				return k
+			}
+		}
+		require.FailNow(t, "created key not returned by GetApiKeys")
+		return nil
+	}
+
+	// Admins should see who created the key and when.
+	expected := fmt.Sprintf(
+		"Created by %s %s at %s",
+		admin.FirstName, admin.LastName,
+		fakeClock.Now().UTC().Format("3:04PM January 2, 2006"))
+	require.Equal(t, expected, getKey(adminCtx).GetCreationMetadata())
+
+	// Non-admins should see the key, but not its creation metadata.
+	require.Empty(t, getKey(devCtx).GetCreationMetadata())
+}
+
 func setupEnv(t *testing.T) *testenv.TestEnv {
 	flags.Set(t, "app.user_owned_keys_enabled", true)
 	env := enterprise_testenv.New(t)

--- a/proto/api_key.proto
+++ b/proto/api_key.proto
@@ -34,6 +34,10 @@ message ApiKey {
   // Optional certificate corresponding to this API key, if
   // requested.
   Certificate certificate = 8;
+
+  // Details about the creation of this API key. Only returned to organization
+  // administrators because it identifies an organization member.
+  string creation_metadata = 9;
 }
 
 message Certificate {

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1006,26 +1006,76 @@ func (s *BuildBuddyServer) UpdateUserListMembership(ctx context.Context, request
 	return &ulpb.UpdateUserListMembershipResponse{}, nil
 }
 
+func (s *BuildBuddyServer) isOrgAdmin(ctx context.Context, groupID string) bool {
+	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
+	if err != nil {
+		return false
+	}
+	return authutil.AuthorizeOrgAdmin(u, groupID) == nil
+}
+
+// displayName returns a human-readable name for the given user, or "" if the
+// user can't be looked up.
+func (s *BuildBuddyServer) displayName(ctx context.Context, userID string) string {
+	udb := s.env.GetUserDB()
+	if udb == nil || userID == "" {
+		return ""
+	}
+	u, err := udb.GetUserByIDWithoutAuthCheck(ctx, userID, &interfaces.GetUserOpts{})
+	if err != nil {
+		log.CtxWarningf(ctx, "Could not look up user %q: %s", userID, err)
+		return ""
+	}
+	if name := u.ToProto().GetName().GetFull(); name != "" {
+		return name
+	}
+	return u.Email
+}
+
+func (s *BuildBuddyServer) apiKeyCreationMetadata(ctx context.Context, k *tables.APIKey) string {
+	creator := s.displayName(ctx, k.CreatedByUserID)
+	createdAt := ""
+	if k.CreatedAtUsec != 0 {
+		createdAt = time.UnixMicro(k.CreatedAtUsec).UTC().Format("3:04PM January 2, 2006")
+	}
+	switch {
+	case creator != "" && createdAt != "":
+		return fmt.Sprintf("Created by %s at %s", creator, createdAt)
+	case creator != "":
+		return fmt.Sprintf("Created by %s", creator)
+	case createdAt != "":
+		return fmt.Sprintf("Created at %s", createdAt)
+	default:
+		return ""
+	}
+}
+
 func (s *BuildBuddyServer) GetApiKeys(ctx context.Context, req *akpb.GetApiKeysRequest) (*akpb.GetApiKeysResponse, error) {
 	authDB := s.env.GetAuthDB()
 	if authDB == nil {
 		return nil, status.UnimplementedError("Not Implemented")
 	}
-	tableKeys, err := authDB.GetAPIKeys(ctx, req.GetRequestContext().GetGroupId())
+	groupID := req.GetRequestContext().GetGroupId()
+	tableKeys, err := authDB.GetAPIKeys(ctx, groupID)
 	if err != nil {
 		return nil, err
 	}
+	includeCreationMetadata := s.isOrgAdmin(ctx, groupID)
 	rsp := &akpb.GetApiKeysResponse{
 		ApiKey: make([]*akpb.ApiKey, 0, len(tableKeys)),
 	}
 	for _, k := range tableKeys {
 		// API Key value must be retrieved via GetAPIKey API.
-		rsp.ApiKey = append(rsp.ApiKey, &akpb.ApiKey{
+		key := &akpb.ApiKey{
 			Id:                  k.APIKeyID,
 			Label:               k.Label,
 			Capability:          capabilities.FromInt(k.Capabilities),
 			VisibleToDevelopers: k.VisibleToDevelopers,
-		})
+		}
+		if includeCreationMetadata {
+			key.CreationMetadata = s.apiKeyCreationMetadata(ctx, k)
+		}
+		rsp.ApiKey = append(rsp.ApiKey, key)
 	}
 	return rsp, nil
 }


### PR DESCRIPTION
Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/8184