### PR TITLE
Enable experimental_remote_downloader_local_fallback

### DIFF
--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -61,6 +61,9 @@ common --noslim_profile
 # TODO(sluongng): make Bazel writes this to output_base automatically
 common --execution_log_compact_file=%workspace%/bazel_compact_exec_log.binpb.zst
 
+# When using --remote_downloader, fallback to local downloads if it fails
+common --experimental_remote_downloader_local_fallback
+
 # Disable https://github.com/aspect-build/tools_telemetry.
 common --repo_env=DO_NOT_TRACK=1
 

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -391,6 +391,7 @@ common:workflows --config=buildbuddy_bes_backend
 common:workflows --config=buildbuddy_bes_results_url
 common:workflows --config=buildbuddy_remote_cache
 common:workflows --config=buildbuddy_experimental_remote_downloader
+common:workflows --noexperimental_remote_downloader_local_fallback
 # Explicitly disable repository cache for BuildBuddy Workflows.
 # This helps reduce disk space usage in the Firecracker, thus reduce the VM snapshot size.
 # Rely on remote downloader to cache downloads through Remote Asset API instead.


### PR DESCRIPTION
--remote_downloader can fail with cache eviction errors. In that case
local fallbacks are fine for this repo. It's off by default in case you
want to avoid bazel doing any network requests besides your cache.
