### PR TITLE
Add a metric tracking distributed cache write requests and bytes by type ('bytes' or 'reference')

### DIFF
--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -879,13 +879,15 @@ func recordReadResponseMetrics(responseType string, r *rspb.ResourceName) {
 }
 
 // recordWriteRequestMetrics records that a peer write committed with its
-// payload sent as requestType ("reference" or "bytes"), attributing the
-// written digest's size to it.
-func recordWriteRequestMetrics(requestType string, r *rspb.ResourceName) {
-	metrics.DistributedCacheWriteRequestCount.With(
-		prometheus.Labels{metrics.DistributedCacheWriteRequestType: requestType}).Inc()
-	metrics.DistributedCacheWriteRequestSizeBytes.With(
-		prometheus.Labels{metrics.DistributedCacheWriteRequestType: requestType}).Add(float64(r.GetDigest().GetSizeBytes()))
+// payload sent as requestType ("reference" or "bytes") and the commit's
+// status code, attributing the written digest's size to it.
+func recordWriteRequestMetrics(requestType string, r *rspb.ResourceName, code codes.Code) {
+	labels := prometheus.Labels{
+		metrics.DistributedCacheWriteRequestType: requestType,
+		metrics.StatusHumanReadableLabel:         code.String(),
+	}
+	metrics.DistributedCacheWriteRequestCount.With(labels).Inc()
+	metrics.DistributedCacheWriteRequestSizeBytes.With(labels).Add(float64(r.GetDigest().GetSizeBytes()))
 }
 
 func (c *Proxy) dereference(ctx context.Context, peer string, ref *refpb.Reference, requested *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
@@ -1131,9 +1133,14 @@ func (wc *streamWriteCloser) Write(data []byte) (int, error) {
 
 func (wc *streamWriteCloser) Commit() error {
 	err := wc.commit()
-	if err == nil {
-		recordWriteRequestMetrics(wc.requestType, wc.r)
+	code := gstatus.Code(err)
+	if err == nil && wc.alreadyExists {
+		// The peer already had the blob and short-circuited the write.
+		// Callers see success, but record it under AlreadyExists so that
+		// status="OK" counts only blobs the peer actually stored.
+		code = codes.AlreadyExists
 	}
+	recordWriteRequestMetrics(wc.requestType, wc.r, code)
 	return err
 }
 
@@ -1156,6 +1163,7 @@ func (wc *streamWriteCloser) commit() error {
 	}
 	_, err := wc.closeAndRecv()
 	if status.IsAlreadyExistsError(err) {
+		wc.alreadyExists = true
 		return nil
 	}
 	if err != nil {

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -878,6 +878,16 @@ func recordReadResponseMetrics(responseType string, r *rspb.ResourceName) {
 		prometheus.Labels{metrics.DistributedCacheReadResponseType: responseType}).Add(float64(r.GetDigest().GetSizeBytes()))
 }
 
+// recordWriteRequestMetrics records that a peer write committed with its
+// payload sent as requestType ("reference" or "bytes"), attributing the
+// written digest's size to it.
+func recordWriteRequestMetrics(requestType string, r *rspb.ResourceName) {
+	metrics.DistributedCacheWriteRequestCount.With(
+		prometheus.Labels{metrics.DistributedCacheWriteRequestType: requestType}).Inc()
+	metrics.DistributedCacheWriteRequestSizeBytes.With(
+		prometheus.Labels{metrics.DistributedCacheWriteRequestType: requestType}).Add(float64(r.GetDigest().GetSizeBytes()))
+}
+
 func (c *Proxy) dereference(ctx context.Context, peer string, ref *refpb.Reference, requested *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
 	refCache, ok := c.cache.(interfaces.ReferenceCache)
 	if !ok {
@@ -1069,6 +1079,10 @@ type streamWriteCloser struct {
 	peer            string
 	handoffPeer     string
 	alreadyExists   bool
+	// requestType records how this write's payload is sent, for metrics:
+	// "reference" for a reference-only write, "bytes" otherwise (a reference
+	// bound late via SetReference rides along on a byte write).
+	requestType string
 }
 
 func (wc *streamWriteCloser) send(req *dcpb.WriteRequest) error {
@@ -1116,6 +1130,14 @@ func (wc *streamWriteCloser) Write(data []byte) (int, error) {
 }
 
 func (wc *streamWriteCloser) Commit() error {
+	err := wc.commit()
+	if err == nil {
+		recordWriteRequestMetrics(wc.requestType, wc.r)
+	}
+	return err
+}
+
+func (wc *streamWriteCloser) commit() error {
 	if wc.alreadyExists {
 		return nil
 	}
@@ -1212,6 +1234,10 @@ func (c *Proxy) newRemoteWriter(ctx context.Context, peer, handoffPeer string, r
 		return nil, nil, err
 	}
 
+	requestType := "bytes"
+	if ref != nil {
+		requestType = "reference"
+	}
 	wc := &streamWriteCloser{
 		cancelFunc:      cancel,
 		sender:          rpcutil.NewSender[*dcpb.WriteRequest, *dcpb.WriteResponse](ctx, stream),
@@ -1220,6 +1246,7 @@ func (c *Proxy) newRemoteWriter(ctx context.Context, peer, handoffPeer string, r
 		r:               r,
 		ref:             ref,
 		refMustBeCloned: refMustBeCloned,
+		requestType:     requestType,
 	}
 	return ioutil.NewDoubleBufferWriter(ctx, wc, c.bufPool, digest.SafeBufferSize(r, writeBufSizeBytes), writeBufSizeBytes), wc, nil
 }

--- a/enterprise/server/util/distributed_client/distributed_client_test.go
+++ b/enterprise/server/util/distributed_client/distributed_client_test.go
@@ -2365,9 +2365,23 @@ func TestRemoteReferenceWriter(t *testing.T) {
 		ref := makeReference(rn, "blobs/rpc-blob", repb.Compressor_IDENTITY)
 		require.NoError(t, te.GetCache().Set(ctx, rn, buf))
 		peer, cache, _ := newPeer(t)
+		dedupedLabels := prometheus.Labels{
+			metrics.DistributedCacheWriteRequestType: "reference",
+			metrics.StatusHumanReadableLabel:         "AlreadyExists",
+		}
+		okLabels := prometheus.Labels{
+			metrics.DistributedCacheWriteRequestType: "reference",
+			metrics.StatusHumanReadableLabel:         "OK",
+		}
+		beforeDeduped := testmetrics.CounterValueForLabels(t, metrics.DistributedCacheWriteRequestCount, dedupedLabels)
+		beforeOK := testmetrics.CounterValueForLabels(t, metrics.DistributedCacheWriteRequestCount, okLabels)
 		require.NoError(t, writeRef(t, peer, "", rn, ref, false))
 		_, gotRN, _ := cache.lastWriteReference()
 		require.Nil(t, gotRN)
+		// The deduped commit succeeds but is recorded under AlreadyExists,
+		// not OK.
+		require.Equal(t, beforeDeduped+1, testmetrics.CounterValueForLabels(t, metrics.DistributedCacheWriteRequestCount, dedupedLabels))
+		require.Equal(t, beforeOK, testmetrics.CounterValueForLabels(t, metrics.DistributedCacheWriteRequestCount, okLabels))
 	})
 
 	t.Run("handoff peer is propagated", func(t *testing.T) {
@@ -2394,9 +2408,17 @@ func TestRemoteReferenceWriter(t *testing.T) {
 		cache.mu.Lock()
 		cache.writeRefErr = status.NotFoundError("backing object may have expired")
 		cache.mu.Unlock()
+		notFoundLabels := prometheus.Labels{
+			metrics.DistributedCacheWriteRequestType: "reference",
+			metrics.StatusHumanReadableLabel:         "NotFound",
+		}
+		before := testmetrics.CounterValueForLabels(t, metrics.DistributedCacheWriteRequestCount, notFoundLabels)
 		err := writeRef(t, peer, "", rn, ref, false)
 		require.Error(t, err)
 		require.True(t, status.IsNotFoundError(err), "expected NotFoundError, got %s", err)
+		// The failed commit is counted under its status code.
+		after := testmetrics.CounterValueForLabels(t, metrics.DistributedCacheWriteRequestCount, notFoundLabels)
+		require.Equal(t, before+1, after)
 	})
 }
 

--- a/enterprise/server/util/distributed_client/distributed_client_test.go
+++ b/enterprise/server/util/distributed_client/distributed_client_test.go
@@ -2292,6 +2292,20 @@ func TestWriteReferenceVerification(t *testing.T) {
 	})
 }
 
+// writeRequestCounts returns the current values of the distributed cache
+// write request count and size counters, keyed by request type.
+func writeRequestCounts(t *testing.T) (counts, sizes map[string]float64) {
+	counts = map[string]float64{}
+	sizes = map[string]float64{}
+	for _, v := range testmetrics.CounterValues(t, metrics.DistributedCacheWriteRequestCount) {
+		counts[v.Labels[metrics.DistributedCacheWriteRequestType]] += v.Value
+	}
+	for _, v := range testmetrics.CounterValues(t, metrics.DistributedCacheWriteRequestSizeBytes) {
+		sizes[v.Labels[metrics.DistributedCacheWriteRequestType]] += v.Value
+	}
+	return counts, sizes
+}
+
 func TestRemoteReferenceWriter(t *testing.T) {
 	te := getTestEnv(t, emptyUserMap)
 	ctx, err := prefix.AttachUserPrefixToContext(context.Background(), te.GetAuthenticator())
@@ -2324,12 +2338,17 @@ func TestRemoteReferenceWriter(t *testing.T) {
 		rn, _ := testdigest.RandomCASResourceBuf(t, 100)
 		ref := makeReference(rn, "blobs/rpc-blob", repb.Compressor_IDENTITY)
 		peer, cache, _ := newPeer(t)
+		beforeCounts, beforeSizes := writeRequestCounts(t)
 		require.NoError(t, writeRef(t, peer, "", rn, ref, false /*=mustClone*/))
 		gotRef, gotRN, gotCloned := cache.lastWriteReference()
 		require.Empty(t, cmp.Diff(ref, gotRef, protocmp.Transform()))
 		require.Empty(t, cmp.Diff(rn, gotRN, protocmp.Transform()))
 		// mustClone=false lets the peer take ownership of the blob.
 		require.False(t, gotCloned)
+		afterCounts, afterSizes := writeRequestCounts(t)
+		require.Equal(t, beforeCounts["reference"]+1, afterCounts["reference"])
+		require.Equal(t, beforeSizes["reference"]+float64(rn.GetDigest().GetSizeBytes()), afterSizes["reference"])
+		require.Equal(t, beforeCounts["bytes"], afterCounts["bytes"])
 	})
 
 	t.Run("must-be-cloned is passed through", func(t *testing.T) {
@@ -2418,6 +2437,7 @@ func TestRemoteVerifiedWriter(t *testing.T) {
 		ref := makeReference(rn, blobName, repb.Compressor_IDENTITY)
 		peer, cache, proxy := newPeer(t, map[string][]byte{blobName: buf})
 		before := writeVerificationCounts(t)
+		beforeCounts, beforeSizes := writeRequestCounts(t)
 		writeAll(t, peer, rn, ref, buf)
 		proxy.WaitForPendingVerificationsForTesting()
 		// The bytes are the write and the reference was verified.
@@ -2428,6 +2448,11 @@ func TestRemoteVerifiedWriter(t *testing.T) {
 		require.Nil(t, gotRN)
 		after := writeVerificationCounts(t)
 		require.Equal(t, before[distributed_client.VerificationSuccess]+1, after[distributed_client.VerificationSuccess])
+		// A verified write is a byte write; the reference only rides along.
+		afterCounts, afterSizes := writeRequestCounts(t)
+		require.Equal(t, beforeCounts["bytes"]+1, afterCounts["bytes"])
+		require.Equal(t, beforeSizes["bytes"]+float64(rn.GetDigest().GetSizeBytes()), afterSizes["bytes"])
+		require.Equal(t, beforeCounts["reference"], afterCounts["reference"])
 	})
 
 	t.Run("an unbound reference is a plain byte write", func(t *testing.T) {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -326,6 +326,11 @@ const (
 	// "bytes" (the blob's bytes, streamed inline).
 	DistributedCacheReadResponseType = "response_type"
 
+	// How a distributed cache write's payload was sent:
+	// "reference" (a pointer to the blob in shared storage) or
+	// "bytes" (the blob's bytes, streamed inline).
+	DistributedCacheWriteRequestType = "request_type"
+
 	// ContentAddressableStorage Server operation: "FindMissingBlobs",
 	// "BatchUpdateBlobs", "BatchReadBlobs", or "GetTree".
 	CASOperation = "op"
@@ -1049,6 +1054,29 @@ var (
 		Help:      "Total digest sizes of blobs read from distributed cache peers, by whether the payload was received as a reference or as inline bytes.",
 	}, []string{
 		DistributedCacheReadResponseType,
+	})
+
+	// DistributedCacheWriteRequestCount counts distributed cache writes by
+	// whether the payload was sent as a reference or as inline bytes.
+	DistributedCacheWriteRequestCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "distributed_cache_write_request_count",
+		Help:      "Count of distributed cache peer writes, by whether the payload was sent as a reference or as inline bytes.",
+	}, []string{
+		DistributedCacheWriteRequestType,
+	})
+
+	// DistributedCacheWriteRequestCount counts the number of bytes written to
+	// the distributed cache by whether the payload was sent as a reference or
+	// as inline bytes.
+	DistributedCacheWriteRequestSizeBytes = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "distributed_cache_write_request_size_bytes",
+		Help:      "Total digest sizes of blobs written to distributed cache peers, by whether the payload was sent as a reference or as inline bytes.",
+	}, []string{
+		DistributedCacheWriteRequestType,
 	})
 
 	// DistributedCacheReferenceVerificationCount counts verifications of

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1057,26 +1057,38 @@ var (
 	})
 
 	// DistributedCacheWriteRequestCount counts distributed cache writes by
-	// whether the payload was sent as a reference or as inline bytes.
+	// whether the payload was sent as a reference or as inline bytes, and by
+	// the commit's gRPC status code ("OK" on success). Writes short-circuited
+	// because the peer already had the blob are recorded under
+	// "AlreadyExists" (though callers see success), so "OK" counts only
+	// blobs the peer actually stored.
 	DistributedCacheWriteRequestCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_cache",
 		Name:      "distributed_cache_write_request_count",
-		Help:      "Count of distributed cache peer writes, by whether the payload was sent as a reference or as inline bytes.",
+		Help:      "Count of distributed cache peer writes, by whether the payload was sent as a reference or as inline bytes, and by status code.",
 	}, []string{
 		DistributedCacheWriteRequestType,
+		StatusHumanReadableLabel,
 	})
 
-	// DistributedCacheWriteRequestCount counts the number of bytes written to
-	// the distributed cache by whether the payload was sent as a reference or
-	// as inline bytes.
+	// DistributedCacheWriteRequestSizeBytes counts the number of bytes written
+	// to the distributed cache by whether the payload was sent as a reference
+	// or as inline bytes, and by the commit's gRPC status code ("OK" on
+	// success, "AlreadyExists" for writes deduped by the peer, so "OK"
+	// counts only blobs actually stored). The size is the requested digest's
+	// (uncompressed) size,
+	// recorded when the write is opened, so ranged writes and compressed writes
+	// count the full, uncompressed blob size rather than the exact number of
+	// bytes transferred.
 	DistributedCacheWriteRequestSizeBytes = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_cache",
 		Name:      "distributed_cache_write_request_size_bytes",
-		Help:      "Total digest sizes of blobs written to distributed cache peers, by whether the payload was sent as a reference or as inline bytes.",
+		Help:      "Total digest sizes of blobs written to distributed cache peers, by whether the payload was sent as a reference or as inline bytes, and by status code.",
 	}, []string{
 		DistributedCacheWriteRequestType,
+		StatusHumanReadableLabel,
 	})
 
 	// DistributedCacheReferenceVerificationCount counts verifications of


### PR DESCRIPTION
These are the write versions of https://github.com/buildbuddy-io/buildbuddy/blob/39908c78f649bfe7cf553433b2b8db849948f2e1/server/metrics/metrics.go#L1028-L1052

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7911