### PR TITLE
commandutil: measure Windows Job Object CPU usage

### DIFF
--- a/enterprise/server/remote_execution/commandutil/BUILD
+++ b/enterprise/server/remote_execution/commandutil/BUILD
@@ -31,6 +31,7 @@ go_test(
     name = "commandutil_test",
     size = "enormous",
     srcs = [
+        "commandutil_internal_windows_test.go",
         "commandutil_test.go",
         "commandutil_unix_test.go",
         "commandutil_windows_test.go",
@@ -39,6 +40,7 @@ go_test(
         "@io_bazel_rules_go//go/platform:windows": [],
         "//conditions:default": ["//enterprise/server/remote_execution/commandutil/test_binary:test_binary_no_cov"],
     }),
+    embed = [":commandutil"],
     tags = ["cpu:4"],
     x_defs = select({
         "@io_bazel_rules_go//go/platform:windows": {},
@@ -47,7 +49,6 @@ go_test(
         },
     }),
     deps = [
-        ":commandutil",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
         "//server/util/status",

--- a/enterprise/server/remote_execution/commandutil/commandutil.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil.go
@@ -301,6 +301,7 @@ func RunWithProcessTreeCleanup(ctx context.Context, cmd *exec.Cmd, opts *RunOpts
 
 	rusage, err := p.wait()
 	stats := <-statsCh
+	p.finalizeUsage(stats)
 	if cleanupErr := p.cleanup(); cleanupErr != nil {
 		log.CtxWarningf(ctx, "Failed to clean up process resources: %s", cleanupErr)
 	}

--- a/enterprise/server/remote_execution/commandutil/commandutil_internal_windows_test.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil_internal_windows_test.go
@@ -1,0 +1,53 @@
+//go:build windows
+
+package commandutil
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMonitorUsageIncludesExitedChildCPU(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	workDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "child.ps1"), []byte(`
+$timer = [System.Diagnostics.Stopwatch]::StartNew()
+while ($timer.ElapsedMilliseconds -lt 250) {}
+`), 0600))
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", `
+		$ErrorActionPreference = 'Stop'
+		$child = Start-Process powershell -ArgumentList '-NoProfile','-NonInteractive','-File','child.ps1' -PassThru
+		$child.WaitForExit()
+		if ($child.ExitCode -ne 0) { exit 1 }
+		Write-Output $child.TotalProcessorTime.Ticks
+	`)
+	cmd.Dir = workDir
+	cmd.SysProcAttr = getDefaultSysProcAttr()
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	p, err := startNewProcess(ctx, cmd)
+	require.NoError(t, err)
+	defer p.cleanup()
+	_, err = p.wait()
+	require.NoError(t, err, "stderr: %s", stderr.String())
+	require.NoError(t, ctx.Err())
+	childCPUTicks, err := strconv.ParseInt(strings.TrimSpace(stdout.String()), 10, 64)
+	require.NoError(t, err)
+	require.Positive(t, childCPUTicks)
+
+	// Neither process exists when monitoring starts. A PID poller cannot
+	// recover their CPU usage, but Job Object accounting must retain at least
+	// the CPU independently measured by the parent for its exited child.
+	stats := p.monitorUsage(nil)
+	require.GreaterOrEqual(t, stats.GetCpuNanos(), childCPUTicks*100)
+}

--- a/enterprise/server/remote_execution/commandutil/commandutil_unix.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil_unix.go
@@ -42,6 +42,9 @@ func (p *process) killRootProcess() error {
 	return p.cmd.Process.Kill()
 }
 
+func (p *process) finalizeUsage(stats *repb.UsageStats) {
+}
+
 func isKilledExitCode(exitCode int, err error) bool {
 	return exitCode == KilledExitCode
 }

--- a/enterprise/server/remote_execution/commandutil/commandutil_windows.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil_windows.go
@@ -56,6 +56,7 @@ type process struct {
 	jobMu     sync.Mutex
 	jobHandle windows.Handle
 	killed    bool
+	inactive  bool
 }
 
 type processKilledError struct {
@@ -140,7 +141,32 @@ func (p *process) postStart() error {
 }
 
 func (p *process) monitorUsage(listener procstats.Listener) *repb.UsageStats {
-	return procstats.Monitor(p.cmd.Process.Pid, listener, p.terminated)
+	treeStats := procstats.NewTreeStats(p.cmd.Process.Pid)
+	return procstats.MonitorProvider(func() (*repb.UsageStats, error) {
+		// Job Objects retain cumulative CPU accounting for processes that have
+		// already exited. Keep using process-tree RSS for memory so it has the
+		// same semantics as task sizing on other platforms.
+		cpuStats, cpuErr := p.jobUsageStats()
+		memoryErr := treeStats.Update()
+		stats := treeStats.Total()
+		if cpuStats != nil {
+			stats.CpuNanos = cpuStats.GetCpuNanos()
+		}
+		if cpuErr != nil {
+			return stats, cpuErr
+		}
+		return stats, memoryErr
+	}, listener, p.terminated)
+}
+
+func (p *process) jobUsageStats() (*repb.UsageStats, error) {
+	accounting, err := p.jobAccounting()
+	if err != nil {
+		return nil, err
+	}
+	return &repb.UsageStats{
+		CpuNanos: (accounting.TotalUserTime + accounting.TotalKernelTime) * 100,
+	}, nil
 }
 
 func (p *process) jobAccounting() (*jobObjectBasicAccountingInformation, error) {
@@ -195,6 +221,12 @@ func (p *process) cleanup() error {
 	return nil
 }
 
+func (p *process) finalizeUsage(stats *repb.UsageStats) {
+	if stats != nil && p.inactive {
+		stats.MemoryBytes = 0
+	}
+}
+
 func (p *process) withProcessHandle(f func(windows.Handle) error) error {
 	var err error
 	if handleErr := p.cmd.Process.WithHandle(func(handle uintptr) {
@@ -230,7 +262,8 @@ func (p *process) wait() (*espb.Rusage, error) {
 		return nil, fmt.Errorf("wait for root process: %w", err)
 	}
 	// Cmd.Wait also waits for stdout/stderr copying. Terminate descendants
-	// holding inherited pipes before waiting for EOF.
+	// holding inherited pipes before waiting for EOF, while retaining the Job
+	// Object's accounting for the final usage sample.
 	p.jobMu.Lock()
 	killed := p.killed
 	var cleanupErr error
@@ -245,6 +278,8 @@ func (p *process) wait() (*espb.Rusage, error) {
 		// Closing the job is the fallback if explicit termination or the
 		// accounting query failed. Do not report successful cleanup.
 		_ = p.cleanup()
+	} else {
+		p.inactive = true
 	}
 	err := p.cmd.Wait()
 	if cleanupErr != nil {
@@ -272,7 +307,8 @@ func (p *process) killProcessTree() error {
 	if p.jobHandle == 0 {
 		return nil
 	}
-	// Keep the job handle open so wait() can check for job inactivity.
+	// Keep the job handle open until wait() completes so the stats monitor can
+	// take a final cumulative sample, including terminated descendants.
 	if err := windows.TerminateJobObject(p.jobHandle, windowsKilledExitCode); err != nil {
 		return err
 	}

--- a/enterprise/server/remote_execution/commandutil/commandutil_windows_test.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil_windows_test.go
@@ -34,31 +34,84 @@ func TestRun_Win_NormalExit_NoError(t *testing.T) {
 	}
 }
 
+func TestRun_Win_NegativeExitIsNotReportedAsKilled(t *testing.T) {
+	cmd := &repb.Command{Arguments: []string{"powershell", "-NoProfile", "-NonInteractive", "-Command", "Exit -1"}}
+
+	res := commandutil.Run(context.Background(), cmd, ".", nopStatsListener, &interfaces.Stdio{})
+
+	require.NoError(t, res.Error)
+}
+
+func TestRun_Win_CompletedJobReportsNoCurrentMemory(t *testing.T) {
+	cmd := &repb.Command{Arguments: []string{"powershell", "-NoProfile", "-NonInteractive", "-Command", `
+		Start-Process powershell -ArgumentList '-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 300' | Out-Null
+		Start-Sleep -Seconds 1
+	`}}
+
+	res := commandutil.Run(context.Background(), cmd, ".", nopStatsListener, &interfaces.Stdio{})
+
+	require.NoError(t, res.Error)
+	require.Zero(t, res.UsageStats.GetMemoryBytes())
+}
+
+func TestRun_Win_TimeoutReturnsDeadlineExceeded(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	cmd := &repb.Command{Arguments: []string{"powershell", "-NoProfile", "-NonInteractive", "-Command", "Start-Sleep -Seconds 300"}}
+
+	res := commandutil.Run(ctx, cmd, ".", nopStatsListener, &interfaces.Stdio{})
+
+	require.True(t, status.IsDeadlineExceededError(res.Error), "expected deadline exceeded, got %v", res.Error)
+	require.Equal(t, commandutil.KilledExitCode, res.ExitCode)
+}
+
+func useCPUPowerShellScript(dur time.Duration) string {
+	return fmt.Sprintf(`
+$timer = [System.Diagnostics.Stopwatch]::StartNew()
+while ($timer.ElapsedMilliseconds -lt %d) {}
+`, dur.Milliseconds())
+}
+
+func useMemoryPowerShellScript(memoryBytes int64, dur time.Duration) string {
+	return fmt.Sprintf(`
+$memory = New-Object byte[] %d
+for ($i = 0; $i -lt $memory.Length; $i += 4096) { $memory[$i] = 1 }
+Start-Sleep -Milliseconds %d
+if ($memory.Length -ne %d) { exit 1 }
+`, memoryBytes, dur.Milliseconds(), memoryBytes)
+}
+
 func TestComplexProcessTree(t *testing.T) {
 	// Setup
 	workDir := testfs.MakeTempDir(t)
 	testfs.WriteAllFileContents(t, workDir, map[string]string{
-		"cpu1.py": useCPUPythonScript(3 * time.Second),
-		"cpu2.py": useCPUPythonScript(1 * time.Second),
-		"mem1.py": useMemPythonScript(500e6, 3*time.Second),
-		"mem2.py": useMemPythonScript(250e6, 2*time.Second),
+		"cpu1.ps1": useCPUPowerShellScript(3 * time.Second),
+		"cpu2.ps1": useCPUPowerShellScript(1 * time.Second),
+		"mem1.ps1": useMemoryPowerShellScript(500e6, 3*time.Second),
+		"mem2.ps1": useMemoryPowerShellScript(250e6, 2*time.Second),
 	})
 
 	// Run
 	cmd := &repb.Command{
-		Arguments: []string{"powershell", "-c", `
-		Start-Job -Name cpu1 -ScriptBlock { python cpu1.py }
-		Start-Job -Name cpu2 -ScriptBlock { python cpu2.py }
-		Start-Job -Name mem1 -ScriptBlock { python mem1.py }
-		Start-Job -Name mem2 -ScriptBlock { python mem2.py }
-		Get-Job | Wait-Job
+		Arguments: []string{"powershell", "-NoProfile", "-NonInteractive", "-Command", `
+		$processes = @(
+			Start-Process powershell -ArgumentList '-NoProfile','-NonInteractive','-File','cpu1.ps1' -WorkingDirectory '.' -PassThru
+			Start-Process powershell -ArgumentList '-NoProfile','-NonInteractive','-File','cpu2.ps1' -WorkingDirectory '.' -PassThru
+			Start-Process powershell -ArgumentList '-NoProfile','-NonInteractive','-File','mem1.ps1' -WorkingDirectory '.' -PassThru
+			Start-Process powershell -ArgumentList '-NoProfile','-NonInteractive','-File','mem2.ps1' -WorkingDirectory '.' -PassThru
+		)
+		$processes | Wait-Process
 		`},
 	}
 	res := commandutil.Run(context.Background(), cmd, workDir, nopStatsListener, &interfaces.Stdio{})
 
 	// Assert
-	assert.NoError(t, res.Error)
-	assert.Equal(t, 0, res.ExitCode)
+	require.NoError(t, res.Error)
+	require.Equal(t, 0, res.ExitCode)
+	// CPU usage includes PowerShell startup and memory initialization, which vary by runner.
+	require.GreaterOrEqual(t, res.UsageStats.GetCpuNanos(), int64(1e9), "expected CPU usage from child processes")
+	require.GreaterOrEqual(t, res.UsageStats.GetPeakMemoryBytes(), int64(750e6), "expected peak memory from child processes")
+	require.LessOrEqual(t, res.UsageStats.GetPeakMemoryBytes(), int64(2e9), "unexpectedly high peak memory")
 }
 
 func TestRun_Win_NormalExit_KillsDescendants(t *testing.T) {
@@ -125,23 +178,4 @@ func TestRun_Win_NormalExit_KillsDescendants(t *testing.T) {
 	waitResult, err := windows.WaitForSingleObject(childHandle, 5000)
 	require.NoError(t, err)
 	require.EqualValues(t, windows.WAIT_OBJECT_0, waitResult, "descendant teardown did not complete")
-}
-
-func TestRun_Win_NegativeExitIsNotReportedAsKilled(t *testing.T) {
-	cmd := &repb.Command{Arguments: []string{"powershell", "-NoProfile", "-NonInteractive", "-Command", "Exit -1"}}
-
-	res := commandutil.Run(context.Background(), cmd, ".", nopStatsListener, &interfaces.Stdio{})
-
-	require.NoError(t, res.Error)
-}
-
-func TestRun_Win_TimeoutReturnsDeadlineExceeded(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
-	cmd := &repb.Command{Arguments: []string{"powershell", "-NoProfile", "-NonInteractive", "-Command", "Start-Sleep -Seconds 300"}}
-
-	res := commandutil.Run(ctx, cmd, ".", nopStatsListener, &interfaces.Stdio{})
-
-	require.True(t, status.IsDeadlineExceededError(res.Error), "expected deadline exceeded, got %v", res.Error)
-	require.Equal(t, commandutil.KilledExitCode, res.ExitCode)
 }

--- a/enterprise/server/util/procstats/BUILD
+++ b/enterprise/server/util/procstats/BUILD
@@ -19,6 +19,7 @@ go_test(
     srcs = ["procstats_test.go"],
     deps = [
         ":procstats",
+        "//proto:remote_execution_go_proto",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/util/procstats/procstats.go
+++ b/enterprise/server/util/procstats/procstats.go
@@ -23,6 +23,9 @@ const (
 // available. This can be used to live-update stats while a command is running.
 type Listener func(*repb.UsageStats)
 
+// StatsProvider returns cumulative resource usage for a process or process group.
+type StatsProvider func() (*repb.UsageStats, error)
+
 // Monitor polls resource usage of a process tree rooted at the given pid. The
 // process identified by pid is expected to have been started before calling
 // this function. The caller must close the given channel when the process is
@@ -30,6 +33,38 @@ type Listener func(*repb.UsageStats)
 // will return any stats collected.
 func Monitor(pid int, listener Listener, processTerminated <-chan struct{}) *repb.UsageStats {
 	ts := NewTreeStats(pid)
+	return monitorProvider(func() (*repb.UsageStats, error) {
+		if err := ts.Update(); err != nil {
+			return nil, err
+		}
+		return ts.Total(), nil
+	}, listener, processTerminated, false)
+}
+
+// MonitorProvider polls cumulative resource usage until the process terminates.
+// It takes one final sample after termination so providers backed by OS-level
+// accounting can include work performed by short-lived and terminated children.
+func MonitorProvider(provider StatsProvider, listener Listener, processTerminated <-chan struct{}) *repb.UsageStats {
+	return monitorProvider(provider, listener, processTerminated, true)
+}
+
+func monitorProvider(provider StatsProvider, listener Listener, processTerminated <-chan struct{}, sampleAfterTermination bool) *repb.UsageStats {
+	last := &repb.UsageStats{}
+	sample := func() {
+		stats, _ := provider()
+		if stats == nil {
+			return
+		}
+		// CPU and peak memory are cumulative. Preserve the highest values if a
+		// provider returns partial or stale data after an earlier successful
+		// sample. Current memory is instantaneous and may legitimately decrease.
+		stats.CpuNanos = max(stats.GetCpuNanos(), last.GetCpuNanos())
+		stats.PeakMemoryBytes = max(stats.GetPeakMemoryBytes(), last.GetPeakMemoryBytes())
+		last = stats
+		if listener != nil {
+			listener(stats)
+		}
+	}
 	// Most processes are short-lived so we need a fast poll rate if we want
 	// to increase the probability of getting at least one sample. But
 	// polling is expensive: a 50ms poll rate consumes around 10% of a CPU
@@ -39,10 +74,12 @@ func Monitor(pid int, listener Listener, processTerminated <-chan struct{}) *rep
 	for {
 		select {
 		case <-processTerminated:
-			return ts.Total()
+			if sampleAfterTermination {
+				sample()
+			}
+			return last
 		case <-time.After(pollInterval):
-			ts.Update() // ignore error
-			listener(ts.Total())
+			sample()
 		}
 		pollInterval = min(time.Duration(float64(pollInterval)*statsPollBackoff), statsMaxPollInterval)
 	}
@@ -137,10 +174,9 @@ func statTree(pid int) (map[int]*repb.UsageStats, error) {
 // the process IDs can be recycled.
 // See https://devblogs.microsoft.com/oldnewthing/20150403-00/?p=44313 for more information.
 //
-// TODO(sluongng): On Windows, it might be better to track stats from the JobObjects instead.
-// See enterprise/server/remote_execution/commandutil/commandutil_windows.go and
-// https://learn.microsoft.com/en-us/windows/win32/api/jobapi2/nf-jobapi2-queryinformationjobobject
-// for more information.
+// Windows command execution uses Job Object accounting for CPU, but continues
+// to use this process-tree accounting for resident memory; see
+// enterprise/server/remote_execution/commandutil/commandutil_windows.go.
 func pidsInTree(pid int) (set.Set[int], error) {
 	procs, err := ps.Processes()
 	if err != nil {

--- a/enterprise/server/util/procstats/procstats_test.go
+++ b/enterprise/server/util/procstats/procstats_test.go
@@ -1,14 +1,71 @@
 package procstats_test
 
 import (
+	"errors"
 	"os"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/procstats"
 	"github.com/stretchr/testify/require"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
 func TestTreeStat(t *testing.T) {
 	ts := procstats.NewTreeStats(os.Getpid())
 	require.NoError(t, ts.Update())
+}
+
+func TestMonitorProviderSamplesAfterTermination(t *testing.T) {
+	terminated := make(chan struct{})
+	close(terminated)
+	providerCalls := 0
+	listenerCalls := 0
+
+	stats := procstats.MonitorProvider(func() (*repb.UsageStats, error) {
+		providerCalls++
+		return &repb.UsageStats{CpuNanos: 123, PeakMemoryBytes: 456}, nil
+	}, func(stats *repb.UsageStats) {
+		listenerCalls++
+		require.Equal(t, int64(123), stats.GetCpuNanos())
+	}, terminated)
+
+	require.Equal(t, 1, providerCalls)
+	require.Equal(t, 1, listenerCalls)
+	require.Equal(t, int64(123), stats.GetCpuNanos())
+	require.Equal(t, int64(456), stats.GetPeakMemoryBytes())
+}
+
+func TestMonitorProviderIgnoresSamplingError(t *testing.T) {
+	terminated := make(chan struct{})
+	close(terminated)
+
+	stats := procstats.MonitorProvider(func() (*repb.UsageStats, error) {
+		return nil, errors.New("unavailable")
+	}, nil, terminated)
+
+	require.NotNil(t, stats)
+	require.Zero(t, stats.GetCpuNanos())
+}
+
+func TestMonitorProviderPreservesCumulativeStatsOnSamplingError(t *testing.T) {
+	terminated := make(chan struct{})
+	providerCalls := 0
+
+	stats := procstats.MonitorProvider(func() (*repb.UsageStats, error) {
+		providerCalls++
+		if providerCalls == 1 {
+			return &repb.UsageStats{CpuNanos: 123, MemoryBytes: 100, PeakMemoryBytes: 456}, nil
+		}
+		return &repb.UsageStats{CpuNanos: 12}, errors.New("partial sample")
+	}, func(*repb.UsageStats) {
+		if providerCalls == 1 {
+			close(terminated)
+		}
+	}, terminated)
+
+	require.Equal(t, 2, providerCalls)
+	require.Equal(t, int64(123), stats.GetCpuNanos())
+	require.Equal(t, int64(456), stats.GetPeakMemoryBytes())
+	require.Zero(t, stats.GetMemoryBytes())
 }


### PR DESCRIPTION
PID polling misses CPU consumed by short-lived Windows descendants,
which can underestimate the resources needed to run an action. Query
the action's Job Object for cumulative CPU and take a final sample
before closing its handle. Keep process-tree RSS for memory accounting.

Report zero current memory once the job is inactive while preserving
peak memory for task sizing. Limit the extra final sample to Windows
so Linux and macOS retain their existing sampling behavior.

Cover child CPU, resident peak memory, and completed-job memory. Verify
final CPU accounting after both root and child have exited, without
intermediate sampling, against the child's independently measured
CPU time.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
