### PR TITLE
Fix task size lookups for commands with injected secrets

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -1001,6 +1001,9 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 		if err != nil {
 			return nil, err
 		}
+		// Task sizing must use the original CAS command, which is reloaded when
+		// recording usage at completion. Add secrets only to the executor's copy.
+		executionTask.Command = command.CloneVT()
 		executionTask.Command.EnvironmentVariables = append(executionTask.Command.EnvironmentVariables, envVars...)
 		secretEnvVarNames := make([]string, 0, len(envVars))
 		for _, envVar := range envVars {

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -986,42 +986,8 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 		}
 	}
 
-	// Add in secrets for any action explicitly requesting secrets, and all workflows.
-	secretService := s.env.GetSecretService()
-	if props.IncludeSecrets || len(props.EnvSecrets) > 0 {
-		if secretService == nil {
-			return nil, status.FailedPreconditionError("Secrets requested but secret service not available")
-		}
-		envVars, err := secretService.GetSecretEnvVars(ctx, taskGroupID, props.EnvSecrets...)
-		if err != nil {
-			return nil, err
-		}
-		isCIRunner := platform.IsCIRunner(command, platform.GetProto(action, command))
-		envVars, err = gcplink.ExchangeRefreshTokenForAuthToken(ctx, envVars, isCIRunner /*=shouldExchangeToken*/)
-		if err != nil {
-			return nil, err
-		}
-		// Task sizing must use the original CAS command, which is reloaded when
-		// recording usage at completion. Add secrets only to the executor's copy.
-		executionTask.Command = command.CloneVT()
-		executionTask.Command.EnvironmentVariables = append(executionTask.Command.EnvironmentVariables, envVars...)
-		secretEnvVarNames := make([]string, 0, len(envVars))
-		for _, envVar := range envVars {
-			secretEnvVarNames = append(secretEnvVarNames, envVar.GetName())
-		}
-		if len(secretEnvVarNames) > 0 {
-			serializedNames, err := json.Marshal(secretEnvVarNames)
-			if err != nil {
-				return nil, status.WrapError(err, "marshal secret env var names")
-			}
-			executionTask.Command.EnvironmentVariables = append(executionTask.Command.EnvironmentVariables, &repb.Command_EnvironmentVariable{
-				Name:  ci_runner_env.BuildBuddySecretEnvVarNamesForRedaction,
-				Value: string(serializedNames),
-			})
-		}
-	}
-
-	executionTask.QueuedTimestamp = timestamppb.Now()
+	// NOTE: compute the task size before applying any volatile env overrides below,
+	// since the command hash is used as part of the task sizing key.
 	defaultTaskSize := tasksize.Default(executionTask)
 	requestedTaskSize := tasksize.Requested(executionTask)
 	taskSize := tasksize.ApplyLimitsWithRequestedSize(ctx, s.env.GetExperimentFlagProvider(), command, props, defaultTaskSize, requestedTaskSize)
@@ -1041,6 +1007,39 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 		}
 	}
 
+	// Add in secrets for any action explicitly requesting secrets, and all workflows.
+	secretService := s.env.GetSecretService()
+	if props.IncludeSecrets || len(props.EnvSecrets) > 0 {
+		if secretService == nil {
+			return nil, status.FailedPreconditionError("Secrets requested but secret service not available")
+		}
+		envVars, err := secretService.GetSecretEnvVars(ctx, taskGroupID, props.EnvSecrets...)
+		if err != nil {
+			return nil, err
+		}
+		isCIRunner := platform.IsCIRunner(command, platform.GetProto(action, command))
+		envVars, err = gcplink.ExchangeRefreshTokenForAuthToken(ctx, envVars, isCIRunner /*=shouldExchangeToken*/)
+		if err != nil {
+			return nil, err
+		}
+		executionTask.Command.EnvironmentVariables = append(executionTask.Command.EnvironmentVariables, envVars...)
+		secretEnvVarNames := make([]string, 0, len(envVars))
+		for _, envVar := range envVars {
+			secretEnvVarNames = append(secretEnvVarNames, envVar.GetName())
+		}
+		if len(secretEnvVarNames) > 0 {
+			serializedNames, err := json.Marshal(secretEnvVarNames)
+			if err != nil {
+				return nil, status.WrapError(err, "marshal secret env var names")
+			}
+			executionTask.Command.EnvironmentVariables = append(executionTask.Command.EnvironmentVariables, &repb.Command_EnvironmentVariable{
+				Name:  ci_runner_env.BuildBuddySecretEnvVarNamesForRedaction,
+				Value: string(serializedNames),
+			})
+		}
+	}
+
+	executionTask.QueuedTimestamp = timestamppb.Now()
 	pool, err := scheduler.GetPoolInfo(ctx, props.OS, props.Arch, props.Pool, props.OriginalPool, props.WorkflowID, props.PoolType)
 	if err != nil {
 		return nil, status.WrapError(err, "get executor pool info")

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -111,6 +111,33 @@ func (s *schedulerServerMock) CancelTask(ctx context.Context, taskID string) (bo
 	return true, nil
 }
 
+type taskSizerMock struct {
+	interfaces.TaskSizer
+
+	getCommand     *repb.Command
+	predictCommand *repb.Command
+}
+
+func (s *taskSizerMock) Get(ctx context.Context, cmd *repb.Command, props *platform.Properties) *scpb.TaskSize {
+	s.getCommand = cmd.CloneVT()
+	return nil
+}
+
+func (s *taskSizerMock) Predict(ctx context.Context, action *repb.Action, cmd *repb.Command, props *platform.Properties) *scpb.TaskSize {
+	s.predictCommand = cmd.CloneVT()
+	return nil
+}
+
+type secretServiceMock struct {
+	interfaces.SecretService
+
+	envVars []*repb.Command_EnvironmentVariable
+}
+
+func (s *secretServiceMock) GetSecretEnvVars(ctx context.Context, groupID string, secretNames ...string) ([]*repb.Command_EnvironmentVariable, error) {
+	return s.envVars, nil
+}
+
 func setupEnvWithClock(t *testing.T, clock clockwork.Clock) (*testenv.TestEnv, *grpc.ClientConn, *testredis.Handle) {
 	env := testenv.GetTestEnv(t)
 	env.SetClock(clock)
@@ -252,6 +279,54 @@ func TestDispatch_ChunkingConfigWithNoopExperimentProvider(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDispatch_TaskSizingUsesCommandWithoutInjectedSecrets(t *testing.T) {
+	env, _, _ := setupEnv(t)
+	sizer := &taskSizerMock{}
+	env.SetTaskSizer(sizer)
+	env.SetSecretService(&secretServiceMock{
+		envVars: []*repb.Command_EnvironmentVariable{{Name: "SECRET", Value: "secret-value"}},
+	})
+	s, err := execution_server.NewExecutionServer(env)
+	require.NoError(t, err)
+	ctx, err := env.GetAuthenticator().(*testauth.TestAuthenticator).WithAuthenticatedUser(t.Context(), "US1")
+	require.NoError(t, err)
+	ctx, err = prefix.AttachUserPrefixToContext(ctx, env.GetAuthenticator())
+	require.NoError(t, err)
+
+	// Completion reloads the command from CAS to record task sizes, so dispatch
+	// must use that command for sizing even when the task requests secrets.
+	cmd := &repb.Command{
+		Arguments:            []string{"echo", "hello"},
+		EnvironmentVariables: []*repb.Command_EnvironmentVariable{{Name: "ORIGINAL", Value: "original-value"}},
+	}
+	action := &repb.Action{
+		Platform: &repb.Platform{Properties: []*repb.Platform_Property{
+			{Name: "include-secrets", Value: "true"},
+		}},
+	}
+	arn := uploadActionWithCommand(ctx, t, env, "", repb.DigestFunction_SHA256, action, cmd)
+	err = s.Dispatch(ctx, &repb.ExecuteRequest{
+		ActionDigest:   arn.GetDigest(),
+		DigestFunction: arn.GetDigestFunction(),
+	}, action, arn.NewUploadString())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(cmd, sizer.getCommand, protocmp.Transform()))
+	require.Empty(t, cmp.Diff(cmd, sizer.predictCommand, protocmp.Transform()))
+
+	// The executor receives the secret along with the original environment.
+	sched := env.GetSchedulerService().(*schedulerServerMock)
+	require.Len(t, sched.scheduleReqs, 1)
+	task := &repb.ExecutionTask{}
+	err = proto.Unmarshal(sched.scheduleReqs[0].GetSerializedTask(), task)
+	require.NoError(t, err)
+	envVars := make(map[string]string)
+	for _, envVar := range task.GetCommand().GetEnvironmentVariables() {
+		envVars[envVar.GetName()] = envVar.GetValue()
+	}
+	require.Equal(t, "secret-value", envVars["SECRET"])
+	require.Equal(t, "original-value", envVars["ORIGINAL"])
 }
 
 func TestDispatch_UploadOutputsChunkedMaxWriteSize(t *testing.T) {


### PR DESCRIPTION
Task size reuse was effectively broken whenever the app injected secret environment variables. Measurements were stored under the original command’s hash, but subsequent lookups used the modified command’s hash and missed. Recorded OOM memory increases (due to OOM kills) were also missed on retry.

The fix in this PR is to move secret injection after `taskSizer.Get`, so that the command mutation doesn't affect the task size lookup.