### PR TITLE
executor: correct resource capacity docs

### DIFF
--- a/docs/config-rbe.md
+++ b/docs/config-rbe.md
@@ -254,7 +254,7 @@ necessary to extend the executor image or mount them from the host.
 
 In addition to the config.yaml, there are also environment variables that executors consume. To get more information about their environment. All of these are optional, but can be useful for more complex configurations.
 
-- `SYS_MEMORY_BYTES`: The amount of memory (in bytes) that this executor is allowed to consume. Defaults to free system memory.
+- `SYS_MEMORY_BYTES`: The amount of memory (in bytes) that this executor is allowed to consume. Defaults to total system memory.
 - `SYS_CPU`: The amount of CPU that this executor is allowed to consume. Can be a core count such as `1.5` or a milli-CPU count such as `1500m`. Defaults to system CPU.
 - `MY_HOSTNAME`: The hostname by which the app can communicate to this executor. Defaults to machine hostname.
 - `MY_PORT`: The port over which the app can communicate with this executor. Defaults to the executor's gRPC port.
@@ -268,7 +268,7 @@ env:
     valueFrom:
       resourceFieldRef:
         resource: limits.memory
-  - name: SYS_MILLICPU
+  - name: SYS_CPU
     valueFrom:
       resourceFieldRef:
         resource: limits.cpu


### PR DESCRIPTION
The executor defaults to total system memory, so describing the
default as free memory understates its configured capacity. Correct
that wording while preserving the distinction between configured
memory and the capacity available for scheduling.

Use SYS_CPU in the Kubernetes example to match the documented variable
and avoid recommending the deprecated, misnamed SYS_MILLICPU alias.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
