### PR TITLE
Remove swc toolchain registration

### DIFF
--- a/deps/web.MODULE.bazel
+++ b/deps/web.MODULE.bazel
@@ -17,8 +17,6 @@ swc.toolchain(
 )
 use_repo(swc, "swc_toolchains")
 
-register_toolchains("@swc_toolchains//:linux-arm64-musl_toolchain")
-
 rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext")
 rules_ts_ext.deps(
     ts_version_from = "@com_github_buildbuddy_io_buildbuddy//:package.json",

--- a/deps/web.MODULE.bazel
+++ b/deps/web.MODULE.bazel
@@ -15,7 +15,6 @@ swc.toolchain(
     name = "swc",
     swc_version = "v1.15.46",
 )
-use_repo(swc, "swc_toolchains")
 
 rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext")
 rules_ts_ext.deps(


### PR DESCRIPTION
The default gnu toolchain works for us now with the smaller image
