### PR TITLE
Don't disable `pkg_tar`'s `portable_mtime` attr when creating a tar that will become an image layer

### DIFF
--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -215,7 +215,6 @@ pkg_tar(
     ],
     include_runfiles = True,
     package_dir = APP_PACKAGE_ROOT,
-    portable_mtime = False,
     remap_paths = {
         ".runfiles/": "%s.runfiles/" % BINARY_NAME,
     },


### PR DESCRIPTION
`portable_mtime` sets all the `mtime` file attributes to the the same time. This is necessary for reproducible builds for our images, which we want.

This only ever got disabled because when I was desperately trying to figure out how to get `pkg_tar` and `rules_img` to play nice with each other, this was one of the (more desperate) things that I tried.
