### PR TITLE
Remove dependency on `corepack`

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -485,7 +485,7 @@
           "REPO_MAPPING:,com_github_buildbuddy_io_buildbuddy ",
           "REPO_MAPPING:aspect_rules_ts+,aspect_rules_ts aspect_rules_ts+",
           "REPO_MAPPING:aspect_rules_ts+,bazel_tools bazel_tools",
-          "FILE:@@//package.json 18fe8275a2c15fffca47651775220bd20d17fd528eb6a10c55fb1dda0e4ed373"
+          "FILE:@@//package.json 34ad80805bb3427ecfde1253fdcb81695ed32c526bab82e62a8e9d45c25ab0ef"
         ],
         "generatedRepoSpecs": {
           "npm_typescript": {

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -485,7 +485,7 @@
           "REPO_MAPPING:,com_github_buildbuddy_io_buildbuddy ",
           "REPO_MAPPING:aspect_rules_ts+,aspect_rules_ts aspect_rules_ts+",
           "REPO_MAPPING:aspect_rules_ts+,bazel_tools bazel_tools",
-          "FILE:@@//package.json c45f54b75dd13605aedaba1a3dc9b48300b1c7ae6c2c20d418a05d36a27c4e06"
+          "FILE:@@//package.json 18fe8275a2c15fffca47651775220bd20d17fd528eb6a10c55fb1dda0e4ed373"
         ],
         "generatedRepoSpecs": {
           "npm_typescript": {
@@ -1198,7 +1198,7 @@
     "@@rules_nodejs+//nodejs:extensions.bzl%node": {
       "general": {
         "bzlTransitiveDigest": "Wk34E3p3A3kbwcuJQ9G/Q0rF/kuE/Dk2i/kPk1AA3oI=",
-        "usagesDigest": "jehcvvALfAciVNufsHD5AADqLHtK8i7m6JN7nVnnptM=",
+        "usagesDigest": "HItd0UAd7VGtOTnmuZ6sXIwWtyLOmdWQFeBibImoVPs=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "nodejs_linux_amd64": {
@@ -1834,6 +1834,9 @@
     }
   },
   "facts": {
+    "@@aspect_rules_js+//npm:extensions.bzl%pnpm": {
+      "11.8.0": "sha512-wfXnxMskHI8XS3Q4UdgvQrgCMkr8iw8Ra5atsVqgZmSUjd42lgo7oQebpbSyndAUATW5S1tfUmNZIknWjlVfJg=="
+    },
     "@@rules_distroless+//apt:extensions.bzl%apt": {
       "formats": {
         "trixie-security/main/amd64/Contents/https://snapshot.debian.org/archive/debian-security/20260318T142916Z": ".gz",

--- a/deps/toolchains.MODULE.bazel
+++ b/deps/toolchains.MODULE.bazel
@@ -40,12 +40,6 @@ use_repo(
     "io_bazel_rules_nogo",
 )
 
-node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
-node.toolchain(
-    name = "nodejs",
-    node_version = "22.20.0",
-)
-
 # Bazel binaries for integration testing
 bazel_binaries = use_extension(
     "@rules_bazel_integration_test//:extensions.bzl",

--- a/deps/web.MODULE.bazel
+++ b/deps/web.MODULE.bazel
@@ -1,3 +1,13 @@
+node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
+node.toolchain(
+    node_version = "22.20.0",
+)
+use_repo(node, "nodejs_toolchains")
+
+pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")
+use_repo(pnpm, "pnpm")
+pnpm.pnpm(pnpm_version_from = "//:package.json")
+
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
 npm.npm_translate_lock(
     name = "npm",
@@ -6,9 +16,6 @@ npm.npm_translate_lock(
     verify_node_modules_ignored = "@com_github_buildbuddy_io_buildbuddy//:.bazelignore",
 )
 use_repo(npm, "npm")
-
-node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
-use_repo(node, "nodejs_toolchains")
 
 swc = use_extension("@aspect_rules_swc//swc:extensions.bzl", "swc")
 swc.toolchain(

--- a/deps/web.MODULE.bazel
+++ b/deps/web.MODULE.bazel
@@ -6,7 +6,7 @@ use_repo(node, "nodejs_toolchains")
 
 pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")
 use_repo(pnpm, "pnpm")
-pnpm.pnpm(pnpm_version_from = "//:package.json")
+pnpm.pnpm(pnpm_version = "11.8.0")
 
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
 npm.npm_translate_lock(

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@types/uuid": "^8.3.4",
     "@types/varint": "^6.0.3",
     "browser-headers": "^0.4.1",
-    "corepack": "^0.34.7",
     "d3-scale": "^4.0.2",
     "d3-time": "^3.1.0",
     "dagre-d3-react": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -55,13 +55,5 @@
     "typescript": "7.0.2",
     "uuid": "^14.0.0",
     "varint": "^6.0.0"
-  },
-  "packageManager": "pnpm@11.8.0",
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "11.8.0",
-      "onFail": "download"
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,47 +8,6 @@ importers:
 
 packages:
 
-  '@pnpm/exe@11.8.0':
-    resolution: {integrity: sha512-Z4yxxE+Q2bi36Ol/hNN/420TLk6MG1LxB80sIFvwFq2cr8zRkO446c8Ho+jFaBOxdFiGE7RPT5a3tvu9JQarsg==}
-    hasBin: true
-
-  '@pnpm/linux-arm64@11.8.0':
-    resolution: {integrity: sha512-GynFy14/J4CBFnAl0yIAZofHFjVT9O630/6SQizF+g/tmtgA/LD8LNydlaqp0IqJHLpAYgP6NCz1GpNjAXDSFw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@pnpm/linux-x64@11.8.0':
-    resolution: {integrity: sha512-t8xZUgi1+3zUDKD7vVv+njzEE22KKVsEx8mDOnHhcrvdk0VQjlXw1gsBRr5qgHm1mSLBHM59p8HYskbIvKs2Bg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@pnpm/linuxstatic-arm64@11.8.0':
-    resolution: {integrity: sha512-sImQtnqan8mkTE4PPil9Kz3pPtQ+pBvhYEMUFBgOzhHAWloxVRDKK0pJvUXJmx+NqQNng5SiEvhjoAUdm5p34g==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@pnpm/linuxstatic-x64@11.8.0':
-    resolution: {integrity: sha512-/amFWeX2wOmsuCpEHs+65RBgniuncIE0eCqWdOI7nBk3rcu8SniVeZ8Lq5rABjqNBYUU65zKwHJ5NyWwc+BrKg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@pnpm/macos-arm64@11.8.0':
-    resolution: {integrity: sha512-r7OWbYzpvO3CPCozezysoAfpYvUNX0w/2DpqA+lX4HcuBQi7GAR4xx6Gdhbg52uPA7Qux+7kHUj3gL/Mn8DEAA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@pnpm/win-arm64@11.8.0':
-    resolution: {integrity: sha512-BGXgcCdDX1QHv7D3QbQnP4aY/jr9DkSV/fqiiCTaYsgDF4/bOqcjlCr+Md6Az7HL/PJ8bxyjPIqHhdBzZh2TSg==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@pnpm/win-x64@11.8.0':
-    resolution: {integrity: sha512-J6inRM26+P1hL3DLWLBLI/imW2VlxjSFJsnSlaVvPC6PiGJbC96JhGZ+7l9Oag8loWjb9Z1DbcOf3ibDA9XRJA==}
-    cpu: [x64]
-    os: [win32]
-
   '@reflink/reflink-darwin-arm64@0.1.19':
     resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
     engines: {node: '>= 10'}
@@ -109,46 +68,7 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  pnpm@11.8.0:
-    resolution: {integrity: sha512-wfXnxMskHI8XS3Q4UdgvQrgCMkr8iw8Ra5atsVqgZmSUjd42lgo7oQebpbSyndAUATW5S1tfUmNZIknWjlVfJg==}
-    engines: {node: '>=22.13'}
-    hasBin: true
-
 snapshots:
-
-  '@pnpm/exe@11.8.0':
-    dependencies:
-      '@reflink/reflink': 0.1.19
-      detect-libc: 2.1.2
-    optionalDependencies:
-      '@pnpm/linux-arm64': 11.8.0
-      '@pnpm/linux-x64': 11.8.0
-      '@pnpm/linuxstatic-arm64': 11.8.0
-      '@pnpm/linuxstatic-x64': 11.8.0
-      '@pnpm/macos-arm64': 11.8.0
-      '@pnpm/win-arm64': 11.8.0
-      '@pnpm/win-x64': 11.8.0
-
-  '@pnpm/linux-arm64@11.8.0':
-    optional: true
-
-  '@pnpm/linux-x64@11.8.0':
-    optional: true
-
-  '@pnpm/linuxstatic-arm64@11.8.0':
-    optional: true
-
-  '@pnpm/linuxstatic-x64@11.8.0':
-    optional: true
-
-  '@pnpm/macos-arm64@11.8.0':
-    optional: true
-
-  '@pnpm/win-arm64@11.8.0':
-    optional: true
-
-  '@pnpm/win-x64@11.8.0':
-    optional: true
 
   '@reflink/reflink-darwin-arm64@0.1.19':
     optional: true
@@ -186,8 +106,6 @@ snapshots:
       '@reflink/reflink-win32-x64-msvc': 0.1.19
 
   detect-libc@2.1.2: {}
-
-  pnpm@11.8.0: {}
 
 ---
 lockfileVersion: '9.0'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,9 +260,6 @@ importers:
       browser-headers:
         specifier: ^0.4.1
         version: 0.4.1
-      corepack:
-        specifier: ^0.34.7
-        version: 0.34.7
       d3-scale:
         specifier: ^4.0.2
         version: 4.0.2
@@ -630,11 +627,6 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
-
-  corepack@0.34.7:
-    resolution: {integrity: sha512-d5OLuTNh4zeJK8+u+G10KScqrnHKNNm6NvR4XO28FZyBFMGE60SNCrBetJLyKR9H1xGCG6U2LyswsyPNdO6kxw==}
-    engines: {node: ^20.10.0 || ^22.11.0 || >=24.0.0}
-    hasBin: true
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -1121,8 +1113,6 @@ snapshots:
   browser-headers@0.4.1: {}
 
   clsx@2.1.1: {}
-
-  corepack@0.34.7: {}
 
   csstype@3.1.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,13 +5,6 @@ importers:
 
   .:
     configDependencies: {}
-    packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 11.8.0
-        version: 11.8.0
-      pnpm:
-        specifier: 11.8.0
-        version: 11.8.0
 
 packages:
 

--- a/rules/pnpm/BUILD
+++ b/rules/pnpm/BUILD
@@ -1,9 +1,3 @@
-load("@npm//:corepack/package_json.bzl", "bin")
-
 package(
     default_visibility = ["//visibility:public"],
-)
-
-bin.corepack_binary(
-    name = "corepack",
 )

--- a/rules/pnpm/index.bzl
+++ b/rules/pnpm/index.bzl
@@ -4,11 +4,10 @@ DEFAULT_CMD_TPL = """
 export BAZEL_BINDIR=. &&
 export ROOTDIR=$$(pwd) &&
 export PACKAGEDIR=$$(dirname $(location {package})) &&
-export PATH=$$ROOTDIR/$$(dirname $(location {corepack})):$$ROOTDIR/$$(dirname $(NODE_PATH)):$$PATH &&
+export PATH=$$ROOTDIR/$$(dirname $(location {pnpm})):$$ROOTDIR/$$(dirname $(NODE_PATH)):$$PATH &&
 cd $$PACKAGEDIR &&
-corepack enable &&
-corepack pnpm install --config.confirmModulesPurge=false &&
-corepack pnpm {command} &&
+pnpm install --config.confirmModulesPurge=false &&
+pnpm {command} &&
 cd build &&
 tar -cvf ../build.tar * &&
 cd $$ROOTDIR &&
@@ -19,10 +18,9 @@ EXECUTABLE_CMD_TPL = (
     """
 cat << EOF > $@
 export BAZEL_BINDIR=. &&
-export PATH=$$(pwd)/$$(dirname $(location {corepack})):$$(pwd)/$$(dirname $(NODE_PATH)):$$PATH &&
+export PATH=$$(pwd)/$$(dirname $(location {pnpm})):$$(pwd)/$$(dirname $(NODE_PATH)):$$PATH &&
 cd $$(dirname $(location {package})) &&
-corepack enable &&
-corepack pnpm install --config.confirmModulesPurge=false &&""" +
+pnpm install --config.confirmModulesPurge=false &&""" +
 
     # To explain the complicated escaping here:
     # starlark resolves `\\` to a literal backslash, giving us `\$$@`
@@ -36,12 +34,12 @@ corepack pnpm install --config.confirmModulesPurge=false &&""" +
     # the bash process that runs the pnpm command then resolves `$@` to the
     # command line arguments, effectively forwarding them to pnpm.
     """
-corepack pnpm {command} \\$$@
+pnpm {command} \\$$@
 EOF
 """
 )
 
-def pnpm(name, srcs, package, command = "build", deps = [], corepack = Label("//rules/pnpm:corepack"), node = Label("@nodejs_toolchains//:resolved_toolchain"), **kwargs):
+def pnpm(name, srcs, package, command = "build", deps = [], pnpm = Label("@pnpm//:pnpm"), node = Label("@nodejs_toolchains//:resolved_toolchain"), **kwargs):
     extension = ".tar"
     executable = False
     if command != "build":
@@ -55,7 +53,7 @@ def pnpm(name, srcs, package, command = "build", deps = [], corepack = Label("//
 
     cmd = cmd_tpl.format(
         package = package,
-        corepack = corepack,
+        pnpm = pnpm,
         command = command,
     )
 
@@ -65,7 +63,7 @@ def pnpm(name, srcs, package, command = "build", deps = [], corepack = Label("//
         outs = [name + extension],
         cmd_bash = cmd,
         executable = executable,
-        tools = [corepack, node],
+        tools = [pnpm, node],
         toolchains = [node],
         local = 1,
         **kwargs

--- a/website/package.json
+++ b/website/package.json
@@ -39,13 +39,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "packageManager": "pnpm@11.8.0",
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "11.8.0",
-      "onFail": "download"
-    }
   }
 }

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -5,56 +5,8 @@ importers:
 
   .:
     configDependencies: {}
-    packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 11.8.0
-        version: 11.8.0
-      pnpm:
-        specifier: 11.8.0
-        version: 11.8.0
 
 packages:
-
-  '@pnpm/exe@11.8.0':
-    resolution: {integrity: sha512-Z4yxxE+Q2bi36Ol/hNN/420TLk6MG1LxB80sIFvwFq2cr8zRkO446c8Ho+jFaBOxdFiGE7RPT5a3tvu9JQarsg==}
-    hasBin: true
-
-  '@pnpm/linux-arm64@11.8.0':
-    resolution: {integrity: sha512-GynFy14/J4CBFnAl0yIAZofHFjVT9O630/6SQizF+g/tmtgA/LD8LNydlaqp0IqJHLpAYgP6NCz1GpNjAXDSFw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@pnpm/linux-x64@11.8.0':
-    resolution: {integrity: sha512-t8xZUgi1+3zUDKD7vVv+njzEE22KKVsEx8mDOnHhcrvdk0VQjlXw1gsBRr5qgHm1mSLBHM59p8HYskbIvKs2Bg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@pnpm/linuxstatic-arm64@11.8.0':
-    resolution: {integrity: sha512-sImQtnqan8mkTE4PPil9Kz3pPtQ+pBvhYEMUFBgOzhHAWloxVRDKK0pJvUXJmx+NqQNng5SiEvhjoAUdm5p34g==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@pnpm/linuxstatic-x64@11.8.0':
-    resolution: {integrity: sha512-/amFWeX2wOmsuCpEHs+65RBgniuncIE0eCqWdOI7nBk3rcu8SniVeZ8Lq5rABjqNBYUU65zKwHJ5NyWwc+BrKg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@pnpm/macos-arm64@11.8.0':
-    resolution: {integrity: sha512-r7OWbYzpvO3CPCozezysoAfpYvUNX0w/2DpqA+lX4HcuBQi7GAR4xx6Gdhbg52uPA7Qux+7kHUj3gL/Mn8DEAA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@pnpm/win-arm64@11.8.0':
-    resolution: {integrity: sha512-BGXgcCdDX1QHv7D3QbQnP4aY/jr9DkSV/fqiiCTaYsgDF4/bOqcjlCr+Md6Az7HL/PJ8bxyjPIqHhdBzZh2TSg==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@pnpm/win-x64@11.8.0':
-    resolution: {integrity: sha512-J6inRM26+P1hL3DLWLBLI/imW2VlxjSFJsnSlaVvPC6PiGJbC96JhGZ+7l9Oag8loWjb9Z1DbcOf3ibDA9XRJA==}
-    cpu: [x64]
-    os: [win32]
 
   '@reflink/reflink-darwin-arm64@0.1.19':
     resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
@@ -116,46 +68,7 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  pnpm@11.8.0:
-    resolution: {integrity: sha512-wfXnxMskHI8XS3Q4UdgvQrgCMkr8iw8Ra5atsVqgZmSUjd42lgo7oQebpbSyndAUATW5S1tfUmNZIknWjlVfJg==}
-    engines: {node: '>=22.13'}
-    hasBin: true
-
 snapshots:
-
-  '@pnpm/exe@11.8.0':
-    dependencies:
-      '@reflink/reflink': 0.1.19
-      detect-libc: 2.1.2
-    optionalDependencies:
-      '@pnpm/linux-arm64': 11.8.0
-      '@pnpm/linux-x64': 11.8.0
-      '@pnpm/linuxstatic-arm64': 11.8.0
-      '@pnpm/linuxstatic-x64': 11.8.0
-      '@pnpm/macos-arm64': 11.8.0
-      '@pnpm/win-arm64': 11.8.0
-      '@pnpm/win-x64': 11.8.0
-
-  '@pnpm/linux-arm64@11.8.0':
-    optional: true
-
-  '@pnpm/linux-x64@11.8.0':
-    optional: true
-
-  '@pnpm/linuxstatic-arm64@11.8.0':
-    optional: true
-
-  '@pnpm/linuxstatic-x64@11.8.0':
-    optional: true
-
-  '@pnpm/macos-arm64@11.8.0':
-    optional: true
-
-  '@pnpm/win-arm64@11.8.0':
-    optional: true
-
-  '@pnpm/win-x64@11.8.0':
-    optional: true
 
   '@reflink/reflink-darwin-arm64@0.1.19':
     optional: true
@@ -193,8 +106,6 @@ snapshots:
       '@reflink/reflink-win32-x64-msvc': 0.1.19
 
   detect-libc@2.1.2: {}
-
-  pnpm@11.8.0: {}
 
 ---
 lockfileVersion: '9.0'


### PR DESCRIPTION
`pnpm` no longer recommends using `corepack` to manage the package manager, and now says to use `pnpm` directly instead. I followed the guidance for setting up `pnpm` with `rules_js` that can be found [here](https://github.com/aspect-build/rules_js/blob/6e0fdb5d7fa3f26e61719f3a7dd8c2af6afad88a/npm/extensions.bzl#L1-L29).

This is done in preparation for upgrading `pnpm` to resolve issues raised by dependabot.
