### PR TITLE
Implement server-side support for sending references in `DistributedCache.GetMulti` responses

### DIFF
--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -328,11 +328,31 @@ func (c *Proxy) GetMulti(ctx context.Context, req *dcpb.GetMultiRequest) (*dcpb.
 	if err != nil {
 		return nil, err
 	}
-	found, err := c.cache.GetMulti(ctx, req.GetResources())
+	rsp := &dcpb.GetMultiResponse{}
+	resources := req.GetResources()
+	if refCache, ok := c.cache.(interfaces.ReferenceCache); ok && c.getMultiSendsReferences(ctx) {
+		byteResources := make([]*rspb.ResourceName, 0, len(resources))
+		for _, rn := range resources {
+			// Minting a reference is best-effort: values that are not backed
+			// by shared storage are returned as bytes.
+			if ref, err := refCache.ReadReference(ctx, rn); err == nil {
+				rsp.KeyValue = append(rsp.KeyValue, &dcpb.KV{
+					Key:            digestToKey(rn.GetDigest()),
+					ValueReference: ref,
+				})
+			} else {
+				byteResources = append(byteResources, rn)
+			}
+		}
+		resources = byteResources
+	}
+	if len(resources) == 0 {
+		return rsp, nil
+	}
+	found, err := c.cache.GetMulti(ctx, resources)
 	if err != nil {
 		return nil, err
 	}
-	rsp := &dcpb.GetMultiResponse{}
 	for d, buf := range found {
 		if len(buf) == 0 {
 			c.log.Warningf("returned a zero-length response for digest %q", d.GetHash())
@@ -343,6 +363,14 @@ func (c *Proxy) GetMulti(ctx context.Context, req *dcpb.GetMultiRequest) (*dcpb.
 		})
 	}
 	return rsp, nil
+}
+
+func (c *Proxy) getMultiSendsReferences(ctx context.Context) bool {
+	fp := c.env.GetExperimentFlagProvider()
+	if fp == nil {
+		return false
+	}
+	return fp.Boolean(ctx, "distributed_cache.get_multi_gcs_references", false)
 }
 
 // referenceReadMode returns whether Read should send the client a reference

--- a/enterprise/server/util/distributed_client/distributed_client_test.go
+++ b/enterprise/server/util/distributed_client/distributed_client_test.go
@@ -1704,18 +1704,22 @@ func (c *serverReferenceCache) lastWriteReference() (*refpb.Reference, *rspb.Res
 }
 
 func setReferenceReadExperiments(t *testing.T, te *testenv.TestEnv, readReferences bool, verifyReferences bool) {
-	provider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"distributed_cache.read_gcs_references": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "on",
-			Variants:       map[string]any{"on": readReferences},
-		},
-		"distributed_cache.verify_read_gcs_references": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "on",
-			Variants:       map[string]any{"on": verifyReferences},
-		},
+	setExperimentFlags(t, te, map[string]bool{
+		"distributed_cache.read_gcs_references":        readReferences,
+		"distributed_cache.verify_read_gcs_references": verifyReferences,
 	})
+}
+
+func setExperimentFlags(t *testing.T, te *testenv.TestEnv, flags map[string]bool) {
+	inMemFlags := make(map[string]memprovider.InMemoryFlag, len(flags))
+	for name, enabled := range flags {
+		inMemFlags[name] = memprovider.InMemoryFlag{
+			State:          memprovider.Enabled,
+			DefaultVariant: "on",
+			Variants:       map[string]any{"on": enabled},
+		}
+	}
+	provider := memprovider.NewInMemoryProvider(inMemFlags)
 	require.NoError(t, openfeature.SetProviderAndWait(provider))
 	fp, err := experiments.NewFlagProvider("")
 	require.NoError(t, err)
@@ -1816,6 +1820,81 @@ func TestReadReferenceExperiments(t *testing.T) {
 		ref, data := readRawResponses(t, peer, noRefRN)
 		require.Nil(t, ref)
 		require.Equal(t, noRefBuf, data)
+	})
+}
+
+// getMultiRaw fetches the given resources from peer with a raw gRPC client,
+// returning the response KVs keyed by digest hash.
+func getMultiRaw(t *testing.T, peer string, rns ...*rspb.ResourceName) map[string]*dcpb.KV {
+	t.Helper()
+	conn, err := grpc.NewClient(peer, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	client := dcpb.NewDistributedCacheClient(conn)
+	rsp, err := client.GetMulti(context.Background(), &dcpb.GetMultiRequest{Resources: rns})
+	require.NoError(t, err)
+	kvs := make(map[string]*dcpb.KV, len(rsp.GetKeyValue()))
+	for _, kv := range rsp.GetKeyValue() {
+		kvs[kv.GetKey().GetKey()] = kv
+	}
+	return kvs
+}
+
+func TestGetMultiReferenceExperiment(t *testing.T) {
+	te := getTestEnv(t, emptyUserMap)
+	ctx, err := prefix.AttachUserPrefixToContext(context.Background(), te.GetAuthenticator())
+	require.NoError(t, err)
+
+	rn, buf := testdigest.RandomCASResourceBuf(t, 100)
+	noRefRN, noRefBuf := testdigest.RandomCASResourceBuf(t, 100)
+	expectedRef := &refpb.Reference{
+		Metadata: &sgpb.FileMetadata{
+			FileRecord: &sgpb.FileRecord{Digest: rn.GetDigest()},
+			StorageMetadata: &sgpb.StorageMetadata{
+				GcsMetadata: &sgpb.StorageMetadata_GCSMetadata{BlobName: "blobs/test-blob"},
+			},
+		},
+	}
+	cache := &serverReferenceCache{
+		Cache: te.GetCache(),
+		refs:  map[string]*refpb.Reference{rn.GetDigest().GetHash(): expectedRef},
+	}
+	peer := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	c := distributed_client.New(te, cache, peer)
+	require.NoError(t, c.StartListening())
+	waitUntilServerIsAlive(peer)
+	require.NoError(t, te.GetCache().Set(ctx, rn, buf))
+	require.NoError(t, te.GetCache().Set(ctx, noRefRN, noRefBuf))
+
+	expectAllBytes := func(t *testing.T) {
+		kvs := getMultiRaw(t, peer, rn, noRefRN)
+		require.Len(t, kvs, 2)
+		require.Equal(t, buf, kvs[rn.GetDigest().GetHash()].GetValue())
+		require.Nil(t, kvs[rn.GetDigest().GetHash()].GetValueReference())
+		require.Equal(t, noRefBuf, kvs[noRefRN.GetDigest().GetHash()].GetValue())
+		require.Nil(t, kvs[noRefRN.GetDigest().GetHash()].GetValueReference())
+	}
+
+	t.Run("no experiment provider", func(t *testing.T) {
+		expectAllBytes(t)
+	})
+
+	t.Run("experiment off", func(t *testing.T) {
+		setExperimentFlags(t, te, map[string]bool{"distributed_cache.get_multi_gcs_references": false})
+		expectAllBytes(t)
+	})
+
+	t.Run("experiment sends references where available", func(t *testing.T) {
+		setExperimentFlags(t, te, map[string]bool{"distributed_cache.get_multi_gcs_references": true})
+		kvs := getMultiRaw(t, peer, rn, noRefRN)
+		require.Len(t, kvs, 2)
+		refKV := kvs[rn.GetDigest().GetHash()]
+		require.Empty(t, refKV.GetValue())
+		require.Empty(t, cmp.Diff(expectedRef, refKV.GetValueReference(), protocmp.Transform()))
+		// A value with no reference available is returned as bytes.
+		byteKV := kvs[noRefRN.GetDigest().GetHash()]
+		require.Equal(t, noRefBuf, byteKV.GetValue())
+		require.Nil(t, byteKV.GetValueReference())
 	})
 }
 


### PR DESCRIPTION
Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/8251