### PR TITLE
Add a max concurrency flag

### DIFF
--- a/enterprise/server/scheduling/priority_task_scheduler/BUILD
+++ b/enterprise/server/scheduling/priority_task_scheduler/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//server/util/alert",
         "//server/util/authutil",
         "//server/util/bazel_request",
+        "//server/util/flag",
         "//server/util/log",
         "//server/util/priority_queue",
         "//server/util/proto",

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
@@ -3,7 +3,6 @@ package priority_task_scheduler
 import (
 	"container/list"
 	"context"
-	"flag"
 	"fmt"
 	"maps"
 	"math"
@@ -22,6 +21,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_request"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/priority_queue"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
@@ -40,7 +40,8 @@ import (
 )
 
 var (
-	exclusiveTaskScheduling = flag.Bool("executor.exclusive_task_scheduling", false, "If true, only one task will be scheduled at a time. Default is false")
+	exclusiveTaskScheduling = flag.Bool("executor.exclusive_task_scheduling", false, "If true, only one task will be scheduled at a time.", flag.Deprecated("Set executor.max_concurrent_tasks=1 instead."))
+	maxConcurrentTasks      = flag.Int("executor.max_concurrent_tasks", 0, "The maximum number of tasks that can execute at the same time on this executor. If 0, the number of concurrent tasks is limited only by the CPU, memory, and custom resource capacity.")
 	shutdownCleanupDuration = flag.Duration("executor.shutdown_cleanup_duration", 15*time.Second, "The minimum duration during the shutdown window to allocate for cleaning up containers. This is capped to the value of `max_shutdown_duration`.")
 	queueTrimInterval       = flag.Duration("executor.queue_trim_interval", 15*time.Second, "The interval between attempts to prune tasks that have already been completed by other executors.  A value <= 0 disables this feature.")
 	excessCapacityThreshold = flag.Float64("executor.excess_capacity_threshold", .40, "A percentage (of RAM and CPU) utilization below which this executor may request additional work")
@@ -363,13 +364,12 @@ type PriorityTaskScheduler struct {
 	rootContext      context.Context
 	rootCancel       context.CancelFunc
 
-	mu                      sync.Mutex
-	q                       *taskQueue
-	activeTaskCancelFuncs   sync.WaitGroup
-	activeCancelFuncsCount  atomic.Int64
-	resourceCapacity        *resourceCounts
-	resourcesUsed           *resourceCounts
-	exclusiveTaskScheduling bool
+	mu                     sync.Mutex
+	q                      *taskQueue
+	activeTaskCancelFuncs  sync.WaitGroup
+	activeCancelFuncsCount atomic.Int64
+	resourceCapacity       *resourceCounts
+	resourcesUsed          *resourceCounts
 
 	// activeTaskStartTimes contains, for each currently running task, the
 	// time at which the task started executing.
@@ -377,6 +377,18 @@ type PriorityTaskScheduler struct {
 }
 
 func NewPriorityTaskScheduler(env environment.Env, exec IExecutor, runnerPool interfaces.RunnerPool, taskLeaser interfaces.TaskLeaser, options *Options) (*PriorityTaskScheduler, error) {
+	// Both flags configure the same concurrency limit, so refuse to start
+	// when both are set rather than silently letting one win.
+	if *exclusiveTaskScheduling && *maxConcurrentTasks != 0 {
+		return nil, status.InvalidArgumentError("executor.exclusive_task_scheduling and executor.max_concurrent_tasks cannot both be set. executor.exclusive_task_scheduling is deprecated; set executor.max_concurrent_tasks=1 instead.")
+	}
+	if *maxConcurrentTasks < 0 {
+		return nil, status.InvalidArgumentErrorf("executor.max_concurrent_tasks must not be negative (got %d)", *maxConcurrentTasks)
+	}
+	concurrencyCapacity := int64(*maxConcurrentTasks)
+	if *exclusiveTaskScheduling {
+		concurrencyCapacity = 1
+	}
 	ramBytesCapacity := options.RAMBytesCapacityOverride
 	if ramBytesCapacity == 0 {
 		ramBytesCapacity = int64(float64(resources.GetAllocatedRAMBytes()) * tasksize.MaxResourceCapacityRatio)
@@ -408,17 +420,18 @@ func NewPriorityTaskScheduler(env environment.Env, exec IExecutor, runnerPool in
 		rootCancel:       rootCancel,
 		shuttingDown:     false,
 		resourceCapacity: &resourceCounts{
-			RAMBytes:  ramBytesCapacity,
-			CPUMillis: cpuMillisCapacity,
-			Custom:    customResourcesCapacity,
+			RAMBytes:    ramBytesCapacity,
+			CPUMillis:   cpuMillisCapacity,
+			Concurrency: concurrencyCapacity,
+			Custom:      customResourcesCapacity,
 		},
 		resourcesUsed: &resourceCounts{
-			RAMBytes:  0,
-			CPUMillis: 0,
-			Custom:    customResourcesUsed,
+			RAMBytes:    0,
+			CPUMillis:   0,
+			Concurrency: 0,
+			Custom:      customResourcesUsed,
 		},
-		exclusiveTaskScheduling: *exclusiveTaskScheduling,
-		activeTaskStartTimes:    make(map[string]time.Time),
+		activeTaskStartTimes: make(map[string]time.Time),
 	}
 	qes.rootContext = qes.enrichContext(qes.rootContext)
 
@@ -649,6 +662,7 @@ func (q *PriorityTaskScheduler) runTask(ctx context.Context, st *repb.ScheduledT
 func (q *PriorityTaskScheduler) trackTask(res *scpb.EnqueueTaskReservationRequest, cancel *context.CancelFunc) {
 	q.activeCancelFuncsCount.Add(1)
 	q.activeTaskStartTimes[res.GetTaskId()] = q.clock.Now()
+	q.resourcesUsed.Concurrency++
 	if size := res.GetTaskSize(); size != nil {
 		q.resourcesUsed.RAMBytes += size.GetEstimatedMemoryBytes()
 		q.resourcesUsed.CPUMillis += size.GetEstimatedMilliCpu()
@@ -671,6 +685,7 @@ func (q *PriorityTaskScheduler) trackTask(res *scpb.EnqueueTaskReservationReques
 func (q *PriorityTaskScheduler) untrackTask(res *scpb.EnqueueTaskReservationRequest, cancel *context.CancelFunc) {
 	q.activeCancelFuncsCount.Add(-1)
 	delete(q.activeTaskStartTimes, res.GetTaskId())
+	q.resourcesUsed.Concurrency--
 	if size := res.GetTaskSize(); size != nil {
 		q.resourcesUsed.RAMBytes -= size.GetEstimatedMemoryBytes()
 		q.resourcesUsed.CPUMillis -= size.GetEstimatedMilliCpu()
@@ -716,12 +731,16 @@ func (q *PriorityTaskScheduler) stats() string {
 	if len(customResourcesStrs) > 0 {
 		customResourcesDesc = fmt.Sprintf(" %s", strings.Join(customResourcesStrs, ", "))
 	}
+	maxConcurrentTasksDesc := ""
+	if q.resourceCapacity.Concurrency > 0 {
+		maxConcurrentTasksDesc = fmt.Sprintf(" of %d max", q.resourceCapacity.Concurrency)
+	}
 	return message.NewPrinter(language.English).Sprintf(
-		"CPU: %d of %d milliCPU allocated (%d remaining), Memory: %d of %d bytes allocated (%d remaining),%s Tasks: %d active, %d queued",
+		"CPU: %d of %d milliCPU allocated (%d remaining), Memory: %d of %d bytes allocated (%d remaining),%s Tasks: %d active%s, %d queued",
 		q.resourcesUsed.CPUMillis, q.resourceCapacity.CPUMillis, cpuMillisRemaining,
 		q.resourcesUsed.RAMBytes, q.resourceCapacity.RAMBytes, ramBytesRemaining,
 		customResourcesDesc,
-		q.activeCancelFuncsCount.Load(), q.q.Len())
+		q.activeCancelFuncsCount.Load(), maxConcurrentTasksDesc, q.q.Len())
 }
 
 // canFitTask returns whether the task can fit, given the resource capacity and
@@ -729,9 +748,9 @@ func (q *PriorityTaskScheduler) stats() string {
 // are currently assigned to executing tasks, plus the resources needed by tasks
 // that are in front of this task in the queue.
 func (q *PriorityTaskScheduler) canFitTask(res *queuedTask, reservedResources *resourceCounts) bool {
-	// If we're running in exclusiveTaskScheduling mode, only ever allow one
-	// task to run at a time. Otherwise fall through to the logic below.
-	if q.exclusiveTaskScheduling && q.activeCancelFuncsCount.Load() >= 1 {
+	// Every task consumes one unit of concurrency, so if a limit is
+	// configured, the task only fits if a concurrency slot is unreserved.
+	if q.resourceCapacity.Concurrency > 0 && reservedResources.Concurrency >= q.resourceCapacity.Concurrency {
 		return false
 	}
 
@@ -1063,7 +1082,11 @@ func (c customResourceCount) String() string {
 type resourceCounts struct {
 	RAMBytes  int64
 	CPUMillis int64
-	Custom    map[string]customResourceCount
+	// Concurrency counts tasks. Every task consumes one unit regardless of
+	// its size, so as a capacity it is the maximum number of tasks that can
+	// execute at the same time. A capacity of 0 means unlimited.
+	Concurrency int64
+	Custom      map[string]customResourceCount
 }
 
 func (q *PriorityTaskScheduler) taskResourceCounts(res *scpb.TaskSize) *resourceCounts {
@@ -1076,9 +1099,10 @@ func (q *PriorityTaskScheduler) taskResourceCounts(res *scpb.TaskSize) *resource
 		custom[r.GetName()] = customResource(r.GetValue())
 	}
 	return &resourceCounts{
-		RAMBytes:  res.GetEstimatedMemoryBytes(),
-		CPUMillis: res.GetEstimatedMilliCpu(),
-		Custom:    custom,
+		RAMBytes:    res.GetEstimatedMemoryBytes(),
+		CPUMillis:   res.GetEstimatedMilliCpu(),
+		Concurrency: 1,
+		Custom:      custom,
 	}
 }
 
@@ -1093,6 +1117,7 @@ func (r *resourceCounts) Clone() *resourceCounts {
 func (r *resourceCounts) Add(other *resourceCounts) {
 	r.RAMBytes += other.RAMBytes
 	r.CPUMillis += other.CPUMillis
+	r.Concurrency += other.Concurrency
 	for k, v := range other.Custom {
 		r.Custom[k] += v
 	}
@@ -1105,6 +1130,9 @@ func (r *resourceCounts) AllGTE(other *resourceCounts) bool {
 		return false
 	}
 	if r.CPUMillis < other.CPUMillis {
+		return false
+	}
+	if r.Concurrency < other.Concurrency {
 		return false
 	}
 	for k, v := range r.Custom {

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler_test.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler_test.go
@@ -306,6 +306,275 @@ func TestPriorityTaskScheduler_QueueSkipping_LargeCustomResourceTasksNotIndefini
 	require.ElementsMatch(t, []string{gpuSmall1TaskID, gpuLargeTaskID}, startedTaskIDs)
 }
 
+func TestPriorityTaskScheduler_MaxConcurrentTasks(t *testing.T) {
+	env := testenv.GetTestEnv(t)
+	env.SetRemoteExecutionClient(&FakeExecutionClient{})
+
+	// Give the executor far more CPU and memory than the tasks need, so that
+	// the concurrency limit is the only thing that can hold tasks back.
+	flags.Set(t, "executor.millicpu", 30_000)
+	flags.Set(t, "executor.memory_bytes", 64_000_000_000)
+	flags.Set(t, "executor.max_concurrent_tasks", 2)
+	err := resources.Configure(false /*=mmapLRUEnabled*/)
+	require.NoError(t, err)
+
+	executor := NewFakeExecutor()
+	runnerPool := &FakeRunnerPool{}
+	leaser := NewFakeTaskLeaser()
+
+	scheduler, err := NewPriorityTaskScheduler(env, executor, runnerPool, leaser, &Options{})
+	require.NoError(t, err)
+	scheduler.Start()
+	ctx := context.Background()
+	t.Cleanup(func() {
+		err := scheduler.Stop()
+		require.NoError(t, err)
+		assert.NoError(t, scheduler.Shutdown(ctx))
+	})
+
+	oneCPU := &scpb.TaskSize{
+		EstimatedMilliCpu:    1000,
+		EstimatedMemoryBytes: 1000,
+	}
+
+	// Enqueue three small tasks. Only two should start, since starting the
+	// third would exceed the concurrency limit even though there is plenty of
+	// CPU and memory to spare.
+	var taskIDs []string
+	for i := range 3 {
+		taskID := fakeTaskID(fmt.Sprintf("task-%d", i))
+		taskIDs = append(taskIDs, taskID)
+		_, err = scheduler.EnqueueTaskReservation(ctx, &scpb.EnqueueTaskReservationRequest{
+			TaskId:             taskID,
+			TaskSize:           oneCPU,
+			SchedulingMetadata: &scpb.SchedulingMetadata{TaskSize: oneCPU},
+		})
+		require.NoError(t, err)
+	}
+	execution1 := <-executor.StartedExecutions
+	execution2 := <-executor.StartedExecutions
+
+	// Give the scheduler a chance to (incorrectly) start the third task.
+	select {
+	case ex := <-executor.StartedExecutions:
+		require.FailNowf(t, "no more tasks should start until a running task completes", "task %q started", ex.ScheduledTask.GetExecutionTask().GetExecutionId())
+	case <-time.After(100 * time.Millisecond):
+	}
+	queueLen := scheduler.q.Len()
+	require.Equal(t, 1, queueLen)
+
+	// Complete one of the running tasks. This frees up a concurrency slot, so
+	// the third task should start.
+	execution1.Complete()
+	execution3 := <-executor.StartedExecutions
+	queueLen = scheduler.q.Len()
+	require.Equal(t, 0, queueLen)
+
+	startedTaskIDs := []string{
+		execution1.ScheduledTask.GetExecutionTask().GetExecutionId(),
+		execution2.ScheduledTask.GetExecutionTask().GetExecutionId(),
+		execution3.ScheduledTask.GetExecutionTask().GetExecutionId(),
+	}
+	require.ElementsMatch(t, taskIDs, startedTaskIDs)
+
+	// Complete the remaining executions to allow a clean shutdown.
+	execution2.Complete()
+	execution3.Complete()
+}
+
+func TestPriorityTaskScheduler_MaxConcurrentTasks_PreventsQueueSkipping(t *testing.T) {
+	env := testenv.GetTestEnv(t)
+	env.SetRemoteExecutionClient(&FakeExecutionClient{})
+
+	// Give the executor far more CPU and memory than the tasks need, along
+	// with a single GPU and a concurrency limit of 2. Custom resources enable
+	// the queue skipping logic, which is where concurrency reservations for
+	// queued tasks come into play.
+	flags.Set(t, "executor.millicpu", 30_000)
+	flags.Set(t, "executor.memory_bytes", 64_000_000_000)
+	flags.Set(t, "executor.custom_resources", []resources.CustomResource{
+		{Name: "gpu", Value: 1.0},
+	})
+	flags.Set(t, "executor.max_concurrent_tasks", 2)
+	err := resources.Configure(false /*=mmapLRUEnabled*/)
+	require.NoError(t, err)
+
+	executor := NewFakeExecutor()
+	runnerPool := &FakeRunnerPool{}
+	leaser := NewFakeTaskLeaser()
+
+	scheduler, err := NewPriorityTaskScheduler(env, executor, runnerPool, leaser, &Options{})
+	require.NoError(t, err)
+	scheduler.Start()
+	ctx := context.Background()
+	t.Cleanup(func() {
+		err := scheduler.Stop()
+		require.NoError(t, err)
+		assert.NoError(t, scheduler.Shutdown(ctx))
+	})
+
+	oneCPU := &scpb.TaskSize{
+		EstimatedMilliCpu:    1000,
+		EstimatedMemoryBytes: 1000,
+	}
+	oneCPUAndOneGPU := &scpb.TaskSize{
+		EstimatedMilliCpu:    1000,
+		EstimatedMemoryBytes: 1000,
+		CustomResources:      []*scpb.CustomResource{{Name: "gpu", Value: 1.0}},
+	}
+	gpuTask1ID := fakeTaskID("gpu-task-1")
+	gpuTask2ID := fakeTaskID("gpu-task-2")
+	cpuTask1ID := fakeTaskID("cpu-task-1")
+
+	// Start a GPU task, which takes the only GPU and one of the two
+	// concurrency slots.
+	_, err = scheduler.EnqueueTaskReservation(ctx, &scpb.EnqueueTaskReservationRequest{
+		TaskId:             gpuTask1ID,
+		TaskSize:           oneCPUAndOneGPU,
+		SchedulingMetadata: &scpb.SchedulingMetadata{TaskSize: oneCPUAndOneGPU},
+	})
+	require.NoError(t, err)
+	execution1 := <-executor.StartedExecutions
+	startedTaskID := execution1.ScheduledTask.GetExecutionTask().GetExecutionId()
+	require.Equal(t, gpuTask1ID, startedTaskID)
+
+	// Enqueue a second GPU task, then a CPU-only task. The second GPU task
+	// is blocked waiting for the GPU, and it reserves the remaining
+	// concurrency slot while it waits. So even though the CPU-only task
+	// would fit in terms of CPU, memory, and GPU, it must not skip ahead.
+	_, err = scheduler.EnqueueTaskReservation(ctx, &scpb.EnqueueTaskReservationRequest{
+		TaskId:             gpuTask2ID,
+		TaskSize:           oneCPUAndOneGPU,
+		SchedulingMetadata: &scpb.SchedulingMetadata{TaskSize: oneCPUAndOneGPU},
+	})
+	require.NoError(t, err)
+	_, err = scheduler.EnqueueTaskReservation(ctx, &scpb.EnqueueTaskReservationRequest{
+		TaskId:             cpuTask1ID,
+		TaskSize:           oneCPU,
+		SchedulingMetadata: &scpb.SchedulingMetadata{TaskSize: oneCPU},
+	})
+	require.NoError(t, err)
+	select {
+	case ex := <-executor.StartedExecutions:
+		require.FailNowf(t, "no tasks should start until the first GPU task completes", "task %q started", ex.ScheduledTask.GetExecutionTask().GetExecutionId())
+	case <-time.After(100 * time.Millisecond):
+	}
+	queueLen := scheduler.q.Len()
+	require.Equal(t, 2, queueLen)
+
+	// Complete the first GPU task. The second GPU task is at the front of the
+	// queue and can now take the GPU, so it should start before the CPU-only
+	// task.
+	execution1.Complete()
+	execution2 := <-executor.StartedExecutions
+	startedTaskID = execution2.ScheduledTask.GetExecutionTask().GetExecutionId()
+	require.Equal(t, gpuTask2ID, startedTaskID)
+
+	// Complete the second GPU task, which lets the CPU-only task start.
+	execution2.Complete()
+	execution3 := <-executor.StartedExecutions
+	startedTaskID = execution3.ScheduledTask.GetExecutionTask().GetExecutionId()
+	require.Equal(t, cpuTask1ID, startedTaskID)
+	queueLen = scheduler.q.Len()
+	require.Equal(t, 0, queueLen)
+	execution3.Complete()
+}
+
+func TestPriorityTaskScheduler_ExclusiveTaskScheduling(t *testing.T) {
+	env := testenv.GetTestEnv(t)
+	env.SetRemoteExecutionClient(&FakeExecutionClient{})
+
+	// Give the executor far more CPU and memory than the tasks need, so that
+	// exclusive scheduling is the only thing that can hold tasks back.
+	flags.Set(t, "executor.millicpu", 30_000)
+	flags.Set(t, "executor.memory_bytes", 64_000_000_000)
+	flags.Set(t, "executor.exclusive_task_scheduling", true)
+	err := resources.Configure(false /*=mmapLRUEnabled*/)
+	require.NoError(t, err)
+
+	executor := NewFakeExecutor()
+	runnerPool := &FakeRunnerPool{}
+	leaser := NewFakeTaskLeaser()
+
+	scheduler, err := NewPriorityTaskScheduler(env, executor, runnerPool, leaser, &Options{})
+	require.NoError(t, err)
+	scheduler.Start()
+	ctx := context.Background()
+	t.Cleanup(func() {
+		err := scheduler.Stop()
+		require.NoError(t, err)
+		assert.NoError(t, scheduler.Shutdown(ctx))
+	})
+
+	oneCPU := &scpb.TaskSize{
+		EstimatedMilliCpu:    1000,
+		EstimatedMemoryBytes: 1000,
+	}
+
+	// Enqueue two small tasks. Only the first should start, since exclusive
+	// task scheduling allows a single task at a time.
+	task1ID := fakeTaskID("task-1")
+	task2ID := fakeTaskID("task-2")
+	_, err = scheduler.EnqueueTaskReservation(ctx, &scpb.EnqueueTaskReservationRequest{
+		TaskId:             task1ID,
+		TaskSize:           oneCPU,
+		SchedulingMetadata: &scpb.SchedulingMetadata{TaskSize: oneCPU},
+	})
+	require.NoError(t, err)
+	_, err = scheduler.EnqueueTaskReservation(ctx, &scpb.EnqueueTaskReservationRequest{
+		TaskId:             task2ID,
+		TaskSize:           oneCPU,
+		SchedulingMetadata: &scpb.SchedulingMetadata{TaskSize: oneCPU},
+	})
+	require.NoError(t, err)
+	execution1 := <-executor.StartedExecutions
+	startedTaskID := execution1.ScheduledTask.GetExecutionTask().GetExecutionId()
+	require.Equal(t, task1ID, startedTaskID)
+
+	// Give the scheduler a chance to (incorrectly) start the second task.
+	select {
+	case ex := <-executor.StartedExecutions:
+		require.FailNowf(t, "no more tasks should start until the running task completes", "task %q started", ex.ScheduledTask.GetExecutionTask().GetExecutionId())
+	case <-time.After(100 * time.Millisecond):
+	}
+	queueLen := scheduler.q.Len()
+	require.Equal(t, 1, queueLen)
+
+	// Complete the running task. The second task should start.
+	execution1.Complete()
+	execution2 := <-executor.StartedExecutions
+	startedTaskID = execution2.ScheduledTask.GetExecutionTask().GetExecutionId()
+	require.Equal(t, task2ID, startedTaskID)
+	queueLen = scheduler.q.Len()
+	require.Equal(t, 0, queueLen)
+	execution2.Complete()
+}
+
+func TestNewPriorityTaskScheduler_RejectsInvalidConcurrencyLimit(t *testing.T) {
+	for _, testCase := range []struct {
+		name                    string
+		exclusiveTaskScheduling bool
+		maxConcurrentTasks      int
+	}{
+		{name: "both flags set", exclusiveTaskScheduling: true, maxConcurrentTasks: 1},
+		{name: "negative max_concurrent_tasks", maxConcurrentTasks: -1},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			env := testenv.GetTestEnv(t)
+			flags.Set(t, "executor.exclusive_task_scheduling", testCase.exclusiveTaskScheduling)
+			flags.Set(t, "executor.max_concurrent_tasks", testCase.maxConcurrentTasks)
+
+			// The scheduler should refuse to start up with a concurrency limit
+			// that is either conflicting or nonsensical, rather than picking
+			// an interpretation on its own.
+			_, err := NewPriorityTaskScheduler(env, NewFakeExecutor(), &FakeRunnerPool{}, NewFakeTaskLeaser(), &Options{})
+			require.Error(t, err)
+			isInvalidArgument := status.IsInvalidArgumentError(err)
+			require.True(t, isInvalidArgument, "unexpected error: %s", err)
+		})
+	}
+}
+
 func TestPriorityTaskScheduler_ExecutionErrorHandling(t *testing.T) {
 	for _, test := range []struct {
 		name string


### PR DESCRIPTION
Add a `max_concurrent_tasks` flag that allows executors to control the max number of tasks they are willing to execute at once, even if all tasks fit in terms of other resource constraints (CPU/memory/custom resources)

This is a useful troubleshooting/debugging flag if we/users suspect that too much concurrency is causing issues. It also allows users to more easily set up their BB executors to match other RBE setups that they might be migrating from.

`exclusive_task_scheduling` is now implemented as `max_concurrent_tasks=1`, so it is deprecated, and the executor fails to start up if both flags are set.

Concurrency is tracked as a resource like CPU and memory, so a queued task that can't run yet reserves a concurrency slot while it waits. If concurrency is the limiting factor, tasks behind it can't skip ahead of it, even when they would fit in terms of CPU, memory, and custom resources. When no limit is set, queue skipping ("backfilling") behaves as before.

Context: https://buildbuddy-corp.slack.com/archives/C0BB56FSVAT/p1788460880733129?thread_ts=1788404213.678499&cid=C0BB56FSVAT