### PR TITLE
ci: run workflows for stacked pull requests

### DIFF
--- a/.github/workflows/build-executor-win.yaml
+++ b/.github/workflows/build-executor-win.yaml
@@ -2,8 +2,6 @@ name: "Build Windows executor"
 
 on:
   pull_request:
-    branches:
-      - master
 
 jobs:
   build:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,8 +2,6 @@ name: PR
 
 on:
   pull_request:
-    branches:
-      - master
 
 jobs:
   build:

--- a/.github/workflows/test-executor-linux-arm64.yaml
+++ b/.github/workflows/test-executor-linux-arm64.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - "master"
   pull_request:
-    branches:
-      - "*"
 
 jobs:
   test:

--- a/.github/workflows/website-pr.yaml
+++ b/.github/workflows/website-pr.yaml
@@ -2,8 +2,6 @@ name: Build Website
 
 on:
   pull_request:
-    branches:
-      - master
     paths:
       - ".github/workflows/website-pr.yaml"
       - "docs/**"


### PR DESCRIPTION
Pull requests targeting feature branches can miss build and test
checks when they aren't registered as native GitHub stacks. The
master base filter excludes these PRs, while the ARM workflow's '*'
filter excludes branch names containing '/'.

Remove PR base-branch filters from the general PR, Windows executor,
Linux ARM64 executor, and website workflows. Preserve website path
filters and keep CodeQL's master filters so its PR targets have branch
analyses available for comparison.

