### PR TITLE
ci: align ARM64 downloader endpoint

### DIFF
--- a/.github/workflows/test-executor-linux-arm64.yaml
+++ b/.github/workflows/test-executor-linux-arm64.yaml
@@ -37,6 +37,7 @@ jobs:
           common --repository_cache=~/repo-cache
           common --bes_backend=remote.buildbuddy.io
           common --bes_results_url=https://app.buildbuddy.io/invocation/
+          common --experimental_remote_downloader=remote.buildbuddy.io
           common --remote_cache=remote.buildbuddy.io
           common --flaky_test_attempts=3
           common --local_test_jobs=1


### PR DESCRIPTION
The Linux ARM64 job consistently fails before tests when fetching a
cold repository archive because the workflow sends FetchBlob and the
subsequent CAS read to different endpoints.

Override the downloader alongside the remote cache so both operations
use the same endpoint.

