### PR TITLE
Turn on filecache dir sharding by default

### DIFF
--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -72,7 +72,7 @@ type sharedDirectoryContextKey struct{}
 
 var (
 	enableAlwaysClone                = flag.Bool("executor.local_cache_always_clone", false, "If true, files from the filecache will always be cloned instead of hardlinked")
-	includeSubdirPrefix              = flag.Bool("executor.include_subdir_prefix", false, "If true, store files under subdirs named by a short prefix of the file digest. This can help improve throughput on systems with high core counts. The prefix length is controlled by subdir_prefix_length.")
+	includeSubdirPrefix              = flag.Bool("executor.include_subdir_prefix", true, "If true, store files under subdirs named by a short prefix of the file digest. This can help improve throughput on systems with high core counts. The prefix length is controlled by subdir_prefix_length.")
 	subdirPrefixLength               = flag.Int("executor.subdir_prefix_length", 2, "The length of the subdir prefix to use if include_subdir_prefix is true.")
 	enableDiskFallbackOnStartup      = flag.Bool("executor.local_cache_enable_disk_fallback_during_startup_scan", true, "If true, fallback to disk lookups while initial local cache scan is in progress.", flag.Internal)
 	deleteFilecacheOnUncleanShutdown = flag.Bool("executor.delete_filecache_on_unclean_shutdown", false, "If true, record the current boot ID in a marker file in the filecache directory while running, and remove it on clean shutdown. If the marker is present at startup with a boot ID from a previous boot session, the machine rebooted before the previous process could shut down cleanly (e.g. power loss), so the filecache is wiped to avoid serving potentially corrupted files.")

--- a/enterprise/server/remote_execution/filecache/filecache_test.go
+++ b/enterprise/server/remote_execution/filecache/filecache_test.go
@@ -160,10 +160,14 @@ func TestFileCacheGroupFromTrustedJWT(t *testing.T) {
 			node := nodeFromString("source", false)
 			require.NoError(t, fc.AddFile(ctx, node, source))
 
+			// Files are stored under the group directory, sharded into a
+			// subdirectory named by the first two characters of the digest
+			// hash (the default subdir prefix length).
 			cacheFileName := node.GetDigest().GetHash()
-			require.FileExists(t, filepath.Join(fcDir, test.wantGroupID, cacheFileName))
+			shardDir := cacheFileName[:2]
+			require.FileExists(t, filepath.Join(fcDir, test.wantGroupID, shardDir, cacheFileName))
 			if test.wantGroupID != interfaces.AuthAnonymousUser {
-				require.NoFileExists(t, filepath.Join(fcDir, interfaces.AuthAnonymousUser, cacheFileName))
+				require.NoFileExists(t, filepath.Join(fcDir, interfaces.AuthAnonymousUser, shardDir, cacheFileName))
 			}
 		})
 	}
@@ -706,8 +710,12 @@ func TestFileAccessBeforeInitialScanCompleteFallsBackToFilesystem(t *testing.T) 
 	filecacheRoot := testfs.MakeTempDir(t)
 	outDir := testfs.MakeTempDir(t)
 
+	// Seed the cache directory with a file laid out the way a previous
+	// executor run would have written it: under the group directory, sharded
+	// by the first two characters of the digest hash.
 	node := nodeFromString("content", false)
-	writeFileContent(t, filecacheRoot, "ANON/"+node.GetDigest().GetHash(), "content", false)
+	digestHash := node.GetDigest().GetHash()
+	writeFileContent(t, filecacheRoot, "ANON/"+digestHash[:2]+"/"+digestHash, "content", false)
 
 	fc, err := filecache.NewFileCache(filecacheRoot, 10_000_000, false)
 	require.NoError(t, err)
@@ -777,6 +785,10 @@ func TestFileCacheEvictionAfterSubdirPrefixing(t *testing.T) {
 
 	var unprefixedNodes []*repb.FileNode
 	{
+		// Start with subdir prefixing disabled so the cache is populated in
+		// the legacy flat layout, which is what an executor upgraded from a
+		// version without sharding will have on disk.
+		flags.Set(t, "executor.include_subdir_prefix", false)
 		fc, err := filecache.NewFileCache(fcDir, 4096*10, false)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
This should help with filecache perf for on-prem / BYOR setups ([context](https://buildbuddy-corp.slack.com/archives/C0BB56FSVAT/p1788460880733129?thread_ts=1788404213.678499&cid=C0BB56FSVAT)). When customers upgrade their executor version to pick up this change, the executor should auto-migrate the existing cache to the new setup (async, during the initial scan).

We have had this enabled for our xfs setups in prod for a while, but based on some local benchmarks, this helps with ext4 as well, not just xfs.

<img width="658" height="277" alt="image" src="https://github.com/user-attachments/assets/db1aae12-e89a-49a9-ad2b-d9707339f7cc" />

The benchmark code is here: https://github.com/buildbuddy-io/buildbuddy/compare/master...fsbench?body=&expand=1&title=WIP