### PR TITLE
gateway: remove deprecated Register/Deregister RPCs

### DIFF
--- a/enterprise/gateway/server/gateway.go
+++ b/enterprise/gateway/server/gateway.go
@@ -65,14 +65,8 @@ type peerInfo struct {
 	registeredAt time.Time // used as last-seen baseline if peer never completed a handshake
 
 	// ctx lives as long as the registration.
-	ctx       context.Context
-	cancelCtx context.CancelFunc
-
-	// closeStream, if set, closes the Connect stream that owns this
-	// registration. removePeerLocked calls it so that a peer removed by
-	// another path (e.g. the stale-peer sweep) doesn't leave its stream
-	// dangling.
-	closeStream context.CancelFunc
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 // Gateway manages a single WireGuard device shared across all groups.
@@ -159,77 +153,11 @@ func New(env environment.Env, hubServices ...HubService) (*Gateway, error) {
 	return gw, nil
 }
 
-// Register authenticates the caller, assigns them an IP within their network,
-// registers the client as a peer on the shared device, and returns the config.
-// The client is responsible for generating its own WireGuard keypair and
-// supplying its public key in the request.
-func (g *Gateway) Register(ctx context.Context, req *gwpb.RegisterRequest) (*gwpb.RegisterResponse, error) {
-	claims, err := g.env.GetAuthenticator().AuthenticatedUser(ctx)
-	if err != nil {
-		return nil, err
-	}
-	groupID := claims.GetGroupID()
-
-	if req.GetPublicKey() == "" {
-		return nil, status.InvalidArgumentError("public_key is required")
-	}
-	clientPubKey, err := wgkeys.ParseHexKey(req.GetPublicKey())
-	if err != nil {
-		return nil, status.InvalidArgumentErrorf("invalid public_key: %s", err)
-	}
-
-	g.mu.Lock()
-	defer g.mu.Unlock()
-
-	ns, err := g.getOrCreateNetwork(groupID, req.GetNetworkName())
-	if err != nil {
-		return nil, err
-	}
-
-	var assignedName string
-	if requested := req.GetPeerName(); requested != "" {
-		if labels, ok := dns.IsDomainName(requested); !ok || labels != 1 {
-			return nil, status.InvalidArgumentErrorf("peer_name %q is not a valid DNS label", requested)
-		}
-		// Find an available name: try the requested name first, then append
-		// numeric suffixes until we find a free slot.
-		assignedName = requested
-		ns.mu.Lock()
-		for i := 1; ; i++ {
-			if _, taken := ns.names[assignedName]; !taken {
-				break
-			}
-			assignedName = fmt.Sprintf("%s-%d", requested, i)
-		}
-		ns.mu.Unlock()
-	}
-
-	// Note: session_id is left empty for Register peers — it is a Connect
-	// concept, and leaving it unset lets List callers distinguish legacy
-	// registrations.
-	assignedIP, err := g.addPeerLocked(ns, clientPubKey.Hex(), assignedName, "" /*=sessionID*/, nil /*=closeStream*/)
-	if err != nil {
-		return nil, err
-	}
-
-	log.Infof("Registered peer %s in group %q network %q, assigned %s (name=%q)",
-		clientPubKey.String()[:8]+"...", groupID, req.GetNetworkName(), assignedIP, assignedName)
-
-	return &gwpb.RegisterResponse{
-		ServerPublicKey:  g.pubKey,
-		ServerEndpoint:   fmt.Sprintf("%s:%d", g.publicHost, g.udpListenPort),
-		AssignedIp:       assignedIP.String(),
-		GatewayIp:        networkHubIP(ns.index).String(),
-		NetworkCidr:      networkPrefix(ns.index).String(),
-		AssignedPeerName: assignedName,
-	}, nil
-}
-
 // Connect implements the streaming registration API. The peer's registration
 // is leased to the stream: the first response carries the tunnel
 // configuration, and the peer stays registered exactly as long as the stream
-// remains open. Unlike the deprecated Register RPC, peer names are unique
-// within a network: a name held by a connected peer causes ALREADY_EXISTS.
+// remains open. Peer names are unique within a network: a name held by a
+// connected peer causes ALREADY_EXISTS.
 func (g *Gateway) Connect(req *gwpb.ConnectRequest, stream gwsvcpb.GatewayService_ConnectServer) error {
 	claims, err := g.env.GetAuthenticator().AuthenticatedUser(stream.Context())
 	if err != nil {
@@ -255,10 +183,10 @@ func (g *Gateway) Connect(req *gwpb.ConnectRequest, stream gwsvcpb.GatewayServic
 		return status.InvalidArgumentError("session_id is required")
 	}
 
-	// ctx is canceled when the client goes away (stream closed, connection
-	// lost, gateway shutdown). removePeerLocked also cancels it when the peer
-	// is removed by another path (e.g. the stale-peer sweep), which closes
-	// this stream and lets the client observe its own eviction.
+	// ctx is the registration's lifetime. It is canceled when the client
+	// goes away (stream closed, connection lost), and by removePeerLocked
+	// when the peer is evicted by another path (e.g. the stale-peer sweep),
+	// which ends this stream and lets the client observe its own eviction.
 	ctx, cancel := context.WithCancel(stream.Context())
 	defer cancel()
 
@@ -279,15 +207,14 @@ func (g *Gateway) Connect(req *gwpb.ConnectRequest, stream gwsvcpb.GatewayServic
 	}
 	// Session IDs uniquely identify connections within a group, so that
 	// removal below (and deregistration by session ID, eventually) is
-	// unambiguous. Note: peers registered via the deprecated Register RPC
-	// have an empty session ID and can never conflict.
+	// unambiguous.
 	for _, info := range g.peers {
 		if info.sessionID == sessionID && info.networkState.groupID == groupID {
 			g.mu.Unlock()
 			return status.AlreadyExistsErrorf("session_id %q is already in use", sessionID)
 		}
 	}
-	assignedIP, err := g.addPeerLocked(ns, clientPubKey.Hex(), name, sessionID, cancel)
+	assignedIP, err := g.addPeerLocked(ctx, cancel, ns, clientPubKey.Hex(), name, sessionID)
 	g.mu.Unlock()
 	if err != nil {
 		return err
@@ -329,8 +256,8 @@ func (g *Gateway) Connect(req *gwpb.ConnectRequest, stream gwsvcpb.GatewayServic
 			}
 		case <-ctx.Done():
 			// If the registration is no longer this session's, another path
-			// (the stale-peer sweep, Deregister) evicted this peer; tell the
-			// client so it can distinguish eviction from a clean shutdown.
+			// (e.g. the stale-peer sweep) evicted this peer; tell the client
+			// so it can distinguish eviction from a clean shutdown.
 			g.mu.Lock()
 			info, ok := g.peers[clientPubKey.Hex()]
 			evicted := !ok || info.sessionID != sessionID
@@ -464,10 +391,11 @@ func (g *Gateway) snapshotPeer(groupID, sessionID string) (*gwpb.Peer, error) {
 }
 
 // addPeerLocked allocates an IP in ns, registers it with the TUN and the
-// WireGuard device, and records the peer. assignedName and sessionID must
-// already be validated (and checked for conflicts) by the caller. Must be
-// called with g.mu held.
-func (g *Gateway) addPeerLocked(ns *networkState, pubKeyHex, assignedName, sessionID string, closeStream context.CancelFunc) (netip.Addr, error) {
+// WireGuard device, and records the peer. ctx and cancel bound the
+// registration's lifetime (see peerInfo.ctx). assignedName and sessionID
+// must already be validated (and checked for conflicts) by the caller. Must
+// be called with g.mu held.
+func (g *Gateway) addPeerLocked(ctx context.Context, cancel context.CancelFunc, ns *networkState, pubKeyHex, assignedName, sessionID string) (netip.Addr, error) {
 	if _, ok := g.peers[pubKeyHex]; ok {
 		return netip.Addr{}, status.AlreadyExistsErrorf("public key %s... is already registered", pubKeyHex[:8])
 	}
@@ -488,7 +416,6 @@ func (g *Gateway) addPeerLocked(ns *networkState, pubKeyHex, assignedName, sessi
 		return netip.Addr{}, status.InternalErrorf("add WireGuard peer: %s", err)
 	}
 
-	ctx, cancelCtx := context.WithCancel(context.Background())
 	info := &peerInfo{
 		ip:           assignedIP,
 		networkState: ns,
@@ -496,8 +423,7 @@ func (g *Gateway) addPeerLocked(ns *networkState, pubKeyHex, assignedName, sessi
 		sessionID:    sessionID,
 		registeredAt: time.Now(),
 		ctx:          ctx,
-		cancelCtx:    cancelCtx,
-		closeStream:  closeStream,
+		cancel:       cancel,
 	}
 	ns.mu.Lock()
 	if assignedName != "" {
@@ -510,36 +436,8 @@ func (g *Gateway) addPeerLocked(ns *networkState, pubKeyHex, assignedName, sessi
 	return assignedIP, nil
 }
 
-// Deregister removes the calling peer from the gateway immediately. Well-behaved
-// clients should call this on clean shutdown rather than waiting for the
-// stale-peer cleanup cycle to reclaim the IP and DNS name.
-func (g *Gateway) Deregister(ctx context.Context, req *gwpb.DeregisterRequest) (*gwpb.DeregisterResponse, error) {
-	if _, err := g.env.GetAuthenticator().AuthenticatedUser(ctx); err != nil {
-		return nil, err
-	}
-
-	if req.GetPublicKey() == "" {
-		return nil, status.InvalidArgumentError("public_key is required")
-	}
-	pubKeyHex := req.GetPublicKey()
-	if _, err := wgkeys.ParseHexKey(pubKeyHex); err != nil {
-		return nil, status.InvalidArgumentErrorf("invalid public_key: %s", err)
-	}
-
-	g.mu.Lock()
-	defer g.mu.Unlock()
-
-	info, ok := g.peers[pubKeyHex]
-	if !ok {
-		return nil, status.NotFoundErrorf("peer %s... not registered", pubKeyHex[:8])
-	}
-	g.removePeerLocked(pubKeyHex, info)
-	return &gwpb.DeregisterResponse{}, nil
-}
-
-// List returns the peers currently registered by the caller's group. Every
-// Connect-registered peer has a session ID and is included, named or not;
-// peers from the deprecated Register RPC have no session ID and are omitted.
+// List returns the peers currently registered by the caller's group, named
+// or not.
 func (g *Gateway) List(ctx context.Context, req *gwpb.ListRequest) (*gwpb.ListResponse, error) {
 	claims, err := g.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
@@ -558,9 +456,6 @@ func (g *Gateway) List(ctx context.Context, req *gwpb.ListRequest) (*gwpb.ListRe
 
 	peers := make([]*gwpb.Peer, 0)
 	for pubKeyHex, info := range g.peers {
-		if info.sessionID == "" {
-			continue
-		}
 		ns := info.networkState
 		if ns.groupID != groupID {
 			continue
@@ -697,8 +592,9 @@ func (g *Gateway) lastHandshakeTimes() (map[string]time.Time, error) {
 }
 
 // removePeerLocked removes a peer from the WireGuard device, the TUN, and the
-// network's name and IP maps, cancels the peer's context, and closes its
-// Connect stream if it has one. Must be called with g.mu held.
+// network's name and IP maps, and cancels the peer's context — ending its
+// Connect stream and any hub-service connections held on its behalf. Must be
+// called with g.mu held.
 func (g *Gateway) removePeerLocked(pubKeyHex string, info *peerInfo) {
 	if err := g.dev.IpcSet(fmt.Sprintf("public_key=%s\nremove=true\n", pubKeyHex)); err != nil {
 		log.Errorf("Remove WireGuard peer %s...: %s", pubKeyHex[:8], err)
@@ -712,10 +608,7 @@ func (g *Gateway) removePeerLocked(pubKeyHex string, info *peerInfo) {
 	delete(ns.peers, info.ip)
 	ns.mu.Unlock()
 	delete(g.peers, pubKeyHex)
-	info.cancelCtx()
-	if info.closeStream != nil {
-		info.closeStream()
-	}
+	info.cancel()
 	g.notifyWatchers()
 	log.Infof("Removed peer %s... (ip=%s name=%q session=%s)", pubKeyHex[:8], info.ip, info.assignedName, info.sessionID)
 }

--- a/enterprise/gateway/server/gateway_test.go
+++ b/enterprise/gateway/server/gateway_test.go
@@ -100,22 +100,20 @@ func TestNetworkClientIP(t *testing.T) {
 	}
 }
 
-func TestRegister_AssignsSequentialIPs(t *testing.T) {
+func TestConnect_AssignsSequentialIPs(t *testing.T) {
 	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
 	gw := setupGateway(t, ta)
 
 	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
 	require.NoError(t, err)
 
-	resp1, err := gw.Register(ctx, &gwpb.RegisterRequest{NetworkName: "net1", PeerName: "peer1", PublicKey: newPubKeyHex(t)})
-	require.NoError(t, err)
+	resp1, _, _ := startConnect(t, gw, ctx, &gwpb.ConnectRequest{NetworkName: "net1", PeerName: "peer1", PublicKey: newPubKeyHex(t), SessionId: "session-1"})
 	require.Equal(t, "fd00:bb::2", resp1.GetAssignedIp())
 	require.Equal(t, "fd00:bb::1", resp1.GetGatewayIp())
 	require.Equal(t, "fd00:bb::/48", resp1.GetNetworkCidr())
 	require.NotEmpty(t, resp1.GetServerPublicKey())
 
-	resp2, err := gw.Register(ctx, &gwpb.RegisterRequest{NetworkName: "net1", PeerName: "peer2", PublicKey: newPubKeyHex(t)})
-	require.NoError(t, err)
+	resp2, _, _ := startConnect(t, gw, ctx, &gwpb.ConnectRequest{NetworkName: "net1", PeerName: "peer2", PublicKey: newPubKeyHex(t), SessionId: "session-2"})
 	require.Equal(t, "fd00:bb::3", resp2.GetAssignedIp())
 
 	// Peers in the same network share the same server endpoint and public key.
@@ -123,7 +121,7 @@ func TestRegister_AssignsSequentialIPs(t *testing.T) {
 	require.Equal(t, resp1.GetServerEndpoint(), resp2.GetServerEndpoint())
 }
 
-func TestRegister_IsolatedNetworks(t *testing.T) {
+func TestConnect_IsolatedNetworks(t *testing.T) {
 	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers(
 		"user1", "group1",
 		"user2", "group2",
@@ -135,10 +133,8 @@ func TestRegister_IsolatedNetworks(t *testing.T) {
 	ctx2, err := ta.WithAuthenticatedUser(context.Background(), "user2")
 	require.NoError(t, err)
 
-	resp1, err := gw.Register(ctx1, &gwpb.RegisterRequest{NetworkName: "net1", PublicKey: newPubKeyHex(t)})
-	require.NoError(t, err)
-	resp2, err := gw.Register(ctx2, &gwpb.RegisterRequest{NetworkName: "net1", PublicKey: newPubKeyHex(t)})
-	require.NoError(t, err)
+	resp1, _, _ := startConnect(t, gw, ctx1, &gwpb.ConnectRequest{NetworkName: "net1", PublicKey: newPubKeyHex(t), SessionId: "session-1"})
+	resp2, _, _ := startConnect(t, gw, ctx2, &gwpb.ConnectRequest{NetworkName: "net1", PublicKey: newPubKeyHex(t), SessionId: "session-2"})
 
 	// All clients share the same WireGuard device and server public key.
 	require.Equal(t, resp1.GetServerPublicKey(), resp2.GetServerPublicKey())
@@ -153,59 +149,40 @@ func TestRegister_IsolatedNetworks(t *testing.T) {
 	require.Equal(t, "fd00:bb:1::2", resp2.GetAssignedIp())
 }
 
-func TestRegister_Unauthenticated(t *testing.T) {
+func TestConnect_Unauthenticated(t *testing.T) {
 	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers())
 	gw := setupGateway(t, ta)
 
-	_, err := gw.Register(context.Background(), &gwpb.RegisterRequest{NetworkName: "net1", PublicKey: newPubKeyHex(t)})
+	stream := &fakeConnectStream{ctx: context.Background(), responses: make(chan *gwpb.ConnectResponse, 1)}
+	err := gw.Connect(&gwpb.ConnectRequest{NetworkName: "net1", PublicKey: newPubKeyHex(t), SessionId: "session-1"}, stream)
 	require.Error(t, err)
 }
 
-func TestRegister_MissingPublicKey(t *testing.T) {
+func TestConnect_MissingPublicKey(t *testing.T) {
 	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
 	gw := setupGateway(t, ta)
 
 	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
 	require.NoError(t, err)
 
-	_, err = gw.Register(ctx, &gwpb.RegisterRequest{NetworkName: "net1"})
-	require.Error(t, err)
+	stream := &fakeConnectStream{ctx: ctx, responses: make(chan *gwpb.ConnectResponse, 1)}
+	err = gw.Connect(&gwpb.ConnectRequest{NetworkName: "net1", SessionId: "session-1"}, stream)
+	require.True(t, status.IsInvalidArgumentError(err), "expected InvalidArgument, got: %v", err)
 }
 
-func TestRegister_InvalidPublicKey(t *testing.T) {
+func TestConnect_InvalidPublicKey(t *testing.T) {
 	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
 	gw := setupGateway(t, ta)
 
 	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
 	require.NoError(t, err)
 
-	_, err = gw.Register(ctx, &gwpb.RegisterRequest{NetworkName: "net1", PublicKey: "notahexkey"})
-	require.Error(t, err)
+	stream := &fakeConnectStream{ctx: ctx, responses: make(chan *gwpb.ConnectResponse, 1)}
+	err = gw.Connect(&gwpb.ConnectRequest{NetworkName: "net1", PublicKey: "notahexkey", SessionId: "session-1"}, stream)
+	require.True(t, status.IsInvalidArgumentError(err), "expected InvalidArgument, got: %v", err)
 }
 
-func TestRegister_PeerNameConflict(t *testing.T) {
-	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
-	gw := setupGateway(t, ta)
-
-	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
-	require.NoError(t, err)
-
-	resp1, err := gw.Register(ctx, &gwpb.RegisterRequest{NetworkName: "net1", PeerName: "foo", PublicKey: newPubKeyHex(t)})
-	require.NoError(t, err)
-	require.Equal(t, "foo", resp1.GetAssignedPeerName())
-
-	// Second peer requesting the same name gets a suffixed name.
-	resp2, err := gw.Register(ctx, &gwpb.RegisterRequest{NetworkName: "net1", PeerName: "foo", PublicKey: newPubKeyHex(t)})
-	require.NoError(t, err)
-	require.Equal(t, "foo-1", resp2.GetAssignedPeerName())
-
-	// Third peer gets foo-2 since foo-1 is now also taken.
-	resp3, err := gw.Register(ctx, &gwpb.RegisterRequest{NetworkName: "net1", PeerName: "foo", PublicKey: newPubKeyHex(t)})
-	require.NoError(t, err)
-	require.Equal(t, "foo-2", resp3.GetAssignedPeerName())
-}
-
-func TestRegister_InvalidPeerName(t *testing.T) {
+func TestConnect_InvalidPeerName(t *testing.T) {
 	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
 	gw := setupGateway(t, ta)
 
@@ -213,59 +190,10 @@ func TestRegister_InvalidPeerName(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, name := range []string{"foo.bar", "foo.bar.baz"} {
-		_, err = gw.Register(ctx, &gwpb.RegisterRequest{NetworkName: "net1", PeerName: name, PublicKey: newPubKeyHex(t)})
+		stream := &fakeConnectStream{ctx: ctx, responses: make(chan *gwpb.ConnectResponse, 1)}
+		err = gw.Connect(&gwpb.ConnectRequest{NetworkName: "net1", PeerName: name, PublicKey: newPubKeyHex(t), SessionId: "session-" + name}, stream)
 		require.Errorf(t, err, "expected error for peer_name %q", name)
 	}
-}
-
-func TestDeregister(t *testing.T) {
-	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
-	gw := setupGateway(t, ta)
-
-	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
-	require.NoError(t, err)
-
-	pubKey := newPubKeyHex(t)
-	resp, err := gw.Register(ctx, &gwpb.RegisterRequest{NetworkName: "net1", PeerName: "mypeer", PublicKey: pubKey})
-	require.NoError(t, err)
-	assignedIP := netip.MustParseAddr(resp.GetAssignedIp())
-
-	_, err = gw.Deregister(ctx, &gwpb.DeregisterRequest{PublicKey: pubKey})
-	require.NoError(t, err)
-
-	gw.mu.Lock()
-	defer gw.mu.Unlock()
-
-	// Peer must be gone from the peer map.
-	require.NotContains(t, gw.peers, pubKey)
-
-	// IP must be unregistered from the TUN.
-	_, inTUN := gw.tun.ipToNetwork.Load(assignedIP)
-	require.False(t, inTUN, "IP should be unregistered after deregister")
-
-	// DNS name must be freed.
-	ns := gw.networks["group1/net1"]
-	_, nameExists := ns.names["mypeer"]
-	require.False(t, nameExists, "DNS name should be removed after deregister")
-}
-
-func TestDeregister_Unauthenticated(t *testing.T) {
-	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
-	gw := setupGateway(t, ta)
-
-	_, err := gw.Deregister(context.Background(), &gwpb.DeregisterRequest{PublicKey: newPubKeyHex(t)})
-	require.Error(t, err)
-}
-
-func TestDeregister_UnknownKey(t *testing.T) {
-	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
-	gw := setupGateway(t, ta)
-
-	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
-	require.NoError(t, err)
-
-	_, err = gw.Deregister(ctx, &gwpb.DeregisterRequest{PublicKey: newPubKeyHex(t)})
-	require.Error(t, err)
 }
 
 func TestList(t *testing.T) {
@@ -287,11 +215,6 @@ func TestList(t *testing.T) {
 		PublicKey:   newPubKeyHex(t),
 		SessionId:   "session-2",
 	})
-	// A peer registered via the deprecated Register RPC has no session ID
-	// and must be omitted.
-	_, err = gw.Register(ctx, &gwpb.RegisterRequest{NetworkName: "net1", PeerName: "legacy", PublicKey: newPubKeyHex(t)})
-	require.NoError(t, err)
-
 	list, err := gw.List(ctx, &gwpb.ListRequest{})
 	require.NoError(t, err)
 	require.Len(t, list.GetPeers(), 2)
@@ -701,23 +624,6 @@ func TestConnect_RefusesDuplicateSessionID(t *testing.T) {
 	require.NoError(t, <-done2)
 }
 
-func TestRegister_RefusesDuplicatePublicKey(t *testing.T) {
-	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
-	gw := setupGateway(t, ta)
-
-	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
-	require.NoError(t, err)
-
-	pubKey := newPubKeyHex(t)
-	_, err = gw.Register(ctx, &gwpb.RegisterRequest{NetworkName: "net1", PublicKey: pubKey})
-	require.NoError(t, err)
-
-	// Re-registering the same public key is refused rather than silently
-	// overwriting (and leaking) the previous registration.
-	_, err = gw.Register(ctx, &gwpb.RegisterRequest{NetworkName: "net1", PublicKey: pubKey})
-	require.True(t, status.IsAlreadyExistsError(err), "expected AlreadyExists, got: %v", err)
-}
-
 func TestConnect_UnnamedPeer(t *testing.T) {
 	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
 	gw := setupGateway(t, ta)
@@ -864,22 +770,22 @@ func TestCleanupStalePeers(t *testing.T) {
 	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
 	require.NoError(t, err)
 
-	// Register two peers in the same network.
+	// Connect two peers in the same network.
 	stalePubKey := newPubKeyHex(t)
-	staleResp, err := gw.Register(ctx, &gwpb.RegisterRequest{
+	staleResp, _, _ := startConnect(t, gw, ctx, &gwpb.ConnectRequest{
 		NetworkName: "net1",
 		PeerName:    "stale",
 		PublicKey:   stalePubKey,
+		SessionId:   "session-stale",
 	})
-	require.NoError(t, err)
 
 	freshPubKey := newPubKeyHex(t)
-	_, err = gw.Register(ctx, &gwpb.RegisterRequest{
+	startConnect(t, gw, ctx, &gwpb.ConnectRequest{
 		NetworkName: "net1",
 		PeerName:    "fresh",
 		PublicKey:   freshPubKey,
+		SessionId:   "session-fresh",
 	})
-	require.NoError(t, err)
 
 	// Backdate the stale peer's registration time so it appears old enough to
 	// be reaped.

--- a/enterprise/gateway/server/hub.go
+++ b/enterprise/gateway/server/hub.go
@@ -29,8 +29,8 @@ type HubNetwork struct {
 	// LookupName resolves a peer name registered in this network.
 	LookupName func(name string) (netip.Addr, bool)
 
-	// PeerContext returns a context that is canceled when the peer at ip is
-	// removed from this network.
+	// PeerContext returns a context that is canceled when the registration
+	// of the peer at ip ends — it is evicted, or its Connect stream closes.
 	PeerContext func(ip netip.Addr) (ctx context.Context, ok bool)
 
 	stack *stack.Stack

--- a/proto/gateway.proto
+++ b/proto/gateway.proto
@@ -53,58 +53,6 @@ message ConnectResponse {
   string network_cidr = 5;
 }
 
-message RegisterRequest {
-  // Optional. Identifies which network within the group to join.
-  // Defaults to "" (the group's default network).
-  string network_name = 1;
-
-  // Optional. Requested DNS name for this peer within the network. Other peers
-  // on the same network can resolve this name to this peer's assigned IP via
-  // the DNS server at <name>.internal. If the requested name is already taken,
-  // the server assigns a unique name by appending a numeric suffix (e.g.
-  // "foo-1"). The actual assigned name is returned in RegisterResponse.
-  string peer_name = 2;
-
-  // Client's WireGuard public key, hex-encoded. The client generates its own
-  // keypair locally and never shares its private key with the server.
-  string public_key = 3;
-}
-
-message RegisterResponse {
-  reserved 1;  // formerly private_key; clients now generate their own keypairs.
-
-  // Gateway's WireGuard public key for this network, hex-encoded.
-  string server_public_key = 2;
-
-  // host:udp_port that clients should configure as their WireGuard endpoint.
-  string server_endpoint = 3;
-
-  // IP address assigned to this client within the tunnel, e.g. "10.0.0.5" or
-  // "fd00:bb::2"
-  string assigned_ip = 4;
-
-  // IP address of the gateway hub within the tunnel. Also serves as the DNS
-  // resolver for peer names: pass this to netstack.CreateNetTUN so that
-  // hostnames registered via peer_name resolve through the tunnel.
-  string gateway_ip = 5;
-
-  // CIDR of the network, e.g. "10.0.0.0/24".
-  string network_cidr = 6;
-
-  // The DNS name actually assigned to this peer (may differ from the requested
-  // peer_name if there was a conflict). Reachable at
-  // <assigned_peer_name>.internal. Empty if no peer_name was requested.
-  string assigned_peer_name = 7;
-}
-
-message DeregisterRequest {
-  // The client's WireGuard public key, hex-encoded. Must match the key used
-  // during Register.
-  string public_key = 1;
-}
-
-message DeregisterResponse {}
-
 message ListRequest {}
 
 // Peer describes a single peer currently registered with the gateway.
@@ -118,8 +66,7 @@ message Peer {
   string ip = 2;
 
   // Uniquely identifies this peer's connection (see
-  // ConnectRequest.session_id). Empty for peers registered via the
-  // deprecated Register RPC.
+  // ConnectRequest.session_id).
   string session_id = 3;
 
   // The time of this peer's most recent WireGuard handshake. Unset if the

--- a/proto/gateway_service.proto
+++ b/proto/gateway_service.proto
@@ -13,24 +13,6 @@ service GatewayService {
   // The peer stays registered exactly as long as the stream is open.
   rpc Connect(ConnectRequest) returns (stream ConnectResponse);
 
-  // Register assigns the caller a WireGuard identity that is not tied to a
-  // connection: the peer stays registered until Deregister is called or the
-  // stale-peer sweep reclaims it after its tunnel goes quiet.
-  //
-  // Deprecated: use Connect instead, which cleans up promptly and enforces
-  // peer name uniqueness.
-  rpc Register(RegisterRequest) returns (RegisterResponse) {
-    option deprecated = true;
-  }
-
-  // Deregister removes a peer created by Register.
-  //
-  // Deprecated: use Connect instead; closing the Connect stream deregisters
-  // the peer.
-  rpc Deregister(DeregisterRequest) returns (DeregisterResponse) {
-    option deprecated = true;
-  }
-
   // Returns the set of currently connected peers owned by the user associated
   // with the provided authentication credentials.
   rpc List(ListRequest) returns (ListResponse);


### PR DESCRIPTION
Simplify the stored peer context since we can now use the context tied to the registration stream.