### PR TITLE
Upgrade `terminal-to-html` to `v3.17.1`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ tool github.com/otiai10/copy
 tool golang.org/x/telemetry/counter
 
 replace (
-	github.com/buildkite/terminal-to-html/v3 => github.com/buildbuddy-io/terminal-to-html/v3 v3.16.8-19
+	github.com/buildkite/terminal-to-html/v3 => github.com/buildbuddy-io/terminal-to-html/v3 v3.17.1-1
 	github.com/lni/dragonboat/v4 => github.com/buildbuddy-io/dragonboat/v4 v4.0.2
 	github.com/lni/goutils v1.4.0 => github.com/buildbuddy-io/goutils v1.4.1
 	github.com/lni/vfs => github.com/buildbuddy-io/vfs v0.2.3
@@ -75,7 +75,7 @@ require (
 	github.com/bradfitz/gomemcache v0.0.0-20230611145640-acc696258285
 	github.com/buildbuddy-io/fastcdc2020 v0.0.2
 	github.com/buildbuddy-io/tensorflow-proto v0.0.0-20220908151343-929b41ab4dc6
-	github.com/buildkite/terminal-to-html/v3 v3.0.0-00010101000000-000000000000
+	github.com/buildkite/terminal-to-html/v3 v3.17.1
 	github.com/cavaliergopher/cpio v1.0.1
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cockroachdb/pebble v1.1.4

--- a/go.sum
+++ b/go.sum
@@ -931,8 +931,8 @@ github.com/buildbuddy-io/kythe v0.0.72 h1:fga2YWn6WRkXuxnoXMj6/fxXZqsoVOkmW4tUpT
 github.com/buildbuddy-io/kythe v0.0.72/go.mod h1:B841wxhIxy3xKwSgja69/VG87060EVNB5VxEu1JwcQk=
 github.com/buildbuddy-io/tensorflow-proto v0.0.0-20220908151343-929b41ab4dc6 h1:LcKnQdAYrT3LOZt0mTgw6uiEi7QVkH75cCxPj+AbkLA=
 github.com/buildbuddy-io/tensorflow-proto v0.0.0-20220908151343-929b41ab4dc6/go.mod h1:sbWYLPDSURZSehjnwnFclswM4ErueZHCVxXimWH6Uo4=
-github.com/buildbuddy-io/terminal-to-html/v3 v3.16.8-19 h1:8+Oxba/4MIBvBY0Zci7sa3qjidrKEj9YzJD5Qw6dsYk=
-github.com/buildbuddy-io/terminal-to-html/v3 v3.16.8-19/go.mod h1:5rnx8QdTRgIETQN8P0IV9/ykb8w4jlutQ6hUCw4ZNDc=
+github.com/buildbuddy-io/terminal-to-html/v3 v3.17.1-1 h1:WNPga68qON1kid0nT+swxfG4/0IRhBoT2GP2gv6dkiY=
+github.com/buildbuddy-io/terminal-to-html/v3 v3.17.1-1/go.mod h1:ONrnI5CFlJP9MIHLTayGw1Uf9Uxcck6xcxdOVzho8Oo=
 github.com/buildbuddy-io/throttled/v2 v2.9.1-rc2 h1:l9PGL9DJwcCgQcVt/zFzVjJbSzb+BmpU8NBeo6leHKU=
 github.com/buildbuddy-io/throttled/v2 v2.9.1-rc2/go.mod h1:LSVJkC18NVPon/lADUB4AabAylh2dnsZbk4SkMCk4KQ=
 github.com/buildbuddy-io/vfs v0.2.3 h1:MR//pf4kj1+XbgbmwJlUrm2tdfxToEGgW8z+1fl3phw=


### PR DESCRIPTION
Picks up upstream fixes, including 24-bit color handling fix.
