### PR TITLE
bazel: enable ephemeral Go module caches

### DIFF
--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -64,6 +64,10 @@ common --execution_log_compact_file=%workspace%/bazel_compact_exec_log.binpb.zst
 # Disable https://github.com/aspect-build/tools_telemetry.
 common --repo_env=DO_NOT_TRACK=1
 
+# Use a temporary Go module cache for Gazelle repository fetches unless an
+# explicit host module cache is configured.
+common --repo_env=GO_REPOSITORY_EPHEMERAL_MODCACHE=1
+
 #############################
 # TESTING/DEVELOPMENT FLAGS #
 #############################


### PR DESCRIPTION
Firecracker workflow snapshots can preserve Gazelle's shared Go
module cache across runs. This is unsafe because concurrent repository
fetches may copy and prune the same extracted module tree, producing
incomplete generated external repositories.

Enable Gazelle's ephemeral module cache in the shared Bazel config. Each
repository fetch gets a temporary GOMODCACHE that is removed after
the fetch, avoiding shared mutable extraction state.

Explicit host cache configuration still takes precedence, so CI jobs
that restore a persistent Go module cache continue using it. Repository
reevaluation may need to download a module again when no host cache
is configured.
