### PR TITLE
Upgrade `pnpm` to `11.10.0` for dependabot

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1835,7 +1835,7 @@
   },
   "facts": {
     "@@aspect_rules_js+//npm:extensions.bzl%pnpm": {
-      "11.8.0": "sha512-wfXnxMskHI8XS3Q4UdgvQrgCMkr8iw8Ra5atsVqgZmSUjd42lgo7oQebpbSyndAUATW5S1tfUmNZIknWjlVfJg=="
+      "11.10.0": "sha512-C3+LmAYAMZBMAX46QesYehbUDuuCm5XE+MsDaBdh/Eq1PdIZEVubRH9NzhoFohR2RGHn03AzkqnzL5URzoyGyA=="
     },
     "@@rules_distroless+//apt:extensions.bzl%apt": {
       "formats": {

--- a/deps/web.MODULE.bazel
+++ b/deps/web.MODULE.bazel
@@ -6,6 +6,7 @@ use_repo(node, "nodejs_toolchains")
 
 pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")
 use_repo(pnpm, "pnpm")
+# To update to v12+, aspect_rules_js will need to be upgraded to support it.
 pnpm.pnpm(pnpm_version = "11.10.0")
 
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")

--- a/deps/web.MODULE.bazel
+++ b/deps/web.MODULE.bazel
@@ -6,7 +6,7 @@ use_repo(node, "nodejs_toolchains")
 
 pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")
 use_repo(pnpm, "pnpm")
-pnpm.pnpm(pnpm_version = "11.8.0")
+pnpm.pnpm(pnpm_version = "11.10.0")
 
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
 npm.npm_translate_lock(


### PR DESCRIPTION
Since we moved to using `pnpm` through `rules_js`, dependabot isn't actually surfacing this alert anymore (and it probably isn't a real security concern), but just for completeness, let's upgrade `pnpm` to the recommended version anyway.
