### PR TITLE
bbcert: support automatic updates

### DIFF
--- a/tools/bbcert/BUILD
+++ b/tools/bbcert/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "bbcert_lib",
@@ -11,6 +11,7 @@ go_library(
         "//server/util/grpc_client",
         "//server/util/log",
         "//server/util/status",
+        "//tools/bbcert/update",
     ],
 )
 
@@ -20,4 +21,17 @@ go_binary(
     pure = "on",
     static = "on",
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/buildbuddy-io/buildbuddy/tools/bbcert.defaultServers": "{STABLE_BBCERT_DEFAULT_SERVERS}",
+        "github.com/buildbuddy-io/buildbuddy/tools/bbcert/update.baseURL": "{STABLE_BBCERT_UPDATE_URL}",
+        # The embedded SHA is used to determine if an update is available.
+        "github.com/buildbuddy-io/buildbuddy/tools/bbcert/update.commitSHA": "{STABLE_COMMIT_SHA}",
+    },
+)
+
+go_test(
+    name = "bbcert_test",
+    srcs = ["bbcert_test.go"],
+    embed = [":bbcert_lib"],
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/tools/bbcert/BUILD
+++ b/tools/bbcert/BUILD
@@ -22,8 +22,6 @@ go_binary(
     static = "on",
     visibility = ["//visibility:public"],
     x_defs = {
-        "github.com/buildbuddy-io/buildbuddy/tools/bbcert.defaultServers": "{STABLE_BBCERT_DEFAULT_SERVERS}",
-        "github.com/buildbuddy-io/buildbuddy/tools/bbcert/update.baseURL": "{STABLE_BBCERT_UPDATE_URL}",
         # The embedded SHA is used to determine if an update is available.
         "github.com/buildbuddy-io/buildbuddy/tools/bbcert/update.commitSHA": "{STABLE_COMMIT_SHA}",
     },

--- a/tools/bbcert/bbcert.go
+++ b/tools/bbcert/bbcert.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
@@ -107,13 +108,7 @@ func updateKubectlConfig(ctx context.Context, kc *cgpb.KubernetesClusterCredenti
 }
 
 func main() {
-	// The subcommand is positional and precedes the flags, so peel it off
-	// before parsing.
-	args := os.Args[1:]
-	var command string
-	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
-		command, args = args[0], args[1:]
-	}
+	command, args := splitCommand(os.Args[1:])
 	os.Args = append(os.Args[:1], args...)
 
 	switch command {
@@ -137,6 +132,15 @@ func main() {
 		fmt.Fprintf(os.Stderr, "unknown command %q\n\n", command)
 		os.Exit(1)
 	}
+}
+
+// splitCommand peels the subcommand, which is positional and precedes the
+// flags, off the arguments.
+func splitCommand(argv []string) (command string, flags []string) {
+	if len(argv) > 0 && !strings.HasPrefix(argv[0], "-") {
+		command, argv = argv[0], argv[1:]
+	}
+	return command, slices.Clone(argv)
 }
 
 // selfUpdate replaces this binary with the latest published one and restarts

--- a/tools/bbcert/bbcert.go
+++ b/tools/bbcert/bbcert.go
@@ -15,13 +15,35 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/tools/bbcert/update"
 
 	cgpb "github.com/buildbuddy-io/buildbuddy/proto/certgenerator"
 )
 
 var (
-	servers = flag.Slice("server", []string{}, "gRPC target(s) for the certificate server(s). Can be specified multiple times.")
+	servers = flag.Slice("server", []string{}, "gRPC target(s) for the certificate server(s). Can be specified multiple times. Defaults to the servers built into this binary, if any (see `bbcert version`).")
+	// TODO: default to true once the publish workflow is in place.
+	autoUpdate = flag.Bool("auto_update", false, "Check for a newer published bbcert before running, and switch to it. "+update.NoUpdateEnv+"=1 disables the check regardless.")
 )
+
+// defaultServers is a comma-separated server list stamped in at link time.
+// This allows a binary to be published embedded with default servers.
+var defaultServers string
+
+// builtInServers parses a stamped server list. An unstamped build leaves the
+// "{STABLE_...}" placeholder, which counts as no servers.
+func builtInServers(stamped string) []string {
+	if stamped == "" || strings.HasPrefix(stamped, "{") {
+		return nil
+	}
+	var out []string
+	for s := range strings.SplitSeq(stamped, ",") {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
 
 var nonAlphanumeric = regexp.MustCompile(`[^a-zA-Z0-9]+`)
 
@@ -85,8 +107,71 @@ func updateKubectlConfig(ctx context.Context, kc *cgpb.KubernetesClusterCredenti
 }
 
 func main() {
-	flag.Parse()
+	// The subcommand is positional and precedes the flags, so peel it off
+	// before parsing.
+	args := os.Args[1:]
+	var command string
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		command, args = args[0], args[1:]
+	}
+	os.Args = append(os.Args[:1], args...)
 
+	switch command {
+	case "":
+		flag.Parse()
+		if *autoUpdate {
+			selfUpdate()
+		}
+		fetchCerts()
+	case "update":
+		os.Exit(update.Run(context.Background(), args))
+	case "version":
+		fmt.Println(update.Version())
+		if s := builtInServers(defaultServers); len(s) > 0 {
+			fmt.Printf("built-in servers: %s\n", strings.Join(s, ", "))
+		}
+		if u := update.BaseURL(); u != "" {
+			fmt.Printf("updates from:     %s\n", u)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command %q\n\n", command)
+		os.Exit(1)
+	}
+}
+
+// selfUpdate replaces this binary with the latest published one and restarts
+// with the same arguments.
+func selfUpdate() {
+	if os.Getenv(update.NoUpdateEnv) != "" || update.Commit() == "" {
+		// Disabled, or a development build, which must not be replaced by
+		// whatever happens to be published.
+		return
+	}
+	ctx := context.Background()
+	u, err := update.Default()
+	if err != nil {
+		log.Warningf("Not checking for updates: %s", err)
+		return
+	}
+	m, needed, err := u.Check(ctx)
+	if err != nil {
+		log.Warningf("Could not check for updates: %s", err)
+		return
+	}
+	if !needed {
+		return
+	}
+	log.Infof("Updating bbcert %.12s -> %.12s (published %s)", update.Commit(), m.Commit, m.PublishedAt)
+	if err := u.Apply(ctx, m); err != nil {
+		log.Warningf("Could not update: %s", err)
+		return
+	}
+	if err := update.Reexec(); err != nil {
+		log.Warningf("Updated, but could not restart (%s); continuing with the previous version. Rerun bbcert to use the new one.", err)
+	}
+}
+
+func fetchCerts() {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		log.Fatalf("Could not determine home directory: %s", err)
@@ -125,11 +210,16 @@ func main() {
 	}
 	token := stdout.String()
 
-	if len(*servers) == 0 {
-		log.Fatalf("At least one --server must be specified.")
+	targets := *servers
+	if len(targets) == 0 {
+		targets = builtInServers(defaultServers)
+		if len(targets) == 0 {
+			log.Fatalf("No --server specified, and this build has no servers built in.")
+		}
+		log.Infof("Using the built-in servers: %s", strings.Join(targets, ", "))
 	}
 
-	for _, srv := range *servers {
+	for _, srv := range targets {
 		if err := fetchCert(ctx, srv, homeDir, keyFile, pub, token); err != nil {
 			log.Errorf("Failed to fetch cert from %s: %s", srv, err)
 		}

--- a/tools/bbcert/bbcert.go
+++ b/tools/bbcert/bbcert.go
@@ -31,10 +31,9 @@ var (
 // This allows a binary to be published embedded with default servers.
 var defaultServers string
 
-// builtInServers parses a stamped server list. An unstamped build leaves the
-// "{STABLE_...}" placeholder, which counts as no servers.
+// builtInServers parses a stamped server list. An unstamped build has none.
 func builtInServers(stamped string) []string {
-	if stamped == "" || strings.HasPrefix(stamped, "{") {
+	if stamped == "" {
 		return nil
 	}
 	var out []string

--- a/tools/bbcert/bbcert.go
+++ b/tools/bbcert/bbcert.go
@@ -29,6 +29,8 @@ var (
 
 // defaultServers is a comma-separated server list stamped in at link time.
 // This allows a binary to be published embedded with default servers.
+// Optionally set via linker flags:
+// --@io_bazel_rules_go//go/config:gc_linkopts='-X=main.defaultServers=foo'
 var defaultServers string
 
 // builtInServers parses a stamped server list. An unstamped build has none.

--- a/tools/bbcert/bbcert_test.go
+++ b/tools/bbcert/bbcert_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuiltInServers(t *testing.T) {
+	require.Equal(t, []string{"grpcs://prod.example.com", "grpcs://dev.example.com"},
+		builtInServers("grpcs://prod.example.com,grpcs://dev.example.com"))
+	require.Equal(t, []string{"grpcs://a"}, builtInServers(" grpcs://a , "), "whitespace and empties are dropped")
+	require.Nil(t, builtInServers(""), "nothing stamped")
+	require.Nil(t, builtInServers("{STABLE_BBCERT_DEFAULT_SERVERS}"), "an unstamped build keeps the placeholder")
+}

--- a/tools/bbcert/bbcert_test.go
+++ b/tools/bbcert/bbcert_test.go
@@ -6,6 +6,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSplitCommand(t *testing.T) {
+	argv := []string{"bbcert", "update", "-commit", "abc123"}
+	command, flags := splitCommand(argv[1:])
+	require.Equal(t, "update", command)
+	// main rebuilds os.Args in place from the flags; that must not change them.
+	argv = append(argv[:1], flags...)
+	require.Equal(t, []string{"-commit", "abc123"}, flags)
+	require.Equal(t, []string{"bbcert", "-commit", "abc123"}, argv)
+
+	command, flags = splitCommand([]string{"-server", "grpcs://a"})
+	require.Equal(t, "", command, "flags alone select the default command")
+	require.Equal(t, []string{"-server", "grpcs://a"}, flags)
+
+	command, flags = splitCommand(nil)
+	require.Equal(t, "", command)
+	require.Empty(t, flags)
+}
+
 func TestBuiltInServers(t *testing.T) {
 	require.Equal(t, []string{"grpcs://prod.example.com", "grpcs://dev.example.com"},
 		builtInServers("grpcs://prod.example.com,grpcs://dev.example.com"))

--- a/tools/bbcert/bbcert_test.go
+++ b/tools/bbcert/bbcert_test.go
@@ -29,5 +29,4 @@ func TestBuiltInServers(t *testing.T) {
 		builtInServers("grpcs://prod.example.com,grpcs://dev.example.com"))
 	require.Equal(t, []string{"grpcs://a"}, builtInServers(" grpcs://a , "), "whitespace and empties are dropped")
 	require.Nil(t, builtInServers(""), "nothing stamped")
-	require.Nil(t, builtInServers("{STABLE_BBCERT_DEFAULT_SERVERS}"), "an unstamped build keeps the placeholder")
 }

--- a/tools/bbcert/update/BUILD
+++ b/tools/bbcert/update/BUILD
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "update",
+    srcs = [
+        "reexec_other.go",
+        "reexec_unix.go",
+        "run.go",
+        "update.go",
+    ],
+    importpath = "github.com/buildbuddy-io/buildbuddy/tools/bbcert/update",
+    visibility = ["//tools/bbcert:__subpackages__"],
+)
+
+go_test(
+    name = "update_test",
+    srcs = ["update_test.go"],
+    embed = [":update"],
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/tools/bbcert/update/reexec_other.go
+++ b/tools/bbcert/update/reexec_other.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package update
+
+import "errors"
+
+func Reexec() error { return errors.New("restart is not supported on this platform") }

--- a/tools/bbcert/update/reexec_unix.go
+++ b/tools/bbcert/update/reexec_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package update
+
+import (
+	"os"
+	"syscall"
+)
+
+// Reexec replaces the current process with the (just updated) executable,
+// keeping the arguments. NoUpdateEnv is set so the new process does not
+// check again.
+func Reexec() error {
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	return syscall.Exec(exe, os.Args, append(os.Environ(), NoUpdateEnv+"=1"))
+}

--- a/tools/bbcert/update/run.go
+++ b/tools/bbcert/update/run.go
@@ -1,0 +1,78 @@
+package update
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+)
+
+// NoUpdateEnv can be used to disable the automatic update check.
+const NoUpdateEnv = "BBCERT_NO_UPDATE"
+
+// Check fetches the published manifest and reports whether it names a
+// different build than this one.
+func (u *Updater) Check(ctx context.Context) (m *Manifest, needed bool, err error) {
+	m, err = u.Latest(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	return m, m.Commit != Commit(), nil
+}
+
+// Run implements `bbcert update`.
+func Run(ctx context.Context, args []string) int {
+	fs := flag.NewFlagSet("bbcert update", flag.ContinueOnError)
+	commit := fs.String("commit", "", "Install this published commit instead of what latest points at.")
+	check := fs.Bool("check", false, "Report what is published without installing it.")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	u, err := Default()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	var m *Manifest
+	if *commit != "" {
+		m, err = u.ForCommit(ctx, *commit)
+	} else {
+		m, err = u.Latest(ctx)
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
+	current := Commit()
+	fmt.Printf("Running:   %s\n", orUnstamped(current))
+	fmt.Printf("Published: %s (%s)\n", m.Commit, m.PublishedAt)
+	if *check {
+		return 0
+	}
+	if m.Commit == current {
+		fmt.Println("Already up to date.")
+		return 0
+	}
+	if err := u.Apply(ctx, m); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	fmt.Printf("Installed %s.\n", short(m.Commit))
+	return 0
+}
+
+func short(commit string) string {
+	if len(commit) > 12 {
+		return commit[:12]
+	}
+	return commit
+}
+
+func orUnstamped(commit string) string {
+	if commit == "" {
+		return "unstamped development build"
+	}
+	return commit
+}

--- a/tools/bbcert/update/run.go
+++ b/tools/bbcert/update/run.go
@@ -28,6 +28,11 @@ func Run(ctx context.Context, args []string) int {
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
+	if fs.NArg() > 0 {
+		fmt.Fprintf(os.Stderr, "unexpected argument %q\n", fs.Arg(0))
+		fs.Usage()
+		return 2
+	}
 
 	u, err := Default()
 	if err != nil {

--- a/tools/bbcert/update/update.go
+++ b/tools/bbcert/update/update.go
@@ -1,0 +1,257 @@
+// Package update keeps an installed bbcert current with the latest version.
+package update
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// baseURL is where binaries are published.
+var baseURL string
+
+// BaseURL returns the stamped manifest location, or "" if this build was
+// not stamped with one.
+func BaseURL() string {
+	if baseURL == "" || strings.HasPrefix(baseURL, "{") {
+		return ""
+	}
+	return strings.TrimRight(baseURL, "/")
+}
+
+// publicKeyPEM is the public key used to verify the bbcert binaries.
+const publicKeyPEM = `
+-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAu3vdQ3oRAqhLQf11lmAQlLUn0zI13s7YT2a8alKYpAg=
+-----END PUBLIC KEY-----
+`
+
+// commitSHA is stamped at link time.
+var commitSHA string
+
+// Commit returns the commit this binary was built from, or "" if it was not
+// stamped.
+func Commit() string {
+	if commitSHA == "" || strings.HasPrefix(commitSHA, "{") || commitSHA == "dev" || commitSHA == "unknown" {
+		return ""
+	}
+	return commitSHA
+}
+
+// Version describes this binary for `bbcert version`.
+func Version() string {
+	commit := Commit()
+	if commit == "" {
+		commit = "unstamped development build"
+	}
+	return fmt.Sprintf("bbcert %s (%s, %s)", commit, Platform(), runtime.Version())
+}
+
+// Platform is the manifest key for the running binary, e.g. "darwin-arm64".
+func Platform() string { return runtime.GOOS + "-" + runtime.GOARCH }
+
+// Manifest is what the publish workflow writes.
+type Manifest struct {
+	Commit      string `json:"commit"`
+	PublishedAt string `json:"published_at"`
+	// SHA256 is the hex digest of each platform's binary, by platform key.
+	SHA256 map[string]string `json:"sha256"`
+}
+
+// BinaryURL is the platform's binary URL for this manifest's
+// commit: <base>/<commit>/bbcert-<platform>.
+func (u *Updater) BinaryURL(m *Manifest, platform string) string {
+	return u.BaseURL + "/" + m.Commit + "/bbcert-" + platform
+}
+
+// Updater fetches manifests and applies them to an executable.
+type Updater struct {
+	BaseURL   string
+	PublicKey ed25519.PublicKey
+	// Executable is the file to replace. Empty means this process's binary.
+	Executable string
+	Platform   string
+	Client     *http.Client
+}
+
+// Default returns the Updater for the running binary, or an error if this
+// build has no manifest location or signing key configured.
+func Default() (*Updater, error) {
+	base := BaseURL()
+	if base == "" {
+		return nil, errors.New("update location is not stamped into this build")
+	}
+	pub, err := parsePublicKey(publicKeyPEM)
+	if err != nil {
+		return nil, err
+	}
+	return &Updater{
+		BaseURL:   base,
+		PublicKey: pub,
+		Platform:  Platform(),
+		Client:    &http.Client{Timeout: 2 * time.Minute},
+	}, nil
+}
+
+func parsePublicKey(pemText string) (ed25519.PublicKey, error) {
+	block, _ := pem.Decode([]byte(pemText))
+	if block == nil {
+		return nil, errors.New("update signing key is not configured in this build")
+	}
+	key, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("update signing key: %w", err)
+	}
+	pub, ok := key.(ed25519.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("update signing key is %T, want ed25519", key)
+	}
+	return pub, nil
+}
+
+// Latest fetches the manifest of what is currently published.
+func (u *Updater) Latest(ctx context.Context) (*Manifest, error) {
+	return u.fetchManifest(ctx, u.BaseURL+"/latest.json")
+}
+
+// ForCommit fetches the manifest of a specific published commit, whether or
+// not it is what "latest" points at.
+func (u *Updater) ForCommit(ctx context.Context, commit string) (*Manifest, error) {
+	return u.fetchManifest(ctx, u.BaseURL+"/"+commit+"/manifest.json")
+}
+
+func (u *Updater) fetchManifest(ctx context.Context, url string) (*Manifest, error) {
+	body, err := u.get(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	sig, err := u.get(ctx, url+".sig")
+	if err != nil {
+		return nil, err
+	}
+	if err := verify(u.PublicKey, body, sig); err != nil {
+		return nil, fmt.Errorf("%s: %w", url, err)
+	}
+	m := &Manifest{}
+	if err := json.Unmarshal(body, m); err != nil {
+		return nil, fmt.Errorf("%s: %w", url, err)
+	}
+	if m.Commit == "" {
+		return nil, fmt.Errorf("%s: manifest names no commit", url)
+	}
+	return m, nil
+}
+
+// verify checks the detached signature over the exact manifest bytes.
+func verify(pub ed25519.PublicKey, manifest, sigB64 []byte) error {
+	sig, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(sigB64)))
+	if err != nil {
+		return fmt.Errorf("signature is not base64: %w", err)
+	}
+	if !ed25519.Verify(pub, manifest, sig) {
+		return errors.New("manifest signature does not verify")
+	}
+	return nil
+}
+
+// Apply replaces the executable with the manifest's binary for this platform.
+// The download is written beside the executable and renamed over it.
+func (u *Updater) Apply(ctx context.Context, m *Manifest) error {
+	digest, ok := m.SHA256[u.Platform]
+	if !ok {
+		return fmt.Errorf("commit %s was not published for %s", m.Commit, u.Platform)
+	}
+	want, err := hex.DecodeString(digest)
+	if err != nil || len(want) != sha256.Size {
+		return fmt.Errorf("manifest has a malformed sha256 for %s", u.Platform)
+	}
+	url := u.BinaryURL(m, u.Platform)
+
+	exe, err := u.executable()
+	if err != nil {
+		return err
+	}
+	dir, base := filepath.Split(exe)
+	tmp, err := os.CreateTemp(dir, "."+base+".update-*")
+	if err != nil {
+		return fmt.Errorf("cannot write next to %s (try with sudo): %w", exe, err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath) // a no-op once renamed
+
+	body, err := u.open(ctx, url)
+	if err != nil {
+		tmp.Close()
+		return err
+	}
+	defer body.Close()
+	h := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(tmp, h), body); err != nil {
+		tmp.Close()
+		return fmt.Errorf("downloading %s: %w", url, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if got := h.Sum(nil); string(got) != string(want) {
+		return fmt.Errorf("%s does not match the digest in the manifest (got %x)", url, got)
+	}
+	if err := os.Chmod(tmpPath, 0o755); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, exe); err != nil {
+		return fmt.Errorf("replacing %s (try with sudo): %w", exe, err)
+	}
+	return nil
+}
+
+func (u *Updater) executable() (string, error) {
+	if u.Executable != "" {
+		return u.Executable, nil
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	// Replace the file, not a symlink to it.
+	return filepath.EvalSymlinks(exe)
+}
+
+func (u *Updater) get(ctx context.Context, url string) ([]byte, error) {
+	body, err := u.open(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	defer body.Close()
+	return io.ReadAll(io.LimitReader(body, 1<<20))
+}
+
+func (u *Updater) open(ctx context.Context, url string) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	rsp, err := u.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if rsp.StatusCode != http.StatusOK {
+		rsp.Body.Close()
+		return nil, fmt.Errorf("GET %s: %s", url, rsp.Status)
+	}
+	return rsp.Body, nil
+}

--- a/tools/bbcert/update/update.go
+++ b/tools/bbcert/update/update.go
@@ -204,6 +204,12 @@ func (u *Updater) Apply(ctx context.Context, m *Manifest) error {
 		tmp.Close()
 		return fmt.Errorf("downloading %s: %w", url, err)
 	}
+	// Flush the download before the rename makes it live, so a crash cannot
+	// leave a truncated executable in its place.
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
 	if err := tmp.Close(); err != nil {
 		return err
 	}

--- a/tools/bbcert/update/update.go
+++ b/tools/bbcert/update/update.go
@@ -27,7 +27,7 @@ var baseURL string
 // BaseURL returns the stamped manifest location, or "" if this build was
 // not stamped with one.
 func BaseURL() string {
-	if baseURL == "" || strings.HasPrefix(baseURL, "{") {
+	if baseURL == "" {
 		return ""
 	}
 	return strings.TrimRight(baseURL, "/")
@@ -46,7 +46,7 @@ var commitSHA string
 // Commit returns the commit this binary was built from, or "" if it was not
 // stamped.
 func Commit() string {
-	if commitSHA == "" || strings.HasPrefix(commitSHA, "{") || commitSHA == "dev" || commitSHA == "unknown" {
+	if commitSHA == "" || commitSHA == "dev" || commitSHA == "unknown" {
 		return ""
 	}
 	return commitSHA

--- a/tools/bbcert/update/update.go
+++ b/tools/bbcert/update/update.go
@@ -22,6 +22,8 @@ import (
 )
 
 // baseURL is where binaries are published.
+// Optionally set via linker flags:
+// --@io_bazel_rules_go//go/config:gc_linkopts='-X=github.com/buildbuddy-io/buildbuddy/tools/bbcert/update.baseURL=foo'
 var baseURL string
 
 // BaseURL returns the stamped manifest location, or "" if this build was

--- a/tools/bbcert/update/update_test.go
+++ b/tools/bbcert/update/update_test.go
@@ -199,6 +199,11 @@ func TestForCommit_FetchesACanary(t *testing.T) {
 	require.Equal(t, "bbb", canary.Commit)
 }
 
+func TestRun_RejectsPositionalArguments(t *testing.T) {
+	// A commit is selected with -commit; a bare one must not quietly install latest.
+	require.Equal(t, 2, Run(context.Background(), []string{"abc123"}))
+}
+
 func TestParsePublicKey(t *testing.T) {
 	pub, _, err := ed25519.GenerateKey(rand.Reader)
 	require.NoError(t, err)

--- a/tools/bbcert/update/update_test.go
+++ b/tools/bbcert/update/update_test.go
@@ -1,0 +1,230 @@
+package update
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// publisher stands in for the publish workflow: it holds the signing key and
+// serves a bucket.
+type publisher struct {
+	pub   ed25519.PublicKey
+	priv  ed25519.PrivateKey
+	files map[string][]byte
+	srv   *httptest.Server
+}
+
+func newPublisher(t *testing.T) *publisher {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	p := &publisher{pub: pub, priv: priv, files: map[string][]byte{}}
+	p.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, ok := p.files[r.URL.Path]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		w.Write(b)
+	}))
+	t.Cleanup(p.srv.Close)
+	return p
+}
+
+// publish writes a binary for the test platform at the conventional path, a
+// manifest naming it, and the manifest's signature, the way the workflow
+// does.
+func (p *publisher) publish(t *testing.T, commit string, binary []byte, latest bool) *Manifest {
+	t.Helper()
+	p.files["/"+commit+"/bbcert-test"] = binary
+	digest := sha256.Sum256(binary)
+	m := &Manifest{
+		Commit:      commit,
+		PublishedAt: "2026-09-04T00:00:00Z",
+		SHA256:      map[string]string{"test": hex.EncodeToString(digest[:])},
+	}
+	body, err := json.Marshal(m)
+	require.NoError(t, err)
+	sig := []byte(base64.StdEncoding.EncodeToString(ed25519.Sign(p.priv, body)))
+	p.files["/"+commit+"/manifest.json"] = body
+	p.files["/"+commit+"/manifest.json.sig"] = sig
+	if latest {
+		p.files["/latest.json"] = body
+		p.files["/latest.json.sig"] = sig
+	}
+	return m
+}
+
+func (p *publisher) updater(t *testing.T, exe string) *Updater {
+	t.Helper()
+	return &Updater{
+		BaseURL:    p.srv.URL,
+		PublicKey:  p.pub,
+		Executable: exe,
+		Platform:   "test",
+		Client:     p.srv.Client(),
+	}
+}
+
+func TestLatest_VerifiesAndParses(t *testing.T) {
+	p := newPublisher(t)
+	want := p.publish(t, "abc123", []byte("new binary"), true /*=latest*/)
+
+	got, err := p.updater(t, "").Latest(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, want.Commit, got.Commit)
+	require.Equal(t, want.SHA256["test"], got.SHA256["test"])
+}
+
+func TestLatest_RefusesTamperedOrForeignManifests(t *testing.T) {
+	p := newPublisher(t)
+	p.publish(t, "abc123", []byte("new binary"), true /*=latest*/)
+
+	t.Run("edited manifest", func(t *testing.T) {
+		orig := p.files["/latest.json"]
+		defer func() { p.files["/latest.json"] = orig }()
+		p.files["/latest.json"] = []byte(`{"commit":"evil","sha256":{"test":"00"}}`)
+		_, err := p.updater(t, "").Latest(context.Background())
+		require.ErrorContains(t, err, "signature does not verify")
+	})
+
+	t.Run("wrong key", func(t *testing.T) {
+		otherPub, _, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+		u := p.updater(t, "")
+		u.PublicKey = otherPub
+		_, err = u.Latest(context.Background())
+		require.ErrorContains(t, err, "signature does not verify")
+	})
+
+	t.Run("missing signature", func(t *testing.T) {
+		sig := p.files["/latest.json.sig"]
+		delete(p.files, "/latest.json.sig")
+		defer func() { p.files["/latest.json.sig"] = sig }()
+		_, err := p.updater(t, "").Latest(context.Background())
+		require.Error(t, err)
+	})
+}
+
+func TestApply_ReplacesTheExecutableAtomically(t *testing.T) {
+	p := newPublisher(t)
+	m := p.publish(t, "abc123", []byte("#!/bin/sh\necho new\n"), true /*=latest*/)
+
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "bbcert")
+	require.NoError(t, os.WriteFile(exe, []byte("old"), 0o755))
+
+	require.NoError(t, p.updater(t, exe).Apply(context.Background(), m))
+
+	got, err := os.ReadFile(exe)
+	require.NoError(t, err)
+	require.Equal(t, "#!/bin/sh\necho new\n", string(got))
+	info, err := os.Stat(exe)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "no temp file left behind")
+}
+
+func TestApply_RefusesABinaryThatDoesNotMatchTheManifest(t *testing.T) {
+	p := newPublisher(t)
+	m := p.publish(t, "abc123", []byte("published"), true /*=latest*/)
+	// The manifest is signed; the binary is not. Swapping it must fail.
+	p.files["/abc123/bbcert-test"] = []byte("swapped")
+
+	exe := filepath.Join(t.TempDir(), "bbcert")
+	require.NoError(t, os.WriteFile(exe, []byte("old"), 0o755))
+
+	err := p.updater(t, exe).Apply(context.Background(), m)
+	require.ErrorContains(t, err, "does not match the digest")
+	got, err := os.ReadFile(exe)
+	require.NoError(t, err)
+	require.Equal(t, "old", string(got), "the executable must be untouched")
+}
+
+func TestApply_RefusesAnUnpublishedPlatform(t *testing.T) {
+	p := newPublisher(t)
+	m := p.publish(t, "abc123", []byte("published"), true /*=latest*/)
+	u := p.updater(t, filepath.Join(t.TempDir(), "bbcert"))
+	u.Platform = "plan9-mips"
+	require.ErrorContains(t, u.Apply(context.Background(), m), "not published for plan9-mips")
+}
+
+func TestCheck_ReportsWhetherThePublishedBuildDiffers(t *testing.T) {
+	p := newPublisher(t)
+	p.publish(t, "abc123", []byte("published"), true /*=latest*/)
+	u := p.updater(t, "")
+
+	defer func(v string) { commitSHA = v }(commitSHA)
+	commitSHA = "abc123"
+	_, needed, err := u.Check(context.Background())
+	require.NoError(t, err)
+	require.False(t, needed, "running the published commit")
+
+	// Any other commit, older or newer: publishing is manual, and
+	// publishing an older commit is how a bad build is rolled back.
+	commitSHA = "999999"
+	m, needed, err := u.Check(context.Background())
+	require.NoError(t, err)
+	require.True(t, needed)
+	require.Equal(t, "abc123", m.Commit)
+}
+
+func TestForCommit_FetchesACanary(t *testing.T) {
+	p := newPublisher(t)
+	p.publish(t, "aaa", []byte("latest"), true /*=latest*/)
+	p.publish(t, "bbb", []byte("canary"), false /*=latest*/)
+
+	u := p.updater(t, "")
+	latest, err := u.Latest(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "aaa", latest.Commit)
+	canary, err := u.ForCommit(context.Background(), "bbb")
+	require.NoError(t, err)
+	require.Equal(t, "bbb", canary.Commit)
+}
+
+func TestParsePublicKey(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	require.NoError(t, err)
+	got, err := parsePublicKey(string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})))
+	require.NoError(t, err)
+	require.Equal(t, pub, got)
+
+	// The key shipped in source is what published binaries verify updates
+	// with, so it has to parse and be the key Default() uses.
+	shipped, err := parsePublicKey(publicKeyPEM)
+	require.NoError(t, err)
+	defer func(v string) { baseURL = v }(baseURL)
+	baseURL = "https://example.com/bbcert"
+	u, err := Default()
+	require.NoError(t, err)
+	require.Equal(t, shipped, u.PublicKey)
+}
+
+func TestBaseURL_IsEmptyUnlessStamped(t *testing.T) {
+	defer func(v string) { baseURL = v }(baseURL)
+	baseURL = ""
+	require.Equal(t, "", BaseURL())
+	baseURL = "{STABLE_BBCERT_UPDATE_URL}"
+	require.Equal(t, "", BaseURL(), "an unstamped build keeps the placeholder")
+	baseURL = "https://example.com/bbcert/"
+	require.Equal(t, "https://example.com/bbcert", BaseURL())
+}

--- a/tools/bbcert/update/update_test.go
+++ b/tools/bbcert/update/update_test.go
@@ -228,8 +228,6 @@ func TestBaseURL_IsEmptyUnlessStamped(t *testing.T) {
 	defer func(v string) { baseURL = v }(baseURL)
 	baseURL = ""
 	require.Equal(t, "", BaseURL())
-	baseURL = "{STABLE_BBCERT_UPDATE_URL}"
-	require.Equal(t, "", BaseURL(), "an unstamped build keeps the placeholder")
 	baseURL = "https://example.com/bbcert/"
 	require.Equal(t, "https://example.com/bbcert", BaseURL())
 }

--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -50,3 +50,10 @@ echo "STABLE_COMMIT_SHA $commit_sha"
 
 latest_cli_version_tag=$(./tools/latest_cli_version_tag.sh)
 echo "STABLE_CLI_VERSION_TAG $latest_cli_version_tag"
+
+if [ -n "${BBCERT_DEFAULT_SERVERS:-}" ]; then
+  echo "STABLE_BBCERT_DEFAULT_SERVERS $BBCERT_DEFAULT_SERVERS"
+fi
+if [ -n "${BBCERT_UPDATE_URL:-}" ]; then
+  echo "STABLE_BBCERT_UPDATE_URL $BBCERT_UPDATE_URL"
+fi

--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -50,10 +50,3 @@ echo "STABLE_COMMIT_SHA $commit_sha"
 
 latest_cli_version_tag=$(./tools/latest_cli_version_tag.sh)
 echo "STABLE_CLI_VERSION_TAG $latest_cli_version_tag"
-
-if [ -n "${BBCERT_DEFAULT_SERVERS:-}" ]; then
-  echo "STABLE_BBCERT_DEFAULT_SERVERS $BBCERT_DEFAULT_SERVERS"
-fi
-if [ -n "${BBCERT_UPDATE_URL:-}" ]; then
-  echo "STABLE_BBCERT_UPDATE_URL $BBCERT_UPDATE_URL"
-fi


### PR DESCRIPTION
I'm going to setup a workflow to publish binaries so people can install pre-built binaries rather than having to rely on manual builds.

Tunnel support will live in this binary so I'd like to make it easier to keep it updated. I'm planning to rename it in a separate PR to better reflect the increased scope of the tool. 