### PR TITLE
Unconditionally compress images

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -262,13 +262,6 @@ config_setting(
 )
 
 config_setting(
-    name = "opt",
-    values = {
-        "compilation_mode": "opt",
-    },
-)
-
-config_setting(
     name = "release_build",
     values = {"define": "release=true"},
 )

--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -231,10 +231,7 @@ layer_from_tar(
         ),
         "org.opencontainers.image.vendor": "BuildBuddy",
     },
-    optimize = select({
-        "//:opt": True,
-        "//conditions:default": False,
-    }),
+    optimize = True,
     tags = ["manual"],
 )
 
@@ -305,10 +302,7 @@ layer_from_tar(
         ),
         "org.opencontainers.image.vendor": "BuildBuddy",
     },
-    optimize = select({
-        "//:opt": True,
-        "//conditions:default": False,
-    }),
+    optimize = True,
     tags = ["manual"],
 )
 

--- a/images/distroless/base-nossl/BUILD
+++ b/images/distroless/base-nossl/BUILD
@@ -39,10 +39,7 @@ package(default_visibility = ["//visibility:public"])
             ),
             "org.opencontainers.image.vendor": "BuildBuddy",
         },
-        optimize = select({
-            "//:opt": True,
-            "//conditions:default": False,
-        }),
+        optimize = True,
         tags = ["manual"],
         target_compatible_with = [
             "@platforms//os:linux",

--- a/images/distroless/static/BUILD
+++ b/images/distroless/static/BUILD
@@ -101,10 +101,7 @@ pkg_tar(
             ),
             "org.opencontainers.image.vendor": "BuildBuddy",
         },
-        optimize = select({
-            "//:opt": True,
-            "//conditions:default": False,
-        }),
+        optimize = True,
         tags = ["manual"],
         target_compatible_with = [
             "@platforms//os:linux",

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -100,8 +100,8 @@ common --downloader_config=bazel_downloader.cfg
 
 # We should probably only build the images we're going to use, so let's always
 # compress images the way we will in production.
-common:release-shared --@rules_img//img/settings:compress=zstd
-common:release-shared --@rules_img//img/settings:compression_level=4
+common --@rules_img//img/settings:compress=zstd
+common --@rules_img//img/settings:compression_level=4
 
 common:race --@io_bazel_rules_go//go/config:race
 common:race --test_timeout=120,600,-1,-1

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -98,6 +98,11 @@ common --test_summary=terse
 
 common --downloader_config=bazel_downloader.cfg
 
+# We should probably only build the images we're going to use, so let's always
+# compress images the way we will in production.
+common:release-shared --@rules_img//img/settings:compress=zstd
+common:release-shared --@rules_img//img/settings:compression_level=4
+
 common:race --@io_bazel_rules_go//go/config:race
 common:race --test_timeout=120,600,-1,-1
 
@@ -331,7 +336,6 @@ common:release-shared --compilation_mode=opt
 common:release-shared --stamp
 common:release-shared --define=release=true
 common:release-shared --strip=always
-common:release-shared --@rules_img//img/settings:compress=zstd
 
 # Configuration used for Linux releases
 common:release --config=release-shared


### PR DESCRIPTION
I was compressing images based on whether or not we were building for release, but that means dev images don't ever get compressed, which is not what we want. Let's always compress the images.
