### PR TITLE
Fix static build

### DIFF
--- a/.github/workflows/test-executor-linux-arm64.yaml
+++ b/.github/workflows/test-executor-linux-arm64.yaml
@@ -61,4 +61,4 @@ jobs:
             //enterprise/server/test/integration/podman:podman_test
 
           # Make sure the executor binary builds.
-          bazel build //enterprise/server/cmd/executor
+          bazel build //enterprise/server/cmd/executor //enterprise/server/cmd/executor:executor_linux_arm64_static

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -12,7 +12,7 @@ actions:
         branches:
           - "*"
     steps:
-      - run: "bazel test //... --config=linux-workflows --config=race --test_tag_filters=-performance,-bare --experimental_enable_execution_graph_log --experimental_execution_graph_log_dep_type=all --experimental_execution_graph_include_change_pruned_actions"
+      - run: "bazel test //enterprise/server/cmd/executor:executor_linux_amd64_static //... --config=linux-workflows --config=race --test_tag_filters=-performance,-bare --experimental_enable_execution_graph_log --experimental_execution_graph_log_dep_type=all --experimental_execution_graph_include_change_pruned_actions"
     allow_concurrent_runs: false
   - name: Check style
     container_image: ubuntu-22.04

--- a/enterprise/server/remote_execution/gpu/BUILD
+++ b/enterprise/server/remote_execution/gpu/BUILD
@@ -14,6 +14,9 @@ go_library(
         "//proto:remote_execution_go_proto",
         "//server/util/flag",
     ] + select({
+        # Static builds compile gpu_unsupported.go instead of gpu_linux.go,
+        # because go-nvml needs glibc-only dlfcn symbols that musl lacks.
+        "//platforms/configs:linux_static": [],
         "@io_bazel_rules_go//go/platform:linux": [
             "//enterprise/server/remote_execution/cgroup",
             "//server/util/log",
@@ -32,6 +35,8 @@ go_test(
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     deps = select({
+        # gpu_linux_test.go is excluded from static builds along with gpu_linux.go.
+        "//platforms/configs:linux_static": [],
         "@io_bazel_rules_go//go/platform:linux": [
             "//proto:remote_execution_go_proto",
             "//server/util/testing/flags",

--- a/enterprise/server/remote_execution/gpu/gpu.go
+++ b/enterprise/server/remote_execution/gpu/gpu.go
@@ -17,7 +17,8 @@ var (
 // Configure validates the GPU memory tracking configuration and initializes
 // its platform implementation when tracking is enabled. The configure and
 // cgroupUsage functions are defined per platform in gpu_linux.go and
-// gpu_unsupported.go.
+// gpu_unsupported.go. Static builds use gpu_unsupported.go, since the NVML
+// bindings cannot be linked statically.
 func Configure() error {
 	if !*gpuMemoryTrackingEnabled {
 		return nil

--- a/enterprise/server/remote_execution/gpu/gpu_linux.go
+++ b/enterprise/server/remote_execution/gpu/gpu_linux.go
@@ -1,4 +1,4 @@
-//go:build linux && !android && cgo
+//go:build linux && !android && cgo && !static
 
 package gpu
 

--- a/enterprise/server/remote_execution/gpu/gpu_linux_test.go
+++ b/enterprise/server/remote_execution/gpu/gpu_linux_test.go
@@ -1,4 +1,4 @@
-//go:build linux && !android && cgo
+//go:build linux && !android && cgo && !static
 
 package gpu
 

--- a/enterprise/server/remote_execution/gpu/gpu_unsupported.go
+++ b/enterprise/server/remote_execution/gpu/gpu_unsupported.go
@@ -1,4 +1,4 @@
-//go:build !linux || android || !cgo
+//go:build !linux || android || !cgo || static
 
 package gpu
 
@@ -8,8 +8,13 @@ import (
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
+// configure rejects GPU memory tracking on platforms where NVML is
+// unavailable. This includes static builds (the "static" Go build tag, set by
+// the musl platforms in //platforms), because go-nvml loads libnvidia-ml with
+// dlopen and needs glibc-only dlfcn symbols, so it cannot be built into a
+// static musl binary.
 func configure() error {
-	return errors.New("GPU memory tracking requires a Linux build with cgo enabled")
+	return errors.New("GPU memory tracking requires a dynamically linked Linux build with cgo enabled")
 }
 
 func cgroupUsage(cgroupPath string) *repb.GPUUsage {

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -1,17 +1,26 @@
 package(default_visibility = ["//visibility:public"])
 
-# Target this platforms with --platforms for a static build linked against musl libc.
+# Target this platform with --platforms for a static build linked against musl libc.
 # Only meant to be used as a target platform.
-alias(
+#
+# The musl platforms also set the "static" Go build tag, so Go sources can opt
+# out of dependencies that cannot be linked statically (e.g. libraries that
+# dlopen shared objects at runtime). Setting the tag on the platform itself
+# rather than in a bazelrc config means it applies however the platform is
+# selected, whether via --config=static, --platforms, or the
+# linux_x86_64_musl_alias transition in //rules:platform_transitions.bzl.
+platform(
     name = "linux_x86_64_musl",
-    actual = "@llvm//platforms:linux_x86_64_musl",
+    flags = ["--@io_bazel_rules_go//go/config:tags=static"],
+    parents = ["@llvm//platforms:linux_x86_64_musl"],
 )
 
-# Target this platforms with --platforms for a static build linked against musl libc.
+# Target this platform with --platforms for a static build linked against musl libc.
 # Only meant to be used as a target platform.
-alias(
+platform(
     name = "linux_arm64_musl",
-    actual = "@llvm//platforms:linux_arm64_musl",
+    flags = ["--@io_bazel_rules_go//go/config:tags=static"],
+    parents = ["@llvm//platforms:linux_arm64_musl"],
 )
 
 platform(

--- a/platforms/configs/BUILD
+++ b/platforms/configs/BUILD
@@ -31,3 +31,14 @@ config_setting(
         "@platforms//cpu:arm64",
     ],
 )
+
+# Matches Linux builds that set the "static" Go build tag, which the musl
+# platforms in //platforms apply. Use this in a select() alongside
+# @io_bazel_rules_go//go/platform:linux to drop deps that cannot be built or
+# linked statically. Bazel picks this setting over the plain linux one when
+# both match, because it is a strict specialization of it.
+config_setting(
+    name = "linux_static",
+    constraint_values = ["@platforms//os:linux"],
+    flag_values = {"@io_bazel_rules_go//go/config:tags": "static"},
+)


### PR DESCRIPTION
Updates the MUSL platforms to apply a `static` build tag, and excludes `NVIDIA/go-nvml` when building with this tag.