### PR TITLE
Add local_cache_always_allow_hardlinks flag

### DIFF
--- a/enterprise/server/remote_execution/filecache/BUILD
+++ b/enterprise/server/remote_execution/filecache/BUILD
@@ -57,6 +57,7 @@ go_test(
     deps = [
         ":filecache",
         "//proto:remote_execution_go_proto",
+        "//server/interfaces",
         "//server/metrics",
         "//server/remote_cache/digest",
         "//server/testutil/testdigest",

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -72,6 +72,7 @@ type sharedDirectoryContextKey struct{}
 
 var (
 	enableAlwaysClone                = flag.Bool("executor.local_cache_always_clone", false, "If true, files from the filecache will always be cloned instead of hardlinked")
+	alwaysAllowHardlinks             = flag.Bool("executor.local_cache_always_allow_hardlinks", false, "If true, always permit hardlinks to and from the local filecache, regardless of authentication status. Only enable this on trusted, single-tenant executors.")
 	includeSubdirPrefix              = flag.Bool("executor.include_subdir_prefix", false, "If true, store files under subdirs named by a short prefix of the file digest. This can help improve throughput on systems with high core counts. The prefix length is controlled by subdir_prefix_length.")
 	subdirPrefixLength               = flag.Int("executor.subdir_prefix_length", 2, "The length of the subdir prefix to use if include_subdir_prefix is true.")
 	enableDiskFallbackOnStartup      = flag.Bool("executor.local_cache_enable_disk_fallback_during_startup_scan", true, "If true, fallback to disk lookups while initial local cache scan is in progress.", flag.Internal)
@@ -1139,7 +1140,7 @@ func (c *fileCache) tempPath(name string) (string, error) {
 }
 
 func cloneOrLink(keyPrefix, source, destination string) error {
-	if keyPrefix == interfaces.AuthAnonymousUser || *enableAlwaysClone {
+	if *enableAlwaysClone || (keyPrefix == interfaces.AuthAnonymousUser && !*alwaysAllowHardlinks) {
 		if err := fastcopy.Clone(source, destination); err != nil {
 			return wrapOSError(err, "clone")
 		}

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -72,7 +72,7 @@ type sharedDirectoryContextKey struct{}
 
 var (
 	enableAlwaysClone                = flag.Bool("executor.local_cache_always_clone", false, "If true, files from the filecache will always be cloned instead of hardlinked")
-	alwaysAllowHardlinks             = flag.Bool("executor.local_cache_always_allow_hardlinks", false, "If true, always permit hardlinks to and from the local filecache, regardless of authentication status. Only enable this on trusted, single-tenant executors.")
+	alwaysAllowHardlinks             = flag.Bool("executor.local_cache_always_allow_hardlinks", false, "If true, allow all filecache entries to use the platform-specific FastCopy operation, potentially using in hardlinks.")
 	includeSubdirPrefix              = flag.Bool("executor.include_subdir_prefix", false, "If true, store files under subdirs named by a short prefix of the file digest. This can help improve throughput on systems with high core counts. The prefix length is controlled by subdir_prefix_length.")
 	subdirPrefixLength               = flag.Int("executor.subdir_prefix_length", 2, "The length of the subdir prefix to use if include_subdir_prefix is true.")
 	enableDiskFallbackOnStartup      = flag.Bool("executor.local_cache_enable_disk_fallback_during_startup_scan", true, "If true, fallback to disk lookups while initial local cache scan is in progress.", flag.Internal)

--- a/enterprise/server/remote_execution/filecache/filecache_test.go
+++ b/enterprise/server/remote_execution/filecache/filecache_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
@@ -109,6 +110,59 @@ func TestFilecache(t *testing.T) {
 	assert.True(t, secondLink, "original file should still link")
 	assert.FileExists(t, filepath.Join(baseDir, "my/fun/second-fastlinkedfile"))
 	assertFileContents(t, filepath.Join(baseDir, "my/fun/second-fastlinkedfile"), "my/fun/file")
+}
+
+func TestFilecacheAlwaysAllowHardlinksDarwin(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("test runs on macOS only")
+	}
+	flags.Set(t, "executor.local_cache_use_hardlinks", true)
+
+	for _, test := range []struct {
+		name                 string
+		alwaysAllowHardlinks bool
+		expectHardlinks      bool
+	}{
+		{
+			name:                 "disabled",
+			alwaysAllowHardlinks: false,
+			expectHardlinks:      false,
+		},
+		{
+			name:                 "enabled",
+			alwaysAllowHardlinks: true,
+			expectHardlinks:      true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			flags.Set(t, "executor.local_cache_always_allow_hardlinks", test.alwaysAllowHardlinks)
+
+			ctx := context.Background()
+			fcDir := testfs.MakeTempDir(t)
+			fc, err := filecache.NewFileCache(fcDir, 100_000, false)
+			require.NoError(t, err)
+			t.Cleanup(func() { fc.Close() })
+			fc.WaitForDirectoryScanToComplete()
+
+			workspaceDir := testfs.MakeTempDir(t)
+			source := writeFileContent(t, workspaceDir, "source", "source", false)
+			node := nodeFromString("source", false)
+			require.NoError(t, fc.AddFile(ctx, node, source))
+
+			cached := filepath.Join(fcDir, interfaces.AuthAnonymousUser, node.GetDigest().GetHash())
+			output := filepath.Join(workspaceDir, "output")
+			require.True(t, fc.FastLinkFile(ctx, node, output))
+
+			sourceInfo, err := os.Stat(source)
+			require.NoError(t, err)
+			cachedInfo, err := os.Stat(cached)
+			require.NoError(t, err)
+			outputInfo, err := os.Stat(output)
+			require.NoError(t, err)
+			require.Equal(t, test.expectHardlinks, os.SameFile(sourceInfo, cachedInfo))
+			require.Equal(t, test.expectHardlinks, os.SameFile(cachedInfo, outputInfo))
+		})
+	}
 }
 
 func TestFileCacheGroupIsolation(t *testing.T) {


### PR DESCRIPTION
Previously self hosted executors always hit the anonymous request path,
which never applies for self hosted executors.
