### PR TITLE
Don't bump the atime of inherited GCS blobs

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2413,20 +2413,14 @@ func (p *PebbleCache) WriteReference(ctx context.Context, ref *refpb.Reference, 
 		return err
 	}
 
-	storageMD := refMD.GetStorageMetadata().CloneVT()
+	var storageMD *sgpb.StorageMetadata
 	if mustClone {
 		storageMD, err = p.fileStorer.CloneBlob(ctx, refMD.GetStorageMetadata().GetGcsMetadata(), fileRecord)
 		if err != nil {
 			return err
 		}
 	} else {
-		// Assuming ownership makes this record responsible for the blob's
-		// lifecycle, so update the blob's atime, like a clone or write would.
-		t := p.clock.Now()
-		if err := p.fileStorer.UpdateBlobAtime(ctx, storageMD.GetGcsMetadata(), t); err != nil {
-			return err
-		}
-		storageMD.GetGcsMetadata().LastCustomTimeUsec = t.UnixMicro()
+		storageMD = refMD.GetStorageMetadata().CloneVT()
 	}
 
 	now := p.clock.Now().UnixMicro()

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -4245,7 +4245,7 @@ func TestWriteReference(t *testing.T) {
 		require.Equal(t, blobName(ref), blobName(dstRef))
 	})
 
-	t.Run("take ownership refreshes the blob TTL", func(t *testing.T) {
+	t.Run("take ownership inherits the blob TTL", func(t *testing.T) {
 		te := testenv.GetTestEnv(t)
 		te.SetAuthenticator(testauth.NewTestAuthenticator(t, emptyUserMap))
 		ctx := getAnonContext(t, te)
@@ -4260,12 +4260,18 @@ func TestWriteReference(t *testing.T) {
 		clock.Advance(20 * time.Hour)
 		require.NoError(t, dst.WriteReference(ctx, ref, rn, false /*=mustClone*/))
 
-		// Taking ownership stamped a fresh custom time, so the entry stays
-		// readable past the blob's original deletion horizon.
-		clock.Advance(20 * time.Hour)
-		got, err := dst.Get(ctx, rn)
+		// Taking ownership does not touch the blob, so the record keeps the
+		// custom time it was written with.
+		dstRef, err := dst.ReadReference(ctx, rn)
 		require.NoError(t, err)
-		require.Equal(t, buf, got)
+		require.Equal(t, ref.GetMetadata().GetStorageMetadata().GetGcsMetadata().GetLastCustomTimeUsec(), dstRef.GetMetadata().GetStorageMetadata().GetGcsMetadata().GetLastCustomTimeUsec())
+
+		// Past the blob's original deletion horizon, the entry is treated as
+		// expired.
+		clock.Advance(20 * time.Hour)
+		_, err = dst.Get(ctx, rn)
+		require.Error(t, err)
+		require.True(t, status.IsNotFoundError(err), "expected NotFoundError, got %s", err)
 	})
 
 	t.Run("clone", func(t *testing.T) {


### PR DESCRIPTION
When a pebble cache accepts a reference without cloning, WriteReference synchronously called `UpdateBlobAtime`, which is a GCS object metadata `Update` (a Class A operation) with no threshold check. It's redundant: the blob was
just uploaded by `CreateReference` with its custom time set to now, and the reference carries that timestamp, so the local record can keep it. Once blobs are shared across all replicas, this would incur one extra GCS op per replica per write.

This PR removes this atime bump. The record now inherits the referenced blob's custom time, and the existing atime path refreshes it on later reads as usual. The "take ownership refreshes the blob TTL" test is inverted to assert that the custom time is carried over and the record expires with the blob.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/8257