### PR TITLE
gateway: make auth pluggable

### DIFF
--- a/enterprise/gateway/apikeyauth/BUILD
+++ b/enterprise/gateway/apikeyauth/BUILD
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = ["//visibility:public"])
+
+go_library(
+    name = "apikeyauth",
+    srcs = ["apikeyauth.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/gateway/apikeyauth",
+    deps = [
+        "//enterprise/gateway/gatewayauth",
+        "//server/interfaces",
+    ],
+)

--- a/enterprise/gateway/apikeyauth/BUILD
+++ b/enterprise/gateway/apikeyauth/BUILD
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_library(
     name = "apikeyauth",

--- a/enterprise/gateway/apikeyauth/apikeyauth.go
+++ b/enterprise/gateway/apikeyauth/apikeyauth.go
@@ -1,0 +1,29 @@
+// Package apikeyauth authenticates gateway callers by their BuildBuddy API
+// key, resolved by the app.
+package apikeyauth
+
+import (
+	"context"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/gatewayauth"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+)
+
+type authenticator struct {
+	auth interfaces.Authenticator
+}
+
+func New(a interfaces.Authenticator) gatewayauth.Authenticator {
+	return &authenticator{auth: a}
+}
+
+func (a *authenticator) Authenticate(ctx context.Context, _ string) (*gatewayauth.Principal, error) {
+	claims, err := a.auth.AuthenticatedUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &gatewayauth.Principal{
+		User:      claims.GetUserID(),
+		Namespace: claims.GetGroupID(),
+	}, nil
+}

--- a/enterprise/gateway/cmd/gateway/BUILD
+++ b/enterprise/gateway/cmd/gateway/BUILD
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/gateway/cmd/gateway",
     visibility = ["//visibility:private"],
     deps = [
+        "//enterprise/gateway/apikeyauth",
         "//enterprise/gateway/server",
         "//enterprise/server/backends/configsecrets",
         "//enterprise/server/remoteauth",

--- a/enterprise/gateway/cmd/gateway/gateway.go
+++ b/enterprise/gateway/cmd/gateway/gateway.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/apikeyauth"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/server"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/configsecrets"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remoteauth"
@@ -119,7 +120,10 @@ func main() {
 }
 
 func startGRPCServers(env *real_environment.RealEnv) error {
-	gw, err := server.New(env, server.DNSService())
+	gw, err := server.New(server.Options{
+		Authenticator: apikeyauth.New(env.GetAuthenticator()),
+		HubServices:   []server.HubService{server.DNSService()},
+	})
 	if err != nil {
 		return err
 	}

--- a/enterprise/gateway/gatewayauth/BUILD
+++ b/enterprise/gateway/gatewayauth/BUILD
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_library(
     name = "gatewayauth",

--- a/enterprise/gateway/gatewayauth/BUILD
+++ b/enterprise/gateway/gatewayauth/BUILD
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = ["//visibility:public"])
+
+go_library(
+    name = "gatewayauth",
+    srcs = ["gatewayauth.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/gateway/gatewayauth",
+)

--- a/enterprise/gateway/gatewayauth/gatewayauth.go
+++ b/enterprise/gateway/gatewayauth/gatewayauth.go
@@ -1,0 +1,29 @@
+// Package gatewayauth defines how the gateway identifies its callers.
+package gatewayauth
+
+import (
+	"context"
+	"time"
+)
+
+// Principal identifies who a gateway RPC acts on behalf of.
+type Principal struct {
+	// User identifies the user for audit/logging purposes.
+	// API key auth: BuildBuddy User ID
+	// Cert auth: e-mail address
+	User string
+
+	// Namespace keys network and IP allocation, and scopes what List reveals. It
+	// is a group ID for API-key callers. Since the gateway drops packets that
+	// cross networks, principals with different namespaces can never reach each
+	// other's peers.
+	Namespace string
+
+	// ExpiresAt bounds a registered peer's lifetime to the credential's own.
+	// Zero means the credential imposes no deadline.
+	ExpiresAt time.Time
+}
+
+type Authenticator interface {
+	Authenticate(ctx context.Context, wgPublicKey string) (*Principal, error)
+}

--- a/enterprise/gateway/relay/BUILD
+++ b/enterprise/gateway/relay/BUILD
@@ -23,6 +23,7 @@ go_test(
     ],
     embed = [":relay"],
     deps = [
+        "//enterprise/gateway/apikeyauth",
         "//enterprise/gateway/server",
         "//enterprise/gateway/testgateway",
         "//server/testutil/testauth",

--- a/enterprise/gateway/relay/relay_e2e_test.go
+++ b/enterprise/gateway/relay/relay_e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/apikeyauth"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/relay"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/server"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/testgateway"
@@ -21,7 +22,10 @@ import (
 // setupRelayGateway creates a gateway running the relay service.
 func setupRelayGateway(t testing.TB, ta *testauth.TestAuthenticator) *server.Gateway {
 	t.Helper()
-	return testgateway.Setup(t, ta, relay.New())
+	return testgateway.Setup(t, server.Options{
+		Authenticator: apikeyauth.New(ta),
+		HubServices:   []server.HubService{relay.New()},
+	})
 }
 
 // startEchoServer starts a TCP server on localhost that echoes what it reads
@@ -147,7 +151,10 @@ func TestRelay_NotComposedMeansNoListener(t *testing.T) {
 	// A gateway that does not compose the relay (the customer-facing shape)
 	// must not have a relay listener at all.
 	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
-	gw := testgateway.Setup(t, ta, server.DNSService())
+	gw := testgateway.Setup(t, server.Options{
+		Authenticator: apikeyauth.New(ta),
+		HubServices:   []server.HubService{server.DNSService()},
+	})
 	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
 	require.NoError(t, err)
 

--- a/enterprise/gateway/server/BUILD
+++ b/enterprise/gateway/server/BUILD
@@ -12,9 +12,9 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/gateway/server",
     visibility = ["//visibility:public"],
     deps = [
+        "//enterprise/gateway/gatewayauth",
         "//proto:gateway_go_proto",
         "//proto:gateway_service_go_proto",
-        "//server/environment",
         "//server/util/flag",
         "//server/util/log",
         "//server/util/status",
@@ -48,10 +48,11 @@ go_test(
     ],
     embed = [":server"],
     deps = [
+        "//enterprise/gateway/apikeyauth",
+        "//enterprise/gateway/gatewayauth",
         "//enterprise/gateway/testgateway",
         "//proto:gateway_go_proto",
         "//server/testutil/testauth",
-        "//server/testutil/testenv",
         "//server/util/status",
         "//server/util/testing/flags",
         "//server/util/wgkeys",

--- a/enterprise/gateway/server/gateway.go
+++ b/enterprise/gateway/server/gateway.go
@@ -1,11 +1,11 @@
 // Package server implements the BuildBuddy WireGuard gateway.
 //
-// A single WireGuard device listens on one UDP port and serves all groups.
-// Each (groupID, networkName) pair is assigned a unique /48 IPv6 prefix,
+// A single WireGuard device listens on one UDP port and serves all callers.
+// Each (namespace, networkName) pair is assigned a unique /48 IPv6 prefix,
 // derived from a monotonically increasing index:
 //
 //	fd00:bb:N::/48  — network N's prefix
-//	fd00:bb:N::1    — network N's hub (DNS)
+//	fd00:bb:N::1    — network N's hub (hub services; see hub.go)
 //	fd00:bb:N::2+   — network N's clients, assigned sequentially
 //
 // Group isolation is enforced inside muxTUN.Write(): packets whose source
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/gatewayauth"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -46,14 +46,14 @@ var (
 )
 
 // networkState holds IP allocation and peer name state for one
-// (groupID, networkName) pair.
+// (namespace, networkName) pair.
 type networkState struct {
-	groupID  string                   // group that owns this network
-	index    int                      // assigned network index; determines the /48 prefix
-	mu       sync.Mutex               // protects names and peers
-	names    map[string]netip.Addr    // peer_name → assigned IP
-	peers    map[netip.Addr]*peerInfo // assigned IP → peer, for HubNetwork.PeerContext
-	nextHost int                      // next host number to assign; starts at 2 (.1 is the hub)
+	namespace string                   // namespace for this network (groupID for api key users)
+	index     int                      // assigned network index; determines the /48 prefix
+	mu        sync.Mutex               // protects names and peers
+	names     map[string]netip.Addr    // peer_name → assigned IP
+	peers     map[netip.Addr]*peerInfo // assigned IP → peer, for HubNetwork.PeerContext
+	nextHost  int                      // next host number to assign; starts at 2 (.1 is the hub)
 }
 
 // peerInfo tracks per-peer state needed for cleanup.
@@ -62,7 +62,11 @@ type peerInfo struct {
 	networkState *networkState
 	assignedName string    // empty if peer registered without a name
 	sessionID    string    // uniquely identifies this connection
+	user         string    // authenticated user that registered this peer
 	registeredAt time.Time // used as last-seen baseline if peer never completed a handshake
+	// expiresAt is when the registering credential stops being valid.
+	// Zero means no deadline.
+	expiresAt time.Time
 
 	// ctx lives as long as the registration.
 	ctx    context.Context
@@ -73,7 +77,7 @@ type peerInfo struct {
 // Network isolation is enforced in the muxTUN layer.
 type Gateway struct {
 	mu            sync.Mutex
-	env           environment.Env
+	auth          gatewayauth.Authenticator
 	dev           *device.Device
 	tun           *muxTUN
 	pubKey        string // server's base64 public key
@@ -94,8 +98,19 @@ type Gateway struct {
 	stateChanged chan struct{}
 }
 
+type Options struct {
+	// Authenticator resolves RPC callers to principals. Required.
+	Authenticator gatewayauth.Authenticator
+	// HubServices are started on each network's hub IP as networks are
+	// created (see hub.go).
+	HubServices []HubService
+}
+
 // New creates a Gateway with a single shared WireGuard device.
-func New(env environment.Env, hubServices ...HubService) (*Gateway, error) {
+func New(opts Options) (*Gateway, error) {
+	if opts.Authenticator == nil {
+		return nil, status.InvalidArgumentError("an Authenticator is required")
+	}
 	serverPrivKey, err := wgkeys.GeneratePrivateKey()
 	if err != nil {
 		return nil, status.InternalErrorf("generate server private key: %s", err)
@@ -104,11 +119,11 @@ func New(env environment.Env, hubServices ...HubService) (*Gateway, error) {
 	tunDev := newMuxTUN(1420)
 
 	gw := &Gateway{
-		env:           env,
+		auth:          opts.Authenticator,
 		tun:           tunDev,
 		networks:      make(map[string]*networkState),
 		peers:         make(map[string]*peerInfo),
-		hubServices:   hubServices,
+		hubServices:   opts.HubServices,
 		publicHost:    *publicHost,
 		udpListenPort: *udpListenPort,
 		done:          make(chan struct{}),
@@ -159,18 +174,17 @@ func New(env environment.Env, hubServices ...HubService) (*Gateway, error) {
 // remains open. Peer names are unique within a network: a name held by a
 // connected peer causes ALREADY_EXISTS.
 func (g *Gateway) Connect(req *gwpb.ConnectRequest, stream gwsvcpb.GatewayService_ConnectServer) error {
-	claims, err := g.env.GetAuthenticator().AuthenticatedUser(stream.Context())
-	if err != nil {
-		return err
-	}
-	groupID := claims.GetGroupID()
-
 	if req.GetPublicKey() == "" {
 		return status.InvalidArgumentError("public_key is required")
 	}
 	clientPubKey, err := wgkeys.ParseHexKey(req.GetPublicKey())
 	if err != nil {
 		return status.InvalidArgumentErrorf("invalid public_key: %s", err)
+	}
+
+	principal, err := g.auth.Authenticate(stream.Context(), req.GetPublicKey())
+	if err != nil {
+		return err
 	}
 	name := req.GetPeerName()
 	if name != "" {
@@ -191,7 +205,7 @@ func (g *Gateway) Connect(req *gwpb.ConnectRequest, stream gwsvcpb.GatewayServic
 	defer cancel()
 
 	g.mu.Lock()
-	ns, err := g.getOrCreateNetwork(groupID, req.GetNetworkName())
+	ns, err := g.getOrCreateNetwork(principal.Namespace, req.GetNetworkName())
 	if err != nil {
 		g.mu.Unlock()
 		return err
@@ -205,16 +219,16 @@ func (g *Gateway) Connect(req *gwpb.ConnectRequest, stream gwsvcpb.GatewayServic
 			return status.AlreadyExistsErrorf("peer name %q is already in use", name)
 		}
 	}
-	// Session IDs uniquely identify connections within a group, so that
+	// Session IDs uniquely identify connections within a namespace, so that
 	// removal below (and deregistration by session ID, eventually) is
 	// unambiguous.
 	for _, info := range g.peers {
-		if info.sessionID == sessionID && info.networkState.groupID == groupID {
+		if info.sessionID == sessionID && info.networkState.namespace == principal.Namespace {
 			g.mu.Unlock()
 			return status.AlreadyExistsErrorf("session_id %q is already in use", sessionID)
 		}
 	}
-	assignedIP, err := g.addPeerLocked(ctx, cancel, ns, clientPubKey.Hex(), name, sessionID)
+	assignedIP, err := g.addPeerLocked(ctx, cancel, ns, clientPubKey.Hex(), name, sessionID, principal)
 	g.mu.Unlock()
 	if err != nil {
 		return err
@@ -239,8 +253,8 @@ func (g *Gateway) Connect(req *gwpb.ConnectRequest, stream gwsvcpb.GatewayServic
 		return err
 	}
 
-	log.Infof("Connected peer %s in group %q network %q, assigned %s (name=%q session=%s)",
-		clientPubKey.String()[:8]+"...", groupID, req.GetNetworkName(), assignedIP, name, sessionID)
+	log.Infof("Connected peer %s for %q network %q, assigned %s (name=%q session=%s expires=%s)",
+		clientPubKey.String()[:8]+"...", principal.Namespace, req.GetNetworkName(), assignedIP, name, sessionID, formatExpiry(principal.ExpiresAt))
 
 	// Send periodic (empty) heartbeat messages. These keep the stream from
 	// being closed by idle-sensitive intermediaries while the tunnel is
@@ -280,11 +294,10 @@ func (g *Gateway) Connect(req *gwpb.ConnectRequest, stream gwsvcpb.GatewayServic
 // While the watched peer is quiet the stream carries periodic empty
 // heartbeat messages (as Connect does); clients ignore them.
 func (g *Gateway) Watch(req *gwpb.WatchRequest, stream gwsvcpb.GatewayService_WatchServer) error {
-	claims, err := g.env.GetAuthenticator().AuthenticatedUser(stream.Context())
+	p, err := g.auth.Authenticate(stream.Context(), "" /*=wgPublicKey*/)
 	if err != nil {
 		return err
 	}
-	groupID := claims.GetGroupID()
 	sessionID := req.GetSessionId()
 	if sessionID == "" {
 		return status.InvalidArgumentError("session_id is required")
@@ -302,7 +315,7 @@ func (g *Gateway) Watch(req *gwpb.WatchRequest, stream gwsvcpb.GatewayService_Wa
 		// the snapshot closes the already-obtained channel, so the select
 		// below wakes instead of missing it.
 		signal := g.watchSignal()
-		peer, err := g.snapshotPeer(groupID, sessionID)
+		peer, err := g.snapshotPeer(p.Namespace, sessionID)
 		if err != nil && !loggedSnapshotErr {
 			// Log once per stream: this runs on every wake, and a
 			// persistently failing IpcGet would otherwise flood the log.
@@ -354,10 +367,10 @@ func (g *Gateway) watchSignal() <-chan struct{} {
 }
 
 // snapshotPeer returns the current state of the peer with the given session
-// ID in groupID, or nil if no such peer is registered. A non-nil error
-// reports a failure to read handshake state; the returned peer is still
-// valid, with last_handshake_time left unset.
-func (g *Gateway) snapshotPeer(groupID, sessionID string) (*gwpb.Peer, error) {
+// ID in the namespace, or nil if no such peer is registered. A non-nil
+// error reports a failure to read handshake state; the returned peer is
+// still valid, with last_handshake_time left unset.
+func (g *Gateway) snapshotPeer(namespace, sessionID string) (*gwpb.Peer, error) {
 	// Locate the peer before touching the WireGuard device: dumping device
 	// state (lastHandshakeTimes) is O(all peers), and the common case for a
 	// watch on a still-booting session is that the peer doesn't exist yet.
@@ -365,7 +378,7 @@ func (g *Gateway) snapshotPeer(groupID, sessionID string) (*gwpb.Peer, error) {
 	var pubKeyHex string
 	g.mu.Lock()
 	for k, info := range g.peers {
-		if info.sessionID != sessionID || info.networkState.groupID != groupID {
+		if info.sessionID != sessionID || info.networkState.namespace != namespace {
 			continue
 		}
 		pubKeyHex = k
@@ -395,7 +408,7 @@ func (g *Gateway) snapshotPeer(groupID, sessionID string) (*gwpb.Peer, error) {
 // registration's lifetime (see peerInfo.ctx). assignedName and sessionID
 // must already be validated (and checked for conflicts) by the caller. Must
 // be called with g.mu held.
-func (g *Gateway) addPeerLocked(ctx context.Context, cancel context.CancelFunc, ns *networkState, pubKeyHex, assignedName, sessionID string) (netip.Addr, error) {
+func (g *Gateway) addPeerLocked(ctx context.Context, cancel context.CancelFunc, ns *networkState, pubKeyHex, assignedName, sessionID string, p *gatewayauth.Principal) (netip.Addr, error) {
 	if _, ok := g.peers[pubKeyHex]; ok {
 		return netip.Addr{}, status.AlreadyExistsErrorf("public key %s... is already registered", pubKeyHex[:8])
 	}
@@ -421,7 +434,9 @@ func (g *Gateway) addPeerLocked(ctx context.Context, cancel context.CancelFunc, 
 		networkState: ns,
 		assignedName: assignedName,
 		sessionID:    sessionID,
+		user:         p.User,
 		registeredAt: time.Now(),
+		expiresAt:    p.ExpiresAt,
 		ctx:          ctx,
 		cancel:       cancel,
 	}
@@ -439,11 +454,10 @@ func (g *Gateway) addPeerLocked(ctx context.Context, cancel context.CancelFunc, 
 // List returns the peers currently registered by the caller's group, named
 // or not.
 func (g *Gateway) List(ctx context.Context, req *gwpb.ListRequest) (*gwpb.ListResponse, error) {
-	claims, err := g.env.GetAuthenticator().AuthenticatedUser(ctx)
+	p, err := g.auth.Authenticate(ctx, "" /*=wgPublicKey*/)
 	if err != nil {
 		return nil, err
 	}
-	groupID := claims.GetGroupID()
 
 	handshakeTimes, err := g.lastHandshakeTimes()
 	if err != nil {
@@ -457,7 +471,7 @@ func (g *Gateway) List(ctx context.Context, req *gwpb.ListRequest) (*gwpb.ListRe
 	peers := make([]*gwpb.Peer, 0)
 	for pubKeyHex, info := range g.peers {
 		ns := info.networkState
-		if ns.groupID != groupID {
+		if ns.namespace != p.Namespace {
 			continue
 		}
 		p := &gwpb.Peer{
@@ -473,10 +487,10 @@ func (g *Gateway) List(ctx context.Context, req *gwpb.ListRequest) (*gwpb.ListRe
 	return &gwpb.ListResponse{Peers: peers}, nil
 }
 
-// getOrCreateNetwork returns the networkState for (groupID, networkName),
+// getOrCreateNetwork returns the networkState for (namespace, networkName),
 // creating it if it doesn't exist. Must be called with g.mu held.
-func (g *Gateway) getOrCreateNetwork(groupID, networkName string) (*networkState, error) {
-	key := groupID + "/" + networkName
+func (g *Gateway) getOrCreateNetwork(namespace, networkName string) (*networkState, error) {
+	key := namespace + "/" + networkName
 	if ns, ok := g.networks[key]; ok {
 		return ns, nil
 	}
@@ -485,11 +499,11 @@ func (g *Gateway) getOrCreateNetwork(groupID, networkName string) (*networkState
 	g.nextIndex++
 
 	ns := &networkState{
-		groupID:  groupID,
-		index:    index,
-		names:    make(map[string]netip.Addr),
-		peers:    make(map[netip.Addr]*peerInfo),
-		nextHost: 2,
+		namespace: namespace,
+		index:     index,
+		names:     make(map[string]netip.Addr),
+		peers:     make(map[netip.Addr]*peerInfo),
+		nextHost:  2,
 	}
 
 	nameLookup := func(name string) (netip.Addr, bool) {
@@ -537,9 +551,10 @@ func (g *Gateway) cleanupLoop() {
 
 // cleanupStalePeers removes peers whose last WireGuard handshake (or
 // registration time, if they never completed one) is older than
-// stalePeerTimeout. For Connect-based peers this is a backstop: their
-// registrations are normally removed when their stream closes, but this
-// catches peers whose stream is somehow alive while their tunnel is dark.
+// stalePeerTimeout, and peers whose registering credential has expired. For
+// Connect-based peers this is a backstop: their registrations are normally
+// removed when their stream closes, but this catches peers whose stream is
+// somehow alive while their tunnel is dark.
 func (g *Gateway) cleanupStalePeers() {
 	handshakeTimes, err := g.lastHandshakeTimes()
 	if err != nil {
@@ -552,6 +567,16 @@ func (g *Gateway) cleanupStalePeers() {
 	defer g.mu.Unlock()
 
 	for pubKeyHex, info := range g.peers {
+		// An expired credential ends the tunnel regardless of how active it
+		// is. WireGuard re-handshakes forever, so without this an expired
+		// credential would buy indefinite access.
+		if !info.expiresAt.IsZero() && now.After(info.expiresAt) {
+			log.Infof("Found EXPIRED peer %s... (ip=%s name=%q user=%s): credential expired at %s",
+				pubKeyHex[:8], info.ip, info.assignedName, info.user, formatExpiry(info.expiresAt))
+			g.removePeerLocked(pubKeyHex, info)
+			continue
+		}
+
 		lastSeen, ok := handshakeTimes[pubKeyHex]
 		if !ok {
 			// Peer never completed a handshake; use registration time as baseline.
@@ -589,6 +614,13 @@ func (g *Gateway) lastHandshakeTimes() (map[string]time.Time, error) {
 		}
 	}
 	return handshakeTimes, nil
+}
+
+func formatExpiry(t time.Time) string {
+	if t.IsZero() {
+		return "never"
+	}
+	return t.UTC().Format(time.RFC3339)
 }
 
 // removePeerLocked removes a peer from the WireGuard device, the TUN, and the

--- a/enterprise/gateway/server/gateway.go
+++ b/enterprise/gateway/server/gateway.go
@@ -454,7 +454,7 @@ func (g *Gateway) addPeerLocked(ctx context.Context, cancel context.CancelFunc, 
 // List returns the peers currently registered by the caller's group, named
 // or not.
 func (g *Gateway) List(ctx context.Context, req *gwpb.ListRequest) (*gwpb.ListResponse, error) {
-	p, err := g.auth.Authenticate(ctx, "" /*=wgPublicKey*/)
+	principal, err := g.auth.Authenticate(ctx, "" /*=wgPublicKey*/)
 	if err != nil {
 		return nil, err
 	}
@@ -471,18 +471,18 @@ func (g *Gateway) List(ctx context.Context, req *gwpb.ListRequest) (*gwpb.ListRe
 	peers := make([]*gwpb.Peer, 0)
 	for pubKeyHex, info := range g.peers {
 		ns := info.networkState
-		if ns.namespace != p.Namespace {
+		if ns.namespace != principal.Namespace {
 			continue
 		}
-		p := &gwpb.Peer{
+		peer := &gwpb.Peer{
 			Name:      info.assignedName,
 			Ip:        info.ip.String(),
 			SessionId: info.sessionID,
 		}
 		if t, ok := handshakeTimes[pubKeyHex]; ok {
-			p.LastHandshakeTime = timestamppb.New(t)
+			peer.LastHandshakeTime = timestamppb.New(t)
 		}
-		peers = append(peers, p)
+		peers = append(peers, peer)
 	}
 	return &gwpb.ListResponse{Peers: peers}, nil
 }
@@ -549,19 +549,9 @@ func (g *Gateway) cleanupLoop() {
 	}
 }
 
-// cleanupStalePeers removes peers whose last WireGuard handshake (or
-// registration time, if they never completed one) is older than
-// stalePeerTimeout, and peers whose registering credential has expired. For
-// Connect-based peers this is a backstop: their registrations are normally
-// removed when their stream closes, but this catches peers whose stream is
-// somehow alive while their tunnel is dark.
-func (g *Gateway) cleanupStalePeers() {
-	handshakeTimes, err := g.lastHandshakeTimes()
-	if err != nil {
-		log.Errorf("Cleanup: %s", err)
-		return
-	}
-
+// cleanupExpiredCredPeers disconnects any peers that are connected with creds
+// that are past their expiry.
+func (g *Gateway) cleanupExpiredCredPeers() {
 	now := time.Now()
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -574,9 +564,30 @@ func (g *Gateway) cleanupStalePeers() {
 			log.Infof("Found EXPIRED peer %s... (ip=%s name=%q user=%s): credential expired at %s",
 				pubKeyHex[:8], info.ip, info.assignedName, info.user, formatExpiry(info.expiresAt))
 			g.removePeerLocked(pubKeyHex, info)
-			continue
 		}
+	}
+}
 
+// cleanupStalePeers removes peers whose last WireGuard handshake (or
+// registration time, if they never completed one) is older than
+// stalePeerTimeout, and peers whose registering credential has expired. For
+// Connect-based peers this is a backstop: their registrations are normally
+// removed when their stream closes, but this catches peers whose stream is
+// somehow alive while their tunnel is dark.
+func (g *Gateway) cleanupStalePeers() {
+	g.cleanupExpiredCredPeers()
+
+	handshakeTimes, err := g.lastHandshakeTimes()
+	if err != nil {
+		log.Errorf("Cleanup: %s", err)
+		return
+	}
+
+	now := time.Now()
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	for pubKeyHex, info := range g.peers {
 		lastSeen, ok := handshakeTimes[pubKeyHex]
 		if !ok {
 			// Peer never completed a handshake; use registration time as baseline.

--- a/enterprise/gateway/server/gateway_e2e_test.go
+++ b/enterprise/gateway/server/gateway_e2e_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/apikeyauth"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/server"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/testgateway"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
@@ -33,7 +34,10 @@ import (
 func TestEndToEnd_WatchReportsHandshake(t *testing.T) {
 	flags.Set(t, "gateway.watch_fallback_poll_interval", time.Minute)
 	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
-	gw := testgateway.Setup(t, ta, server.DNSService())
+	gw := testgateway.Setup(t, server.Options{
+		Authenticator: apikeyauth.New(ta),
+		HubServices:   []server.HubService{server.DNSService()},
+	})
 
 	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
 	require.NoError(t, err)
@@ -69,7 +73,10 @@ func TestEndToEnd_WatchReportsHandshake(t *testing.T) {
 // can exchange data over the WireGuard tunnel using direct IP addressing.
 func TestEndToEnd_PeersCanCommunicate(t *testing.T) {
 	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
-	gw := testgateway.Setup(t, ta, server.DNSService())
+	gw := testgateway.Setup(t, server.Options{
+		Authenticator: apikeyauth.New(ta),
+		HubServices:   []server.HubService{server.DNSService()},
+	})
 
 	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
 	require.NoError(t, err)
@@ -111,7 +118,10 @@ func TestEndToEnd_PeersCanCommunicate(t *testing.T) {
 // that name.
 func TestEndToEnd_DNSResolution(t *testing.T) {
 	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
-	gw := testgateway.Setup(t, ta, server.DNSService())
+	gw := testgateway.Setup(t, server.Options{
+		Authenticator: apikeyauth.New(ta),
+		HubServices:   []server.HubService{server.DNSService()},
+	})
 
 	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
 	require.NoError(t, err)
@@ -162,7 +172,10 @@ func TestEndToEnd_DNSResolution(t *testing.T) {
 //	  --test_arg=-test.run='^$'
 func BenchmarkGatewayThroughput(b *testing.B) {
 	ta := testauth.NewTestAuthenticator(b, testauth.TestUsers("user1", "group1"))
-	gw := testgateway.Setup(b, ta, server.DNSService())
+	gw := testgateway.Setup(b, server.Options{
+		Authenticator: apikeyauth.New(ta),
+		HubServices:   []server.HubService{server.DNSService()},
+	})
 
 	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
 	require.NoError(b, err)

--- a/enterprise/gateway/server/gateway_test.go
+++ b/enterprise/gateway/server/gateway_test.go
@@ -8,8 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/apikeyauth"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/gatewayauth"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
-	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/buildbuddy-io/buildbuddy/server/util/wgkeys"
@@ -21,13 +22,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m,
-		// testenv starts a healthcheck goroutine that is not stopped on cleanup.
-		goleak.IgnoreTopFunction("github.com/buildbuddy-io/buildbuddy/server/util/healthcheck.(*HealthChecker).handleSignals"),
-		// testenv starts a DB stats polling goroutine that sleeps between polls
-		// and is not stopped on cleanup.
-		goleak.IgnoreTopFunction("time.Sleep"),
-	)
+	goleak.VerifyTestMain(m)
 }
 
 func newPubKeyHex(t *testing.T) string {
@@ -47,13 +42,18 @@ func freeUDPPort(t testing.TB) int {
 
 func setupGateway(t testing.TB, ta *testauth.TestAuthenticator) *Gateway {
 	t.Helper()
+	return setupGatewayWithOptions(t, Options{
+		Authenticator: apikeyauth.New(ta),
+		HubServices:   []HubService{DNSService()},
+	})
+}
+
+func setupGatewayWithOptions(t testing.TB, opts Options) *Gateway {
+	t.Helper()
 	flags.Set(t, "gateway.udp_listen_port", freeUDPPort(t))
 	flags.Set(t, "gateway.public_host", "127.0.0.1")
 
-	env := testenv.GetTestEnv(t)
-	env.SetAuthenticator(ta)
-
-	gw, err := New(env, DNSService())
+	gw, err := New(opts)
 	require.NoError(t, err)
 	t.Cleanup(gw.Close)
 	return gw
@@ -194,6 +194,26 @@ func TestConnect_InvalidPeerName(t *testing.T) {
 		err = gw.Connect(&gwpb.ConnectRequest{NetworkName: "net1", PeerName: name, PublicKey: newPubKeyHex(t), SessionId: "session-" + name}, stream)
 		require.Errorf(t, err, "expected error for peer_name %q", name)
 	}
+}
+
+func TestConnect_InvalidPeerNameLeavesNoPeer(t *testing.T) {
+	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("user1", "group1"))
+	gw := setupGateway(t, ta)
+
+	ctx, err := ta.WithAuthenticatedUser(context.Background(), "user1")
+	require.NoError(t, err)
+
+	pubKey := newPubKeyHex(t)
+	stream := &fakeConnectStream{ctx: ctx, responses: make(chan *gwpb.ConnectResponse, 1)}
+	err = gw.Connect(&gwpb.ConnectRequest{NetworkName: "net1", PeerName: "not.one.label", PublicKey: pubKey, SessionId: "session-1"}, stream)
+	require.Error(t, err)
+
+	gw.mu.Lock()
+	defer gw.mu.Unlock()
+	require.Empty(t, gw.peers, "a rejected registration must not leave a peer behind")
+	ipc, err := gw.dev.IpcGet()
+	require.NoError(t, err)
+	require.NotContains(t, ipc, pubKey, "the rejected key must not be configured on the WireGuard device")
 }
 
 func TestList(t *testing.T) {
@@ -813,4 +833,69 @@ func TestCleanupStalePeers(t *testing.T) {
 	require.False(t, staleNameExists, "stale peer's DNS name should be removed")
 	_, freshNameExists := ns.names["fresh"]
 	require.True(t, freshNameExists, "fresh peer's DNS name should remain")
+}
+
+// staticAuthenticator returns a fixed principal, standing in for any
+// credential type. Gateway behavior depends only on the principal, so these
+// tests cover cert- and API-key-shaped callers alike.
+type staticAuthenticator struct {
+	p *gatewayauth.Principal
+}
+
+func (s staticAuthenticator) Authenticate(context.Context, string) (*gatewayauth.Principal, error) {
+	principal := *s.p
+	return &principal, nil
+}
+
+func TestConnect_RecordsPrincipal(t *testing.T) {
+	// What the authenticator reports is what the cleanup sweep acts on later
+	// (credential expiry) and what log lines attribute, so it must be
+	// recorded on the peer faithfully.
+	expiry := time.Now().Add(12 * time.Hour)
+	gw := setupGatewayWithOptions(t, Options{
+		Authenticator: staticAuthenticator{&gatewayauth.Principal{
+			User:      "vadim@buildbuddy.io",
+			Namespace: "user:vadim@buildbuddy.io",
+			ExpiresAt: expiry,
+		}},
+	})
+
+	pubKey := newPubKeyHex(t)
+	startConnect(t, gw, context.Background(), &gwpb.ConnectRequest{PublicKey: pubKey, SessionId: "session-1"})
+
+	gw.mu.Lock()
+	info := gw.peers[pubKey]
+	gw.mu.Unlock()
+	require.NotNil(t, info)
+	require.Equal(t, "vadim@buildbuddy.io", info.user)
+	require.Equal(t, expiry, info.expiresAt)
+	require.Equal(t, "user:vadim@buildbuddy.io", info.networkState.namespace)
+}
+
+func TestCleanup_ExpiredCredentialEndsTheTunnel(t *testing.T) {
+	// An expiring credential must not buy an unbounded tunnel. WireGuard
+	// re-handshakes forever, so the cleanup sweep is what enforces expiry.
+	gw := setupGatewayWithOptions(t, Options{
+		Authenticator: staticAuthenticator{&gatewayauth.Principal{
+			User:      "vadim@buildbuddy.io",
+			Namespace: "user:vadim@buildbuddy.io",
+			ExpiresAt: time.Now().Add(2 * time.Second),
+		}},
+	})
+
+	pubKey := newPubKeyHex(t)
+	startConnect(t, gw, context.Background(), &gwpb.ConnectRequest{PublicKey: pubKey, SessionId: "session-1"})
+
+	gw.mu.Lock()
+	_, registered := gw.peers[pubKey]
+	gw.mu.Unlock()
+	require.True(t, registered)
+
+	require.Eventually(t, func() bool {
+		gw.cleanupStalePeers()
+		gw.mu.Lock()
+		defer gw.mu.Unlock()
+		_, stillThere := gw.peers[pubKey]
+		return !stillThere
+	}, 30*time.Second, 250*time.Millisecond, "the peer should be reaped once its credential expires")
 }

--- a/enterprise/gateway/testgateway/BUILD
+++ b/enterprise/gateway/testgateway/BUILD
@@ -11,8 +11,6 @@ go_library(
         "//enterprise/gateway/server",
         "//proto:gateway_go_proto",
         "//proto:gateway_service_go_proto",
-        "//server/testutil/testauth",
-        "//server/testutil/testenv",
         "//server/util/testing/flags",
         "//server/util/wgkeys",
         "@com_github_stretchr_testify//require",

--- a/enterprise/gateway/testgateway/testgateway.go
+++ b/enterprise/gateway/testgateway/testgateway.go
@@ -12,8 +12,6 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/server"
-	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
-	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/buildbuddy-io/buildbuddy/server/util/wgkeys"
 	"github.com/stretchr/testify/require"
@@ -26,17 +24,14 @@ import (
 	gwsvcpb "github.com/buildbuddy-io/buildbuddy/proto/gateway_service"
 )
 
-// Setup starts a gateway composing the given hub services on a free UDP port,
+// Setup starts a gateway with the given options on a free UDP port,
 // registered for cleanup with t.
-func Setup(t testing.TB, ta *testauth.TestAuthenticator, services ...server.HubService) *server.Gateway {
+func Setup(t testing.TB, opts server.Options) *server.Gateway {
 	t.Helper()
 	flags.Set(t, "gateway.udp_listen_port", freeUDPPort(t))
 	flags.Set(t, "gateway.public_host", "127.0.0.1")
 
-	env := testenv.GetTestEnv(t)
-	env.SetAuthenticator(ta)
-
-	gw, err := server.New(env, services...)
+	gw, err := server.New(opts)
 	require.NoError(t, err)
 	t.Cleanup(gw.Close)
 	return gw


### PR DESCRIPTION
The existing gateway will continue to use API-key auth.

The new relay gateway will use certs for auth.

Under cert auth, the caller signs the wgPublicKey using the cert private key to prove ownership. The API key implementation does not care about the WireGuard public key.