### PR TITLE
shared bazelrc: centralize test tag filters

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,16 +21,8 @@ import %workspace%/shared.bazelrc
 # so OSS / anonymous users can still send events to our server.
 common --config=anon-bes
 
-# Don't run Docker and Firecracker tests by default, because they cannot be run on all environments
-# Firecracker tests can only be run on Linux machines with bare execution, and we want to avoid a hard dependency
-# on Docker for development
-#
-# Exclude tests which require BuildBuddy Secrets from the default unauthenticated builds
-# These often require "include-secrets: true" exec property in their BUILD file.
-#
-# Don't run benchmarks by default; benchmarks should only run if we are
-# explicitly doing performance testing.
-common --test_tag_filters=-docker,-bare,-secrets,-performance
+# Use the local test suite by default. Suite definitions live in shared.bazelrc.
+common --config=tests-local
 
 # CI invocations from public repo should be publicly accessible.
 common:ci-shared --build_metadata=VISIBILITY=PUBLIC
@@ -39,6 +31,12 @@ common:ci-shared --build_metadata=VISIBILITY=PUBLIC
 common:ci --config=ci-shared
 common:ci --config=remote-minimal
 common:ci --remote_instance_name=buildbuddy-io/buildbuddy/ci/rin20260818
+# Select the CI suite after the remote config. Bare tests run in the separate
+# "Baremetal tests" workflow in this repo.
+common:ci --config=tests-ci
+
+# Extend the imported config with this repo's CI suite.
+common:untrusted-ci --config=tests-ci
 
 # Configuration used for GitHub actions-based CI for anonymous users (e.g. external contributors)
 common:ci-anon --config=ci

--- a/.github/workflows/build-executor-win.yaml
+++ b/.github/workflows/build-executor-win.yaml
@@ -119,7 +119,6 @@ jobs:
                    --windows_enable_symlinks `
                    test `
                    --config=untrusted-ci-windows `
-                   --test_tag_filters=-performance `
                    @authArgs `
                    -- `
                    //enterprise/server/cmd/executor:executor_windows_amd64 `
@@ -144,7 +143,7 @@ jobs:
       #              --windows_enable_symlinks `
       #              test `
       #              --config=untrusted-ci-windows `
-      #              --test_tag_filters=performance `
+      #              --config=performance `
       #              --test_output=all `
       #              @authArgs `
       #              -- `

--- a/.github/workflows/build-executor-win.yaml
+++ b/.github/workflows/build-executor-win.yaml
@@ -144,6 +144,7 @@ jobs:
       #              test `
       #              --config=untrusted-ci-windows `
       #              --config=performance `
+      #              --config=tests-performance `
       #              --test_output=all `
       #              @authArgs `
       #              -- `

--- a/.github/workflows/test-executor-linux-arm64.yaml
+++ b/.github/workflows/test-executor-linux-arm64.yaml
@@ -47,7 +47,7 @@ jobs:
           common --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }}
           EOF
 
-          bazel test --test_tag_filters=-performance,-docker \
+          bazel test --config=tests-linux-arm64 \
             -- \
             //enterprise/server/remote_execution/... \
             //enterprise/server/test/integration/remote_execution/... \
@@ -58,7 +58,7 @@ jobs:
           # Run a separate bazel invocation to invoke tests with the "docker" tag.
           # TODO: improve platform setup so that we can run this whenever the
           # host has podman available.
-          bazel test --test_tag_filters=+docker \
+          bazel test --config=tests-docker \
             //enterprise/server/test/integration/podman:podman_test
 
           # Make sure the executor binary builds.

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -12,7 +12,7 @@ actions:
         branches:
           - "*"
     steps:
-      - run: "bazel test //enterprise/server/cmd/executor:executor_linux_amd64_static //... --config=linux-workflows --config=race --test_tag_filters=-performance,-bare --experimental_enable_execution_graph_log --experimental_execution_graph_log_dep_type=all --experimental_execution_graph_include_change_pruned_actions"
+      - run: "bazel test //enterprise/server/cmd/executor:executor_linux_amd64_static //... --config=linux-workflows --config=race --config=tests-ci --experimental_enable_execution_graph_log --experimental_execution_graph_log_dep_type=all --experimental_execution_graph_include_change_pruned_actions"
     allow_concurrent_runs: false
   - name: Check style
     container_image: ubuntu-22.04
@@ -44,7 +44,7 @@ actions:
     # TODO: Fix the tests below on Mac, and re-enable.
     steps:
       - run: >-
-          bazel test --config=mac-workflows --test_tag_filters=-performance,-webdriver,-docker,-bare
+          bazel test --config=mac-workflows
           --
           //...
           -//server/backends/disk_cache:all
@@ -72,7 +72,7 @@ actions:
     # TODO: Fix the tests below on Mac, and re-enable.
     steps:
       - run: >-
-          bazel test --config=mac-workflows --test_tag_filters=-performance,-webdriver,-docker,-bare
+          bazel test --config=mac-workflows
           --
           //...
           -//server/backends/disk_cache:all
@@ -91,7 +91,7 @@ actions:
         branches:
           - "master"
     steps:
-      - run: "bazel test //... --config=linux-workflows --config=performance --test_tag_filters=+performance"
+      - run: "bazel test //... --config=linux-workflows --config=performance"
   - name: Baremetal tests
     container_image: ubuntu-22.04
     triggers:
@@ -103,7 +103,7 @@ actions:
           - "*"
         merge_with_base_interval: 3h
     steps:
-      - run: "bazel test //... --config=linux-workflows --config=race --test_tag_filters=+bare --build_tag_filters=+bare"
+      - run: "bazel test //... --config=linux-workflows --config=race --config=tests-bare"
     allow_concurrent_runs: false
   - name: Nightly non-determinism check
     triggers:

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -91,7 +91,7 @@ actions:
         branches:
           - "master"
     steps:
-      - run: "bazel test //... --config=linux-workflows --config=performance"
+      - run: "bazel test //... --config=linux-workflows --config=performance --config=tests-performance"
   - name: Baremetal tests
     container_image: ubuntu-22.04
     triggers:

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -114,8 +114,8 @@ genrule(
 
 # NOTE: to run this test locally, use `test.sh` or `bench.sh`
 #
-# To remotely execute this test, a couple of tag_filters are needed:
-# bazel test --config=remote --test_tag_filters=+bare \
+# To remotely execute this test, select the bare test suite:
+# bazel test --config=remote --config=tests-bare \
 # //enterprise/server/remote_execution/containers/firecracker:firecracker_test
 go_test(
     name = "firecracker_test",

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -159,8 +159,15 @@ common:tests-macos --test_tag_filters=-performance,-webdriver,-docker,-bare
 # Windows CI runs locally and excludes benchmarks.
 common:tests-windows --test_tag_filters=-performance
 
+# Linux arm64 CI runs locally over a curated target list. Docker tests run in a
+# separate invocation using the docker suite below.
+common:tests-linux-arm64 --test_tag_filters=-performance,-docker
+
 common:tests-bare --test_tag_filters=+bare
 common:tests-bare --build_tag_filters=+bare
+
+# Unlike the bare suite, this doesn't filter builds; consumers name their targets.
+common:tests-docker --test_tag_filters=+docker
 
 common:tests-performance --test_tag_filters=+performance
 

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -110,6 +110,7 @@ common:race --@io_bazel_rules_go//go/config:race
 common:race --test_timeout=120,600,-1,-1
 
 common:performance --compilation_mode=opt
+common:performance --config=tests-performance
 
 # Configurations used to debug flaky tests
 common:quarantine --config=remote-minimal
@@ -131,6 +132,38 @@ common:webdriver-debug --test_env=DISPLAY
 # When debugging, only run one webdriver test at a time (it's overwhelming
 # otherwise).
 common:webdriver-debug --local_test_jobs=1
+
+
+###############
+# TEST SUITES #
+###############
+
+# Keep test tag filters here. Each suite specifies the complete filter because
+# --test_tag_filters replaces the previous value; filters are not additive.
+# Select a suite after execution configs so it overrides their default suite.
+# Repos choose their default and CI suites in their own .bazelrc.
+
+# Local development should not require Docker, bare execution (Firecracker), or
+# BuildBuddy Secrets ("include-secrets: true"). Benchmarks are opt-in as well.
+common:tests-local --test_tag_filters=-docker,-bare,-secrets,-performance
+
+# Authenticated RBE supports Docker, bare execution, and secrets. Performance
+# tests need a consistent environment and must be selected explicitly.
+common:tests-remote --test_tag_filters=-performance
+
+# Ordinary Linux CI; bare tests run in a separate workflow.
+common:tests-ci --test_tag_filters=-performance,-bare
+
+# Mac CI excludes tests that require unsupported services or isolation types.
+common:tests-macos --test_tag_filters=-performance,-webdriver,-docker,-bare
+
+# Windows CI runs locally and excludes benchmarks.
+common:tests-windows --test_tag_filters=-performance
+
+common:tests-bare --test_tag_filters=+bare
+common:tests-bare --build_tag_filters=+bare
+
+common:tests-performance --test_tag_filters=+performance
 
 
 ###################################
@@ -253,6 +286,7 @@ common:download-minimal --nobuild_runfile_links
 
 # Flags shared across remote configs
 common:remote-shared --config=cache-shared
+common:remote-shared --config=tests-remote
 common:remote-shared --jobs=100
 common:remote-shared --verbose_failures
 common:remote-shared --rewind_lost_inputs
@@ -262,10 +296,6 @@ common:remote-shared --extra_execution_platforms=@toolchains_buildbuddy//platfor
 common:remote-prod-shared --config=remote-shared
 common:remote-prod-shared --experimental_remote_downloader=grpcs://buildbuddy.buildbuddy.io
 common:remote-prod-shared --remote_executor=grpcs://buildbuddy.buildbuddy.io
-# Tests tagged with "docker" or "bare" can be run if using authenticated RBE,
-# but performance tests should not be run remotely since the environment
-# is not consistent or stable.
-common:remote-prod-shared --test_tag_filters=-performance
 
 # Flags shared for dev BES, RBE and cache
 # Note: Dev BES needed to override the default prod BES urls.
@@ -273,10 +303,6 @@ common:remote-dev-shared --config=dev
 common:remote-dev-shared --config=remote-shared
 common:remote-dev-shared --experimental_remote_downloader=grpcs://buildbuddy.buildbuddy.dev
 common:remote-dev-shared --remote_executor=grpcs://buildbuddy.buildbuddy.dev
-# Tests tagged with "docker" or "bare" can be run if using authenticated RBE,
-# but performance tests should not be run remotely since the environment
-# is not consistent or stable.
-common:remote-dev-shared --test_tag_filters=-performance
 
 # Build with --config=remote to use BuildBuddy RBE, generally as a human from
 # the command line. Other configs shoudn't embed this.
@@ -385,6 +411,7 @@ common:untrusted-ci --remote_cache=grpcs://remote.buildbuddy.io
 
 # Disabled RBE for Windows
 common:untrusted-ci-windows --config=ci-shared
+common:untrusted-ci-windows --config=tests-windows
 common:untrusted-ci-windows --remote_instance_name=buildbuddy-io/buildbuddy/untrusted-ci-windows-25/rin20260818
 common:untrusted-ci-windows --repository_cache=C:/bazel/repo-cache/
 common:untrusted-ci-windows --bes_results_url=https://app.buildbuddy.io/invocation/
@@ -416,6 +443,7 @@ common:linux-workflows --build_metadata=TAGS=linux-workflow
 # TODO(bduffany): Enable RBE for Mac workflows, and reconcile this with other configs
 common:mac-workflows --config=cache
 common:mac-workflows --config=workflows
+common:mac-workflows --config=tests-macos
 common:mac-workflows --build_metadata=TAGS=mac-workflow
 
 # Build fully static binaries linked against musl on Linux.

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -110,7 +110,6 @@ common:race --@io_bazel_rules_go//go/config:race
 common:race --test_timeout=120,600,-1,-1
 
 common:performance --compilation_mode=opt
-common:performance --config=tests-performance
 
 # Configurations used to debug flaky tests
 common:quarantine --config=remote-minimal
@@ -286,7 +285,6 @@ common:download-minimal --nobuild_runfile_links
 
 # Flags shared across remote configs
 common:remote-shared --config=cache-shared
-common:remote-shared --config=tests-remote
 common:remote-shared --jobs=100
 common:remote-shared --verbose_failures
 common:remote-shared --rewind_lost_inputs
@@ -294,6 +292,7 @@ common:remote-shared --extra_execution_platforms=@toolchains_buildbuddy//platfor
 
 # Flags shared for prod RBE and cache
 common:remote-prod-shared --config=remote-shared
+common:remote-prod-shared --config=tests-remote
 common:remote-prod-shared --experimental_remote_downloader=grpcs://buildbuddy.buildbuddy.io
 common:remote-prod-shared --remote_executor=grpcs://buildbuddy.buildbuddy.io
 
@@ -301,6 +300,7 @@ common:remote-prod-shared --remote_executor=grpcs://buildbuddy.buildbuddy.io
 # Note: Dev BES needed to override the default prod BES urls.
 common:remote-dev-shared --config=dev
 common:remote-dev-shared --config=remote-shared
+common:remote-dev-shared --config=tests-remote
 common:remote-dev-shared --experimental_remote_downloader=grpcs://buildbuddy.buildbuddy.dev
 common:remote-dev-shared --remote_executor=grpcs://buildbuddy.buildbuddy.dev
 


### PR DESCRIPTION
Remote execution configs replace the default test tag filter, allowing
bare tests to run in ordinary CI even though a dedicated workflow
covers them. Keeping complete filters in multiple configs and workflow
commands also makes the effective test selection difficult to maintain.

Define the named test suites together in shared.bazelrc and select them
from the existing presets. Use the remote suite in remote-shared,
and let performance, Mac workflows, and Windows CI select their
own suites.  Select the public CI suite after the remote config so
bare tests remain excluded from ordinary CI.

Keep the bare suite in its dedicated workflow and leave the ARM64 job
and ad hoc Docker filtering unchanged. Direct remote-shared consumers,
including Linux workflows and probers, now inherit the remote suite.
Consumers with repository-specific exclusions must include them in
the selected suite because test tag filters replace the entire list.
