### PR TITLE
Fix cache probe false failures caused by random seed collisions

### DIFF
--- a/tools/probers/bazelcache/bazelcache.go
+++ b/tools/probers/bazelcache/bazelcache.go
@@ -22,7 +22,6 @@ package main
 import (
 	"bytes"
 	"context"
-	cryptorand "crypto/rand"
 	"flag"
 	"fmt"
 	"io"
@@ -43,6 +42,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/metadata"
 
+	cryptorand "crypto/rand"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )

--- a/tools/probers/bazelcache/bazelcache.go
+++ b/tools/probers/bazelcache/bazelcache.go
@@ -22,6 +22,7 @@ package main
 import (
 	"bytes"
 	"context"
+	cryptorand "crypto/rand"
 	"flag"
 	"fmt"
 	"io"
@@ -200,15 +201,21 @@ func (p *prober) checkActionCache() error {
 
 func (p *prober) checkCAS(compressor repb.Compressor_Value) error {
 	c := compressorName(compressor)
-	gen := digest.RandomGenerator(rand.Int63())
 	const numBlobs = 3
 
 	var digests []*repb.Digest
 	blobsByHash := make(map[string][]byte, numBlobs)
 	for i := 0; i < numBlobs; i++ {
-		d, buf, err := gen.RandomDigestBuf(1024)
-		if err != nil {
+		// math/rand.NewSource only has about 2^31 distinct seeds, so using
+		// digest.RandomGenerator can repeat batches from previous probe runs.
+		buf := make([]byte, 1024)
+		if _, err := cryptorand.Read(buf); err != nil {
 			log.Errorf("failed to generate random data: %s", err)
+			return err
+		}
+		d, err := digest.Compute(bytes.NewReader(buf), repb.DigestFunction_SHA256)
+		if err != nil {
+			log.Errorf("failed to compute digest: %s", err)
 			return err
 		}
 		digests = append(digests, d)

--- a/tools/probers/bazelcache/bazelcache.go
+++ b/tools/probers/bazelcache/bazelcache.go
@@ -43,6 +43,7 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	cryptorand "crypto/rand"
+
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )


### PR DESCRIPTION
The cache probe assumed its three generated CAS blobs were new, but `digest.RandomGenerator` uses
  `math/rand.NewSource`, which has only about 2³¹ distinct seeds. Repeated seeds reproduce entire
  batches, causing false probe failures when earlier uploads remain cached.

  Generate CAS blob contents with `crypto/rand` to avoid these collisions.

  At one run per minute, 8 connections × 2 compressor modes produce 23,040 batches per day.
  Starting with an empty cache and no eviction, the probability of a repeated batch reaches 50%
  after about 2.4 days.

  For an established cache retaining R days of probe batches, the expected collision rate per
  endpoint is approximately:

  `23,040 × (23,040 × R) / (2³¹ − 1) ≈ 0.247 × R collisions/day`

  That is about 1.7 collisions/day with 7 days of retained data, or 7.4/day with 30 days. These
  estimates assume one probe instance and an independent cache namespace - with shared 
  namespaces this is even higher.