### PR TITLE
commandutil: clean up Windows process resources

### DIFF
--- a/.github/workflows/build-executor-win.yaml
+++ b/.github/workflows/build-executor-win.yaml
@@ -122,6 +122,7 @@ jobs:
                    //enterprise/server/cmd/executor:executor_windows_amd64 `
                    //enterprise/server/cmd/executor:executor_windows_386 `
                    //enterprise/server/cmd/executor:executor_windows_arm64 `
+                   //enterprise/server/remote_execution/commandutil:commandutil_test `
                    //enterprise/server/remote_execution/filecache:filecache_test `
                    //enterprise/server/remote_execution/workspace:workspace_test `
                    //enterprise/server/util/procstats:procstats_test `

--- a/enterprise/server/remote_execution/commandutil/BUILD
+++ b/enterprise/server/remote_execution/commandutil/BUILD
@@ -63,6 +63,7 @@ go_test(
         ],
         "@io_bazel_rules_go//go/platform:windows": [
             "//server/testutil/testfs",
+            "@org_golang_x_sys//windows",
         ],
         "//conditions:default": [],
     }),

--- a/enterprise/server/remote_execution/commandutil/commandutil.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil.go
@@ -3,6 +3,7 @@ package commandutil
 import (
 	"bytes"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -231,9 +232,15 @@ func startNewProcess(ctx context.Context, cmd *exec.Cmd) (*process, error) {
 		return nil, fmt.Errorf("fail to setup preStart: %w", err)
 	}
 	if err := p.cmd.Start(); err != nil {
+		_ = p.cleanup()
 		return nil, err
 	}
 	if err := p.postStart(); err != nil {
+		// Even if Kill reports that the process is already done, Wait is still
+		// required to release exec.Cmd's parent-side resources and I/O goroutines.
+		_ = p.cleanup()
+		_ = p.killRootProcess()
+		_, _ = p.wait()
 		return nil, fmt.Errorf("fail to setup postStart: %w", err)
 	}
 
@@ -260,7 +267,7 @@ func (p *process) monitor(statsListener procstats.Listener) chan *repb.UsageStat
 		if statsListener == nil {
 			return
 		}
-		statsCh <- procstats.Monitor(p.cmd.Process.Pid, statsListener, p.terminated)
+		statsCh <- p.monitorUsage(statsListener)
 	}()
 
 	return statsCh
@@ -294,6 +301,9 @@ func RunWithProcessTreeCleanup(ctx context.Context, cmd *exec.Cmd, opts *RunOpts
 
 	rusage, err := p.wait()
 	stats := <-statsCh
+	if cleanupErr := p.cleanup(); cleanupErr != nil {
+		log.CtxWarningf(ctx, "Failed to clean up process resources: %s", cleanupErr)
+	}
 	if rusage != nil {
 		// If process tree monitoring was not requested, then the stats returned
 		// by the channel will be nil. At least return the top-level process
@@ -386,7 +396,7 @@ func ExitCode(ctx context.Context, cmd *exec.Cmd, err error) (int, error) {
 
 	// If we fail to get the exit code of the process for any other reason, it might
 	// be a transient error that the client can retry, so return UNAVAILABLE for now.
-	exitErr, ok := err.(*exec.ExitError)
+	exitErr, ok := errors.AsType[*exec.ExitError](err)
 	if !ok {
 		return NoExitCode, status.UnavailableError(err.Error())
 	}
@@ -402,7 +412,8 @@ func ExitCode(ctx context.Context, cmd *exec.Cmd, err error) (int, error) {
 	// can be retried if it was OOM killed. Note that KilledExitCode does not
 	// imply that SIGKILL was received.
 
-	if exitCode == KilledExitCode {
+	if isKilledExitCode(exitCode, err) {
+		exitCode = KilledExitCode
 		if ctx.Err() == context.Canceled {
 			return exitCode, status.CanceledErrorf("command was canceled: %s", err.Error())
 		}

--- a/enterprise/server/remote_execution/commandutil/commandutil_unix.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil_unix.go
@@ -10,9 +10,11 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/procstats"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
 type process struct {
@@ -26,6 +28,22 @@ func (p *process) preStart() error {
 
 func (p *process) postStart() error {
 	return nil
+}
+
+func (p *process) monitorUsage(listener procstats.Listener) *repb.UsageStats {
+	return procstats.Monitor(p.cmd.Process.Pid, listener, p.terminated)
+}
+
+func (p *process) cleanup() error {
+	return nil
+}
+
+func (p *process) killRootProcess() error {
+	return p.cmd.Process.Kill()
+}
+
+func isKilledExitCode(exitCode int, err error) bool {
+	return exitCode == KilledExitCode
 }
 
 func (p *process) wait() (*espb.Rusage, error) {

--- a/enterprise/server/remote_execution/commandutil/commandutil_windows.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil_windows.go
@@ -4,15 +4,21 @@ package commandutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
+	"runtime"
+	"sync"
 	"syscall"
+	"time"
 	"unsafe"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/procstats"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"golang.org/x/sys/windows"
 
 	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	putil "github.com/shirou/gopsutil/v3/process"
 )
 
@@ -26,6 +32,15 @@ const (
 	// - https://learn.microsoft.com/en-us/windows/win32/api/jobapi2/nf-jobapi2-assignprocesstojobobject#parameters
 	// - https://learn.microsoft.com/en-us/windows/win32/procthread/process-security-and-access-rights
 	processWithJobObjPerm = windows.PROCESS_SET_QUOTA | windows.PROCESS_TERMINATE | windows.PROCESS_QUERY_LIMITED_INFORMATION
+
+	// Exit code given to TerminateJobObject when killing the process tree.
+	// Go converts the process's DWORD exit code to int without sign
+	// extension, so this value reads back from ProcessState.ExitCode as
+	// 4294967295 on 64-bit builds and -1 only on windows_386. Compare
+	// uint32(exitCode) against this constant instead of checking for
+	// KilledExitCode.
+	// https://learn.microsoft.com/en-us/windows/win32/api/jobapi2/nf-jobapi2-terminatejobobject#parameters
+	windowsKilledExitCode = ^uint32(0)
 )
 
 // process struct is a wrapper around exec.Cmd that adds support for killing the
@@ -38,16 +53,36 @@ type process struct {
 	cmd        *exec.Cmd
 	terminated chan struct{}
 
+	jobMu     sync.Mutex
 	jobHandle windows.Handle
+	killed    bool
 }
 
-func createJobObjInfo() (uintptr, uint32) {
-	extLimitInfo := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
-		BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
-			LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
-		},
-	}
-	return uintptr(unsafe.Pointer(&extLimitInfo)), uint32(unsafe.Sizeof(extLimitInfo))
+type processKilledError struct {
+	err error
+}
+
+func (e *processKilledError) Error() string {
+	return e.err.Error()
+}
+
+func (e *processKilledError) Unwrap() error {
+	return e.err
+}
+
+// jobObjectBasicAccountingInformation mirrors the Windows
+// JOBOBJECT_BASIC_ACCOUNTING_INFORMATION structure. CPU times are expressed in
+// 100-nanosecond ticks.
+// https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_basic_accounting_information
+type jobObjectBasicAccountingInformation struct {
+	TotalUserTime             int64
+	TotalKernelTime           int64
+	ThisPeriodTotalUserTime   int64
+	ThisPeriodTotalKernelTime int64
+	TotalPageFaultCount       uint32
+	TotalProcesses            uint32
+	ActiveProcesses           uint32
+	TotalTerminatedProcesses  uint32
 }
 
 // preStart creates a job object and sets the job object info.
@@ -57,15 +92,27 @@ func (p *process) preStart() error {
 		return fmt.Errorf("failed to create job object: %w", err)
 	}
 
-	jobObjInfo, jobObjInfoLength := createJobObjInfo()
+	jobObjInfo := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
+		BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
+			LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+		},
+	}
+	// SetInformationJobObject takes uintptr, so pin the buffer across the
+	// wrapper call to keep it alive and prevent stack movement.
+	var pin runtime.Pinner
+	pin.Pin(&jobObjInfo)
+	defer pin.Unpin()
 	if _, err := windows.SetInformationJobObject(
 		job,
 		windows.JobObjectExtendedLimitInformation,
-		jobObjInfo,
-		jobObjInfoLength); err != nil {
+		uintptr(unsafe.Pointer(&jobObjInfo)),
+		uint32(unsafe.Sizeof(jobObjInfo))); err != nil {
+		_ = windows.CloseHandle(job)
 		return fmt.Errorf("failed to set job object info: %w", err)
 	}
+	p.jobMu.Lock()
 	p.jobHandle = job
+	p.jobMu.Unlock()
 
 	return nil
 }
@@ -92,9 +139,120 @@ func (p *process) postStart() error {
 	return proc.ResumeWithContext(context.TODO())
 }
 
+func (p *process) monitorUsage(listener procstats.Listener) *repb.UsageStats {
+	return procstats.Monitor(p.cmd.Process.Pid, listener, p.terminated)
+}
+
+func (p *process) jobAccounting() (*jobObjectBasicAccountingInformation, error) {
+	p.jobMu.Lock()
+	defer p.jobMu.Unlock()
+	if p.jobHandle == 0 {
+		return nil, fmt.Errorf("job object is closed")
+	}
+	accounting := &jobObjectBasicAccountingInformation{}
+	if err := windows.QueryInformationJobObject(
+		p.jobHandle,
+		windows.JobObjectBasicAccountingInformation,
+		uintptr(unsafe.Pointer(accounting)),
+		uint32(unsafe.Sizeof(*accounting)),
+		nil,
+	); err != nil {
+		return nil, fmt.Errorf("query job object accounting information: %w", err)
+	}
+	return accounting, nil
+}
+
+// Wait until the job reports no active processes before taking the final
+// cumulative accounting sample. Windows may finish process teardown and
+// signal individual process handles after the active count reaches zero.
+func (p *process) waitForJobInactive() error {
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		accounting, err := p.jobAccounting()
+		if err != nil {
+			return err
+		}
+		if accounting.ActiveProcesses == 0 {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for %d job processes to become inactive", accounting.ActiveProcesses)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func (p *process) cleanup() error {
+	p.jobMu.Lock()
+	defer p.jobMu.Unlock()
+	if p.jobHandle == 0 {
+		return nil
+	}
+	if err := windows.CloseHandle(p.jobHandle); err != nil {
+		return err
+	}
+	p.jobHandle = 0
+	return nil
+}
+
+func (p *process) withProcessHandle(f func(windows.Handle) error) error {
+	var err error
+	if handleErr := p.cmd.Process.WithHandle(func(handle uintptr) {
+		err = f(windows.Handle(handle))
+	}); handleErr != nil {
+		return handleErr
+	}
+	return err
+}
+
+func (p *process) killRootProcess() error {
+	// Use the existing handle so startup recovery does not need to allocate
+	// another handle when setup failed due to resource pressure.
+	return p.withProcessHandle(func(handle windows.Handle) error {
+		return windows.TerminateProcess(handle, 1)
+	})
+}
+
+func isKilledExitCode(exitCode int, err error) bool {
+	var killedErr *processKilledError
+	return uint32(exitCode) == windowsKilledExitCode && errors.As(err, &killedErr)
+}
+
 func (p *process) wait() (*espb.Rusage, error) {
 	defer close(p.terminated)
+	if err := p.withProcessHandle(func(handle windows.Handle) error {
+		_, err := windows.WaitForSingleObject(handle, windows.INFINITE)
+		return err
+	}); err != nil {
+		_ = p.cleanup()
+		_ = p.killRootProcess()
+		_ = p.cmd.Wait()
+		return nil, fmt.Errorf("wait for root process: %w", err)
+	}
+	// Cmd.Wait also waits for stdout/stderr copying. Terminate descendants
+	// holding inherited pipes before waiting for EOF.
+	p.jobMu.Lock()
+	killed := p.killed
+	var cleanupErr error
+	if p.jobHandle != 0 {
+		cleanupErr = windows.TerminateJobObject(p.jobHandle, windowsKilledExitCode)
+	}
+	p.jobMu.Unlock()
+	if cleanupErr == nil {
+		cleanupErr = p.waitForJobInactive()
+	}
+	if cleanupErr != nil {
+		// Closing the job is the fallback if explicit termination or the
+		// accounting query failed. Do not report successful cleanup.
+		_ = p.cleanup()
+	}
 	err := p.cmd.Wait()
+	if cleanupErr != nil {
+		return nil, fmt.Errorf("wait for job processes: %w", cleanupErr)
+	}
+	if killed && err != nil {
+		err = &processKilledError{err: err}
+	}
 	return nil, err
 }
 
@@ -109,7 +267,17 @@ func (p *process) signal(sig syscall.Signal) error {
 // and https://learn.microsoft.com/en-us/windows/win32/procthread/nested-jobs
 // for more details.
 func (p *process) killProcessTree() error {
-	return windows.CloseHandle(p.jobHandle)
+	p.jobMu.Lock()
+	defer p.jobMu.Unlock()
+	if p.jobHandle == 0 {
+		return nil
+	}
+	// Keep the job handle open so wait() can check for job inactivity.
+	if err := windows.TerminateJobObject(p.jobHandle, windowsKilledExitCode); err != nil {
+		return err
+	}
+	p.killed = true
+	return nil
 }
 
 // SetCredential adds credentials to the cmd by resolving a "USER[:GROUP]" string

--- a/enterprise/server/remote_execution/commandutil/commandutil_windows_test.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil_windows_test.go
@@ -5,6 +5,10 @@ package commandutil_test
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,7 +16,10 @@ import (
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
 )
 
 func TestRun_Win_NormalExit_NoError(t *testing.T) {
@@ -52,4 +59,89 @@ func TestComplexProcessTree(t *testing.T) {
 	// Assert
 	assert.NoError(t, res.Error)
 	assert.Equal(t, 0, res.ExitCode)
+}
+
+func TestRun_Win_NormalExit_KillsDescendants(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	workDir := testfs.MakeTempDir(t)
+	pidPath := filepath.Join(workDir, "child.pid")
+	releasePath := filepath.Join(workDir, "release-parent")
+	var childHandle windows.Handle
+	var res *interfaces.CommandResult
+	done := make(chan struct{})
+	t.Cleanup(func() {
+		cancel()
+		if childHandle != 0 {
+			_ = windows.TerminateProcess(childHandle, 1)
+			_ = windows.CloseHandle(childHandle)
+		}
+		<-done
+	})
+	script := fmt.Sprintf(`
+		$ErrorActionPreference = 'Stop'
+		$child = Start-Process powershell -ArgumentList '-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 300' -NoNewWindow -PassThru
+		Set-Content -LiteralPath '%s' -Value $child.Id
+		while (!(Test-Path -LiteralPath '%s')) { Start-Sleep -Milliseconds 10 }
+	`, pidPath, releasePath)
+	cmd := &repb.Command{Arguments: []string{"powershell", "-NoProfile", "-NonInteractive", "-Command", script}}
+	go func() {
+		defer close(done)
+		res = commandutil.Run(ctx, cmd, workDir, nopStatsListener, &interfaces.Stdio{})
+	}()
+
+	// Retain the child's handle before allowing the parent to exit, so the
+	// final check cannot accidentally open a recycled PID on a busy runner.
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for childHandle == 0 {
+		select {
+		case <-ctx.Done():
+			t.Fatal("timed out waiting for the child PID")
+		case <-done:
+			t.Fatalf("parent exited before publishing child PID: %+v", res)
+		case <-ticker.C:
+			pidBytes, err := os.ReadFile(pidPath)
+			if err != nil {
+				continue
+			}
+			pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+			if err != nil {
+				continue
+			}
+			childHandle, err = windows.OpenProcess(windows.SYNCHRONIZE|windows.PROCESS_TERMINATE|windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+			require.NoError(t, err)
+		}
+	}
+	require.NoError(t, os.WriteFile(releasePath, nil, 0600))
+	<-done
+	require.NoError(t, res.Error)
+	require.Zero(t, res.ExitCode)
+	require.NoError(t, ctx.Err(), "inherited output pipes kept the command running until cancellation")
+	var exitCode uint32
+	require.NoError(t, windows.GetExitCodeProcess(childHandle, &exitCode))
+	require.Equal(t, ^uint32(0), exitCode, "descendant did not receive the job termination exit code")
+	// The job can become inactive before Windows signals individual process
+	// handles. Confirm teardown completes using the retained child handle.
+	waitResult, err := windows.WaitForSingleObject(childHandle, 5000)
+	require.NoError(t, err)
+	require.EqualValues(t, windows.WAIT_OBJECT_0, waitResult, "descendant teardown did not complete")
+}
+
+func TestRun_Win_NegativeExitIsNotReportedAsKilled(t *testing.T) {
+	cmd := &repb.Command{Arguments: []string{"powershell", "-NoProfile", "-NonInteractive", "-Command", "Exit -1"}}
+
+	res := commandutil.Run(context.Background(), cmd, ".", nopStatsListener, &interfaces.Stdio{})
+
+	require.NoError(t, res.Error)
+}
+
+func TestRun_Win_TimeoutReturnsDeadlineExceeded(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	cmd := &repb.Command{Arguments: []string{"powershell", "-NoProfile", "-NonInteractive", "-Command", "Start-Sleep -Seconds 300"}}
+
+	res := commandutil.Run(ctx, cmd, ".", nopStatsListener, &interfaces.Stdio{})
+
+	require.True(t, status.IsDeadlineExceededError(res.Error), "expected deadline exceeded, got %v", res.Error)
+	require.Equal(t, commandutil.KilledExitCode, res.ExitCode)
 }


### PR DESCRIPTION
Windows commands can leak Job Object handles on startup failure or
normal completion, leaving descendants alive after the root exits.
Descendants holding inherited output pipes can also block exec.Cmd.Wait.
Wait for root exit separately, terminate remaining job processes,
and wait for job inactivity before draining output and closing the
Job Object.

Close the job before reaping a child after post-start setup fails. Use
the existing process handle to kill the root without allocating another
handle during resource exhaustion. Serialize Job Object operations with
cancellation and close the handle if its initial configuration fails.

Track explicit termination so cancellation preserves its deadline or
canceled status without misclassifying an ordinary negative exit code.

Move usage monitoring behind platform hooks and cover normal-exit
cleanup with a bounded inherited-pipe regression test. Include
commandutil tests in the Windows executor workflow, including pull
requests targeting stack branches, so each cleanup and accounting
layer gets native coverage.

Retain a descendant process handle before allowing the root to exit,
so the cleanup assertion cannot inspect a recycled PID. Use that same
handle for test recovery. Check its termination exit code at return
and allow a bounded wait for asynchronous process teardown.

Pin the Job Object configuration buffer across the Windows wrapper
call so its uintptr argument cannot outlive or lose track of the Go
object during stack movement.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
