### PR TITLE
Add `tz-legacy` to `static` image

### DIFF
--- a/images/distroless/static/BUILD
+++ b/images/distroless/static/BUILD
@@ -65,6 +65,7 @@ cacerts(
             "@debian13//base-files/%s" % arch,
             "@debian13//netbase/%s" % arch,
             "@debian13//tzdata/%s" % arch,
+            "@debian13//tzdata-legacy/%s" % arch,
             "@debian13//media-types/%s" % arch,
             ":groups",
             ":passwd",


### PR DESCRIPTION
I think I missed this the first time around when creating our own `static` distroless images. These are just the legacy timezone files.
