### PR TITLE
gateway: add cert authenticator for use in the relay gateway

### DIFF
--- a/enterprise/gateway/certauth/BUILD
+++ b/enterprise/gateway/certauth/BUILD
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "certauth",
+    srcs = ["certauth.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/gateway/certauth",
+    deps = [
+        "//enterprise/gateway/gatewayauth",
+        "//server/util/flag",
+        "//server/util/log",
+        "//server/util/relayauth",
+        "//server/util/status",
+        "@org_golang_google_grpc//metadata",
+    ],
+)
+
+go_test(
+    name = "certauth_test",
+    srcs = ["certauth_test.go"],
+    embed = [":certauth"],
+    deps = [
+        "//enterprise/gateway/gatewayauth",
+        "//server/testutil/testauthrelay",
+        "//server/util/relayauth",
+        "//server/util/testing/flags",
+        "//server/util/wgkeys",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//metadata",
+        "@org_golang_google_grpc//status",
+    ],
+)

--- a/enterprise/gateway/certauth/certauth.go
+++ b/enterprise/gateway/certauth/certauth.go
@@ -1,0 +1,84 @@
+// Package certauth authenticates gateway users using certs.
+package certauth
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/gatewayauth"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/relayauth"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+
+	"google.golang.org/grpc/metadata"
+)
+
+var (
+	certAuthCA       = flag.String("gateway.cert_auth.ca", "", "PEM encoded CA certificate that issues certificates.")
+	certAuthCAFile   = flag.String("gateway.cert_auth.ca_file", "", "Path to a PEM encoded CA certificate that issues certificates.")
+	certAuthAudience = flag.String("gateway.cert_auth.audience", "", "This gateway's identity, which clients must name in their credential. Required.")
+)
+
+type certAuthenticator struct {
+	verifier *relayauth.Verifier
+}
+
+func New() (gatewayauth.Authenticator, error) {
+	if *certAuthCA == "" && *certAuthCAFile == "" {
+		return nil, status.FailedPreconditionError("one of gateway.cert_auth.ca and gateway.cert_auth.ca_file is required")
+	}
+	caPEM := []byte(*certAuthCA)
+	if *certAuthCAFile != "" {
+		if *certAuthCA != "" {
+			return nil, status.FailedPreconditionError("set only one of gateway.cert_auth.ca and gateway.cert_auth.ca_file")
+		}
+		b, err := os.ReadFile(*certAuthCAFile)
+		if err != nil {
+			return nil, status.FailedPreconditionErrorf("read gateway.cert_auth.ca_file: %s", err)
+		}
+		caPEM = b
+	}
+	if *certAuthAudience == "" {
+		return nil, status.FailedPreconditionError("gateway.cert_auth.audience is required")
+	}
+	v, err := relayauth.NewVerifier(caPEM, *certAuthAudience)
+	if err != nil {
+		return nil, status.FailedPreconditionErrorf("configure tunnel certificate auth: %s", err)
+	}
+	log.Infof("Tunnel certificate auth enabled for audience %q", *certAuthAudience)
+	return &certAuthenticator{verifier: v}, nil
+}
+
+// Authenticate verifies the cert-based credentials in ctx.
+func (c *certAuthenticator) Authenticate(ctx context.Context, wgPublicKey string) (*gatewayauth.Principal, error) {
+	values := metadata.ValueFromIncomingContext(ctx, relayauth.CredentialHeader)
+	if len(values) == 0 {
+		return nil, status.UnauthenticatedError("no tunnel credential provided")
+	}
+	if len(values) > 1 {
+		return nil, status.UnauthenticatedError("multiple tunnel credentials provided")
+	}
+
+	id, err := c.verifier.Verify(values[0])
+	if err != nil {
+		log.Warningf("Rejected tunnel credential: %s", err)
+		return nil, status.UnauthenticatedErrorf("tunnel credential is not valid: %s", err)
+	}
+
+	// The signed data contains the wireguard public key.
+	// For RPCs that contain the public key (i.e. Connect), sanity-check that
+	// the verified public key matches the provided public key.
+	if wgPublicKey != "" && !strings.EqualFold(id.WireGuardPublicKey, wgPublicKey) {
+		return nil, status.PermissionDeniedError("tunnel credential is bound to a different WireGuard public key")
+	}
+
+	return &gatewayauth.Principal{
+		User: id.Email,
+		// In the relay gateway, users never connect to each other so we give
+		// each user their own namespace.
+		Namespace: "cert:" + strings.ToLower(id.Email),
+		ExpiresAt: id.CertNotAfter,
+	}, nil
+}

--- a/enterprise/gateway/certauth/certauth_test.go
+++ b/enterprise/gateway/certauth/certauth_test.go
@@ -1,0 +1,182 @@
+package certauth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/gatewayauth"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauthrelay"
+	"github.com/buildbuddy-io/buildbuddy/server/util/relayauth"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/buildbuddy-io/buildbuddy/server/util/wgkeys"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+const testGatewayAudience = "relay.moon.buildbuddy.io"
+
+// newAuthenticator builds an authenticator trusting ca, with the test audience.
+func newAuthenticator(t testing.TB, ca *testauthrelay.CA) gatewayauth.Authenticator {
+	t.Helper()
+	flags.Set(t, "gateway.cert_auth.ca", ca.PEM())
+	flags.Set(t, "gateway.cert_auth.audience", testGatewayAudience)
+	a, err := New()
+	require.NoError(t, err)
+	return a
+}
+
+func newPubKeyHex(t testing.TB) string {
+	t.Helper()
+	priv, err := wgkeys.GeneratePrivateKey()
+	require.NoError(t, err)
+	return priv.PublicKey().Hex()
+}
+
+func credCtx(t testing.TB, ca *testauthrelay.CA, email, wgPubKey string) context.Context {
+	t.Helper()
+	return testauthrelay.CredentialContext(t, ca.Signer(t, email), testGatewayAudience, wgPubKey)
+}
+
+func TestAuthenticate_Succeeds(t *testing.T) {
+	ca := testauthrelay.NewCA(t)
+	a := newAuthenticator(t, ca)
+
+	pubKey := newPubKeyHex(t)
+	p, err := a.Authenticate(credCtx(t, ca, "vadim@buildbuddy.io", pubKey), pubKey)
+	require.NoError(t, err)
+
+	// The principal is attributed to the human, so log lines name a person,
+	// and lives in a namespace that can never collide with a BuildBuddy group
+	// ID.
+	assert.Equal(t, "vadim@buildbuddy.io", p.User)
+	assert.Equal(t, "cert:vadim@buildbuddy.io", p.Namespace)
+	assert.False(t, p.ExpiresAt.IsZero(), "a certificate principal must carry an expiry")
+}
+
+func TestAuthenticate_EachEmployeeIsADistinctNamespace(t *testing.T) {
+	// Namespaces key network allocation, so distinct namespaces is what gives
+	// each employee their own /48 — and workstation-to-workstation isolation.
+	ca := testauthrelay.NewCA(t)
+	a := newAuthenticator(t, ca)
+
+	key1, key2 := newPubKeyHex(t), newPubKeyHex(t)
+	p1, err := a.Authenticate(credCtx(t, ca, "vadim@buildbuddy.io", key1), key1)
+	require.NoError(t, err)
+	p2, err := a.Authenticate(credCtx(t, ca, "someone-else@buildbuddy.io", key2), key2)
+	require.NoError(t, err)
+	assert.NotEqual(t, p1.Namespace, p2.Namespace)
+
+	// The flip side: the same employee's machines share one namespace, so
+	// they can see each other.
+	key3 := newPubKeyHex(t)
+	p3, err := a.Authenticate(credCtx(t, ca, "vadim@buildbuddy.io", key3), key3)
+	require.NoError(t, err)
+	assert.Equal(t, p1.Namespace, p3.Namespace)
+}
+
+func TestAuthenticate_CredentialBoundToADifferentKeyIsRejected(t *testing.T) {
+	// Capturing a credential must not let an attacker register a tunnel of
+	// their own: the assertion names one WireGuard key.
+	ca := testauthrelay.NewCA(t)
+	a := newAuthenticator(t, ca)
+
+	victimKey := newPubKeyHex(t)
+	attackerKey := newPubKeyHex(t)
+	_, err := a.Authenticate(credCtx(t, ca, "vadim@buildbuddy.io", victimKey), attackerKey)
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+func TestAuthenticate_NoKeyNamedSkipsBinding(t *testing.T) {
+	// RPCs that don't name a WireGuard key (List) pass "" and are still
+	// authenticated; the credential remains audience-scoped and short-lived.
+	ca := testauthrelay.NewCA(t)
+	a := newAuthenticator(t, ca)
+
+	pubKey := newPubKeyHex(t)
+	_, err := a.Authenticate(credCtx(t, ca, "vadim@buildbuddy.io", pubKey), "")
+	require.NoError(t, err)
+}
+
+func TestAuthenticate_ExpiredCertIsRejected(t *testing.T) {
+	ca := testauthrelay.NewCA(t)
+	a := newAuthenticator(t, ca)
+
+	pubKey := newPubKeyHex(t)
+	expired := ca.SignerWithExpiry(t, "vadim@buildbuddy.io", time.Now().Add(-time.Minute))
+	ctx := testauthrelay.CredentialContext(t, expired, testGatewayAudience, pubKey)
+
+	_, err := a.Authenticate(ctx, pubKey)
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestAuthenticate_WrongAudienceIsRejected(t *testing.T) {
+	ca := testauthrelay.NewCA(t)
+	a := newAuthenticator(t, ca)
+
+	pubKey := newPubKeyHex(t)
+	ctx := testauthrelay.CredentialContext(t, ca.Signer(t, "vadim@buildbuddy.io"), "gateway.dev.buildbuddy.io", pubKey)
+
+	_, err := a.Authenticate(ctx, pubKey)
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestAuthenticate_CertFromAnotherCAIsRejected(t *testing.T) {
+	ca := testauthrelay.NewCA(t)
+	a := newAuthenticator(t, ca)
+
+	other := testauthrelay.NewCA(t)
+	pubKey := newPubKeyHex(t)
+	_, err := a.Authenticate(credCtx(t, other, "attacker@buildbuddy.io", pubKey), pubKey)
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestAuthenticate_MalformedCredentialIsRejected(t *testing.T) {
+	ca := testauthrelay.NewCA(t)
+	a := newAuthenticator(t, ca)
+
+	ctx := metadata.NewIncomingContext(context.Background(),
+		metadata.Pairs(relayauth.CredentialHeader, "this-is-not-a-credential"))
+
+	_, err := a.Authenticate(ctx, newPubKeyHex(t))
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestAuthenticate_MissingCredentialIsRejected(t *testing.T) {
+	// There is no other credential to fall back to: no tunnel certificate
+	// means no access, whatever else the caller may hold.
+	ca := testauthrelay.NewCA(t)
+	a := newAuthenticator(t, ca)
+
+	_, err := a.Authenticate(context.Background(), newPubKeyHex(t))
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestNew_RequiresAudience(t *testing.T) {
+	ca := testauthrelay.NewCA(t)
+	flags.Set(t, "gateway.cert_auth.ca", ca.PEM())
+
+	// Without an audience the gateway would accept credentials minted for any
+	// other gateway, so it must refuse to start instead.
+	_, err := New()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "audience")
+}
+
+func TestNew_RequiresCA(t *testing.T) {
+	// A tunnel gateway with no CA cannot authenticate anyone; refuse to start
+	// rather than coming up unusable.
+	flags.Set(t, "gateway.cert_auth.audience", testGatewayAudience)
+	_, err := New()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cert_auth.ca")
+}

--- a/enterprise/gateway/gatewayauth/gatewayauth.go
+++ b/enterprise/gateway/gatewayauth/gatewayauth.go
@@ -14,9 +14,10 @@ type Principal struct {
 	User string
 
 	// Namespace keys network and IP allocation, and scopes what List reveals. It
-	// is a group ID for API-key callers. Since the gateway drops packets that
-	// cross networks, principals with different namespaces can never reach each
-	// other's peers.
+	// is a group ID for API-key callers and "cert:<email>" for certificate
+	// callers.
+	// Since the gateway drops packets that cross networks,
+	// principals with different namespaces can never reach each other's peers.
 	Namespace string
 
 	// ExpiresAt bounds a registered peer's lifetime to the credential's own.

--- a/enterprise/gateway/relay/BUILD
+++ b/enterprise/gateway/relay/BUILD
@@ -24,9 +24,11 @@ go_test(
     embed = [":relay"],
     deps = [
         "//enterprise/gateway/apikeyauth",
+        "//enterprise/gateway/certauth",
         "//enterprise/gateway/server",
         "//enterprise/gateway/testgateway",
         "//server/testutil/testauth",
+        "//server/testutil/testauthrelay",
         "//server/util/relaywire",
         "//server/util/status",
         "//server/util/testing/flags",

--- a/enterprise/gateway/relay/relay_e2e_test.go
+++ b/enterprise/gateway/relay/relay_e2e_test.go
@@ -9,10 +9,12 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/apikeyauth"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/certauth"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/relay"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/server"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/gateway/testgateway"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauthrelay"
 	"github.com/buildbuddy-io/buildbuddy/server/util/relaywire"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
@@ -206,4 +208,39 @@ func TestRelay_TargetRefusesConnection(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, status.IsUnavailableError(err), "got %v", err)
 	require.Contains(t, status.Message(err), "refused", "the gateway's dial error reaches the client verbatim")
+}
+
+func TestRelay_CertGatewayEndToEnd(t *testing.T) {
+	// The employee tunnel-gateway shape, end to end: certificate
+	// authentication, then egress through the relay.
+	const audience = "relay.moon.buildbuddy.io"
+	echoPort := startEchoServer(t)
+
+	ca := testauthrelay.NewCA(t)
+	flags.Set(t, "gateway.cert_auth.ca", ca.PEM())
+	flags.Set(t, "gateway.cert_auth.audience", audience)
+	certAuth, err := certauth.New()
+	require.NoError(t, err)
+	gw := testgateway.Setup(t, server.Options{
+		Authenticator: certAuth,
+		HubServices:   []server.HubService{relay.New()},
+	})
+	signer := ca.Signer(t, "vadim@buildbuddy.io")
+
+	peer := testgateway.RegisterAndConnectAs(t, gw, func(pubKey string) context.Context {
+		return testauthrelay.CredentialContext(t, signer, audience, pubKey)
+	}, "net1", "")
+
+	conn, err := dialRelay(t, peer, "localhost", echoPort)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	const want = "hello from an employee"
+	_, err = io.WriteString(conn, want)
+	require.NoError(t, err)
+	require.NoError(t, conn.(interface{ CloseWrite() error }).CloseWrite())
+	conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+	got, err := io.ReadAll(conn)
+	require.NoError(t, err)
+	require.Equal(t, want, string(got))
 }

--- a/enterprise/gateway/testgateway/testgateway.go
+++ b/enterprise/gateway/testgateway/testgateway.go
@@ -77,15 +77,31 @@ func RegisterAndConnect(t testing.TB, gw *server.Gateway, ctx context.Context, n
 	return RegisterAndConnectWithSessionID(t, gw, ctx, networkName, peerName, NextSessionID())
 }
 
+// RegisterAndConnectAs is RegisterAndConnect for credentials that have to name
+// the WireGuard key being registered, as tunnel certificates do: ctxFor is
+// called with the freshly generated public key.
+func RegisterAndConnectAs(t testing.TB, gw *server.Gateway, ctxFor func(pubKeyHex string) context.Context, networkName, peerName string) Peer {
+	t.Helper()
+	return connectPeer(t, gw, ctxFor, networkName, peerName, NextSessionID())
+}
+
 // RegisterAndConnectWithSessionID is like RegisterAndConnect but allows session ID to be specified by the caller.
+func RegisterAndConnectWithSessionID(t testing.TB, gw *server.Gateway, ctx context.Context, networkName, peerName, sessionID string) Peer {
+	t.Helper()
+	return connectPeer(t, gw, func(string) context.Context { return ctx }, networkName, peerName, sessionID)
+}
+
+// connectPeer is the fully general form: explicit session ID and a per-key
+// credential context.
 //
 // persistent_keepalive_interval=1 is used so that the first outbound packet
 // triggers an immediate WireGuard handshake rather than waiting for the
 // gateway to initiate one.
-func RegisterAndConnectWithSessionID(t testing.TB, gw *server.Gateway, ctx context.Context, networkName, peerName, sessionID string) Peer {
+func connectPeer(t testing.TB, gw *server.Gateway, ctxFor func(pubKeyHex string) context.Context, networkName, peerName, sessionID string) Peer {
 	t.Helper()
 	privKey, err := wgkeys.GeneratePrivateKey()
 	require.NoError(t, err)
+	ctx := ctxFor(privKey.PublicKey().Hex())
 
 	resp, cancel, done := StartConnect(t, gw, ctx, &gwpb.ConnectRequest{
 		NetworkName: networkName,

--- a/server/testutil/testauthrelay/BUILD
+++ b/server/testutil/testauthrelay/BUILD
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "testauthrelay",
+    srcs = ["testauthrelay.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/testutil/testauthrelay",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//server/util/relayauth",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//metadata",
+    ],
+)

--- a/server/testutil/testauthrelay/testauthrelay.go
+++ b/server/testutil/testauthrelay/testauthrelay.go
@@ -1,0 +1,117 @@
+// Package testauthrelay mints tunnel certificate authorities and credentials
+// for tests, standing in for the real issuer.
+package testauthrelay
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/relayauth"
+	"github.com/stretchr/testify/require"
+
+	"google.golang.org/grpc/metadata"
+)
+
+// CredentialContext returns a context carrying a tunnel credential for
+// wgPubKey scoped to audience, as the workstation daemon would send it.
+func CredentialContext(t testing.TB, signer *relayauth.Signer, audience, wgPubKey string) context.Context {
+	t.Helper()
+	cred, err := signer.Sign(audience, wgPubKey, relayauth.DefaultAssertionLifetime)
+	require.NoError(t, err)
+	return metadata.NewIncomingContext(context.Background(),
+		metadata.Pairs(relayauth.CredentialHeader, cred))
+}
+
+// CA is a throwaway certificate authority that issues tunnel client
+// certificates in the shape the gateway expects.
+type CA struct {
+	cert   *x509.Certificate
+	key    crypto.Signer
+	pem    []byte
+	serial int64
+}
+
+// NewCA creates a self-signed CA.
+func NewCA(t testing.TB) *CA {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test Tunnel CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return &CA{
+		cert: cert,
+		key:  key,
+		pem:  pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+	}
+}
+
+// PEM returns the CA certificate, for gateway.cert_auth.ca.
+func (ca *CA) PEM() string { return string(ca.pem) }
+
+// IssuePEM returns a client certificate and key for email, both PEM encoded,
+// valid until notAfter. A zero notAfter means 12 hours out.
+func (ca *CA) IssuePEM(t testing.TB, email string, notAfter time.Time) (certPEM, keyPEM []byte) {
+	t.Helper()
+	if notAfter.IsZero() {
+		notAfter = time.Now().Add(12 * time.Hour)
+	}
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	ca.serial++
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(ca.serial + 100),
+		Subject: pkix.Name{
+			CommonName:   email,
+			Organization: []string{"BuildBuddy Tunnel"},
+		},
+		EmailAddresses:        []string{email},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, ca.cert, key.Public(), ca.key)
+	require.NoError(t, err)
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+}
+
+// Signer issues a credential signer for email, valid for 12 hours.
+func (ca *CA) Signer(t testing.TB, email string) *relayauth.Signer {
+	t.Helper()
+	return ca.SignerWithExpiry(t, email, time.Time{})
+}
+
+// SignerWithExpiry issues a credential signer whose certificate expires at
+// notAfter, which may be in the past.
+func (ca *CA) SignerWithExpiry(t testing.TB, email string, notAfter time.Time) *relayauth.Signer {
+	t.Helper()
+	certPEM, keyPEM := ca.IssuePEM(t, email, notAfter)
+	signer, err := relayauth.NewSigner(certPEM, keyPEM)
+	require.NoError(t, err)
+	return signer
+}

--- a/server/util/relayauth/BUILD
+++ b/server/util/relayauth/BUILD
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "relayauth",
+    srcs = ["relayauth.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/relayauth",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_golang_jwt_jwt_v4//:jwt"],
+)
+
+go_test(
+    name = "relayauth_test",
+    srcs = ["relayauth_test.go"],
+    embed = [":relayauth"],
+    deps = [
+        "@com_github_golang_jwt_jwt_v4//:jwt",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/server/util/relayauth/relayauth.go
+++ b/server/util/relayauth/relayauth.go
@@ -1,0 +1,293 @@
+// Package relayauth authenticates WireGuard gateway clients using
+// short-lived X.509 client certificates.
+//
+// The client signs a JWT using the private key and the relay gateway verifies
+// that the user certificate is signed by the tunnel CA.
+package relayauth
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// CredentialHeader is the gRPC metadata key carrying the credential.
+const CredentialHeader = "x-buildbuddy-tunnel-credential"
+
+// credentialType is the JWT "typ" header.
+const credentialType = "tunnel-credential+jwt"
+
+// MaxAssertionLifetime bounds how far in the future a credential may expire.
+// The signed JWT is only used during registration so it only needs to be valid
+// for a short amount of time.
+const MaxAssertionLifetime = 10 * time.Minute
+
+// DefaultAssertionLifetime is the expiry clients should ask for. Registration
+// is a single short RPC, so this only needs to cover one call plus skew.
+const DefaultAssertionLifetime = 2 * time.Minute
+
+type claims struct {
+	jwt.RegisteredClaims
+	// WireGuardPublicKey is the hex-encoded WireGuard public key this
+	// credential authorizes registering.
+	WireGuardPublicKey string `json:"wg"`
+}
+
+// allowedMethods restricts signing methods. We only allow ES256.
+var allowedMethods = []string{jwt.SigningMethodES256.Alg()}
+
+// Signer holds a certificate and its private key and mints credentials.
+type Signer struct {
+	certDER []byte
+	cert    *x509.Certificate
+	key     crypto.Signer
+}
+
+// NewSigner parses a PEM certificate and private key pair, as issued by the
+// tunnel CA.
+func NewSigner(certPEM, keyPEM []byte) (*Signer, error) {
+	certBlock, _ := pem.Decode(certPEM)
+	if certBlock == nil {
+		return nil, fmt.Errorf("relayauth: certificate is not valid PEM")
+	}
+	cert, err := x509.ParseCertificate(certBlock.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("relayauth: parse certificate: %w", err)
+	}
+
+	keyBlock, _ := pem.Decode(keyPEM)
+	if keyBlock == nil {
+		return nil, fmt.Errorf("relayauth: private key is not valid PEM")
+	}
+	key, err := parsePrivateKey(keyBlock.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// A cert and key that don't belong together produce signatures that fail
+	// verification remotely, with an error that points nowhere near the cause.
+	// Catch it here instead.
+	pub, ok := key.Public().(interface{ Equal(crypto.PublicKey) bool })
+	if !ok {
+		return nil, fmt.Errorf("relayauth: private key of type %T cannot be compared to the certificate", key)
+	}
+	if !pub.Equal(cert.PublicKey) {
+		return nil, fmt.Errorf("relayauth: private key does not match certificate")
+	}
+
+	if err := checkKey(cert.PublicKey); err != nil {
+		return nil, err
+	}
+
+	return &Signer{certDER: certBlock.Bytes, cert: cert, key: key}, nil
+}
+
+// parsePrivateKey parses the PKCS#8 key bbcert generates alongside the
+// certificate request.
+func parsePrivateKey(der []byte) (crypto.Signer, error) {
+	key, err := x509.ParsePKCS8PrivateKey(der)
+	if err != nil {
+		return nil, fmt.Errorf("relayauth: parse private key: %w", err)
+	}
+	signer, ok := key.(crypto.Signer)
+	if !ok {
+		return nil, fmt.Errorf("relayauth: private key of type %T cannot sign", key)
+	}
+	return signer, nil
+}
+
+// Email returns the identity the certificate asserts.
+func (s *Signer) Email() string { return s.cert.Subject.CommonName }
+
+// NotAfter returns when the underlying certificate expires. Callers use it to
+// tell a user their credential needs renewing.
+func (s *Signer) NotAfter() time.Time { return s.cert.NotAfter }
+
+// Sign mints a credential authorizing the registration of wgPublicKey at the
+// gateway identified by audience.
+func (s *Signer) Sign(audience, wgPublicKey string, lifetime time.Duration) (string, error) {
+	if audience == "" {
+		return "", fmt.Errorf("relayauth: audience is required")
+	}
+	if wgPublicKey == "" {
+		return "", fmt.Errorf("relayauth: WireGuard public key is required")
+	}
+	if lifetime <= 0 || lifetime > MaxAssertionLifetime {
+		return "", fmt.Errorf("relayauth: lifetime %s is outside (0, %s]", lifetime, MaxAssertionLifetime)
+	}
+
+	now := time.Now()
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, &claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Audience:  jwt.ClaimStrings{audience},
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(lifetime)),
+		},
+		WireGuardPublicKey: wgPublicKey,
+	})
+	token.Header["typ"] = credentialType
+	token.Header["x5c"] = []string{base64.StdEncoding.EncodeToString(s.certDER)}
+
+	cred, err := token.SignedString(s.key)
+	if err != nil {
+		return "", fmt.Errorf("relayauth: sign credential: %w", err)
+	}
+	return cred, nil
+}
+
+// Identity is the verified result of a credential.
+type Identity struct {
+	// Email is the certificate's common name.
+	Email string
+	// WireGuardPublicKey is the key the credential authorizes. Callers MUST
+	// check it against the key in the request being authenticated.
+	WireGuardPublicKey string
+	// CertNotAfter is when the certificate expires. Callers use it to bound
+	// the lifetime of whatever they grant.
+	CertNotAfter time.Time
+}
+
+// Verifier checks credentials against the tunnel CA and audience.
+type Verifier struct {
+	roots    *x509.CertPool
+	audience string
+	// now is overridable in tests.
+	now func() time.Time
+}
+
+// NewVerifier builds a Verifier trusting the PEM CA certificate(s) in caPEM.
+// audience must match what clients sign, and identifies this gateway.
+func NewVerifier(caPEM []byte, audience string) (*Verifier, error) {
+	if audience == "" {
+		return nil, fmt.Errorf("relayauth: audience is required")
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("relayauth: no CA certificates found in PEM input")
+	}
+	return &Verifier{roots: roots, audience: audience, now: time.Now}, nil
+}
+
+// Verify checks a credential and returns the identity it establishes.
+func (v *Verifier) Verify(credential string) (*Identity, error) {
+	// The parser enforces the algorithm allowlist and the signature, using
+	// the key from the x5c certificate once that chains to our CA. Claims are
+	// checked below rather than by the parser, which only knows the wall
+	// clock and does not insist on an expiry.
+	var leaf *x509.Certificate
+	c := &claims{}
+	parser := jwt.NewParser(jwt.WithValidMethods(allowedMethods), jwt.WithoutClaimsValidation())
+	token, err := parser.ParseWithClaims(credential, c, func(t *jwt.Token) (interface{}, error) {
+		cert, err := v.leafCertificate(t.Header)
+		if err != nil {
+			return nil, err
+		}
+		leaf = cert
+		return cert.PublicKey, nil
+	})
+	if err != nil {
+		var verr *jwt.ValidationError
+		if errors.As(err, &verr) {
+			switch {
+			case verr.Errors&jwt.ValidationErrorSignatureInvalid != 0:
+				return nil, fmt.Errorf("relayauth: credential signature is invalid: %w", err)
+			case verr.Inner != nil:
+				// leafCertificate's own error: an untrusted or malformed
+				// certificate.
+				return nil, fmt.Errorf("relayauth: %w", verr.Inner)
+			}
+		}
+		return nil, fmt.Errorf("relayauth: malformed credential: %w", err)
+	}
+
+	if typ, _ := token.Header["typ"].(string); typ != credentialType {
+		return nil, fmt.Errorf("relayauth: credential has type %q, not %q", typ, credentialType)
+	}
+
+	now := v.now()
+	if !c.VerifyAudience(v.audience, true) {
+		return nil, fmt.Errorf("relayauth: credential is for audience %v, not %q", []string(c.Audience), v.audience)
+	}
+	if c.ExpiresAt == nil {
+		return nil, fmt.Errorf("relayauth: credential has no expiry")
+	}
+	exp := c.ExpiresAt.Time
+	if !exp.After(now) {
+		return nil, fmt.Errorf("relayauth: credential expired at %s", exp.UTC().Format(time.RFC3339))
+	}
+	if exp.After(now.Add(MaxAssertionLifetime)) {
+		return nil, fmt.Errorf("relayauth: credential expires at %s, more than %s out",
+			exp.UTC().Format(time.RFC3339), MaxAssertionLifetime)
+	}
+	if c.WireGuardPublicKey == "" {
+		return nil, fmt.Errorf("relayauth: credential does not name a WireGuard public key")
+	}
+
+	if leaf.Subject.CommonName == "" {
+		return nil, fmt.Errorf("relayauth: certificate has no common name to identify the holder")
+	}
+
+	return &Identity{
+		Email:              leaf.Subject.CommonName,
+		WireGuardPublicKey: c.WireGuardPublicKey,
+		CertNotAfter:       leaf.NotAfter,
+	}, nil
+}
+
+// leafCertificate reads the user certificate out of a JWT's x5c header and
+// verifies it against the pinned CA for client authentication.
+func (v *Verifier) leafCertificate(header map[string]interface{}) (*x509.Certificate, error) {
+	x5c, _ := header["x5c"].([]interface{})
+	if len(x5c) != 1 {
+		return nil, fmt.Errorf("credential must carry exactly one certificate in x5c, has %d", len(x5c))
+	}
+	encoded, ok := x5c[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("malformed x5c header")
+	}
+	der, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("decode certificate: %w", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, fmt.Errorf("parse certificate: %w", err)
+	}
+
+	// Chain to a trusted CA. This also enforces the validity window, so an
+	// expired certificate is rejected here.
+	if _, err := cert.Verify(x509.VerifyOptions{
+		Roots:       v.roots,
+		CurrentTime: v.now(),
+		KeyUsages:   []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}); err != nil {
+		return nil, fmt.Errorf("certificate is not trusted: %w", err)
+	}
+	if !slices.Contains(cert.ExtKeyUsage, x509.ExtKeyUsageClientAuth) {
+		return nil, fmt.Errorf("certificate is not trusted: not valid for client authentication")
+	}
+	return cert, nil
+}
+
+// checkKey requires the one key type the credential is pinned to (see
+// allowedMethods).
+func checkKey(pub crypto.PublicKey) error {
+	switch k := pub.(type) {
+	case *ecdsa.PublicKey:
+		if k.Curve == elliptic.P256() {
+			return nil
+		}
+		return fmt.Errorf("relayauth: certificate key must be ECDSA P-256, got curve %s", k.Curve.Params().Name)
+	default:
+		return fmt.Errorf("relayauth: certificate key must be ECDSA P-256, got %T", pub)
+	}
+}

--- a/server/util/relayauth/relayauth.go
+++ b/server/util/relayauth/relayauth.go
@@ -32,8 +32,12 @@ const credentialType = "tunnel-credential+jwt"
 const MaxAssertionLifetime = 10 * time.Minute
 
 // DefaultAssertionLifetime is the expiry clients should ask for. Registration
-// is a single short RPC, so this only needs to cover one call plus skew.
+// is a single short RPC, so this only needs to cover one call.
 const DefaultAssertionLifetime = 2 * time.Minute
+
+// clockSkew is how far the client's and the gateway's clocks may disagree
+// before a credential is rejected as expired, or as expiring too far out.
+const clockSkew = time.Minute
 
 type claims struct {
 	jwt.RegisteredClaims
@@ -200,9 +204,10 @@ func (v *Verifier) Verify(credential string) (*Identity, error) {
 			switch {
 			case verr.Errors&jwt.ValidationErrorSignatureInvalid != 0:
 				return nil, fmt.Errorf("relayauth: credential signature is invalid: %w", err)
-			case verr.Inner != nil:
+			case verr.Errors&jwt.ValidationErrorUnverifiable != 0 && verr.Inner != nil:
 				// leafCertificate's own error: an untrusted or malformed
-				// certificate.
+				// certificate. A malformed token carries an Inner error too,
+				// flagged Malformed instead, and falls through.
 				return nil, fmt.Errorf("relayauth: %w", verr.Inner)
 			}
 		}
@@ -221,10 +226,10 @@ func (v *Verifier) Verify(credential string) (*Identity, error) {
 		return nil, fmt.Errorf("relayauth: credential has no expiry")
 	}
 	exp := c.ExpiresAt.Time
-	if !exp.After(now) {
+	if !exp.After(now.Add(-clockSkew)) {
 		return nil, fmt.Errorf("relayauth: credential expired at %s", exp.UTC().Format(time.RFC3339))
 	}
-	if exp.After(now.Add(MaxAssertionLifetime)) {
+	if exp.After(now.Add(MaxAssertionLifetime + clockSkew)) {
 		return nil, fmt.Errorf("relayauth: credential expires at %s, more than %s out",
 			exp.UTC().Format(time.RFC3339), MaxAssertionLifetime)
 	}

--- a/server/util/relayauth/relayauth_test.go
+++ b/server/util/relayauth/relayauth_test.go
@@ -1,0 +1,528 @@
+package relayauth
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testAudience = "relay.moon.buildbuddy.io"
+	testWGKey    = "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90"
+)
+
+type testCA struct {
+	cert   *x509.Certificate
+	key    crypto.Signer
+	pem    []byte
+	serial int64
+}
+
+func newTestCA(t *testing.T) *testCA {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test Tunnel CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return &testCA{
+		cert: cert,
+		key:  key,
+		pem:  pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+	}
+}
+
+type certOpts struct {
+	email     string
+	notBefore time.Time
+	notAfter  time.Time
+	// noClientAuth omits the client-auth extended key usage.
+	noClientAuth bool
+	// rsaKey issues an RSA cert instead of the default P-256 one.
+	rsaKey bool
+	// curve overrides the default P-256 for ECDSA certs.
+	curve elliptic.Curve
+}
+
+// issue returns a client cert and its key, both PEM encoded.
+func (ca *testCA) issue(t *testing.T, opts certOpts) (certPEM, keyPEM []byte) {
+	t.Helper()
+	if opts.email == "" {
+		opts.email = "vadim@buildbuddy.io"
+	}
+	if opts.notBefore.IsZero() {
+		opts.notBefore = time.Now().Add(-time.Minute)
+	}
+	if opts.notAfter.IsZero() {
+		opts.notAfter = time.Now().Add(12 * time.Hour)
+	}
+
+	var key crypto.Signer
+	var err error
+	if opts.rsaKey {
+		key, err = rsa.GenerateKey(rand.Reader, 2048)
+	} else {
+		curve := opts.curve
+		if curve == nil {
+			curve = elliptic.P256()
+		}
+		key, err = ecdsa.GenerateKey(curve, rand.Reader)
+	}
+	require.NoError(t, err)
+
+	ca.serial++
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(ca.serial + 100),
+		Subject:               pkix.Name{CommonName: opts.email},
+		NotBefore:             opts.notBefore,
+		NotAfter:              opts.notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	if !opts.noClientAuth {
+		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, ca.cert, key.Public(), ca.key)
+	require.NoError(t, err)
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+}
+
+func TestRoundTrip(t *testing.T) {
+	ca := newTestCA(t)
+	certPEM, keyPEM := ca.issue(t, certOpts{email: "vadim@buildbuddy.io"})
+
+	signer, err := NewSigner(certPEM, keyPEM)
+	require.NoError(t, err)
+	assert.Equal(t, "vadim@buildbuddy.io", signer.Email())
+	assert.WithinDuration(t, time.Now().Add(12*time.Hour), signer.NotAfter(), time.Minute)
+
+	cred, err := signer.Sign(testAudience, testWGKey, DefaultAssertionLifetime)
+	require.NoError(t, err)
+
+	v, err := NewVerifier(ca.pem, testAudience)
+	require.NoError(t, err)
+	id, err := v.Verify(cred)
+	require.NoError(t, err)
+
+	assert.Equal(t, "vadim@buildbuddy.io", id.Email)
+	assert.Equal(t, testWGKey, id.WireGuardPublicKey)
+	assert.WithinDuration(t, time.Now().Add(12*time.Hour), id.CertNotAfter, time.Minute)
+}
+
+func TestOnlyP256KeysAreAccepted(t *testing.T) {
+	// The credential is pinned to ES256: bbcert generates P-256 keys and
+	// certgenerator certifies nothing else, so a signer refuses any other key
+	// up front rather than minting a token the gateway would reject.
+	ca := newTestCA(t)
+	for name, opts := range map[string]certOpts{
+		"RSA":   {rsaKey: true},
+		"P-384": {curve: elliptic.P384()},
+	} {
+		t.Run(name, func(t *testing.T) {
+			certPEM, keyPEM := ca.issue(t, opts)
+			_, err := NewSigner(certPEM, keyPEM)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "P-256")
+		})
+	}
+}
+
+func TestWrongAudienceIsRejected(t *testing.T) {
+	// A credential minted for the dev gateway must not work against prod.
+	ca := newTestCA(t)
+	certPEM, keyPEM := ca.issue(t, certOpts{})
+	signer, err := NewSigner(certPEM, keyPEM)
+	require.NoError(t, err)
+	cred, err := signer.Sign("gateway.dev.buildbuddy.io", testWGKey, DefaultAssertionLifetime)
+	require.NoError(t, err)
+
+	v, err := NewVerifier(ca.pem, "gateway.prod.buildbuddy.io")
+	require.NoError(t, err)
+	_, err = v.Verify(cred)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "audience")
+}
+
+func TestExpiredAssertionIsRejected(t *testing.T) {
+	ca := newTestCA(t)
+	certPEM, keyPEM := ca.issue(t, certOpts{})
+	signer, err := NewSigner(certPEM, keyPEM)
+	require.NoError(t, err)
+	cred, err := signer.Sign(testAudience, testWGKey, time.Minute)
+	require.NoError(t, err)
+
+	v, err := NewVerifier(ca.pem, testAudience)
+	require.NoError(t, err)
+	// The certificate is still good; only the assertion has aged out.
+	v.now = func() time.Time { return time.Now().Add(2 * time.Minute) }
+
+	_, err = v.Verify(cred)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expired")
+}
+
+func TestAssertionTooFarInTheFutureIsRejected(t *testing.T) {
+	// Bounds the replay window even if a client asks for a long-lived
+	// assertion, so a captured credential goes stale quickly.
+	ca := newTestCA(t)
+	// Backdate the certificate so that rewinding the verifier's clock below
+	// tests the assertion bound rather than the certificate's own window.
+	certPEM, keyPEM := ca.issue(t, certOpts{notBefore: time.Now().Add(-24 * time.Hour)})
+	signer, err := NewSigner(certPEM, keyPEM)
+	require.NoError(t, err)
+
+	_, err = signer.Sign(testAudience, testWGKey, 2*time.Hour)
+	require.Error(t, err, "the signer should refuse to mint a long-lived assertion")
+
+	// A client that bypasses the signer still can't get one past a verifier.
+	cred, err := signer.Sign(testAudience, testWGKey, MaxAssertionLifetime)
+	require.NoError(t, err)
+	v, err := NewVerifier(ca.pem, testAudience)
+	require.NoError(t, err)
+	v.now = func() time.Time { return time.Now().Add(-time.Hour) }
+	_, err = v.Verify(cred)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "more than")
+}
+
+func TestCertFromAnotherCAIsRejected(t *testing.T) {
+	trusted := newTestCA(t)
+	other := newTestCA(t)
+	certPEM, keyPEM := other.issue(t, certOpts{})
+	signer, err := NewSigner(certPEM, keyPEM)
+	require.NoError(t, err)
+	cred, err := signer.Sign(testAudience, testWGKey, DefaultAssertionLifetime)
+	require.NoError(t, err)
+
+	v, err := NewVerifier(trusted.pem, testAudience)
+	require.NoError(t, err)
+	_, err = v.Verify(cred)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not trusted")
+}
+
+func TestExpiredCertIsRejected(t *testing.T) {
+	// This is what makes a 12h certificate actually expire: the chain
+	// check enforces the certificate's validity window.
+	ca := newTestCA(t)
+	certPEM, keyPEM := ca.issue(t, certOpts{
+		notBefore: time.Now().Add(-24 * time.Hour),
+		notAfter:  time.Now().Add(-time.Hour),
+	})
+	signer, err := NewSigner(certPEM, keyPEM)
+	require.NoError(t, err)
+	cred, err := signer.Sign(testAudience, testWGKey, DefaultAssertionLifetime)
+	require.NoError(t, err)
+
+	v, err := NewVerifier(ca.pem, testAudience)
+	require.NoError(t, err)
+	_, err = v.Verify(cred)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not trusted")
+}
+
+func TestCertWithoutClientAuthIsRejected(t *testing.T) {
+	ca := newTestCA(t)
+	certPEM, keyPEM := ca.issue(t, certOpts{noClientAuth: true})
+	signer, err := NewSigner(certPEM, keyPEM)
+	require.NoError(t, err)
+	cred, err := signer.Sign(testAudience, testWGKey, DefaultAssertionLifetime)
+	require.NoError(t, err)
+
+	v, err := NewVerifier(ca.pem, testAudience)
+	require.NoError(t, err)
+	_, err = v.Verify(cred)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not trusted")
+}
+
+func TestSubstitutedWireGuardKeyIsRejected(t *testing.T) {
+	// The whole point of the binding: an attacker who captures a credential
+	// must not be able to point it at a WireGuard key they control.
+	ca := newTestCA(t)
+	certPEM, keyPEM := ca.issue(t, certOpts{})
+	signer, err := NewSigner(certPEM, keyPEM)
+	require.NoError(t, err)
+	cred, err := signer.Sign(testAudience, testWGKey, DefaultAssertionLifetime)
+	require.NoError(t, err)
+
+	attackerKey := strings.Repeat("f", 64)
+	forged, err := signer.Sign(testAudience, attackerKey, DefaultAssertionLifetime)
+	require.NoError(t, err)
+
+	// Splice the attacker's payload onto the captured credential, keeping the
+	// original signature.
+	origParts := strings.Split(cred, ".")
+	forgedParts := strings.Split(forged, ".")
+	require.Len(t, origParts, 3)
+	spliced := strings.Join([]string{origParts[0], forgedParts[1], origParts[2]}, ".")
+
+	v, err := NewVerifier(ca.pem, testAudience)
+	require.NoError(t, err)
+	_, err = v.Verify(spliced)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "signature")
+}
+
+func TestBorrowedCertIsRejected(t *testing.T) {
+	// Certificates are public. Presenting someone else's, with an assertion
+	// signed by your own key, must fail.
+	ca := newTestCA(t)
+	victimCert, _ := ca.issue(t, certOpts{email: "victim@buildbuddy.io"})
+	attackerCert, attackerKey := ca.issue(t, certOpts{email: "attacker@buildbuddy.io"})
+
+	signer, err := NewSigner(attackerCert, attackerKey)
+	require.NoError(t, err)
+	cred, err := signer.Sign(testAudience, testWGKey, DefaultAssertionLifetime)
+	require.NoError(t, err)
+
+	victimBlock, _ := pem.Decode(victimCert)
+	require.NotNil(t, victimBlock)
+	parts := strings.Split(cred, ".")
+	require.Len(t, parts, 3)
+	spliced := strings.Join([]string{headerSegment(t, "ES256", victimBlock.Bytes), parts[1], parts[2]}, ".")
+
+	v, err := NewVerifier(ca.pem, testAudience)
+	require.NoError(t, err)
+	_, err = v.Verify(spliced)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "signature")
+}
+
+func TestMismatchedCertAndKeyIsCaughtLocally(t *testing.T) {
+	ca := newTestCA(t)
+	certPEM, _ := ca.issue(t, certOpts{})
+	_, otherKeyPEM := ca.issue(t, certOpts{})
+
+	_, err := NewSigner(certPEM, otherKeyPEM)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match")
+}
+
+func TestMalformedCredentials(t *testing.T) {
+	ca := newTestCA(t)
+	certPEM, keyPEM := ca.issue(t, certOpts{})
+	signer, err := NewSigner(certPEM, keyPEM)
+	require.NoError(t, err)
+	valid, err := signer.Sign(testAudience, testWGKey, DefaultAssertionLifetime)
+	require.NoError(t, err)
+	parts := strings.Split(valid, ".")
+
+	for name, cred := range map[string]string{
+		"empty":         "",
+		"one segment":   parts[0],
+		"two segments":  parts[0] + "." + parts[1],
+		"four segments": valid + ".extra",
+		"bad base64":    "!!!." + parts[1] + "." + parts[2],
+		"not a cert":    headerSegment(t, "ES256", []byte("hello")) + "." + parts[1] + "." + parts[2],
+		"empty payload": parts[0] + ".." + parts[2],
+		"no signature":  parts[0] + "." + parts[1] + ".",
+	} {
+		t.Run(name, func(t *testing.T) {
+			v, err := NewVerifier(ca.pem, testAudience)
+			require.NoError(t, err)
+			_, err = v.Verify(cred)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestVerifierRequiresCAAndAudience(t *testing.T) {
+	ca := newTestCA(t)
+
+	_, err := NewVerifier(ca.pem, "")
+	assert.Error(t, err, "an empty audience would accept assertions minted for any gateway")
+
+	_, err = NewVerifier([]byte("not a pem file"), testAudience)
+	assert.Error(t, err)
+}
+
+func TestSignerRejectsIncompleteArguments(t *testing.T) {
+	ca := newTestCA(t)
+	certPEM, keyPEM := ca.issue(t, certOpts{})
+	signer, err := NewSigner(certPEM, keyPEM)
+	require.NoError(t, err)
+
+	_, err = signer.Sign("", testWGKey, DefaultAssertionLifetime)
+	assert.Error(t, err)
+	_, err = signer.Sign(testAudience, "", DefaultAssertionLifetime)
+	assert.Error(t, err)
+	_, err = signer.Sign(testAudience, testWGKey, 0)
+	assert.Error(t, err)
+
+	_, err = NewSigner([]byte("nope"), keyPEM)
+	assert.Error(t, err)
+	_, err = NewSigner(certPEM, []byte("nope"))
+	assert.Error(t, err)
+}
+
+// headerSegment returns a base64url-encoded JWT header for alg, carrying
+// certDER in x5c when non-nil.
+func headerSegment(t *testing.T, alg string, certDER []byte) string {
+	t.Helper()
+	h := map[string]interface{}{"alg": alg, "typ": credentialType}
+	if certDER != nil {
+		h["x5c"] = []string{base64.StdEncoding.EncodeToString(certDER)}
+	}
+	b, err := json.Marshal(h)
+	require.NoError(t, err)
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func TestHostileHeadersAreRejected(t *testing.T) {
+	// The JWT header is attacker-controlled. Nothing in it may pick the
+	// verification key or the algorithm: the key comes from a certificate that
+	// chains to our CA, and the algorithm must be one that key supports.
+	ca := newTestCA(t)
+	certPEM, keyPEM := ca.issue(t, certOpts{})
+	signer, err := NewSigner(certPEM, keyPEM)
+	require.NoError(t, err)
+	valid, err := signer.Sign(testAudience, testWGKey, DefaultAssertionLifetime)
+	require.NoError(t, err)
+	parts := strings.Split(valid, ".")
+	require.Len(t, parts, 3)
+	certBlock, _ := pem.Decode(certPEM)
+	require.NotNil(t, certBlock)
+	keyBlock, _ := pem.Decode(keyPEM)
+	require.NotNil(t, keyBlock)
+	key, err := parsePrivateKey(keyBlock.Bytes)
+	require.NoError(t, err)
+
+	withHeader := func(alg string, extra map[string]interface{}) string {
+		t.Helper()
+		token := jwt.NewWithClaims(jwt.GetSigningMethod(alg), &claims{
+			RegisteredClaims: jwt.RegisteredClaims{
+				Audience:  jwt.ClaimStrings{testAudience},
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(DefaultAssertionLifetime)),
+			},
+			WireGuardPublicKey: testWGKey,
+		})
+		token.Header["typ"] = credentialType
+		token.Header["x5c"] = []string{base64.StdEncoding.EncodeToString(certBlock.Bytes)}
+		for k, v := range extra {
+			token.Header[k] = v
+		}
+		var signingKey interface{} = key
+		switch alg {
+		case "none":
+			signingKey = jwt.UnsafeAllowNoneSignatureType
+		case "HS256":
+			signingKey = []byte("a secret the presenter chose")
+		}
+		cred, err := token.SignedString(signingKey)
+		require.NoError(t, err)
+		return cred
+	}
+
+	// A P-384 certificate the CA did sign, presented with the matching ES384
+	// token: a valid signature by a valid certificate, but not the one
+	// algorithm the verifier is pinned to.
+	p384Cert, p384Key := ca.issue(t, certOpts{curve: elliptic.P384()})
+	es384 := func() string {
+		cb, _ := pem.Decode(p384Cert)
+		require.NotNil(t, cb)
+		kb, _ := pem.Decode(p384Key)
+		require.NotNil(t, kb)
+		p384, err := parsePrivateKey(kb.Bytes)
+		require.NoError(t, err)
+		token := jwt.NewWithClaims(jwt.SigningMethodES384, &claims{
+			RegisteredClaims: jwt.RegisteredClaims{
+				Audience:  jwt.ClaimStrings{testAudience},
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(DefaultAssertionLifetime)),
+			},
+			WireGuardPublicKey: testWGKey,
+		})
+		token.Header["typ"] = credentialType
+		token.Header["x5c"] = []string{base64.StdEncoding.EncodeToString(cb.Bytes)}
+		cred, err := token.SignedString(p384)
+		require.NoError(t, err)
+		return cred
+	}()
+
+	for name, tc := range map[string]struct {
+		cred string
+		want string
+	}{
+		"alg none": {
+			cred: withHeader("none", nil),
+			want: "signature",
+		},
+		"ES384 with a P-384 certificate": {
+			cred: es384,
+			want: "signature",
+		},
+		"HMAC with a presenter-chosen key": {
+			cred: withHeader("HS256", nil),
+			want: "signature",
+		},
+		"no certificate": {
+			cred: headerSegment(t, "ES256", nil) + "." + parts[1] + "." + parts[2],
+			want: "certificate",
+		},
+		// x5c is not a chain here: the CA is pinned, so anything beyond the
+		// user certificate is something to distrust rather than verify.
+		"two certificates": {
+			cred: headerWithX5C(t, certBlock.Bytes, certBlock.Bytes) + "." + parts[1] + "." + parts[2],
+			want: "exactly one",
+		},
+		"wrong type": {
+			cred: withHeader("ES256", map[string]interface{}{"typ": "JWT"}),
+			want: "type",
+		},
+		// A jwk/jku header naming the attacker's key must be ignored in
+		// favor of the certificate: the signature is by the wrong key.
+		"header-supplied key": {
+			cred: headerSegment(t, "ES256", certBlock.Bytes) + "." + parts[1] + "." + strings.Repeat("A", len(parts[2])),
+			want: "signature",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			v, err := NewVerifier(ca.pem, testAudience)
+			require.NoError(t, err)
+			_, err = v.Verify(tc.cred)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+// headerWithX5C returns a base64url-encoded ES256 JWT header carrying certs in
+// x5c.
+func headerWithX5C(t *testing.T, certs ...[]byte) string {
+	t.Helper()
+	x5c := make([]string, 0, len(certs))
+	for _, c := range certs {
+		x5c = append(x5c, base64.StdEncoding.EncodeToString(c))
+	}
+	b, err := json.Marshal(map[string]interface{}{"alg": "ES256", "typ": credentialType, "x5c": x5c})
+	require.NoError(t, err)
+	return base64.RawURLEncoding.EncodeToString(b)
+}

--- a/server/util/relayauth/relayauth_test.go
+++ b/server/util/relayauth/relayauth_test.go
@@ -189,6 +189,32 @@ func TestExpiredAssertionIsRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "expired")
 }
 
+func TestClockSkewIsTolerated(t *testing.T) {
+	// Client and gateway clocks disagree by a little in either direction;
+	// neither the expiry nor the lifetime cap may reject a credential for it.
+	ca := newTestCA(t)
+	certPEM, keyPEM := ca.issue(t, certOpts{notBefore: time.Now().Add(-24 * time.Hour)})
+	signer, err := NewSigner(certPEM, keyPEM)
+	require.NoError(t, err)
+
+	// A gateway 30s ahead sees a default credential 30s past its expiry.
+	cred, err := signer.Sign(testAudience, testWGKey, DefaultAssertionLifetime)
+	require.NoError(t, err)
+	v, err := NewVerifier(ca.pem, testAudience)
+	require.NoError(t, err)
+	v.now = func() time.Time { return time.Now().Add(DefaultAssertionLifetime + 30*time.Second) }
+	_, err = v.Verify(cred)
+	require.NoError(t, err)
+
+	// A gateway 30s behind sees a maximum-lifetime credential expiring 30s
+	// beyond the cap.
+	cred, err = signer.Sign(testAudience, testWGKey, MaxAssertionLifetime)
+	require.NoError(t, err)
+	v.now = func() time.Time { return time.Now().Add(-30 * time.Second) }
+	_, err = v.Verify(cred)
+	require.NoError(t, err)
+}
+
 func TestAssertionTooFarInTheFutureIsRejected(t *testing.T) {
 	// Bounds the replay window even if a client asks for a long-lived
 	// assertion, so a captured credential goes stale quickly.
@@ -336,21 +362,29 @@ func TestMalformedCredentials(t *testing.T) {
 	require.NoError(t, err)
 	parts := strings.Split(valid, ".")
 
-	for name, cred := range map[string]string{
-		"empty":         "",
-		"one segment":   parts[0],
-		"two segments":  parts[0] + "." + parts[1],
-		"four segments": valid + ".extra",
-		"bad base64":    "!!!." + parts[1] + "." + parts[2],
-		"not a cert":    headerSegment(t, "ES256", []byte("hello")) + "." + parts[1] + "." + parts[2],
-		"empty payload": parts[0] + ".." + parts[2],
-		"no signature":  parts[0] + "." + parts[1] + ".",
+	// Each is rejected with an error that says what kind of problem it is:
+	// a token the parser cannot read, a certificate it cannot use, or a bad
+	// signature.
+	for name, tc := range map[string]struct{ cred, want string }{
+		"empty":         {"", "malformed credential"},
+		"one segment":   {parts[0], "malformed credential"},
+		"two segments":  {parts[0] + "." + parts[1], "malformed credential"},
+		"four segments": {valid + ".extra", "malformed credential"},
+		"bad base64":    {"!!!." + parts[1] + "." + parts[2], "malformed credential"},
+		"header not json": {
+			base64.RawURLEncoding.EncodeToString([]byte("{")) + "." + parts[1] + "." + parts[2],
+			"malformed credential",
+		},
+		"not a cert":    {headerSegment(t, "ES256", []byte("hello")) + "." + parts[1] + "." + parts[2], "parse certificate"},
+		"empty payload": {parts[0] + ".." + parts[2], "malformed credential"},
+		"no signature":  {parts[0] + "." + parts[1] + ".", "signature is invalid"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			v, err := NewVerifier(ca.pem, testAudience)
 			require.NoError(t, err)
-			_, err = v.Verify(cred)
-			assert.Error(t, err)
+			_, err = v.Verify(tc.cred)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
 		})
 	}
 }


### PR DESCRIPTION
Depends on https://github.com/buildbuddy-io/buildbuddy/pull/13165

bbcert will obtain a new certificate for use with the relay gateway.

The client will sign a JWT and present it to the gateway. The authenticator validates the JWT and checks that the certificate presented was signed by the CA.