### PR TITLE
Add Linux ARM64 support to the community on-prem image

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -7,7 +7,7 @@ load("@com_github_sluongng_nogo_analyzer//staticcheck:def.bzl", "ANALYZERS", "st
 load("@io_bazel_rules_go//go:def.bzl", "nogo")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@pypi//:requirements.bzl", "all_whl_requirements")
-load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 load("@rules_python_gazelle_plugin//manifest:defs.bzl", "gazelle_python_manifest")
 load("@rules_python_gazelle_plugin//modules_mapping:def.bzl", "modules_mapping")
@@ -348,4 +348,10 @@ py_library(
     srcs = ["release.py"],
     visibility = ["//:__subpackages__"],
     deps = ["@pypi//requests"],
+)
+
+py_test(
+    name = "release_test",
+    srcs = ["release_test.py"],
+    deps = [":buildbuddy_py_library"],
 )

--- a/release.py
+++ b/release.py
@@ -103,12 +103,29 @@ def confirm_new_version(version):
         version = get_version_override()
     return version
 
-def get_image(project, tag):
+IMAGE_MANIFEST_MEDIA_TYPES = [
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+]
+
+LINUX_IMAGE_PLATFORMS = [
+    ("amd64", "//platforms:linux_x86_64"),
+    ("arm64", "//platforms:linux_arm64"),
+]
+
+def get_image_digest(project, tag):
     query_url = f"https://gcr.io/v2/{project}/manifests/{tag}"
-    r = requests.get(query_url)
+    r = requests.get(query_url, headers={"Accept": ", ".join(IMAGE_MANIFEST_MEDIA_TYPES)})
     if r.status_code == 404:
         return None
-    return r.json()
+    if not r.ok:
+        die(f"Could not fetch image gcr.io/{project}:{tag}: HTTP {r.status_code}")
+    digest = r.headers.get("Docker-Content-Digest")
+    if digest is None:
+        die(f"Registry did not return a digest for image gcr.io/{project}:{tag}.")
+    return digest
 
 def create_and_push_tag(old_version, new_version, release_notes=''):
     commit_message = "Bump tag %s -> %s (release.py)" % (old_version, new_version)
@@ -126,38 +143,61 @@ def create_and_push_tag(old_version, new_version, release_notes=''):
     run_or_die(push_tag_cmd)
 
 def push_image_for_project(project, version_tag, bazel_target, skip_update_latest_tag):
-    version_image = get_image(project, version_tag)
-    if version_image is None:
+    version_digest = get_image_digest(project, version_tag)
+    if version_digest is None:
         build_image_with_bazel(bazel_target)
         tag_and_push_image_with_docker(bazel_target, project, version_tag)
     else:
         print(f'Image gcr.io/{project}:{version_tag} already exists, skipping bazel build.')
 
+    update_latest_tag(project, version_tag, version_digest, skip_update_latest_tag)
+
+def push_multi_platform_image_for_project(project, version_tag, bazel_target, skip_update_latest_tag):
+    version_digest = get_image_digest(project, version_tag)
+    if version_digest is None:
+        architecture_images = []
+        for architecture, platform_target in LINUX_IMAGE_PLATFORMS:
+            architecture_tag = f"{version_tag}-{architecture}"
+            architecture_digest = get_image_digest(project, architecture_tag)
+            if architecture_digest is None:
+                build_image_with_bazel(bazel_target, platform_target)
+                tag_and_push_image_with_docker(bazel_target, project, architecture_tag)
+            else:
+                print(f'Image gcr.io/{project}:{architecture_tag} already exists, skipping bazel build.')
+            architecture_images.append(f"gcr.io/{project}:{architecture_tag}")
+        create_and_push_multi_platform_manifest(project, version_tag, architecture_images)
+    else:
+        print(f'Image gcr.io/{project}:{version_tag} already exists, skipping bazel build.')
+
+    update_latest_tag(project, version_tag, version_digest, skip_update_latest_tag)
+
+def update_latest_tag(project, version_tag, version_digest, skip_update_latest_tag):
     if skip_update_latest_tag:
         return
 
-    version_image = version_image or get_image(project, version_tag)
-    if version_image is None:
+    version_digest = version_digest or get_image_digest(project, version_tag)
+    if version_digest is None:
         die(f"Could not fetch image with tag {version_tag} from project {project}.")
 
-    latest_image = get_image(project, "latest")
-    if latest_image is None:
+    latest_digest = get_image_digest(project, "latest")
+    if latest_digest is None:
         print(f"No 'latest' tag found for {project}; tagging current version as latest.")
         should_update_latest_tag = True
     else:
-        should_update_latest_tag = version_image["config"]["digest"] != latest_image["config"]["digest"]
+        should_update_latest_tag = version_digest != latest_digest
 
     if should_update_latest_tag:
         add_tag_cmd = f"echo 'yes' | gcloud container images add-tag gcr.io/{project}:{version_tag} gcr.io/{project}:latest"
         run_or_die(add_tag_cmd)
 
-def build_image_with_bazel(bazel_target):
+def build_image_with_bazel(bazel_target, platform_target=None):
     print(f"Building docker image target {bazel_target}")
     # Note: we are not using container_push targets here, because it has a bug
     # where it uses "application/vnd.oci.image.layer.v1.tar" mediaType for some
     # image layers on arm64, which podman and containerd cannot handle.
     # https://github.com/buildbuddy-io/buildbuddy-internal/issues/3316
-    run_or_die(f'bazel run -c opt --stamp --define=release=true {bazel_target}')
+    platform_flag = f" --platforms={platform_target}" if platform_target else ""
+    run_or_die(f'bazel run -c opt --stamp --define=release=true{platform_flag} {bazel_target}')
 
 def tag_and_push_image_with_docker(bazel_target, project, version_tag):
     # rules_docker uses a convention where "//PACKAGE:LABEL" gets locally tagged
@@ -168,13 +208,19 @@ def tag_and_push_image_with_docker(bazel_target, project, version_tag):
     run_or_die(f'docker tag {local_image_ref} {remote_image_ref}')
     run_or_die(f'docker push {remote_image_ref}')
 
+def create_and_push_multi_platform_manifest(project, version_tag, architecture_images):
+    remote_image_ref = f'gcr.io/{project}:{version_tag}'
+    print(f'Creating and pushing multi-platform manifest {remote_image_ref}')
+    run_or_die(f'docker manifest create {remote_image_ref} {" ".join(architecture_images)}')
+    run_or_die(f'docker manifest push --purge {remote_image_ref}')
+
 def update_docker_images(images, version_tag, skip_update_latest_tag, arch_specific_executor_tag, arch_specific_proxy_tag):
     clean_cmd = 'bazel clean --expunge'
     run_or_die(clean_cmd)
 
     # OSS app
     if 'buildbuddy-app-onprem' in images:
-        push_image_for_project("flame-public/buildbuddy-app-onprem", version_tag, '//server/cmd/buildbuddy:buildbuddy_image', skip_update_latest_tag)
+        push_multi_platform_image_for_project("flame-public/buildbuddy-app-onprem", version_tag, '//server/cmd/buildbuddy:buildbuddy_image', skip_update_latest_tag)
     # Enterprise app
     if 'buildbuddy-app-enterprise' in images:
         push_image_for_project("flame-public/buildbuddy-app-enterprise", 'enterprise-' + version_tag, '//enterprise/server/cmd/server:buildbuddy_image', skip_update_latest_tag)

--- a/release_test.py
+++ b/release_test.py
@@ -1,0 +1,86 @@
+import unittest
+from unittest import mock
+
+import release
+
+
+class ReleaseTest(unittest.TestCase):
+
+    @mock.patch.object(release.requests, "get")
+    def test_get_image_digest_accepts_multi_platform_images(self, get):
+        get.return_value.ok = True
+        get.return_value.status_code = 200
+        get.return_value.headers = {
+            "Docker-Content-Digest": "sha256:index",
+        }
+
+        self.assertEqual(
+            "sha256:index",
+            release.get_image_digest("example/project", "v1.2.3"),
+        )
+        get.assert_called_once_with(
+            "https://gcr.io/v2/example/project/manifests/v1.2.3",
+            headers={"Accept": ", ".join(release.IMAGE_MANIFEST_MEDIA_TYPES)},
+        )
+
+    @mock.patch.object(release, "create_and_push_multi_platform_manifest")
+    @mock.patch.object(release, "tag_and_push_image_with_docker")
+    @mock.patch.object(release, "build_image_with_bazel")
+    @mock.patch.object(release, "get_image_digest", return_value=None)
+    def test_push_multi_platform_image_builds_each_architecture(
+        self,
+        get_image_digest,
+        build_image_with_bazel,
+        tag_and_push_image_with_docker,
+        create_and_push_multi_platform_manifest,
+    ):
+        release.push_multi_platform_image_for_project(
+            "example/project",
+            "v1.2.3",
+            "//example:image",
+            True,
+        )
+
+        self.assertEqual(3, get_image_digest.call_count)
+        build_image_with_bazel.assert_has_calls([
+            mock.call("//example:image", "//platforms:linux_x86_64"),
+            mock.call("//example:image", "//platforms:linux_arm64"),
+        ])
+        tag_and_push_image_with_docker.assert_has_calls([
+            mock.call("//example:image", "example/project", "v1.2.3-amd64"),
+            mock.call("//example:image", "example/project", "v1.2.3-arm64"),
+        ])
+        create_and_push_multi_platform_manifest.assert_called_once_with(
+            "example/project",
+            "v1.2.3",
+            [
+                "gcr.io/example/project:v1.2.3-amd64",
+                "gcr.io/example/project:v1.2.3-arm64",
+            ],
+        )
+
+    @mock.patch.object(release, "run_or_die")
+    def test_create_and_push_multi_platform_manifest(self, run_or_die):
+        release.create_and_push_multi_platform_manifest(
+            "example/project",
+            "v1.2.3",
+            [
+                "gcr.io/example/project:v1.2.3-amd64",
+                "gcr.io/example/project:v1.2.3-arm64",
+            ],
+        )
+
+        run_or_die.assert_has_calls([
+            mock.call(
+                "docker manifest create gcr.io/example/project:v1.2.3 "
+                "gcr.io/example/project:v1.2.3-amd64 "
+                "gcr.io/example/project:v1.2.3-arm64"
+            ),
+            mock.call(
+                "docker manifest push --purge gcr.io/example/project:v1.2.3"
+            ),
+        ])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/cmd/buildbuddy/BUILD
+++ b/server/cmd/buildbuddy/BUILD
@@ -29,7 +29,17 @@ go_binary(
 
 container_image(
     name = "base_image",
-    base = "@buildbuddy_go_image_base//image",
+    architecture = select({
+        "@platforms//cpu:arm64": "arm64",
+        "//conditions:default": "amd64",
+    }),
+    # Base layers (libc, dynamic linker, etc.) are architecture-specific, so the
+    # base image must match the target architecture. Setting `architecture`
+    # above only stamps the image config metadata; it does not swap these layers.
+    base = select({
+        "@platforms//cpu:arm64": "@buildbuddy_go_image_base_arm64//image",
+        "//conditions:default": "@buildbuddy_go_image_base//image",
+    }),
     symlinks = {
         "config.yaml": "app/server/cmd/buildbuddy/buildbuddy.runfiles/%s/config/buildbuddy.release.yaml" % runfiles_directory(),
         "buildbuddy": "tmp",
@@ -46,6 +56,10 @@ container_image(
 
 go_image(
     name = "buildbuddy_go_image",
+    architecture = select({
+        "@platforms//cpu:arm64": "arm64",
+        "//conditions:default": "amd64",
+    }),
     base = ":base_image",
     binary = ":buildbuddy",
     tags = ["manual"],
@@ -54,6 +68,10 @@ go_image(
 
 container_image(
     name = "buildbuddy_image",
+    architecture = select({
+        "@platforms//cpu:arm64": "arm64",
+        "//conditions:default": "amd64",
+    }),
     base = ":buildbuddy_go_image",
     tags = ["manual"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
## Problem

Running BuildBuddy on k3s on an Apple Silicon MacBook currently requires emulating the official linux/amd64 community image. This makes local Kubernetes testing slower and less representative, even though the source and Bazel platform definitions already support ARM64.

## Solution

Publish gcr.io/flame-public/buildbuddy-app-onprem:<version> as a multi-platform image containing both linux/amd64 and linux/arm64.

This change selects the correct architecture-specific base image in the community server Bazel target and updates the release script to build both variants before publishing a single manifest list. It also makes registry digest handling compatible with multi-platform images when updating latest.

Enterprise image behavior is unchanged. Focused tests cover multi-platform release orchestration and registry digest lookup.