### PR TITLE
[FC] Add OS/arch to rootfs image snapshot key

### DIFF
--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -1496,7 +1497,7 @@ func groupID(ctx context.Context, env environment.Env) (string, error) {
 func containerImageSnapshotKey(instanceName, imageRef string) *fcpb.SnapshotKeySet {
 	return &fcpb.SnapshotKeySet{BranchKey: &fcpb.SnapshotKey{
 		InstanceName:      instanceName,
-		ConfigurationHash: hashStrings("__UnpackContainerImage", imageRef),
+		ConfigurationHash: hashStrings("__UnpackContainerImage", runtime.GOOS, runtime.GOARCH, imageRef),
 	}}
 }
 


### PR DESCRIPTION
To prepare for [sharing chunked EXT4s for RBE actions,](https://github.com/buildbuddy-io/buildbuddy/pull/13095) we need to make sure OS + arch are included in the snapshot key so we don't try to share chunks between arm and amd executors 

Note that this will invalidate every locally chunked EXT4. This only affects clean runners (not snapshotted ones). This won't cause more image pulls, but it will cause rechunking every EXT4 until a complete chunked EXT4 is saved under the new manifest