### PR TITLE
Add support for references to `DistributedCache.GetMulti` RPC

### DIFF
--- a/proto/distributed_cache.proto
+++ b/proto/distributed_cache.proto
@@ -111,9 +111,15 @@ message GetWithMetadataResponse {
   MetadataResponse metadata = 2;
 }
 
+// Next Tag: 4
 message KV {
   Key key = 1;
+
+  // The bytes of the value. Mutually exclusive with value_reference.
   bytes value = 2;
+
+  // A reference to the value. Mutually exclusive with value.
+  reference.Reference value_reference = 3;
 }
 
 message GetMultiRequest {


### PR DESCRIPTION
I wrapped these in a `oneof` because I think it's OK to skip verification on this path for simplicity. Let me know if you disagree.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/8251