### PR TITLE
Use `zstd` to compress all `rules_img` container layers

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -262,6 +262,13 @@ config_setting(
 )
 
 config_setting(
+    name = "opt",
+    values = {
+        "compilation_mode": "opt",
+    },
+)
+
+config_setting(
     name = "release_build",
     values = {"define": "release=true"},
 )

--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -199,7 +199,6 @@ image_layer(
         ),
         "org.opencontainers.image.vendor": "BuildBuddy",
     },
-    compress = "gzip",
     # Do not include runfiles so that we can separate configuration files out
     # into a separate layer. This lets us use a base image without those files
     # when building our production images.
@@ -233,7 +232,10 @@ layer_from_tar(
         ),
         "org.opencontainers.image.vendor": "BuildBuddy",
     },
-    compress = "gzip",
+    optimize = select({
+        "//:opt": True,
+        "//conditions:default": False,
+    }),
     tags = ["manual"],
 )
 
@@ -304,6 +306,10 @@ layer_from_tar(
         ),
         "org.opencontainers.image.vendor": "BuildBuddy",
     },
+    optimize = select({
+        "//:opt": True,
+        "//conditions:default": False,
+    }),
     tags = ["manual"],
 )
 

--- a/images/distroless/base-nossl/BUILD
+++ b/images/distroless/base-nossl/BUILD
@@ -39,7 +39,10 @@ package(default_visibility = ["//visibility:public"])
             ),
             "org.opencontainers.image.vendor": "BuildBuddy",
         },
-        compress = "gzip",
+        optimize = select({
+            "//:opt": True,
+            "//conditions:default": False,
+        }),
         tags = ["manual"],
         target_compatible_with = [
             "@platforms//os:linux",

--- a/images/distroless/static/BUILD
+++ b/images/distroless/static/BUILD
@@ -88,7 +88,10 @@ cacerts(
             ),
             "org.opencontainers.image.vendor": "BuildBuddy",
         },
-        compress = "gzip",
+        optimize = select({
+            "//:opt": True,
+            "//conditions:default": False,
+        }),
         tags = ["manual"],
         target_compatible_with = [
             "@platforms//os:linux",

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -331,8 +331,7 @@ common:release-shared --compilation_mode=opt
 common:release-shared --stamp
 common:release-shared --define=release=true
 common:release-shared --strip=always
-common:release-shared --@rules_img//img/settings:compress=gzip
-common:release-shared --@rules_img//img/settings:compression_level=9
+common:release-shared --@rules_img//img/settings:compress=zstd
 
 # Configuration used for Linux releases
 common:release --config=release-shared


### PR DESCRIPTION
`layer_from_tar` ignores compression settings and just uses however the tar has been compressed (or not) unless `optimize` is set. Additionally, `zstd` provides better compression for our images empirically, and `--@rules_img//img/settings:compression_level` is set to `auto` by default, which correctly chooses the higheset compression level for `opt` builds and the lowest for `fastbuild` builds.
