### PR TITLE
go: roll forward SDK 1.27.1 upgrade

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1687,162 +1687,162 @@
           "c17e09676be0faad3cbed1c81bb02f38fb73e2f93d048571cc13730fe23f2d5b"
         ]
       },
-      "1.27.0": {
+      "1.27.1": {
         "aix_ppc64": [
-          "go1.27.0.aix-ppc64.tar.gz",
-          "5066984959bdbec093042582c72c62ebf8f788e6ecc90a55483698b1c87e84a0"
+          "go1.27.1.aix-ppc64.tar.gz",
+          "43b4827f082b94b7b6de28a49dd80df268e06935fd82a1b57aab3a772343bf6c"
         ],
         "darwin_amd64": [
-          "go1.27.0.darwin-amd64.tar.gz",
-          "d3314e25496e4381d71a5c51d2907e7af655d199f6780b549f015bd85fef4986"
+          "go1.27.1.darwin-amd64.tar.gz",
+          "8f8f52c6649542cf027bbc9b9c68d1ec042f9f34808a40413f0b8b3f66f3caa4"
         ],
         "darwin_arm64": [
-          "go1.27.0.darwin-arm64.tar.gz",
-          "90493b3bbd5e10f91d12153198bf1994fd756399b4fec93b49b0c6e2acdeeb3e"
+          "go1.27.1.darwin-arm64.tar.gz",
+          "ee215d57e0ec269c60cc9ceca68e6bda321ba9ee5afe24f4b0988703c2d87d12"
         ],
         "dragonfly_amd64": [
-          "go1.27.0.dragonfly-amd64.tar.gz",
-          "9a6a8b541d8e1295a037e6992bc4a730bf1ffc761763b30afa9e1f3b7a0836f5"
+          "go1.27.1.dragonfly-amd64.tar.gz",
+          "bda1f327b9a792be80da856a3ea8f92cbfd138a3991e0a97049ee4d4904196a2"
         ],
         "freebsd_386": [
-          "go1.27.0.freebsd-386.tar.gz",
-          "db350b8961e4b01e0d0f3d4e4f98d6218bdab84ca112dedb27f1463c887d437f"
+          "go1.27.1.freebsd-386.tar.gz",
+          "a01f190a079150ada777fcd1a7fb27ab1a98caf9f09b2411b2ffb7e9486e0030"
         ],
         "freebsd_amd64": [
-          "go1.27.0.freebsd-amd64.tar.gz",
-          "2c24ddcca6dbd5e0be775a48cec4171e9ca616e654b63b02c9cbc515238dae31"
+          "go1.27.1.freebsd-amd64.tar.gz",
+          "9761194512938a640948ae5ba273df73a441f4229ea21a1503937e55c69bf107"
         ],
         "freebsd_arm": [
-          "go1.27.0.freebsd-arm.tar.gz",
-          "79d202335f72966d4bd0ba3ac6b4e584337afe60e8cff1ad608d2b04284e039a"
+          "go1.27.1.freebsd-arm.tar.gz",
+          "e5b55c9f6646373c221f8384cee60321128e7f48b42da3b7da7bce3fae44a88c"
         ],
         "freebsd_arm64": [
-          "go1.27.0.freebsd-arm64.tar.gz",
-          "0d33b993d26337cd4cedaa57d4d0fec71c4b578a5b47d8d08cb153eb337b27c7"
+          "go1.27.1.freebsd-arm64.tar.gz",
+          "8b155a723a584fb29125c6b36fc9cb0d5489a3f7fb76670508a2c51af718074d"
         ],
         "illumos_amd64": [
-          "go1.27.0.illumos-amd64.tar.gz",
-          "9420d121a4989066beec936e5c4df7d21108b220f0aea905a9368883f46be7d8"
+          "go1.27.1.illumos-amd64.tar.gz",
+          "ed04719b94b176745e08847f48d8a9e92b49330f2ff4ca2cf34e1b66cb5fd682"
         ],
         "linux_386": [
-          "go1.27.0.linux-386.tar.gz",
-          "eac4abaca4113170a1cf261b8bf1d38480e61e99deecbc6a14767deb8b19e8ad"
+          "go1.27.1.linux-386.tar.gz",
+          "3b72028095439d2bc0ce84e271cc70328a878d879020c5721eaa46df5f72fbc0"
         ],
         "linux_amd64": [
-          "go1.27.0.linux-amd64.tar.gz",
-          "675c26c449cbb18fc24b74650de1eabbae6e16f64326fd85a283fb3b58280685"
+          "go1.27.1.linux-amd64.tar.gz",
+          "63d339f0da5ab53635a56f2490a7984dfe12dfcff22ad749f63edaf590168445"
         ],
         "linux_arm64": [
-          "go1.27.0.linux-arm64.tar.gz",
-          "51798d2c42d0e1c6ed7fd9f48728b4193abac9e8aad6dbac2fe96a81f5909bda"
+          "go1.27.1.linux-arm64.tar.gz",
+          "3450b45a3f9ee8568792736a5c5e70a1f2e9b36c35a8f74958c03e51d7d92bec"
         ],
         "linux_armv6l": [
-          "go1.27.0.linux-armv6l.tar.gz",
-          "e337ecd9c321377c0d8832690c2cb10463447c0bd0e65e2e3413dfff63a3435b"
+          "go1.27.1.linux-armv6l.tar.gz",
+          "44893f200fb034791d4188df9fc9b9e73eadbb5fceafd5166703f0b9bab73fc2"
         ],
         "linux_loong64": [
-          "go1.27.0.linux-loong64.tar.gz",
-          "a1f198e34c8bc42a4a9393220cfc5b6299b27c3e9c641b9399f576965c4f760c"
+          "go1.27.1.linux-loong64.tar.gz",
+          "a3df3db12e0b16d932bbfd3f6025473faf8bfeb13ea2177de5e8fac1d4124b7f"
         ],
         "linux_mips": [
-          "go1.27.0.linux-mips.tar.gz",
-          "2592c31126c2a4c4cf6c5899a7ae84e4fb801ef92f29f740116c93b7091d5a92"
+          "go1.27.1.linux-mips.tar.gz",
+          "a6e637864e6801408d2d8d7f5d429b90bf8854ac320eb70778f4ac36e9b8e889"
         ],
         "linux_mips64": [
-          "go1.27.0.linux-mips64.tar.gz",
-          "f36fbf43c10a1b0b9f0ae7b67279690790bba42ffd763a0c0aa773b331ba58fa"
+          "go1.27.1.linux-mips64.tar.gz",
+          "ba3d2d4969d901cdf15d930f0cbcaa761da9d4c98386a6a26d4a82cdf596aa9f"
         ],
         "linux_mips64le": [
-          "go1.27.0.linux-mips64le.tar.gz",
-          "6fea6d2a56312dcc07295f9299246bcb6efe6e70ee7d74a1db1d001b07bac258"
+          "go1.27.1.linux-mips64le.tar.gz",
+          "23f9b4ce864764849ca792d8cf6bd8e00880ef3c6070a2717509f8d3f6059ba5"
         ],
         "linux_mipsle": [
-          "go1.27.0.linux-mipsle.tar.gz",
-          "0482ebaa3baf96f6bf5564c36b666ff210310157ea72ac5362cba277cdc9d411"
+          "go1.27.1.linux-mipsle.tar.gz",
+          "06cfb6c5528a54d53580c6390efea9ad0362322518bc32129ea6c0145f1e6a23"
         ],
         "linux_ppc64": [
-          "go1.27.0.linux-ppc64.tar.gz",
-          "054e10f470d0f58b11cf6cacbae6a53b9fc8d2ef73e6099f0cd2ef70e8644edd"
+          "go1.27.1.linux-ppc64.tar.gz",
+          "e91dee51bdfa08e034d9ed4016929a2008f179caa004922d637a97d5cda05778"
         ],
         "linux_ppc64le": [
-          "go1.27.0.linux-ppc64le.tar.gz",
-          "068085e257a6014c036c723ca62943edbf48fd168b8d00a6d39527d10b656255"
+          "go1.27.1.linux-ppc64le.tar.gz",
+          "ad1ff83c24f783c2d4a025852b928a05c199e8742a14a5482d88de0293d2bd0d"
         ],
         "linux_riscv64": [
-          "go1.27.0.linux-riscv64.tar.gz",
-          "e631e2e1e5aec4979960787f5f8cdb549001bb144c279e134447e54ffe8bd2d3"
+          "go1.27.1.linux-riscv64.tar.gz",
+          "62287667ee5e5f540f30fb9b7529a27fe582f22c6bfd726ece9b045f4c54ee61"
         ],
         "linux_s390x": [
-          "go1.27.0.linux-s390x.tar.gz",
-          "cb5c89fa48cba4123c68aee62b217ca030f281546df0898a0c32889c340b928c"
+          "go1.27.1.linux-s390x.tar.gz",
+          "c9e1ad7bddea40e2eb10b4d3267ae06d462667839bf0ba94c2e2d160b06f9b9e"
         ],
         "netbsd_386": [
-          "go1.27.0.netbsd-386.tar.gz",
-          "621cc0efea0524fdba1e51050be23c486fca622ec135cf11e1d1564d28a9e090"
+          "go1.27.1.netbsd-386.tar.gz",
+          "6bde412641300348cc571cfcf3384071934c5005c8057325e29763963107b932"
         ],
         "netbsd_amd64": [
-          "go1.27.0.netbsd-amd64.tar.gz",
-          "7183b26dee2011c000b52c2aa5660165ae26d9691dcf1e338310bcc3b0cb699c"
+          "go1.27.1.netbsd-amd64.tar.gz",
+          "4ace14c14e7c6eb1d06890433afe81f8c2dc746d1d5f4df3ae6d2d7dd0481ba2"
         ],
         "netbsd_arm": [
-          "go1.27.0.netbsd-arm.tar.gz",
-          "c9e98dd5c3e7c38b6b7ff8b65617b2f8d89c74d2465adf5936c6a6e096805c09"
+          "go1.27.1.netbsd-arm.tar.gz",
+          "da7db485266e309cca263bcad95197d2c21e747e14698bc1d95704e9939fd07a"
         ],
         "netbsd_arm64": [
-          "go1.27.0.netbsd-arm64.tar.gz",
-          "d2afe05d454b4bf6b842991d769b0bc9fb78a3ba59fee928424058a64cd5fb20"
+          "go1.27.1.netbsd-arm64.tar.gz",
+          "c0ac5527cdde89e31d40e536a1cec4a8d8b2903f79e2356645c862dfab6f3181"
         ],
         "openbsd_386": [
-          "go1.27.0.openbsd-386.tar.gz",
-          "9c7681021273111e24892909f00a171eedcc77e5c58cbae01b058fd252c69b97"
+          "go1.27.1.openbsd-386.tar.gz",
+          "3434ae1ef067666d4df50f883e985a49e7589d6004a412329e7684ff80f40852"
         ],
         "openbsd_amd64": [
-          "go1.27.0.openbsd-amd64.tar.gz",
-          "864724aa23cf2473bb3e5f8575a3544b4d4f5c58f32dd427e61cd2155c6fc177"
+          "go1.27.1.openbsd-amd64.tar.gz",
+          "db0566b3b3ddf6eda09cb3434a9401eb2583ffa539475e45592812813f11c792"
         ],
         "openbsd_arm": [
-          "go1.27.0.openbsd-arm.tar.gz",
-          "5a32a54210d362849a125a270feb187460f93e19d1375871fe8d6020cd119159"
+          "go1.27.1.openbsd-arm.tar.gz",
+          "5423e99d338cf9ccebbfce0e373095e63b62fbedd7a1b99436bb7e0f3184069c"
         ],
         "openbsd_arm64": [
-          "go1.27.0.openbsd-arm64.tar.gz",
-          "a9a031972399a3f3a99de872beec54c60a28b8c7fdcebbd84d465be9839424be"
+          "go1.27.1.openbsd-arm64.tar.gz",
+          "953142ae3734098e65118ddca29ed2f469a85f039a78a1572da98ba271042e65"
         ],
         "openbsd_ppc64": [
-          "go1.27.0.openbsd-ppc64.tar.gz",
-          "e838256c11384e80d3a5404355d5945a6183fdb501770ca29be6c2527584c261"
+          "go1.27.1.openbsd-ppc64.tar.gz",
+          "93e32d7c0ba24e56f5f75aed454e9301c7204605c11508d65ecb39356c221106"
         ],
         "openbsd_riscv64": [
-          "go1.27.0.openbsd-riscv64.tar.gz",
-          "0db7de927d67148f680a19e294a7534f99008b40f50c5ea3b0440e0f76e39192"
+          "go1.27.1.openbsd-riscv64.tar.gz",
+          "1683c8e86157739bfee080d38919750366aeed8fe77576b0798460a2f06d6b98"
         ],
         "plan9_386": [
-          "go1.27.0.plan9-386.tar.gz",
-          "164a354483e81d67c35d3f323e786b8eecfa5471ab09e0b1aff652d4e8d13131"
+          "go1.27.1.plan9-386.tar.gz",
+          "7dbc261ab5c1100581427aa009964c142abb46520af6a31f6ff761b0f0a61f33"
         ],
         "plan9_amd64": [
-          "go1.27.0.plan9-amd64.tar.gz",
-          "0035e7354a859052ce5be1eeda0f7163c50ac11bdf691e23ca0cb06faa6da811"
+          "go1.27.1.plan9-amd64.tar.gz",
+          "fc546629513ba62403657d2355b3982b7ff59934fec5ca0cde32e18d9f2b65b9"
         ],
         "plan9_arm": [
-          "go1.27.0.plan9-arm.tar.gz",
-          "e55f69a5ee86ecde93ed028789aa838c046758a632c4cce878040fb6adf43933"
+          "go1.27.1.plan9-arm.tar.gz",
+          "5e420ef8837a708246a7959bf56b1b6c6ca765c4f16dd953b4e09290d9cd4b53"
         ],
         "solaris_amd64": [
-          "go1.27.0.solaris-amd64.tar.gz",
-          "c72177608076b035735fae53e5f31835fbe1ba7a630369aff70804f8c11c31b6"
+          "go1.27.1.solaris-amd64.tar.gz",
+          "7efd1b6d470ea724db178f17d3bd1b66931e2aa79c4389fe75228f2aef6014a4"
         ],
         "windows_386": [
-          "go1.27.0.windows-386.zip",
-          "009b767e3619b0e9b41eb66d1f1402c6db3e752bf0be1b3eaf200bb5b888efaa"
+          "go1.27.1.windows-386.zip",
+          "1670510496778ee976de09c91b7960f76cb7dbf90968cfea98bb51fa80c9de91"
         ],
         "windows_amd64": [
-          "go1.27.0.windows-amd64.zip",
-          "f0c0a0d33ba94f4d2c5dbc887334ce678b21813504ddb3aafcb06e60a5a667c4"
+          "go1.27.1.windows-amd64.zip",
+          "a3911b5e0e1b1053f25ed0675f4c1c6aad1e2bfcf253df2b9be4caabd2edd95d"
         ],
         "windows_arm64": [
-          "go1.27.0.windows-arm64.zip",
-          "6e0156b9788209931dd340fadc04171ce15063c17b51c92e7b86b51109626e90"
+          "go1.27.1.windows-arm64.zip",
+          "13b69b87bb0e83f96bc68560a8cace7f0343b1e03469f1110ea18d17e3234069"
         ]
       }
     }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildbuddy-io/buildbuddy
 
-go 1.27.0
+go 1.27.1
 
 // Device Manager
 tool gitlab.com/arm-research/smarter/smarter-device-manager


### PR DESCRIPTION
The previous Go 1.27.1 upgrade was reverted because a workflow
generated an incomplete external Go repository, causing cascading
compile errors in prometheus/procfs. The shared Bazel configuration
now enables Gazelle's ephemeral module cache for workflow fetches,
isolating the mutable module tree involved in that failure.

Roll forward the hermetic SDK upgrade from Go 1.27.0 to Go 1.27.1 and
regenerate the per-platform archive metadata. This picks up upstream
fixes for cgo, the compiler, runtime, go fix, and standard-library
packages.

See the Go 1.27.1 release notes:
https://go.dev/doc/devel/release#go1.27.0
