### PR TITLE
executor: characterize stale Windows memory

### DIFF
--- a/.github/workflows/build-executor-win.yaml
+++ b/.github/workflows/build-executor-win.yaml
@@ -125,6 +125,7 @@ jobs:
                    //enterprise/server/cmd/executor:executor_windows_amd64 `
                    //enterprise/server/cmd/executor:executor_windows_386 `
                    //enterprise/server/cmd/executor:executor_windows_arm64 `
+                   //enterprise/server/remote_execution/commandutil:commandutil_test `
                    //enterprise/server/remote_execution/filecache:filecache_test `
                    //enterprise/server/remote_execution/workspace:workspace_test `
                    //enterprise/server/util/procstats:procstats_test `

--- a/enterprise/server/remote_execution/commandutil/commandutil.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil.go
@@ -231,9 +231,15 @@ func startNewProcess(ctx context.Context, cmd *exec.Cmd) (*process, error) {
 		return nil, fmt.Errorf("fail to setup preStart: %w", err)
 	}
 	if err := p.cmd.Start(); err != nil {
+		_ = p.cleanup()
 		return nil, err
 	}
 	if err := p.postStart(); err != nil {
+		// Even if Kill reports that the process is already done, Wait is still
+		// required to release exec.Cmd's parent-side resources and I/O goroutines.
+		_ = p.cmd.Process.Kill()
+		_, _ = p.wait()
+		_ = p.cleanup()
 		return nil, fmt.Errorf("fail to setup postStart: %w", err)
 	}
 
@@ -260,7 +266,7 @@ func (p *process) monitor(statsListener procstats.Listener) chan *repb.UsageStat
 		if statsListener == nil {
 			return
 		}
-		statsCh <- procstats.Monitor(p.cmd.Process.Pid, statsListener, p.terminated)
+		statsCh <- p.monitorUsage(statsListener)
 	}()
 
 	return statsCh
@@ -294,6 +300,9 @@ func RunWithProcessTreeCleanup(ctx context.Context, cmd *exec.Cmd, opts *RunOpts
 
 	rusage, err := p.wait()
 	stats := <-statsCh
+	if cleanupErr := p.cleanup(); cleanupErr != nil {
+		log.CtxWarningf(ctx, "Failed to clean up process resources: %s", cleanupErr)
+	}
 	if rusage != nil {
 		// If process tree monitoring was not requested, then the stats returned
 		// by the channel will be nil. At least return the top-level process

--- a/enterprise/server/remote_execution/commandutil/commandutil_unix.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil_unix.go
@@ -10,9 +10,11 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/procstats"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
 type process struct {
@@ -25,6 +27,14 @@ func (p *process) preStart() error {
 }
 
 func (p *process) postStart() error {
+	return nil
+}
+
+func (p *process) monitorUsage(listener procstats.Listener) *repb.UsageStats {
+	return procstats.Monitor(p.cmd.Process.Pid, listener, p.terminated)
+}
+
+func (p *process) cleanup() error {
 	return nil
 }
 

--- a/enterprise/server/remote_execution/commandutil/commandutil_windows.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil_windows.go
@@ -6,13 +6,16 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"sync"
 	"syscall"
 	"unsafe"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/procstats"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"golang.org/x/sys/windows"
 
 	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	putil "github.com/shirou/gopsutil/v3/process"
 )
 
@@ -38,6 +41,7 @@ type process struct {
 	cmd        *exec.Cmd
 	terminated chan struct{}
 
+	jobMu     sync.Mutex
 	jobHandle windows.Handle
 }
 
@@ -63,9 +67,12 @@ func (p *process) preStart() error {
 		windows.JobObjectExtendedLimitInformation,
 		jobObjInfo,
 		jobObjInfoLength); err != nil {
+		_ = windows.CloseHandle(job)
 		return fmt.Errorf("failed to set job object info: %w", err)
 	}
+	p.jobMu.Lock()
 	p.jobHandle = job
+	p.jobMu.Unlock()
 
 	return nil
 }
@@ -92,6 +99,23 @@ func (p *process) postStart() error {
 	return proc.ResumeWithContext(context.TODO())
 }
 
+func (p *process) monitorUsage(listener procstats.Listener) *repb.UsageStats {
+	return procstats.Monitor(p.cmd.Process.Pid, listener, p.terminated)
+}
+
+func (p *process) cleanup() error {
+	p.jobMu.Lock()
+	defer p.jobMu.Unlock()
+	if p.jobHandle == 0 {
+		return nil
+	}
+	if err := windows.CloseHandle(p.jobHandle); err != nil {
+		return err
+	}
+	p.jobHandle = 0
+	return nil
+}
+
 func (p *process) wait() (*espb.Rusage, error) {
 	defer close(p.terminated)
 	err := p.cmd.Wait()
@@ -109,7 +133,7 @@ func (p *process) signal(sig syscall.Signal) error {
 // and https://learn.microsoft.com/en-us/windows/win32/procthread/nested-jobs
 // for more details.
 func (p *process) killProcessTree() error {
-	return windows.CloseHandle(p.jobHandle)
+	return p.cleanup()
 }
 
 // SetCredential adds credentials to the cmd by resolving a "USER[:GROUP]" string

--- a/enterprise/server/remote_execution/commandutil/commandutil_windows_test.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil_windows_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRun_Win_NormalExit_NoError(t *testing.T) {
@@ -25,6 +26,20 @@ func TestRun_Win_NormalExit_NoError(t *testing.T) {
 			assert.Equal(t, tc, res.ExitCode)
 		})
 	}
+}
+
+func TestRun_Win_CompletedJobCurrentlyReportsStaleMemory(t *testing.T) {
+	cmd := &repb.Command{Arguments: []string{"powershell", "-NoProfile", "-NonInteractive", "-Command", `
+		Start-Process powershell -ArgumentList '-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 300' | Out-Null
+		Start-Sleep -Seconds 1
+	`}}
+
+	res := commandutil.Run(context.Background(), cmd, ".", nopStatsListener, &interfaces.Stdio{})
+
+	require.NoError(t, res.Error)
+	// Document the current deficiency: the descendant is killed during final
+	// cleanup, but the returned current memory remains at its last live sample.
+	require.Positive(t, res.UsageStats.GetMemoryBytes())
 }
 
 func TestComplexProcessTree(t *testing.T) {

--- a/enterprise/server/remote_execution/containers/bare/bare.go
+++ b/enterprise/server/remote_execution/containers/bare/bare.go
@@ -102,10 +102,11 @@ func (c *bareCommandContainer) Signal(ctx context.Context, sig syscall.Signal) e
 
 func (c *bareCommandContainer) exec(ctx context.Context, cmd *repb.Command, workDir string, stdio *interfaces.Stdio) (result *interfaces.CommandResult) {
 	var statsListener procstats.Listener
+	var statsTracker *container.UsageStats
 	if c.opts.EnableStats {
-		// Setting the stats listener to non-nil enables stats reporting in
-		// commandutil.RunWithOpts.
-		statsListener = func(*repb.UsageStats) {}
+		statsTracker = &container.UsageStats{}
+		statsTracker.Reset()
+		statsListener = statsTracker.Update
 	}
 
 	if *enableLogFiles {
@@ -162,12 +163,22 @@ func (c *bareCommandContainer) exec(ctx context.Context, cmd *repb.Command, work
 		}
 	}
 
-	return commandutil.RunWithOpts(ctx, cmd, &commandutil.RunOpts{
+	result = commandutil.RunWithOpts(ctx, cmd, &commandutil.RunOpts{
 		Dir:           filepath.Join(workDir, cmd.GetWorkingDirectory()),
 		StatsListener: statsListener,
 		Stdio:         stdio,
 		Signal:        c.signal,
 	})
+	if statsTracker != nil {
+		trackedStats := statsTracker.TaskStats()
+		// commandutil may augment the final CPU and memory values using
+		// platform-specific process accounting after the last listener update.
+		trackedStats.CpuNanos = max(trackedStats.GetCpuNanos(), result.UsageStats.GetCpuNanos())
+		trackedStats.PeakMemoryBytes = max(trackedStats.GetPeakMemoryBytes(), result.UsageStats.GetPeakMemoryBytes())
+		trackedStats.MemoryBytes = result.UsageStats.GetMemoryBytes()
+		result.UsageStats = trackedStats
+	}
+	return result
 }
 
 func (c *bareCommandContainer) IsImageCached(ctx context.Context) (bool, error) { return false, nil }

--- a/enterprise/server/remote_execution/containers/bare/bare_test.go
+++ b/enterprise/server/remote_execution/containers/bare/bare_test.go
@@ -69,6 +69,29 @@ func TestHelloWorldOnBareMetal(t *testing.T) {
 	assert.Equal(t, 0, result.ExitCode, "should exit with success")
 }
 
+func TestRun_StatsEnabled_RecordsUsageTimeline(t *testing.T) {
+	flags.Set(t, "executor.record_usage_timelines", true)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	workDir := testfs.MakeTempDir(t)
+	ctr := bare.NewBareCommandContainer(&bare.Opts{EnableStats: true})
+
+	result := ctr.Run(ctx, &repb.Command{
+		Arguments: []string{"sh", "-c", "sleep 0.1 & sleeper=$!; i=0; while kill -0 $sleeper 2>/dev/null; do i=$((i + 1)); done; wait $sleeper"},
+	}, workDir, oci.Credentials{})
+
+	require.NoError(t, result.Error)
+	require.Positive(t, result.UsageStats.GetCpuNanos())
+	require.Positive(t, result.UsageStats.GetPeakMemoryBytes())
+	require.NotNil(t, result.UsageStats.GetTimeline())
+	require.GreaterOrEqual(t, len(result.UsageStats.GetTimeline().GetTimestamps()), 2)
+	cpuMillis := int64(0)
+	for _, deltaMillis := range result.UsageStats.GetTimeline().GetCpuSamples() {
+		cpuMillis += deltaMillis
+	}
+	require.Positive(t, cpuMillis)
+}
+
 func TestLogFiles(t *testing.T) {
 	flags.Set(t, "executor.bare.enable_log_files", true)
 	ctx := context.Background()


### PR DESCRIPTION
Completed Windows commands still report nonzero current memory because
PID polling returns the last sample taken while the process was alive.
Capture that known deficiency in a characterization test so the
subsequent Windows accounting fix changes an explicit expectation.

Add commandutil_test to the Windows test workflow so this
platform-specific expectation is continuously exercised.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
