### PR TITLE
Fix flake

### DIFF
--- a/enterprise/server/test/integration/ci_runner/ci_runner_test.go
+++ b/enterprise/server/test/integration/ci_runner/ci_runner_test.go
@@ -2242,8 +2242,7 @@ actions:
       push: { branches: [ master ] }
     steps:
       - run: |
-          output_base=$(bazel info output_base)
-          bazel run :simulate_oom "$output_base"
+          bazel run :simulate_oom "$PWD/../output-base"
 `,
 	}
 
@@ -2322,8 +2321,7 @@ actions:
       push: { branches: [ master ] }
     steps:
       - run: |
-          output_base=$(bazel info output_base)
-          bazel run :write_java_log "$output_base"
+          bazel run :write_java_log "$PWD/../output-base"
 `,
 	}
 


### PR DESCRIPTION
The fixture’s redundant `bazel info` could race the subsequent command under `--noblock_for_lock`, causing Bazel exit 37. It now uses the CI runner’s known output-base path directly; the full Bazel test passes.