### PR TITLE
Add `/etc/nsswitch.conf` to `static` image

### DIFF
--- a/images/distroless/static/BUILD
+++ b/images/distroless/static/BUILD
@@ -56,8 +56,8 @@ pkg_tar(
     srcs = [
         "nsswitch.conf",
     ],
-    package_dir = "etc",
     mode = "0644",
+    package_dir = "etc",
     tags = ["manual"],
 )
 

--- a/images/distroless/static/BUILD
+++ b/images/distroless/static/BUILD
@@ -4,6 +4,7 @@ load("@rules_distroless//distroless:defs.bzl", "cacerts", "flatten", "group", "j
 load("@rules_img//img:image.bzl", "image_index", "image_manifest")
 load("@rules_img//img:layer.bzl", "layer_from_tar")
 load("@rules_img//img:load.bzl", "image_load")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -50,6 +51,15 @@ cacerts(
     }),
 )
 
+pkg_tar(
+    name = "nsswitch_conf",
+    srcs = [
+        "nsswitch.conf",
+    ],
+    package_dir = "etc",
+    tags = ["manual"],
+)
+
 [
     flatten(
         name = "tar_%s" % arch,
@@ -69,6 +79,7 @@ cacerts(
             "@debian13//media-types/%s" % arch,
             ":groups",
             ":passwd",
+            ":nsswitch_conf",
             ":ca_certificates",
         ],
     )

--- a/images/distroless/static/BUILD
+++ b/images/distroless/static/BUILD
@@ -57,6 +57,7 @@ pkg_tar(
         "nsswitch.conf",
     ],
     package_dir = "etc",
+    mode = "0644",
     tags = ["manual"],
 )
 

--- a/images/distroless/static/nsswitch.conf
+++ b/images/distroless/static/nsswitch.conf
@@ -1,0 +1,20 @@
+# /etc/nsswitch.conf
+#
+# Example configuration of GNU Name Service Switch functionality.
+# If you have the `glibc-doc-reference' and `info' packages installed, try:
+# `info libc "Name Service Switch"' for information about this file.
+
+passwd:         compat
+group:          compat
+shadow:         compat
+gshadow:        files
+
+hosts:          files dns
+networks:       files
+
+protocols:      db files
+services:       db files
+ethers:         db files
+rpc:            db files
+
+netgroup:       nis


### PR DESCRIPTION
This mirrors what is now done to create the `distroless` static image in the `distroless` repo.

I'm not an expert on networking, but this is a fairly important networking file on linux systems, so it seems safer to include it.
