### PR TITLE
Add a minimal image for RBE

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1733,13 +1733,13 @@
     "@@toolchains_buildbuddy+//:extensions.bzl%buildbuddy": {
       "general": {
         "bzlTransitiveDigest": "lWa6Z0bfkK+GLxGpbRuJ/rFqT50PcvllkL8aIGUpSc4=",
-        "usagesDigest": "8/KE2qqH9tCyyG1SrEetb86YjMxaTzx7ysvgHvTfSTo=",
+        "usagesDigest": "P3vutyXebYlvZ7DdW8/hhO4NIwygVk6t+fItmOWXo9I=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "buildbuddy_toolchain": {
             "repoRuleId": "@@toolchains_buildbuddy+//:rules.bzl%_buildbuddy_toolchain",
             "attributes": {
-              "container_image": "docker://buildpack-deps@sha256:fa56fe73b4475655b2f39d6376b6a6664d24b5c43227f709d4a923609f3286a1",
+              "container_image": "docker://gcr.io/flame-public/rbe-ubuntu20-04-minimal:latest",
               "llvm": false,
               "java_version": "",
               "gcc_version": "",

--- a/deps/docker.MODULE.bazel
+++ b/deps/docker.MODULE.bazel
@@ -48,6 +48,11 @@ dockerfile_image(
 )
 
 dockerfile_image(
+    name = "rbe-ubuntu20-04-minimal_image",
+    dockerfile = "@com_github_buildbuddy_io_buildbuddy//dockerfiles/rbe-ubuntu20-04-minimal:Dockerfile",
+)
+
+dockerfile_image(
     name = "rbe-ubuntu20-04-webtest_image",
     dockerfile = "@com_github_buildbuddy_io_buildbuddy//dockerfiles/rbe-ubuntu20-04-webtest:Dockerfile",
 )

--- a/deps/toolchains.MODULE.bazel
+++ b/deps/toolchains.MODULE.bazel
@@ -1,5 +1,5 @@
 buildbuddy = use_extension("@toolchains_buildbuddy//:extensions.bzl", "buildbuddy")
-buildbuddy.platform(container_image = "docker://buildpack-deps@sha256:fa56fe73b4475655b2f39d6376b6a6664d24b5c43227f709d4a923609f3286a1")
+buildbuddy.platform(container_image = "docker://gcr.io/flame-public/rbe-ubuntu20-04-minimal:latest")
 buildbuddy.msvc_toolchain(
     # This is the MSVC available on Github Action win22 image
     # https://github.com/actions/runner-images/blob/win25/20250727.1/images/windows/Windows2025-Readme.md#visual-studio-enterprise-2022

--- a/dockerfiles/rbe-ubuntu20-04-minimal/Dockerfile
+++ b/dockerfiles/rbe-ubuntu20-04-minimal/Dockerfile
@@ -1,0 +1,34 @@
+FROM docker.io/library/docker:27.0.3-dind AS docker
+
+RUN apk add --no-cache binutils upx && \
+    strip --strip-all \
+      /usr/local/bin/docker \
+      /usr/local/bin/dockerd \
+      /usr/local/bin/runc && \
+    upx --best --lzma \
+      /usr/local/bin/containerd \
+      /usr/local/bin/containerd-shim-runc-v2 \
+      /usr/local/bin/docker \
+      /usr/local/bin/docker-proxy \
+      /usr/local/bin/dockerd \
+      /usr/local/bin/runc
+
+FROM docker.io/library/ubuntu:20.04
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      ca-certificates \
+      iptables \
+      && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY --from=docker \
+  /usr/local/bin/containerd \
+  /usr/local/bin/containerd-shim-runc-v2 \
+  /usr/local/bin/docker \
+  /usr/local/bin/docker-proxy \
+  /usr/local/bin/dockerd \
+  /usr/local/bin/runc \
+  /usr/local/bin/
+
+CMD ["bash"]

--- a/enterprise/deployment/BUILD
+++ b/enterprise/deployment/BUILD
@@ -36,6 +36,7 @@ container_push(
 # login to gcp and then run these commands:
 #
 # ./enterprise/tools/build_images/build_image.py --registry=gcr.io --repository=flame-public/rbe-ubuntu20-04 --tag=latest --no-suffix --dockerfile=dockerfiles/rbe-ubuntu20-04/Dockerfile --platform=amd64 --platform=arm64 --user=_dcgcloud_token
+# ./enterprise/tools/build_images/build_image.py --registry=gcr.io --repository=flame-public/rbe-ubuntu20-04-minimal --tag=latest --no-suffix --dockerfile=dockerfiles/rbe-ubuntu20-04-minimal/Dockerfile --platform=amd64 --platform=arm64 --user=_dcgcloud_token
 # ./enterprise/tools/build_images/build_image.py --registry=gcr.io --repository=flame-public/rbe-ubuntu20-04-workflows --tag=latest --no-suffix --dockerfile=dockerfiles/rbe-ubuntu20-04-workflows/Dockerfile --platform=amd64 --platform=arm64 --user=_dcgcloud_token
 # ./enterprise/tools/build_images/build_image.py --registry=gcr.io --repository=flame-public/rbe-ubuntu20-04-webtest --tag=latest --no-suffix --dockerfile=dockerfiles/rbe-ubuntu20-04-webtest/Dockerfile --platform=amd64 --platform=arm64 --user=_dcgcloud_token
 # ./enterprise/tools/build_images/build_image.py --registry=gcr.io --repository=flame-public/rbe-ubuntu22-04 --tag=latest --no-suffix --dockerfile=dockerfiles/rbe-ubuntu22-04/Dockerfile --platform=amd64 --platform=arm64 --user=_dcgcloud_token

--- a/enterprise/server/api/BUILD
+++ b/enterprise/server/api/BUILD
@@ -103,7 +103,6 @@ go_test(
     embed = [":api"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",

--- a/enterprise/server/auditlog/BUILD
+++ b/enterprise/server/auditlog/BUILD
@@ -33,7 +33,6 @@ go_test(
     srcs = ["auditlog_test.go"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",

--- a/enterprise/server/backends/authdb/BUILD
+++ b/enterprise/server/backends/authdb/BUILD
@@ -76,7 +76,6 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         # We don't want different different db tests to be assigned to the samed
@@ -125,7 +124,6 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         # We don't want different different db tests to be assigned to the samed

--- a/enterprise/server/backends/userdb/BUILD
+++ b/enterprise/server/backends/userdb/BUILD
@@ -71,7 +71,6 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         # We don't want different different db tests to be assigned to the samed
@@ -121,7 +120,6 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         # We don't want different different db tests to be assigned to the samed

--- a/enterprise/server/execution_search_service/BUILD
+++ b/enterprise/server/execution_search_service/BUILD
@@ -29,7 +29,6 @@ go_test(
     srcs = ["execution_search_service_test.go"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",

--- a/enterprise/server/execution_service/BUILD
+++ b/enterprise/server/execution_service/BUILD
@@ -41,7 +41,6 @@ go_test(
     srcs = ["execution_service_test.go"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",

--- a/enterprise/server/invocation_search_service/BUILD
+++ b/enterprise/server/invocation_search_service/BUILD
@@ -38,7 +38,6 @@ go_test(
     srcs = ["invocation_search_service_test.go"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         # We don't want different different db tests to be assigned to the samed

--- a/enterprise/server/invocation_stat_service/BUILD
+++ b/enterprise/server/invocation_stat_service/BUILD
@@ -37,7 +37,6 @@ go_test(
     embed = [":invocation_stat_service"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         # We don't want different different db tests to be assigned to the samed

--- a/enterprise/server/oci/ociregistry/BUILD
+++ b/enterprise/server/oci/ociregistry/BUILD
@@ -59,7 +59,6 @@ go_test(
     timeout = "moderate",
     srcs = ["ociregistry_client_test.go"],
     exec_properties = {
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.workload-isolation-type": "firecracker",
         "test.init-dockerd": "true",
         "test.EstimatedComputeUnits": "4",

--- a/enterprise/server/remote_execution/containers/docker/BUILD
+++ b/enterprise/server/remote_execution/containers/docker/BUILD
@@ -37,7 +37,6 @@ go_test(
     exec_properties = {
         # TODO(https://github.com/buildbuddy-io/buildbuddy-internal/issues/1094): Require less manual configuration here.
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
     },
     shard_count = 2,

--- a/enterprise/server/test/integration/clickhouse_schema/BUILD
+++ b/enterprise/server/test/integration/clickhouse_schema/BUILD
@@ -6,7 +6,6 @@ go_test(
     name = "clickhouse_schema_test",
     srcs = ["clickhouse_schema_test.go"],
     exec_properties = {
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",

--- a/enterprise/server/test/integration/remote_execution/docker_rbe/BUILD
+++ b/enterprise/server/test/integration/remote_execution/docker_rbe/BUILD
@@ -10,7 +10,6 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "busybox",

--- a/enterprise/server/usage/BUILD
+++ b/enterprise/server/usage/BUILD
@@ -76,7 +76,6 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse:25.3",
@@ -119,7 +118,6 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         # We don't want different different db tests to be assigned to the samed
@@ -166,7 +164,6 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         # We don't want different different db tests to be assigned to the samed

--- a/enterprise/server/usage_service/BUILD
+++ b/enterprise/server/usage_service/BUILD
@@ -57,7 +57,6 @@ go_test(
     srcs = ["usage_service_olap_test.go"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",

--- a/enterprise/server/usagealert/BUILD
+++ b/enterprise/server/usagealert/BUILD
@@ -46,7 +46,6 @@ go_test(
     embed = [":usagealert_lib"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",

--- a/enterprise/tools/clickhouse_backup/BUILD
+++ b/enterprise/tools/clickhouse_backup/BUILD
@@ -38,7 +38,6 @@ go_test(
     exec_properties = {
         "test.EstimatedComputeUnits": "4",
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",

--- a/enterprise/tools/metronome_exporter/BUILD
+++ b/enterprise/tools/metronome_exporter/BUILD
@@ -36,7 +36,6 @@ go_test(
     embed = [":metronome_exporter_lib"],
     exec_properties = {
         "test.EstimatedComputeUnits": "4",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",

--- a/server/backends/invocationdb/BUILD
+++ b/server/backends/invocationdb/BUILD
@@ -53,7 +53,6 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         # We don't want different different db tests to be assigned to the samed
@@ -83,7 +82,6 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         # We don't want different different db tests to be assigned to the samed

--- a/server/build_event_protocol/target_tracker/BUILD
+++ b/server/build_event_protocol/target_tracker/BUILD
@@ -29,7 +29,6 @@ go_test(
     srcs = ["target_tracker_test.go"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         # We don't want different different db tests to be assigned to the samed

--- a/server/target/BUILD
+++ b/server/target/BUILD
@@ -35,7 +35,6 @@ go_test(
     srcs = ["target_test.go"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",

--- a/server/util/clickhouse/BUILD
+++ b/server/util/clickhouse/BUILD
@@ -34,7 +34,6 @@ go_test(
     srcs = ["clickhouse_test.go"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622",
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",


### PR DESCRIPTION
Similar to the last image this is ~100mbs, but now it includes docker so
we can use it for tests that had to keep using the old image otherwise.
