### PR TITLE
Fix VFS prefetch when preserve-workspace is enabled

### DIFF
--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -353,7 +353,7 @@ func (ws *Workspace) DownloadInputs(ctx context.Context, layout *container.FileS
 	opts.ChunkedInputFiles = slices.Contains(ws.task.GetExperiments(), "executor.download_inputs_chunked")
 	opts.RecordInputFetchMetadata = *recordInputFetchMetadata && slices.Contains(ws.task.GetExperiments(), "remote_execution.record_input_fetch_metadata")
 	if ws.Opts.Preserve {
-		opts.Skip = ws.Inputs
+		opts.KnownInputs = ws.Inputs
 		opts.TrackTransfers = true
 	}
 	tf, err := dirtools.NewTreeFetcher(ctx, ws.env, execReq.GetInstanceName(), execReq.GetDigestFunction(), layout.Inputs, opts)

--- a/enterprise/server/remote_execution/workspace/workspace_test.go
+++ b/enterprise/server/remote_execution/workspace/workspace_test.go
@@ -18,10 +18,9 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/buildbuddy-io/buildbuddy/server/util/fspath"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
@@ -606,6 +605,65 @@ func TestDownloadInputs_WorkingDirectoryNestedMissing(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, status.IsFailedPreconditionError(err), "expected FailedPrecondition, got: %v", err)
 	assert.Contains(t, err.Error(), "a/b")
+}
+
+func TestDownloadInputs_VFSPrefetchModeAll_PreserveWorkspace(t *testing.T) {
+	ctx := t.Context()
+	te := testenv.GetTestEnv(t)
+	_, runServer, lis := testenv.RegisterLocalGRPCServer(t, te)
+	testcache.Setup(t, te, lis)
+	go runServer()
+	fc, err := filecache.NewFileCache(testfs.MakeTempDir(t), 1e9, false)
+	require.NoError(t, err)
+	fc.WaitForDirectoryScanToComplete()
+	te.SetFileCache(fc)
+	inputDigest, err := cachetools.UploadBlob(ctx, te.GetByteStreamClient(), "", repb.DigestFunction_SHA256, strings.NewReader("input"))
+	require.NoError(t, err)
+	inputNode := &repb.FileNode{Name: "input.txt", Digest: inputDigest}
+	layout := &container.FileSystemLayout{
+		DigestFunction: repb.DigestFunction_SHA256,
+		Inputs: &repb.Tree{Root: &repb.Directory{
+			Files: []*repb.FileNode{inputNode},
+		}},
+	}
+	ws, err := workspace.New(te, testfs.MakeTempDir(t), &workspace.Opts{
+		Preserve:        true,
+		CleanInputs:     "*",
+		VFSPrefetchMode: workspace.VFSPrefetchModeAll,
+	})
+	require.NoError(t, err)
+
+	// The first task prefetches the input into the file cache. The workspace
+	// remembers the entry for cleanup bookkeeping across tasks.
+	ws.SetTask(ctx, &repb.ExecutionTask{})
+	require.NoError(t, ws.DownloadInputs(ctx, layout))
+	info, err := ws.TaskFinished()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, info.FileCount)
+	require.True(t, fc.ContainsFile(ctx, inputNode))
+	require.Contains(t, ws.Inputs, fspath.NewKey(inputNode.GetName(), false))
+	require.NoError(t, ws.Clean())
+
+	// If the cached contents are evicted between tasks, the preserved entry
+	// must not prevent the next task from prefetching them again.
+	require.True(t, fc.DeleteFile(ctx, inputNode))
+	ws.SetTask(ctx, &repb.ExecutionTask{})
+	require.NoError(t, ws.DownloadInputs(ctx, layout))
+	info, err = ws.TaskFinished()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, info.FileCount)
+	require.True(t, fc.ContainsFile(ctx, inputNode))
+	require.NoError(t, ws.Clean())
+
+	// When the input is already cached, another task reuses its contents
+	// without downloading them again.
+	ws.SetTask(ctx, &repb.ExecutionTask{})
+	require.NoError(t, ws.DownloadInputs(ctx, layout))
+	info, err = ws.TaskFinished()
+	require.NoError(t, err)
+	require.Zero(t, info.FileCount)
+	require.EqualValues(t, 1, info.LinkCount)
+	require.NoError(t, ws.Clean())
 }
 
 func TestDownloadInputs_VFSPrefetchMode(t *testing.T) {

--- a/server/cache/dirtools/dirtools.go
+++ b/server/cache/dirtools/dirtools.go
@@ -638,12 +638,12 @@ type FilePointer struct {
 }
 
 // removeExisting removes any existing file pointed to by the FilePointer if
-// it exists in the opts.Skip (pre-existing files) map. This is needed so that
+// it exists in the opts.KnownInputs map. This is needed so that
 // we overwrite existing files without silently dropping errors when linking
 // the file. (Note, it is not needed when writing a fresh copy of the file.)
 func removeExisting(fp *FilePointer, opts *DownloadTreeOpts) error {
 	pathKey := fspath.NewKey(fp.RelativePath, opts.CaseInsensitive)
-	if _, ok := opts.Skip[pathKey]; ok {
+	if _, ok := opts.KnownInputs[pathKey]; ok {
 		if err := os.Remove(fp.FullPath); err != nil && !os.IsNotExist(err) {
 			return err
 		}
@@ -1262,10 +1262,15 @@ type DownloadTreeOpts struct {
 	// CaseInsensitive specifies whether the filesystem is case-insensitive.
 	// If true, the paths will be normalized to lowercase.
 	CaseInsensitive bool
-	// Skip specifies file paths to skip, along with their file nodes. If the
-	// file metadata or contents to be downloaded don't match the file in this
-	// map, then it is re-downloaded (not skipped).
-	Skip map[fspath.Key]*repb.FileNode
+	// KnownInputs maps workspace-relative input paths to file nodes retained
+	// from previous tasks. When TrackTransfers is enabled, paths also present
+	// in the current tree are returned in InputsState.Exist so cleanup can
+	// preserve them.
+	//
+	// When RootDir is set, unchanged known inputs are reused without downloading.
+	// When RootDir is empty, cache availability is checked independently since
+	// evicting cached contents does not remove the corresponding VFS entry.
+	KnownInputs map[fspath.Key]*repb.FileNode
 	// RootDir specifies the destination directory for the downloaded tree.
 	// If not specified, tree digests will be downloaded directly into the filecache.
 	RootDir string
@@ -1559,11 +1564,22 @@ func (f *TreeFetcher) Start() (*InputsState, error) {
 				}
 
 				pathKey := fspath.NewKey(relPath, f.opts.CaseInsensitive)
-				skippedNode, ok := f.opts.Skip[pathKey]
+				knownNode, ok := f.opts.KnownInputs[pathKey]
 				if ok {
 					trackExistsFn(relPath, node)
 				}
-				if ok && nodesEqual(node, skippedNode) {
+				// To avoid downloading inputs again when reusing a workspace,
+				// the caller supplies KnownInputs, a map of input paths and
+				// file metadata retained from previous tasks. If the file
+				// exists from a previous task and its contents haven't changed,
+				// we can skip downloading it.
+				//
+				// Edge case: for VFS prefetch, the file contents live in the
+				// file cache, which can evict them without removing the VFS
+				// entry. An unchanged known input therefore does not guarantee
+				// that the contents are available. Let prefetch check the file
+				// cache to decide whether another download is needed.
+				if ok && nodesEqual(node, knownNode) && !onlyDownloadToFileCache {
 					return
 				}
 				dk := newFetchKey(d, node.IsExecutable)

--- a/server/cache/dirtools/dirtools_test.go
+++ b/server/cache/dirtools/dirtools_test.go
@@ -1254,7 +1254,7 @@ func TestDownloadTree_InputFetchMetadataPreservesUnsetLeafIndices(t *testing.T) 
 	info, err := dirtools.DownloadTree(ctx, env, instanceName, repb.DigestFunction_SHA256, tree, &dirtools.DownloadTreeOpts{
 		RootDir:                  tmpDir,
 		RecordInputFetchMetadata: true,
-		Skip: map[fspath.Key]*repb.FileNode{
+		KnownInputs: map[fspath.Key]*repb.FileNode{
 			fspath.NewKey("preserved.txt", false): preservedNode,
 		},
 	})


### PR DESCRIPTION
With `preserve-workspace=true` we pass a `Skip` list containing files that already exist in the workspace, so we can skip downloading them. For VFS however, the file may exist virtually (as a node in the tree), but is not guaranteed to exist physically (i.e. it's not guaranteed that we actually fetched that file, depending on prefetch mode, and the file could also have gotten evicted from filecache).

This PR makes it so we always consult the local cache + remote cache when fetching the input tree for VFS. It also renames `Skip` to `KnownInputs` to avoid confusion, since we no longer unconditionally skip fetching these files.