### PR TITLE
Update remote bazel tests to avoid C++ compilers

### DIFF
--- a/cli/remotebazel/BUILD
+++ b/cli/remotebazel/BUILD
@@ -57,6 +57,7 @@ go_test(
         "//cli/parser",
         "//cli/parser/test_data",
         "//cli/storage",
+        "//proto:build_event_stream_go_proto",
         "//proto:buildbuddy_service_go_proto",
         "//proto:eventlog_go_proto",
         "//server/testutil/testgit",

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -990,8 +990,10 @@ func envForLocalRun(env []string, runfilesDir, workspaceDir, workingDir string) 
 		}
 		filteredEnv = append(filteredEnv, entry)
 	}
+	if runfilesDir != "" {
+		filteredEnv = append(filteredEnv, "RUNFILES_DIR="+runfilesDir)
+	}
 	return append(filteredEnv,
-		"RUNFILES_DIR="+runfilesDir,
 		"BUILD_WORKSPACE_DIRECTORY="+workspaceDir,
 		"BUILD_WORKING_DIRECTORY="+workingDir,
 	)
@@ -1284,23 +1286,30 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 					return 1, fmt.Errorf("prepare binary %q for execution: %w", absBinPath, err)
 				}
 
-				// runfilesWorkDir is the working directory inside the downloaded runfiles tree.
-				runfilesWorkDir, err := filepath.Abs(filepath.Join(outputsBaseDir, BuildBuddyArtifactDir, runfilesRoot))
-				if err != nil {
-					return 1, fmt.Errorf("compute absolute runfiles working directory: %w", err)
-				}
-				// runfilesDir is the absolute path to the downloaded runfiles directory.
-				// This is one level up from the working directory `runfilesWorkDir`.
-				runfilesDir := filepath.Dir(runfilesWorkDir)
-				info, err := os.Stat(runfilesDir)
-				if err != nil {
-					return 1, fmt.Errorf("locate downloaded runfiles directory %q: %w", runfilesDir, err)
-				}
-				if !info.IsDir() {
-					return 1, fmt.Errorf("downloaded runfiles path %q is not a directory", runfilesDir)
-				}
-				if err := removeRunfilesManifests(absBinPath, runfilesDir); err != nil {
-					return 1, err
+				// Targets without runfiles, such as executable genrules, should run from
+				// the directory where remote Bazel was invoked. For targets with
+				// runfiles, use the working directory from Bazel's run script, mapped
+				// into the downloaded runfiles tree.
+				runfilesWorkDir := opts.AbsLocalWorkingDirectory
+				runfilesDir := ""
+				if runfilesRoot != "" {
+					runfilesWorkDir, err = filepath.Abs(filepath.Join(outputsBaseDir, BuildBuddyArtifactDir, runfilesRoot))
+					if err != nil {
+						return 1, fmt.Errorf("compute absolute runfiles working directory: %w", err)
+					}
+					// runfilesDir is the absolute path to the downloaded runfiles directory.
+					// This is one level up from the working directory `runfilesWorkDir`.
+					runfilesDir = filepath.Dir(runfilesWorkDir)
+					info, err := os.Stat(runfilesDir)
+					if err != nil {
+						return 1, fmt.Errorf("locate downloaded runfiles directory %q: %w", runfilesDir, err)
+					}
+					if !info.IsDir() {
+						return 1, fmt.Errorf("downloaded runfiles path %q is not a directory", runfilesDir)
+					}
+					if err := removeRunfilesManifests(absBinPath, runfilesDir); err != nil {
+						return 1, err
+					}
 				}
 
 				execArgs := defaultRunArgs

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -975,6 +975,19 @@ func downloadedExecutablePath(downloadedFiles map[string]struct{}, outputBaseDir
 	return binPath, nil
 }
 
+func hasSupportingRunfiles(runfiles []*bespb.Runfile, runfileDirectories []*bespb.Tree, executablePath string) bool {
+	if len(runfileDirectories) > 0 {
+		return true
+	}
+	executablePath = filepath.Clean(executablePath)
+	for _, runfile := range runfiles {
+		if filepath.Clean(runfile.GetFile().GetName()) != executablePath {
+			return true
+		}
+	}
+	return false
+}
+
 // envForLocalRun ensures a locally-run target (build-remotely-run-locally)
 // resolves runfiles from the downloaded runfiles directory and sees the local
 // Bazel workspace. The runfiles manifest contains absolute paths from the
@@ -1292,7 +1305,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 				// into the downloaded runfiles tree.
 				runfilesWorkDir := opts.AbsLocalWorkingDirectory
 				runfilesDir := ""
-				if runfilesRoot != "" {
+				if runfilesRoot != "" && hasSupportingRunfiles(runfiles, runfileDirectories, executablePath) {
 					runfilesWorkDir, err = filepath.Abs(filepath.Join(outputsBaseDir, BuildBuddyArtifactDir, runfilesRoot))
 					if err != nil {
 						return 1, fmt.Errorf("compute absolute runfiles working directory: %w", err)

--- a/cli/remotebazel/remotebazel_test.go
+++ b/cli/remotebazel/remotebazel_test.go
@@ -965,6 +965,24 @@ func TestEnvForLocalRun(t *testing.T) {
 	}, envForLocalRun(env, "/new/runfiles", "/new/workspace", "/new/working-directory"))
 }
 
+func TestEnvForLocalRun_NoRunfiles(t *testing.T) {
+	env := []string{
+		"PATH=/usr/bin",
+		"RUNFILES_DIR=/old/runfiles",
+		"RUNFILES_MANIFEST_FILE=/old/MANIFEST",
+		"BUILD_WORKSPACE_DIRECTORY=/old/workspace",
+		"BUILD_WORKING_DIRECTORY=/old/working-directory",
+		"USER=test",
+	}
+
+	require.Equal(t, []string{
+		"PATH=/usr/bin",
+		"USER=test",
+		"BUILD_WORKSPACE_DIRECTORY=/new/workspace",
+		"BUILD_WORKING_DIRECTORY=/new/working-directory",
+	}, envForLocalRun(env, "", "/new/workspace", "/new/working-directory"))
+}
+
 func TestQuoteRemoteBazelArgs_RunScriptEnvVarExpanded(t *testing.T) {
 	// This flag should not be quoted with shlex.Quote, which explicitly prevents env var expansion.
 	// The path should be quoted with double quotes, so the remote shell expands the BUILDBUDDY_CI_RUNNER_ROOT_DIR

--- a/cli/remotebazel/remotebazel_test.go
+++ b/cli/remotebazel/remotebazel_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
+	bespb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
 	elpb "github.com/buildbuddy-io/buildbuddy/proto/eventlog"
 )
@@ -981,6 +982,22 @@ func TestEnvForLocalRun_NoRunfiles(t *testing.T) {
 		"BUILD_WORKSPACE_DIRECTORY=/new/workspace",
 		"BUILD_WORKING_DIRECTORY=/new/working-directory",
 	}, envForLocalRun(env, "", "/new/workspace", "/new/working-directory"))
+}
+
+func TestHasSupportingRunfiles(t *testing.T) {
+	executablePath := "bazel-out/k8-fastbuild/bin/main.sh"
+	executable := &bespb.Runfile{File: &bespb.File{Name: executablePath}}
+
+	require.False(t, hasSupportingRunfiles([]*bespb.Runfile{executable}, nil, executablePath))
+	require.True(t, hasSupportingRunfiles([]*bespb.Runfile{
+		executable,
+		{File: &bespb.File{Name: "bazel-out/k8-fastbuild/bin/main.sh.runfiles/_main/data.txt"}},
+	}, nil, executablePath))
+	require.True(t, hasSupportingRunfiles(
+		[]*bespb.Runfile{executable},
+		[]*bespb.Tree{{Name: "bazel-out/k8-fastbuild/bin/main.sh.runfiles/_main/data"}},
+		executablePath,
+	))
 }
 
 func TestQuoteRemoteBazelArgs_RunScriptEnvVarExpanded(t *testing.T) {

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1727,6 +1727,12 @@ func processRunScript(ctx context.Context, runScript string) (*runInfo, error) {
 	}
 
 	runfilesDir := bin + ".runfiles"
+	// Executable genrules do not have a runfiles tree. In that case, the cd
+	// command in points into the remote checkout, which is not valid for a
+	// local run.
+	if _, err := os.Stat(runfilesDir); os.IsNotExist(err) {
+		runfilesRoot = ""
+	}
 	runfiles, runfileDirs, runfileEntries, err := uploadRunfiles(ctx, wsRoot, runfilesDir, bin)
 	if err != nil {
 		return nil, err

--- a/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
+++ b/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
@@ -399,7 +399,7 @@ genrule(
 		fmt.Sprintf("--remote_header=x-buildbuddy-api-key=%s", env.APIKey1))
 	// Check that the remote build output was fetched locally.
 	// The outputs will be downloaded to a directory that may change with the platform,
-	// so recursively search for the build output named `hello_world_go`.
+	// so recursively search for the build output named `main.sh`.
 	findFile := func(rootDir, targetFile string) (string, error) {
 		var outputPath string
 		err := filepath.WalkDir(rootDir, func(path string, d os.DirEntry, err error) error {
@@ -435,23 +435,15 @@ genrule(
 func TestBuildRemotelyRunLocally(t *testing.T) {
 	repoDir, _ := makeLocalGitRepo(t, map[string]string{
 		"BUILD": `
-load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
-
 genrule(
-    name = "generated_script",
+    name = "main",
     srcs = ["main.in"],
-    outs = ["main-generated.sh"],
+    outs = ["main.sh"],
     cmd = "cp $< $@",
     executable = True,
 )
-
-sh_binary(
-    name = "main",
-    srcs = [":generated_script"],
-)
 `,
-		"main.in":  "#!/bin/sh\nprintf 'Hello from main!'\n",
-		".bazelrc": "common --lockfile_mode=off --check_direct_dependencies=off\n",
+		"main.in": "#!/bin/sh\nprintf 'Hello from main!'\n",
 	})
 
 	// Run a server and executor locally to run remote bazel against

--- a/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
+++ b/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
@@ -372,22 +372,15 @@ func TestCancel(t *testing.T) {
 func TestFetchRemoteBuildOutputs(t *testing.T) {
 	repoDir, _ := makeLocalGitRepo(t, map[string]string{
 		"BUILD": `
-load("@rules_cc//cc:defs.bzl", "cc_binary")
-cc_binary(
+genrule(
     name = "main",
-    srcs = ["main.c"],
+    srcs = ["main.in"],
+    outs = ["main.sh"],
+    cmd = "cp $< $@",
+    executable = True,
 )
 `,
-		"main.c": `
-#include <stdio.h>
-
-int main() {
-    printf("Hello from main!");
-    return 0;
-}
-`,
-		"MODULE.bazel": `bazel_dep(name = "rules_cc", version = "0.0.17")` + "\n",
-		".bazelrc":     "common --lockfile_mode=off --check_direct_dependencies=off\n",
+		"main.in": "#!/bin/sh\nprintf 'Hello from main!'\n",
 	})
 
 	// Run a server and executor locally to run remote bazel against
@@ -424,7 +417,7 @@ int main() {
 		return outputPath, err
 	}
 	t.Chdir(repoDir)
-	downloadedOutputPath, err := findFile(remotebazel.BuildBuddyArtifactDir, "main")
+	downloadedOutputPath, err := findFile(remotebazel.BuildBuddyArtifactDir, "main.sh")
 	require.NoError(t, err)
 
 	// Make sure we can successfully run the fetched binary.
@@ -442,22 +435,23 @@ int main() {
 func TestBuildRemotelyRunLocally(t *testing.T) {
 	repoDir, _ := makeLocalGitRepo(t, map[string]string{
 		"BUILD": `
-load("@rules_cc//cc:defs.bzl", "cc_binary")
-cc_binary(
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
+genrule(
+    name = "generated_script",
+    srcs = ["main.in"],
+    outs = ["main-generated.sh"],
+    cmd = "cp $< $@",
+    executable = True,
+)
+
+sh_binary(
     name = "main",
-    srcs = ["main.c"],
+    srcs = [":generated_script"],
 )
 `,
-		"main.c": `
-#include <stdio.h>
-
-int main() {
-    printf("Hello from main!");
-    return 0;
-}
-`,
-		"MODULE.bazel": `bazel_dep(name = "rules_cc", version = "0.0.17")` + "\n",
-		".bazelrc":     "common --lockfile_mode=off --check_direct_dependencies=off\n",
+		"main.in":  "#!/bin/sh\nprintf 'Hello from main!'\n",
+		".bazelrc": "common --lockfile_mode=off --check_direct_dependencies=off\n",
 	})
 
 	// Run a server and executor locally to run remote bazel against
@@ -465,7 +459,7 @@ int main() {
 
 	// Run remote bazel
 	randomStr := fmt.Sprintf("%d", time.Now().UnixMilli())
-	runRemoteBazelInSeparateProcess(t, repoDir, bbServer.GRPCAddress(),
+	output := runRemoteBazelInSeparateProcess(t, repoDir, bbServer.GRPCAddress(),
 		// Ensure the build is happening on a clean runner, because if the build
 		// artifact is locally cached, we won't upload it to the remote cache
 		// and we won't be able to fetch it.
@@ -476,6 +470,7 @@ int main() {
 		"run",
 		":main",
 		fmt.Sprintf("--remote_header=x-buildbuddy-api-key=%s", env.APIKey1))
+	require.Contains(t, output, "Hello from main!")
 
 	// Check that the remote runner didn't run the script
 	bbClient := env.GetBuildBuddyServiceClient()


### PR DESCRIPTION
Previously this assumed the test image had a C++ compiler which I'm
trying to remove so we can use a smaller remote exec image. As far as I
can tell this doesn't affect the intent of the tests.
