### PR TITLE
nogo: scope modernization to maintained sources

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -13,32 +13,28 @@ load("@rules_python_gazelle_plugin//manifest:defs.bzl", "gazelle_python_manifest
 load("@rules_python_gazelle_plugin//modules_mapping:def.bzl", "modules_mapping")
 load("@rules_uv//uv:pip.bzl", "pip_compile")
 load("//rules/go:index.bzl", "go_sdk_tool")
-load("//rules/go/analyzer:def.bzl", "MODERNIZE_ANALYZERS")
+load("//rules/go/analyzer:def.bzl", "MODERNIZE_ANALYZERS", "MODERNIZE_CONFIG")
 
 package(default_visibility = ["//visibility:public"])
 
 npm_link_all_packages(name = "node_modules")
 
 # Rendered JSON result could be checked by doing:
-#   bazel build //:no_go_config
-#   cat bazel-bin/no_go_config.json | jq .
+#   bazel build //:nogo_config
+#   cat bazel-bin/nogo_config.json | jq .
 write_file(
     name = "nogo_config",
     out = "nogo_config.json",
     content = [
         json.encode_indent(
-            {
-                "exhaustive": {
+            dict(
+                MODERNIZE_CONFIG,
+                exhaustive = {
                     "analyzer_flags": {
                         "default-signifies-exhaustive": "true",
                     },
                 },
-                "slicescontains": {
-                    "exclude_files": {
-                        ".*/gazelle\\+/cmd/gazelle/.*": "third-party gazelle sources compiled by //cli/fix/langs:gazelle",
-                    },
-                },
-            },
+            ),
         ),
     ],
 )

--- a/rules/go/analyzer/def.bzl
+++ b/rules/go/analyzer/def.bzl
@@ -22,3 +22,15 @@ ANALYZERS = [
 ]
 
 MODERNIZE_ANALYZERS = ["//rules/go/analyzer:" + analyzer for analyzer in ANALYZERS]
+
+# Modernize repository-owned source, leaving generator and upstream output alone.
+# Keep these exclusions local to modernize so other nogo checks still run.
+MODERNIZE_CONFIG = {
+    analyzer: {
+        "exclude_files": {
+            ".*\\.pb\\.go$": "generated protobuf sources",
+            ".*/gazelle\\+/cmd/gazelle/.*": "third-party gazelle sources compiled by //cli/fix/langs:gazelle",
+        },
+    }
+    for analyzer in ANALYZERS
+}


### PR DESCRIPTION
Enabling more modernizers would report syntax in generated
protobuf files and upstream Gazelle sources compiled by the local
Gazelle binary. Those files cannot be migrated sustainably in this
repository. Generate the same narrow exclusions for every enabled
modernizer, preserving the existing Gazelle exclusion and adding
generated protobuf outputs. Other vet and staticcheck analyzers retain
their current coverage.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>