### PR TITLE
Use fully-qualified image names when loading images into containerd

### DIFF
--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -337,6 +337,8 @@ image_load(
     # with the expected digest.
     daemon = "containerd",
     image = ":image_manifest",
-    tag = "buildbuddy_image:latest",
+    registry = "buildbuddy.io",
+    repository = "enterprise/app",
+    tag = "latest",
     tags = ["manual"],
 )

--- a/images/distroless/base-nossl/BUILD
+++ b/images/distroless/base-nossl/BUILD
@@ -97,6 +97,8 @@ image_load(
     # with the expected digest.
     daemon = "containerd",
     image = ":index",  # References an image_index
-    tag = "bb-distroless_base-nossl:latest",
+    registry = "buildbuddy.io",
+    repository = "distroless/base-nossl",
+    tag = "latest",
     tags = ["manual"],
 )

--- a/images/distroless/static/BUILD
+++ b/images/distroless/static/BUILD
@@ -150,6 +150,8 @@ image_load(
     # with the expected digest.
     daemon = "containerd",
     image = ":index",  # References an image_index
-    tag = "bb-distroless_static:latest",
+    registry = "buildbuddy.io",
+    repository = "distroless/static",
+    tag = "latest",
     tags = ["manual"],
 )


### PR DESCRIPTION
Unlike docker, containerd does not recognize or support truncated image names, so if we want to be able to actually use `nerdctl` to refer to the images we create (and we do), we must include a registry domain in addition to the repository and tag that were already present. Since these images do not get pushed, I just used `buildbuddy.io`, but `example.com` would technically do just as well.
