### PR TITLE
ci_runner: drop redundant static="on" to share build config with goinit

### DIFF
--- a/enterprise/server/cmd/ci_runner/BUILD
+++ b/enterprise/server/cmd/ci_runner/BUILD
@@ -58,8 +58,15 @@ go_library(
 go_binary(
     name = "ci_runner",
     embed = [":ci_runner_lib"],
+    # pure = "on" (CGO_ENABLED=0) already yields a statically linked binary via
+    # the internal Go linker; in rules_go, static = "on" only adds -static to the
+    # external-linker flags, which are unused with internal linking. Leaving
+    # static unset lets this binary share its configuration
+    # (and thus its stdlib + all shared package compiles) with the other
+    # pure-Go binaries embedded in the executor (e.g. goinit), which
+    # removes ~800 duplicate GoCompilePkg actions + one GoStdlib from cold
+    # executor builds.
     pure = "on",
-    static = "on",
 )
 
 container_image(


### PR DESCRIPTION
pure = "on" (CGO_ENABLED=0, internal linking) already produces a statically linked binary; static = "on" only adds -static to external-linker flags that the internal linker never uses. But the extra setting puts ci_runner in a different Bazel configuration from goinit (also pure), so in cold builds of the executor (which embeds both) ~800 Go packages and the Go stdlib were compiled twice. Reviewed by codex: no change to the produced binary.


Claude-Session: https://claude.ai/code/session_013fGGG4zDRuT9sBNdECj7uA