### PR TITLE
Add `CreationMetadata` to ApiKey protocol message

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -56,6 +56,7 @@ proto_library(
         ":capability_proto",
         ":context_proto",
         "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 
@@ -1989,6 +1990,7 @@ ts_proto_library(
         ":capability_ts_proto",
         ":context_ts_proto",
         ":duration_ts_proto",
+        ":timestamp_ts_proto",
     ],
 )
 

--- a/proto/api_key.proto
+++ b/proto/api_key.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 import "proto/capability.proto";
 import "proto/context.proto";
 import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
 
 package api_key;
 
@@ -34,6 +35,18 @@ message ApiKey {
   // Optional certificate corresponding to this API key, if
   // requested.
   Certificate certificate = 8;
+
+  // Metadata about the creation of this API key.
+  CreationMetadata creation_metadata = 9;
+}
+
+message CreationMetadata {
+  // The time at which the API key was created, if known.
+  google.protobuf.Timestamp created_at = 1;
+
+  // The display name of the user who created this API key. Only provided if
+  // known and if the requesting user may view this information.
+  string created_by = 2;
 }
 
 message Certificate {


### PR DESCRIPTION
This will be used to render the date/time at which a key was created and the name of the user who created it on the API keys page. I initially tried to server-side render this, but that makes it difficult to render the time in the correct timezone, so I decided to abandon that approach.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/8184