### PR TITLE
Fix execution platform for local RBE

### DIFF
--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -198,11 +198,13 @@ common:local --config=cache-shared
 # containerized execution, such as docker (the default), podman, or oci.
 common:local-rbe-linux --remote_executor=grpc://localhost:1985
 common:local-rbe-linux --config=target-linux-x86
+common:local-rbe-linux --extra_execution_platforms=@toolchains_buildbuddy//platforms:linux_x86_64
 common:local-rbe-linux --config=local
 
 # Build with --config=local-rbe-mac to target a local executor on macOS.
 common:local-rbe-mac --remote_executor=grpc://localhost:1985
 common:local-rbe-mac --config=target-darwin-arm64
+common:local-rbe-mac --extra_execution_platforms=@toolchains_buildbuddy//platforms:darwin_arm64
 common:local-rbe-mac --config=local
 
 # Build with --config=dev to send build logs to the dev server


### PR DESCRIPTION
Commit [`6d96194e0e`](https://github.com/buildbuddy-io/buildbuddy/commit/6d96194e0eb1e90e62433a5229a242007b4a53ac) moved `--extra_execution_platforms` from the `target-*` configs into `remote-shared` so that RBE can execute across multiple architectures. The `local-rbe-*` configs do not include `remote-shared`, so local RBE was left with only the host execution platform.

That breaks local RBE in two ways. Tests fail at analysis, because Bazel's default test toolchain requires an execution platform that satisfies every target platform constraint, and the host platform lacks the target's compiler constraint. Compile actions still run, but exec_properties (container image, OSFamily, Arch) come from the execution platform, so they are dispatched without any and run in the executor's default image instead of the RBE image.

Register the target platform as the only execution platform in each `local-rbe-*` config. A local executor serves exactly one platform, and `--extra_execution_platforms` is not cumulative, so the config that sets `--remote_executor` is the right place to declare it.
