### PR TITLE
Increase timeout on pebble tests

### DIFF
--- a/enterprise/server/backends/pebble_cache/BUILD
+++ b/enterprise/server/backends/pebble_cache/BUILD
@@ -54,7 +54,7 @@ go_library(
 
 go_test(
     name = "pebble_cache_test",
-    size = "medium",
+    size = "large",
     srcs = [
         "pebble_cache_internal_test.go",
         "pebble_cache_test.go",


### PR DESCRIPTION
The disk-heavy suite exceeded its 300-second `medium` timeout under CI contention (exit 142). Changed its Bazel size to `large`