### PR TITLE
Add a strict source VERSION reader with unit and CLI tests

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,4 +1,4 @@
-load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -14,4 +14,21 @@ py_library(
     srcs = ["check_release_assets_uploaded.py"],
     visibility = ["//:__subpackages__"],
     deps = ["@pypi//requests"],
+)
+
+py_binary(
+    name = "source_version",
+    srcs = ["source_version.py"],
+)
+
+py_library(
+    name = "source_version_lib",
+    srcs = ["source_version.py"],
+)
+
+py_test(
+    name = "source_version_test",
+    size = "small",
+    srcs = ["source_version_test.py"],
+    deps = [":source_version_lib"],
 )

--- a/tools/source_version.py
+++ b/tools/source_version.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Read the checkout's root VERSION, never Git tags.
+
+The file must contain ASCII vMAJOR.MINOR.PATCH or vMAJOR.MINOR.PATCH-dev,
+optionally followed by one LF or CRLF line ending. Each numeric component is
+either 0 or starts with 1-9; leading zeroes and all other whitespace are rejected.
+
+Usage: python3 tools/source_version.py [path/to/VERSION]
+The default path is relative to this module, not the current working directory.
+Explicit relative paths are resolved from the current working directory.
+"""
+
+import argparse
+from pathlib import Path
+import re
+import sys
+
+
+DEFAULT_VERSION_PATH = Path(__file__).resolve().parent.parent / "VERSION"
+_VERSION_PATTERN = re.compile(
+    rb"v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-dev)?(?:\r?\n)?"
+)
+
+
+def read_version(path=None):
+    """Return a validated version without its optional trailing line ending.
+
+    Raises OSError if the file cannot be read, or ValueError for invalid content.
+    No version is inferred when VERSION is absent or invalid.
+    """
+    path = DEFAULT_VERSION_PATH if path is None else Path(path)
+    content = path.read_bytes()
+    if _VERSION_PATTERN.fullmatch(content) is None:
+        raise ValueError(
+            f"{path}: expected vMAJOR.MINOR.PATCH or vMAJOR.MINOR.PATCH-dev "
+            "with canonical ASCII numbers and at most one LF or CRLF line ending"
+        )
+    return content.rstrip(b"\r\n").decode("ascii")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "path", nargs="?", help="VERSION file to read (default: checkout root VERSION)"
+    )
+    args = parser.parse_args(argv)
+    try:
+        version = read_version(args.path)
+    except (OSError, ValueError) as error:
+        print(f"source_version: {error}", file=sys.stderr)
+        return 1
+    print(version)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/source_version_test.py
+++ b/tools/source_version_test.py
@@ -1,0 +1,203 @@
+"""Unit and subprocess CLI tests; no checkout VERSION or Git state is needed."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+from tools import source_version
+
+
+VALID_CONTENTS = (
+    (b"v0.0.0", "v0.0.0"),
+    (b"v1.2.3\n", "v1.2.3"),
+    (b"v10.20.300-dev", "v10.20.300-dev"),
+    (b"v0.0.0-dev\n", "v0.0.0-dev"),
+    (b"v1.2.3\r\n", "v1.2.3"),
+    (b"v1.2.3-dev\r\n", "v1.2.3-dev"),
+)
+INVALID_CONTENTS = (
+    b"",
+    b"\n",
+    b"1.2.3",
+    b"V1.2.3",
+    b"v1.2",
+    b"v1.2.3.4",
+    b"v01.2.3",
+    b"v1.02.3",
+    b"v1.2.03-dev",
+    b"v-1.2.3",
+    b"v+1.2.3",
+    b"v1.2.3-rc1",
+    b"v1.2.3-DEV",
+    b"v1.2.3-dev.1",
+    b"v1.2.3+build",
+    b" v1.2.3",
+    b"v1.2.3 ",
+    b"v1.2.3\t",
+    b"v1.2.3\r",
+    b"v1.2.3\r\n\r\n",
+    b"v1.2.3\r\n\n",
+    b"v1.2.3\n\n",
+    b"\nv1.2.3",
+    b"v1.2.3\nv4.5.6",
+    b"v1.2.3\x00",
+    b"\xef\xbb\xbfv1.2.3",
+    "v١.2.3".encode("utf-8"),
+    b"v1.2.\xff",
+)
+
+
+class ReadVersionTest(unittest.TestCase):
+    def setUp(self):
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        self.path = Path(temp.name) / "VERSION"
+
+    def test_valid_versions(self):
+        for content, expected in VALID_CONTENTS:
+            with self.subTest(content=content):
+                self.path.write_bytes(content)
+                self.assertEqual(source_version.read_version(self.path), expected)
+                self.assertEqual(source_version.read_version(str(self.path)), expected)
+
+    def test_invalid_versions(self):
+        for content in INVALID_CONTENTS:
+            with self.subTest(content=content):
+                self.path.write_bytes(content)
+                with self.assertRaisesRegex(ValueError, "expected vMAJOR"):
+                    source_version.read_version(self.path)
+
+    def test_missing_file(self):
+        with self.assertRaises(FileNotFoundError):
+            source_version.read_version(self.path)
+
+    def test_unreadable_file(self):
+        with mock.patch.object(Path, "read_bytes", side_effect=PermissionError("denied")):
+            with self.assertRaises(PermissionError):
+                source_version.read_version(self.path)
+
+    def test_directory_is_not_a_version_file(self):
+        with self.assertRaises(OSError):
+            source_version.read_version(self.path.parent)
+
+
+class SourceVersionCLITest(unittest.TestCase):
+    def setUp(self):
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        self.root = Path(temp.name)
+        tools = self.root / "tools"
+        tools.mkdir()
+        self.script = tools / "source_version.py"
+        shutil.copyfile(source_version.__file__, self.script)
+        self.version = self.root / "VERSION"
+        self.cwd = self.root / "unrelated"
+        self.cwd.mkdir()
+        # A valid cwd VERSION must not hide a missing/invalid checkout VERSION.
+        (self.cwd / "VERSION").write_text("v99.99.99\n")
+
+    def run_cli(self, *args, env=None):
+        return subprocess.run(
+            [sys.executable, str(self.script), *map(str, args)],
+            cwd=self.cwd,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def assert_failure(self, result, path):
+        self.assertEqual(result.returncode, 1, result)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("source_version:", result.stderr)
+        self.assertIn(str(path), result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+
+    def test_default_path_is_cwd_independent(self):
+        for content, expected in VALID_CONTENTS:
+            with self.subTest(content=content):
+                self.version.write_bytes(content)
+                result = self.run_cli()
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout, expected + "\n")
+                self.assertEqual(result.stderr, "")
+
+    def test_imported_helper_default_is_cwd_independent(self):
+        self.version.write_bytes(b"v2.3.4-dev\n")
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import sys; sys.path.insert(0, sys.argv[1]); "
+                "from source_version import read_version; print(read_version())",
+                str(self.script.parent),
+            ],
+            cwd=self.cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "v2.3.4-dev\n")
+        self.assertEqual(result.stderr, "")
+
+    def test_explicit_absolute_and_relative_paths(self):
+        explicit = self.cwd / "other-version"
+        explicit.write_bytes(b"v3.4.5-dev")
+        for path in (explicit, explicit.name):
+            with self.subTest(path=path):
+                result = self.run_cli(path)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout, "v3.4.5-dev\n")
+                self.assertEqual(result.stderr, "")
+
+    def test_invalid_versions(self):
+        for content in INVALID_CONTENTS:
+            with self.subTest(content=content):
+                self.version.write_bytes(content)
+                self.assert_failure(self.run_cli(), self.version)
+
+    def test_missing_default_and_explicit_file(self):
+        self.assert_failure(self.run_cli(), self.version)
+        self.assert_failure(self.run_cli(self.cwd / "missing"), self.cwd / "missing")
+
+    def test_directory_is_unreadable_as_a_file(self):
+        self.assert_failure(self.run_cli(self.cwd), self.cwd)
+
+    def test_permission_denied(self):
+        self.version.write_bytes(b"v1.2.3")
+        self.version.chmod(0)
+        self.addCleanup(self.version.chmod, 0o600)
+        if os.access(self.version, os.R_OK):
+            self.skipTest("current user can read files with no read permissions")
+        self.assert_failure(self.run_cli(), self.version)
+
+    @unittest.skipUnless(os.name == "posix", "fake Git executable uses a POSIX shell")
+    def test_never_falls_back_to_git(self):
+        bin_dir = self.root / "bin"
+        bin_dir.mkdir()
+        marker = self.root / "git-called"
+        git = bin_dir / "git"
+        git.write_text('#!/bin/sh\nprintf called > "$GIT_MARKER"\nprintf "v88.88.88\\n"\n')
+        git.chmod(0o755)
+        env = dict(os.environ, PATH=str(bin_dir), GIT_MARKER=str(marker))
+        for content in (None, b"not a version", b"v1.2.3\n"):
+            with self.subTest(content=content):
+                if content is not None:
+                    self.version.write_bytes(content)
+                result = self.run_cli(env=env)
+                if content == b"v1.2.3\n":
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertEqual(result.stdout, "v1.2.3\n")
+                else:
+                    self.assert_failure(result, self.version)
+                self.assertFalse(marker.exists(), "reader must not invoke Git")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add an opt-in stdlib reader for final and -dev product versions, with checkout-relative defaults and explicit file paths. Reject missing, unreadable, and malformed files without consulting Git tags. Accept a single LF or CRLF line ending. Register Bazel targets and cover the helper and CLI with tests. No VERSION file or production callers are added.