### PR TITLE
Add graphs showing distributed cache traffic and errors by transmission mechanism to the distributed cache row of the BuildBuddy dashboard

### DIFF
--- a/tools/metrics/grafana/generated/buildbuddy/buildbuddy.go
+++ b/tools/metrics/grafana/generated/buildbuddy/buildbuddy.go
@@ -266,6 +266,20 @@ func distributedCacheRow() *dashboard.RowBuilder {
 			WithTarget(dash.PromQuery(`histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{`+filters+`}[${window}])) by (le))`, "P50").RefId("C")).
 			WithTarget(dash.PromQuery(`sum(rate(grpc_server_handled_total{`+filters+`}[${window}])) by (grpc_service)`, "QPS").RefId("D"))
 	}
+	// transmissionPanel plots op rate against throughput, both broken down by
+	// whether the payload moved as a reference to shared storage or as inline
+	// bytes. Rates go on the left axis, bytes/sec on the right.
+	transmissionPanel := func(title, description, typeLabel, countMetric, sizeMetric string) *timeseries.PanelBuilder {
+		filters := `region="${region}", job="buildbuddy-app"`
+		return ts(title, dash.UnitRequestsPerSec).
+			Description(description).
+			AxisPlacement(common.AxisPlacementLeft).
+			Legend(rightLegend()).
+			Tooltip(multiTooltip()).
+			OverrideByQuery("B", rightAxisProps(dash.UnitBytesPerSec)).
+			WithTarget(dash.PromQuery(fmt.Sprintf(`sum by (%s) (rate(%s{%s}[${window}]))`, typeLabel, countMetric, filters), fmt.Sprintf("{{%s}} rate", typeLabel)).RefId("A")).
+			WithTarget(dash.PromQuery(fmt.Sprintf(`sum by (%s) (rate(%s{%s}[${window}]))`, typeLabel, sizeMetric, filters), fmt.Sprintf("{{%s}} throughput", typeLabel)).RefId("B"))
+	}
 	return row("Distributed Cache").
 		WithPanel(ts("Request Mix", "").
 			WithTarget(dash.PromQuery(`sum(rate(grpc_server_started_total{region="${region}", job="buildbuddy-app",grpc_service="distributed_cache.DistributedCache"}[${window}])) by (grpc_method)`, "{{grpc_method}}"))).
@@ -275,6 +289,18 @@ func distributedCacheRow() *dashboard.RowBuilder {
 		WithPanel(methodPanel("FindMissing")).
 		WithPanel(methodPanel("Write")).
 		WithPanel(methodPanel("Read")).
+		WithPanel(transmissionPanel(
+			"Reads by Transmission Mechanism",
+			"Distributed cache peer reads, split by whether the payload came back as a reference to shared storage or as inline bytes.",
+			"response_type",
+			"buildbuddy_remote_cache_distributed_cache_read_response_count",
+			"buildbuddy_remote_cache_distributed_cache_read_response_size_bytes")).
+		WithPanel(transmissionPanel(
+			"Writes by Transmission Mechanism",
+			"Distributed cache peer writes, split by whether the payload was sent as a reference to shared storage or as inline bytes.",
+			"request_type",
+			"buildbuddy_remote_cache_distributed_cache_write_request_count",
+			"buildbuddy_remote_cache_distributed_cache_write_request_size_bytes")).
 		WithPanel(ts("Lookaside cache hits and misses", dash.UnitRequestsPerSec).
 			AxisPlacement(common.AxisPlacementLeft).
 			Legend(rightLegend()).

--- a/tools/metrics/grafana/generated/buildbuddy/buildbuddy.go
+++ b/tools/metrics/grafana/generated/buildbuddy/buildbuddy.go
@@ -301,6 +301,12 @@ func distributedCacheRow() *dashboard.RowBuilder {
 			"request_type",
 			"buildbuddy_remote_cache_distributed_cache_write_request_count",
 			"buildbuddy_remote_cache_distributed_cache_write_request_size_bytes")).
+		WithPanel(ts("Read and Write Errors by Status", dash.UnitRequestsPerSec).
+			Description("Distributed cache peer reads and writes that did not succeed. Writes deduped by the peer report \"AlreadyExists\" and are counted as successes, not errors.").
+			Legend(rightLegend()).
+			Tooltip(multiTooltip()).
+			WithTarget(dash.PromQuery(`sum by (status, response_type) (rate(buildbuddy_remote_cache_distributed_cache_read_response_count{region="${region}", job="buildbuddy-app", status!="OK"}[${window}]))`, "read {{response_type}} {{status}}").RefId("A")).
+			WithTarget(dash.PromQuery(`sum by (status, request_type) (rate(buildbuddy_remote_cache_distributed_cache_write_request_count{region="${region}", job="buildbuddy-app", status!~"OK|AlreadyExists"}[${window}]))`, "write {{request_type}} {{status}}").RefId("B"))).
 		WithPanel(ts("Lookaside cache hits and misses", dash.UnitRequestsPerSec).
 			AxisPlacement(common.AxisPlacementLeft).
 			Legend(rightLegend()).


### PR DESCRIPTION
This adds 3 graphs to the "Distributed Cache" family of graphs on the main, BuildBuddy dashboard. Two showing the number of requests and the number of bytes sent between distributed cache peers to read and write cache artifacts by transmission type: bytes or reference, and one showing the rate of errors, by status, for each read/write transmission mechanism.

<img width="3124" height="612" alt="Screenshot 2026-09-01 at 4 33 02 PM" src="https://github.com/user-attachments/assets/0f20a3f3-8af6-44ba-af18-e8ec2b416057" />

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7911