### PR TITLE
[DNM] Singleflight chunking and saving EXT4 snapshots

### DIFF
--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -65,7 +65,8 @@ var (
 	ErrRemoved = status.UnavailableError("container has been removed")
 
 	recordUsageTimelines          = flag.Bool("executor.record_usage_timelines", false, "Capture resource usage timeseries data in UsageStats for each task.")
-	imagePullTimeout              = flag.Duration("executor.image_pull_timeout", 5*time.Minute, "How long to wait for the container image to be pulled before returning an Unavailable (retryable) error for an action execution attempt. Applies to all isolation types (docker, firecracker, etc.)")
+	imagePullTimeout              = flag.Duration("executor.image_pull_timeout", 5*time.Minute, "How long to wait for the container image to be prepared before returning an Unavailable (retryable) error for an action execution attempt. Applies to all isolation types (docker, oci, etc.), except firecracker, which uses executor.firecracker_image_pull_timeout.")
+	firecrackerImagePullTimeout   = flag.Duration("executor.firecracker_image_pull_timeout", 10*time.Minute, "Overrides executor.image_pull_timeout for firecracker. Preparing a firecracker image also converts it to EXT4 and caches it as a chunked containerfs, which can take longer. Set to 0 to use executor.image_pull_timeout.")
 	cgroupStatsPollInterval       = flag.Duration("executor.cgroup_stats_poll_interval", 500*time.Millisecond, "How often to poll container stats.")
 	debugUseLocalImagesOnly       = flag.Bool("debug_use_local_images_only", false, "Do not pull OCI images and only used locally cached images. This can be set to test local image builds during development without needing to push to a container registry. Not intended for production use.")
 	debugEnableAnonymousRecycling = flag.Bool("debug_enable_anonymous_runner_recycling", false, "Whether to enable runner recycling for unauthenticated requests. For debugging purposes only - do not use in production.")
@@ -665,6 +666,17 @@ func ShouldCountImagePullError(err error) bool {
 	}
 }
 
+// imagePullTimeoutFor returns how long to wait for an image to be prepared for
+// the given isolation type. Firecracker has its own timeout because preparing
+// its image does more than pull it: the image is also converted to EXT4 and
+// cached as a chunked containerfs.
+func imagePullTimeoutFor(isolationType string) time.Duration {
+	if isolationType == string(platform.FirecrackerContainerType) && *firecrackerImagePullTimeout > 0 {
+		return *firecrackerImagePullTimeout
+	}
+	return *imagePullTimeout
+}
+
 // PullImageIfNecessary pulls the image configured for the container if it
 // is not cached locally.
 func PullImageIfNecessary(ctx context.Context, env environment.Env, ctr CommandContainer, creds oci.Credentials, imageRef string, useOCIFetcher bool) error {
@@ -675,9 +687,9 @@ func PullImageIfNecessary(ctx context.Context, env environment.Env, ctr CommandC
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	if *imagePullTimeout > 0 {
+	if timeout := imagePullTimeoutFor(ctr.IsolationType()); timeout > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, *imagePullTimeout)
+		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}
 

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2933,16 +2933,14 @@ func (c *FirecrackerContainer) IsImageCached(ctx context.Context) (bool, error) 
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	// Checking for the EXT4 image on local disk is cheap, so do it first.
-	cached, err := ociconv.IsImageCached(ctx, c.env.GetFileCache(), c.executorConfig.CacheRoot, c.containerImage)
-	if err != nil || cached {
-		return cached, err
+	// We check whether there is a valid snapshot first, because even if the EXT4 image is cached
+	// (the ociconv.IsImageCached check below), we might still need to chunk it and cache the chunks.
+	// That work happens in PullImage, and we don't want to skip it if there's no snapshot.
+	if snaputil.IsChunkedSnapshotSharingEnabled() {
+		return c.cachedContainerfs(ctx) != nil, nil
 	}
 
-	// The image also doesn't need to be pulled if the chunked containerfs is
-	// cached, since then the VM reads rootfs chunks over VBD rather than
-	// reading the EXT4 image.
-	return c.cachedContainerfs(ctx) != nil, nil
+	return ociconv.IsImageCached(ctx, c.env.GetFileCache(), c.executorConfig.CacheRoot, c.containerImage)
 }
 
 // PullImage pulls the container image from the remote. It always

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -196,6 +196,9 @@ const (
 	// The containerfs drive ID.
 	containerFSName  = "containerfs.ext4"
 	containerDriveID = "containerfs"
+	// containerfsScratchDirName is scratch space for chunking the container
+	// image; the chunks themselves live in the filecache.
+	containerfsScratchDirName = "containerfs-chunk-scratchspace"
 
 	// The networking deets for host and vm interfaces.
 	// All VMs are configured with the same IP and tap device via boot args,
@@ -2999,7 +3002,40 @@ func (c *FirecrackerContainer) PullImage(ctx context.Context, creds oci.Credenti
 		return err
 	}
 
+	c.cacheContainerfs(ctx, containerFSPath)
+
 	return nil
+}
+
+// cacheContainerfs converts the pulled EXT4 image into a chunked containerfs
+// snapshot and caches it.
+//
+// This runs here, rather than when the VM's rootfs is created, so that it is
+// covered by the per-image lock that container.PullImageIfNecessary holds.
+// Otherwise every VM starting from the same uncached image would convert and
+// re-cache it independently.
+//
+// It is best-effort.
+func (c *FirecrackerContainer) cacheContainerfs(ctx context.Context, containerFSPath string) {
+	if !snaputil.IsChunkedSnapshotSharingEnabled() {
+		return
+	}
+	chunkDir := filepath.Join(c.getChroot(), containerfsScratchDirName)
+	defer func() {
+		// When the VM starts, chunks are lazily loaded from the filecache, so this scratch copy is
+		// no longer needed.
+		if err := os.RemoveAll(chunkDir); err != nil {
+			log.CtxWarningf(ctx, "Failed to remove containerfs chunk dir: %s", err)
+		}
+	}()
+	instanceName := c.snapshotKeySet.GetBranchKey().GetInstanceName()
+	if err := snaploader.CacheContainerImage(ctx, c.loader, instanceName, c.containerImage, containerFSPath, chunkDir, cowChunkSizeBytes(), c.remoteContainerImageAccess); err != nil {
+		log.CtxWarningf(ctx, "Failed to cache chunked containerfs for image %q: %s", c.containerImage, err)
+		return
+	}
+	// The chunked containerfs is cached now, so drop the memoized lookup from
+	// before the pull and let initRootfsStore pick it up.
+	c.containerfsSnapshotOnce = sync.Once{}
 }
 
 // Remove kills any processes currently running inside the container and

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -695,6 +695,87 @@ func TestFirecrackerPullImage_SkipsPullWhenContainerfsCached(t *testing.T) {
 	require.Greater(t, manifestRequests.Load(), int32(0))
 }
 
+func TestFirecrackerPullImage_CachesChunkedContainerfs(t *testing.T) {
+	ctx := context.Background()
+	flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.1/32"})
+
+	// Mock requests to the container registry.
+	var blobRequests atomic.Int32
+	reg := testregistry.Run(t, testregistry.Opts{
+		HttpInterceptor: func(w http.ResponseWriter, r *http.Request) bool {
+			if strings.Contains(r.URL.Path, "/blobs/") {
+				blobRequests.Add(1)
+			}
+			return true
+		},
+	})
+	t.Cleanup(func() {
+		require.NoError(t, reg.Shutdown())
+	})
+
+	// The test registry listens on a random port, so this image ref is unique
+	// to this test run and is guaranteed not to be present in the executor
+	// image cache, which may be shared across runs.
+	imageRef, _ := reg.PushNamedImage(t, "firecracker-cache-containerfs:latest", nil)
+	blobRequests.Store(0)
+
+	env := getTestEnv(ctx, t, envOpts{})
+	opts := firecracker.ContainerOpts{
+		ContainerImage:         imageRef,
+		ActionWorkingDirectory: testfs.MakeTempDir(t),
+		VMConfiguration: &fcpb.VMConfiguration{
+			NumCpus:           1,
+			MemSizeMb:         minMemSizeMB,
+			NetworkMode:       fcpb.NetworkMode_NETWORK_MODE_OFF,
+			ScratchDiskSizeMb: 100,
+		},
+		ExecutorConfig: getExecutorConfig(t),
+	}
+	instanceName := snaputil.SnapshotPartitionPrefix + "/instance"
+	newContainer := func() *firecracker.FirecrackerContainer {
+		containerOpts := opts
+		containerOpts.ActionWorkingDirectory = testfs.MakeTempDir(t)
+		c, err := firecracker.NewContainer(ctx, env, &repb.ExecutionTask{
+			ExecuteRequest: &repb.ExecuteRequest{InstanceName: instanceName},
+		}, containerOpts)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, c.Remove(context.Background()))
+		})
+		return c
+	}
+	loader, err := snaploader.New(env)
+	require.NoError(t, err)
+
+	// Sanity check: neither the image nor a chunked containerfs is cached yet.
+	c := newContainer()
+	cached, err := c.IsImageCached(ctx)
+	require.NoError(t, err)
+	require.False(t, cached)
+	_, err = snaploader.GetCachedContainerImage(ctx, loader, instanceName, imageRef, true /*=remoteEnabled*/)
+	require.True(t, status.IsNotFoundError(err), "expected NotFound, got: %v", err)
+
+	// Pull the image, as a clean VM run would. This converts it to EXT4 and
+	// should also cache a chunked containerfs, so that VMs starting from this
+	// image later don't each have to convert it themselves.
+	require.NoError(t, c.PullImage(ctx, oci.Credentials{}))
+	require.Greater(t, blobRequests.Load(), int32(0), "expected the image layers to be pulled")
+
+	snap, err := snaploader.GetCachedContainerImage(ctx, loader, instanceName, imageRef, true /*=remoteEnabled*/)
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+
+	// A container for a subsequent task should now be satisfied by the cached
+	// chunked containerfs, and skip the pull entirely.
+	blobRequests.Store(0)
+	next := newContainer()
+	cached, err = next.IsImageCached(ctx)
+	require.NoError(t, err)
+	require.True(t, cached)
+	require.NoError(t, next.PullImage(ctx, oci.Credentials{}))
+	require.Equal(t, int32(0), blobRequests.Load(), "expected no layer pulls once the containerfs is cached")
+}
+
 func TestFirecrackerVMExecReadySignalAfterSnapshotResume(t *testing.T) {
 	flags.Set(t, "executor.firecracker_vmexec_ready_signal", true)
 	ctx := context.Background()

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -544,6 +544,11 @@ func TestFirecrackerPullImageIfNecessary_CachedImageRequiresReauth(t *testing.T)
 		require.NoError(t, err)
 		require.True(t, cached, "sanity check: image should already be cached")
 	}
+	requireNotCached := func(ctx context.Context, c *firecracker.FirecrackerContainer) {
+		cached, err := c.IsImageCached(ctx)
+		require.NoError(t, err)
+		require.False(t, cached, "image cached by another group should not be reported as cached")
+	}
 
 	authedCtx, err := ta.WithAuthenticatedUser(ctx, "US1")
 	require.NoError(t, err)
@@ -555,11 +560,11 @@ func TestFirecrackerPullImageIfNecessary_CachedImageRequiresReauth(t *testing.T)
 		oci.Credentials{Username: registryCreds.Username, Password: registryCreds.Password},
 		opts.ContainerImage, opts.UseOCIFetcher,
 	))
-	requireCached(ctx, gr1Container)
+	requireCached(authedCtx, gr1Container)
 
 	// Try an unauthorized pull as GR1 (with wrong creds). Should fail
 	gr1WrongCredsContainer := newContainer(authedCtx)
-	requireCached(ctx, gr1WrongCredsContainer)
+	requireCached(authedCtx, gr1WrongCredsContainer)
 	err = gr1WrongCredsContainer.PullImage(
 		authedCtx,
 		oci.Credentials{Username: registryCreds.Username, Password: "wrong"},
@@ -574,7 +579,8 @@ func TestFirecrackerPullImageIfNecessary_CachedImageRequiresReauth(t *testing.T)
 
 	// Try to do an unauthorized pull as ANON (should fail)
 	anonymousContainer := newContainer(ctx)
-	requireCached(ctx, anonymousContainer)
+	// Should not see the snapshot written by gr1.
+	requireNotCached(ctx, anonymousContainer)
 	err = container.PullImageIfNecessary(ctx, env, anonymousContainer, oci.Credentials{}, opts.ContainerImage, opts.UseOCIFetcher)
 	require.Error(t, err)
 	require.True(
@@ -588,7 +594,8 @@ func TestFirecrackerPullImageIfNecessary_CachedImageRequiresReauth(t *testing.T)
 	gr2Ctx, err := ta.WithAuthenticatedUser(ctx, "US2")
 	require.NoError(t, err)
 	gr2Container := newContainer(gr2Ctx)
-	requireCached(ctx, gr2Container)
+	// Should not see the snapshot written by gr1.
+	requireNotCached(gr2Ctx, gr2Container)
 	err = container.PullImageIfNecessary(gr2Ctx, env, gr2Container, oci.Credentials{}, opts.ContainerImage, opts.UseOCIFetcher)
 	require.Error(t, err)
 	require.True(
@@ -755,25 +762,14 @@ func TestFirecrackerPullImage_CachesChunkedContainerfs(t *testing.T) {
 	_, err = snaploader.GetCachedContainerImage(ctx, loader, instanceName, imageRef, true /*=remoteEnabled*/)
 	require.True(t, status.IsNotFoundError(err), "expected NotFound, got: %v", err)
 
-	// Pull the image, as a clean VM run would. This converts it to EXT4 and
-	// should also cache a chunked containerfs, so that VMs starting from this
-	// image later don't each have to convert it themselves.
+	// Pull the image, as a clean VM run would.
 	require.NoError(t, c.PullImage(ctx, oci.Credentials{}))
 	require.Greater(t, blobRequests.Load(), int32(0), "expected the image layers to be pulled")
 
+	// The chunked containerfs should be cached after PullImage.
 	snap, err := snaploader.GetCachedContainerImage(ctx, loader, instanceName, imageRef, true /*=remoteEnabled*/)
 	require.NoError(t, err)
 	require.NotNil(t, snap)
-
-	// A container for a subsequent task should now be satisfied by the cached
-	// chunked containerfs, and skip the pull entirely.
-	blobRequests.Store(0)
-	next := newContainer()
-	cached, err = next.IsImageCached(ctx)
-	require.NoError(t, err)
-	require.True(t, cached)
-	require.NoError(t, next.PullImage(ctx, oci.Credentials{}))
-	require.Equal(t, int32(0), blobRequests.Load(), "expected no layer pulls once the containerfs is cached")
 }
 
 func TestFirecrackerVMExecReadySignalAfterSnapshotResume(t *testing.T) {

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -1618,6 +1618,43 @@ func resetContainerImageOutputDir(outDir string) error {
 	return os.MkdirAll(outDir, 0755)
 }
 
+// CacheContainerImage converts the EXT4 image at imageExt4Path into a chunked
+// containerfs snapshot and adds it to cache.
+func CacheContainerImage(ctx context.Context, l *FileCacheLoader, instanceName, imageRef, imageExt4Path, chunkDir string, chunkSize int64, imageOpts RemoteContainerImageAccessOptions) error {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+
+	// Exit early if the container image is already cached.
+	// We re-check this here so we can avoid duplicate conversion work if another caller populated the cache since this caller's initial lookup.
+	// EXT4 conversion can be slow, so there's a good chance another executor already converted the image and cached it.
+	snap, err := GetCachedContainerImage(ctx, l, instanceName, imageRef, imageOpts.RemoteReadsEnabled)
+	if err != nil {
+		if ctx.Err() != nil {
+			return status.FromContextError(ctx)
+		}
+		if !status.IsNotFoundError(err) {
+			log.CtxWarningf(ctx, "Failed to read cached container image %q; converting the pulled image instead: %s", imageRef, err)
+		}
+	}
+	if snap != nil {
+		return nil
+	}
+
+	// ConvertFileToCOW requires an empty data directory.
+	if err := resetContainerImageOutputDir(chunkDir); err != nil {
+		return status.WrapError(err, "prepare container image chunk directory")
+	}
+	cow, err := convertAndCacheContainerImage(ctx, l, instanceName, imageRef, imageExt4Path, chunkDir, chunkSize, imageOpts)
+	if err != nil {
+		return err
+	}
+	// Each VM lazily maps its own chunks from the cache, so this COW is not needed.
+	if err := cow.Close(); err != nil {
+		log.CtxWarningf(ctx, "Failed to close container image COW: %s", err)
+	}
+	return nil
+}
+
 // UnpackContainerImage returns a ChunkedFile representing the given container
 // image. The chunk dir is stored as a child directory of the given outDir.
 //
@@ -1660,6 +1697,14 @@ func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, instanceName,
 	}
 	// containerfs is not available in cache; convert the EXT4 image to a
 	// ChunkedFile then add it to cache.
+	return convertAndCacheContainerImage(ctx, l, instanceName, imageRef, imageExt4Path, outDir, chunkSize, imageOpts)
+}
+
+// convertAndCacheContainerImage splits the EXT4 image into a chunked
+// containerfs in outDir and adds it to cache, returning the new COWStore.
+//
+// Caching is best-effort. If it fails, the returned COWStore is still usable.
+func convertAndCacheContainerImage(ctx context.Context, l *FileCacheLoader, instanceName, imageRef, imageExt4Path, outDir string, chunkSize int64, imageOpts RemoteContainerImageAccessOptions) (*copy_on_write.COWStore, error) {
 	start := time.Now()
 	cow, err := copy_on_write.ConvertFileToCOW(ctx, l.env, imageExt4Path, chunkSize, outDir, instanceName, imageOpts.RemoteReadsEnabled, snaputil.ConvertToCOWConcurrency)
 	if err != nil {


### PR DESCRIPTION
We [singleflight image pulls and EXT4 conversions by locking around PullImage](https://github.com/buildbuddy-io/buildbuddy/blob/master/enterprise/server/remote_execution/container/container.go#L725). This PR adds EXT4 chunking + caching to Pull Image, so that it's protected by the lock as well and concurrent actions using the same image don't repeat that work