### PR TITLE
Add support for references to `DistributedCache.GetWithMetadata` RPC

### DIFF
--- a/proto/distributed_cache.proto
+++ b/proto/distributed_cache.proto
@@ -106,8 +106,14 @@ message GetWithMetadataRequest {
   resource.ResourceName resource = 1;
 }
 
+// Next Tag: 4
 message GetWithMetadataResponse {
   bytes data = 1;
+
+  // If set, this response carries no data bytes. The data should be retrieved
+  // using the provided reference.
+  reference.Reference reference = 3;
+
   MetadataResponse metadata = 2;
 }
 

--- a/proto/distributed_cache.proto
+++ b/proto/distributed_cache.proto
@@ -108,10 +108,10 @@ message GetWithMetadataRequest {
 
 // Next Tag: 4
 message GetWithMetadataResponse {
+  // The bytes of the data. Mutually exclusive with reference.
   bytes data = 1;
 
-  // If set, this response carries no data bytes. The data should be retrieved
-  // using the provided reference.
+  // A reference to the data. Mutually exlusive with data.
   reference.Reference reference = 3;
 
   MetadataResponse metadata = 2;


### PR DESCRIPTION
I wrapped these in a `oneof` because I think it's OK to skip verification on this path for simplicity. Let me know if you disagree.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/8252