### PR TITLE
bare: record command usage timelines

### DIFF
--- a/enterprise/server/remote_execution/containers/bare/bare.go
+++ b/enterprise/server/remote_execution/containers/bare/bare.go
@@ -102,10 +102,11 @@ func (c *bareCommandContainer) Signal(ctx context.Context, sig syscall.Signal) e
 
 func (c *bareCommandContainer) exec(ctx context.Context, cmd *repb.Command, workDir string, stdio *interfaces.Stdio) (result *interfaces.CommandResult) {
 	var statsListener procstats.Listener
+	var statsTracker *container.UsageStats
 	if c.opts.EnableStats {
-		// Setting the stats listener to non-nil enables stats reporting in
-		// commandutil.RunWithOpts.
-		statsListener = func(*repb.UsageStats) {}
+		statsTracker = &container.UsageStats{}
+		statsTracker.Reset()
+		statsListener = statsTracker.Update
 	}
 
 	if *enableLogFiles {
@@ -162,12 +163,26 @@ func (c *bareCommandContainer) exec(ctx context.Context, cmd *repb.Command, work
 		}
 	}
 
-	return commandutil.RunWithOpts(ctx, cmd, &commandutil.RunOpts{
+	result = commandutil.RunWithOpts(ctx, cmd, &commandutil.RunOpts{
 		Dir:           filepath.Join(workDir, cmd.GetWorkingDirectory()),
 		StatsListener: statsListener,
 		Stdio:         stdio,
 		Signal:        c.signal,
 	})
+	if statsTracker != nil {
+		// commandutil may augment the final CPU and memory values using
+		// platform-specific process accounting after the last listener update.
+		// Record that reading even if the command finished before the first poll.
+		if result.UsageStats != nil {
+			statsTracker.Update(result.UsageStats)
+		}
+		trackedStats := statsTracker.TaskStats()
+		trackedStats.CpuNanos = max(trackedStats.GetCpuNanos(), result.UsageStats.GetCpuNanos())
+		trackedStats.PeakMemoryBytes = max(trackedStats.GetPeakMemoryBytes(), result.UsageStats.GetPeakMemoryBytes())
+		trackedStats.MemoryBytes = result.UsageStats.GetMemoryBytes()
+		result.UsageStats = trackedStats
+	}
+	return result
 }
 
 func (c *bareCommandContainer) IsImageCached(ctx context.Context) (bool, error) { return false, nil }

--- a/enterprise/server/remote_execution/containers/bare/bare_test.go
+++ b/enterprise/server/remote_execution/containers/bare/bare_test.go
@@ -69,6 +69,44 @@ func TestHelloWorldOnBareMetal(t *testing.T) {
 	assert.Equal(t, 0, result.ExitCode, "should exit with success")
 }
 
+func TestRun_StatsEnabled_RecordsUsageTimeline(t *testing.T) {
+	flags.Set(t, "executor.record_usage_timelines", true)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	workDir := testfs.MakeTempDir(t)
+	ctr := bare.NewBareCommandContainer(&bare.Opts{EnableStats: true})
+
+	result := ctr.Run(ctx, &repb.Command{
+		Arguments: []string{"sh", "-c", "sleep 0.1 & sleeper=$!; i=0; while kill -0 $sleeper 2>/dev/null; do i=$((i + 1)); done; wait $sleeper"},
+	}, workDir, oci.Credentials{})
+
+	require.NoError(t, result.Error)
+	require.Positive(t, result.UsageStats.GetCpuNanos())
+	require.Positive(t, result.UsageStats.GetPeakMemoryBytes())
+	require.NotNil(t, result.UsageStats.GetTimeline())
+	require.GreaterOrEqual(t, len(result.UsageStats.GetTimeline().GetTimestamps()), 2)
+	cpuMillis := int64(0)
+	for _, deltaMillis := range result.UsageStats.GetTimeline().GetCpuSamples() {
+		cpuMillis += deltaMillis
+	}
+	require.Positive(t, cpuMillis)
+	require.Equal(t, result.UsageStats.GetCpuNanos()/int64(time.Millisecond), cpuMillis)
+}
+
+func TestRun_StatsEnabled_RecordsFastCommandTimeline(t *testing.T) {
+	flags.Set(t, "executor.record_usage_timelines", true)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctr := bare.NewBareCommandContainer(&bare.Opts{EnableStats: true})
+	result := ctr.Run(ctx, &repb.Command{
+		Arguments: []string{"sh", "-c", "exit 0"},
+	}, testfs.MakeTempDir(t), oci.Credentials{})
+
+	require.NoError(t, result.Error)
+	require.Zero(t, result.ExitCode)
+	require.NotEmpty(t, result.UsageStats.GetTimeline().GetTimestamps())
+}
+
 func TestLogFiles(t *testing.T) {
 	flags.Set(t, "executor.bare.enable_log_files", true)
 	ctx := context.Background()


### PR DESCRIPTION
Bare commands discard each usage sample, so task sizing cannot use
percentile CPU estimates even when usage timelines are enabled. Feed
samples into the existing UsageStats tracker and return its timeline
alongside the final CPU and memory accounting from commandutil.

Record the final platform accounting sample so fast commands still
have a timeline and the timeline includes CPU consumed after the
last poll. Cover both a bounded CPU loop and a command that exits
immediately.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
