### PR TITLE
Use a smaller remote exec image

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -937,13 +937,13 @@
     "@@toolchains_buildbuddy+//:extensions.bzl%buildbuddy": {
       "general": {
         "bzlTransitiveDigest": "lWa6Z0bfkK+GLxGpbRuJ/rFqT50PcvllkL8aIGUpSc4=",
-        "usagesDigest": "0aqGArWWoTiJTvk7EUVZOtOj+zrO+Ns5dO+UJ8AHFvg=",
+        "usagesDigest": "8/KE2qqH9tCyyG1SrEetb86YjMxaTzx7ysvgHvTfSTo=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "buildbuddy_toolchain": {
             "repoRuleId": "@@toolchains_buildbuddy+//:rules.bzl%_buildbuddy_toolchain",
             "attributes": {
-              "container_image": "gcr.io/flame-public/rbe-ubuntu20-04:latest",
+              "container_image": "docker://buildpack-deps@sha256:fa56fe73b4475655b2f39d6376b6a6664d24b5c43227f709d4a923609f3286a1",
               "llvm": false,
               "java_version": "",
               "gcc_version": "",

--- a/deps/toolchains.MODULE.bazel
+++ b/deps/toolchains.MODULE.bazel
@@ -1,5 +1,5 @@
 buildbuddy = use_extension("@toolchains_buildbuddy//:extensions.bzl", "buildbuddy")
-buildbuddy.platform(buildbuddy_container_image = "UBUNTU20_04_IMAGE")
+buildbuddy.platform(container_image = "docker://buildpack-deps@sha256:fa56fe73b4475655b2f39d6376b6a6664d24b5c43227f709d4a923609f3286a1")
 buildbuddy.msvc_toolchain(
     # This is the MSVC available on Github Action win22 image
     # https://github.com/actions/runner-images/blob/win25/20250727.1/images/windows/Windows2025-Readme.md#visual-studio-enterprise-2022

--- a/enterprise/server/api/BUILD
+++ b/enterprise/server/api/BUILD
@@ -103,6 +103,7 @@ go_test(
     embed = [":api"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",

--- a/enterprise/server/auditlog/BUILD
+++ b/enterprise/server/auditlog/BUILD
@@ -33,6 +33,7 @@ go_test(
     srcs = ["auditlog_test.go"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",

--- a/enterprise/server/backends/authdb/BUILD
+++ b/enterprise/server/backends/authdb/BUILD
@@ -76,6 +76,7 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         # We don't want different different db tests to be assigned to the samed
@@ -124,6 +125,7 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         # We don't want different different db tests to be assigned to the samed

--- a/enterprise/server/backends/userdb/BUILD
+++ b/enterprise/server/backends/userdb/BUILD
@@ -71,6 +71,7 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         # We don't want different different db tests to be assigned to the samed
@@ -120,6 +121,7 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         # We don't want different different db tests to be assigned to the samed

--- a/enterprise/server/execution_search_service/BUILD
+++ b/enterprise/server/execution_search_service/BUILD
@@ -29,6 +29,7 @@ go_test(
     srcs = ["execution_search_service_test.go"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",

--- a/enterprise/server/execution_service/BUILD
+++ b/enterprise/server/execution_service/BUILD
@@ -41,6 +41,7 @@ go_test(
     srcs = ["execution_service_test.go"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",

--- a/enterprise/server/invocation_search_service/BUILD
+++ b/enterprise/server/invocation_search_service/BUILD
@@ -38,6 +38,7 @@ go_test(
     srcs = ["invocation_search_service_test.go"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         # We don't want different different db tests to be assigned to the samed

--- a/enterprise/server/invocation_stat_service/BUILD
+++ b/enterprise/server/invocation_stat_service/BUILD
@@ -37,6 +37,7 @@ go_test(
     embed = [":invocation_stat_service"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         # We don't want different different db tests to be assigned to the samed

--- a/enterprise/server/oci/ociregistry/BUILD
+++ b/enterprise/server/oci/ociregistry/BUILD
@@ -59,6 +59,7 @@ go_test(
     timeout = "moderate",
     srcs = ["ociregistry_client_test.go"],
     exec_properties = {
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.workload-isolation-type": "firecracker",
         "test.init-dockerd": "true",
         "test.EstimatedComputeUnits": "4",

--- a/enterprise/server/remote_execution/containers/docker/BUILD
+++ b/enterprise/server/remote_execution/containers/docker/BUILD
@@ -37,6 +37,7 @@ go_test(
     exec_properties = {
         # TODO(https://github.com/buildbuddy-io/buildbuddy-internal/issues/1094): Require less manual configuration here.
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
     },
     shard_count = 2,

--- a/enterprise/server/test/integration/clickhouse_schema/BUILD
+++ b/enterprise/server/test/integration/clickhouse_schema/BUILD
@@ -6,6 +6,7 @@ go_test(
     name = "clickhouse_schema_test",
     srcs = ["clickhouse_schema_test.go"],
     exec_properties = {
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",

--- a/enterprise/server/test/integration/remote_execution/docker_rbe/BUILD
+++ b/enterprise/server/test/integration/remote_execution/docker_rbe/BUILD
@@ -10,6 +10,7 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "busybox",

--- a/enterprise/server/usage/BUILD
+++ b/enterprise/server/usage/BUILD
@@ -76,6 +76,7 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse:25.3",
@@ -118,6 +119,7 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         # We don't want different different db tests to be assigned to the samed
@@ -164,6 +166,7 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         # We don't want different different db tests to be assigned to the samed

--- a/enterprise/server/usage_service/BUILD
+++ b/enterprise/server/usage_service/BUILD
@@ -57,6 +57,7 @@ go_test(
     srcs = ["usage_service_olap_test.go"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",

--- a/enterprise/server/usagealert/BUILD
+++ b/enterprise/server/usagealert/BUILD
@@ -46,6 +46,7 @@ go_test(
     embed = [":usagealert_lib"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",

--- a/enterprise/tools/clickhouse_backup/BUILD
+++ b/enterprise/tools/clickhouse_backup/BUILD
@@ -38,6 +38,7 @@ go_test(
     exec_properties = {
         "test.EstimatedComputeUnits": "4",
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",

--- a/enterprise/tools/metronome_exporter/BUILD
+++ b/enterprise/tools/metronome_exporter/BUILD
@@ -36,6 +36,7 @@ go_test(
     embed = [":metronome_exporter_lib"],
     exec_properties = {
         "test.EstimatedComputeUnits": "4",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",

--- a/server/backends/invocationdb/BUILD
+++ b/server/backends/invocationdb/BUILD
@@ -53,6 +53,7 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         # We don't want different different db tests to be assigned to the samed
@@ -82,6 +83,7 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         # We don't want different different db tests to be assigned to the samed

--- a/server/build_event_protocol/target_tracker/BUILD
+++ b/server/build_event_protocol/target_tracker/BUILD
@@ -29,6 +29,7 @@ go_test(
     srcs = ["target_tracker_test.go"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         # We don't want different different db tests to be assigned to the samed

--- a/server/target/BUILD
+++ b/server/target/BUILD
@@ -35,6 +35,7 @@ go_test(
     srcs = ["target_test.go"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",

--- a/server/util/clickhouse/BUILD
+++ b/server/util/clickhouse/BUILD
@@ -34,6 +34,7 @@ go_test(
     srcs = ["clickhouse_test.go"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",


### PR DESCRIPTION
Previously our image was ~900mbs, now it's ~100mbs. We could get smaller
with a newer custom image, maybe down to ~50mbs, but this is a good
start. We had to keep the old image for some tests for now. At the very least
they need `docker` which the small image doesn't provide
