### PR TITLE
go: replace empty interfaces with any

### DIFF
--- a/cli/cmd/sidecar/sidecar.go
+++ b/cli/cmd/sidecar/sidecar.go
@@ -104,14 +104,14 @@ func startInactivityWatcher(ctx context.Context, inactiveCallbackFn func()) {
 }
 
 func inactivityUnaryInterceptor() grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
 		maybeUpdateLastUse()
 		return handler(ctx, req)
 	}
 }
 
 func inactivityStreamInterceptor() grpc.StreamServerInterceptor {
-	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		maybeUpdateLastUse()
 		return handler(srv, stream)
 	}

--- a/cli/log/log.go
+++ b/cli/log/log.go
@@ -39,7 +39,7 @@ func Debug(v ...any) {
 	log.Print(append([]any{debugPrefix}, v...)...)
 }
 
-func Debugf(format string, v ...interface{}) {
+func Debugf(format string, v ...any) {
 	if !verbose {
 		return
 	}
@@ -50,7 +50,7 @@ func Print(v ...any) {
 	log.Print(v...)
 }
 
-func Printf(format string, v ...interface{}) {
+func Printf(format string, v ...any) {
 	log.Printf(format, v...)
 }
 
@@ -58,11 +58,11 @@ func Warn(v ...any) {
 	log.Print(append([]any{WarningPrefix}, v...)...)
 }
 
-func Warnf(format string, v ...interface{}) {
+func Warnf(format string, v ...any) {
 	log.Printf(WarningPrefix+format, v...)
 }
 
-func Fatalf(format string, v ...interface{}) {
+func Fatalf(format string, v ...any) {
 	log.Fatalf(format, v...)
 }
 

--- a/cli/translate/yaml/yaml.go
+++ b/cli/translate/yaml/yaml.go
@@ -66,7 +66,7 @@ func (y *yamlTranslator) translateRule(m yaml.MapSlice, isModule bool) string {
 				log.Warnf("load: must be a list")
 			}
 		case "rules":
-			if rules, ok := i.Value.([]interface{}); ok {
+			if rules, ok := i.Value.([]any); ok {
 				for _, rule := range rules {
 					s = s + y.translateRule(rule.(yaml.MapSlice), isModule) + newLineSeparator
 				}
@@ -74,7 +74,7 @@ func (y *yamlTranslator) translateRule(m yaml.MapSlice, isModule bool) string {
 				log.Warnf("rules: must be a list")
 			}
 		case "deps":
-			if load, ok := i.Value.([]interface{}); ok {
+			if load, ok := i.Value.([]any); ok {
 				s = s + y.translateDeps(load, isModule) + newLineSeparator
 			} else {
 				log.Warnf("deps: must be a list, instead it was %T", i.Value)
@@ -94,7 +94,7 @@ func (y *yamlTranslator) translateRule(m yaml.MapSlice, isModule bool) string {
 		case "templates":
 			if load, ok := i.Value.(yaml.MapSlice); ok {
 				y.translateTemplateMap(load)
-			} else if load, ok := i.Value.([]interface{}); ok {
+			} else if load, ok := i.Value.([]any); ok {
 				y.translateTemplate(load)
 			} else {
 				log.Warnf("template: must be a list or a map, instead it was %T", i.Value)
@@ -123,7 +123,7 @@ func (y *yamlTranslator) translateMap(m yaml.MapSlice) string {
 	return strings.Join(values, commaSeparator)
 }
 
-func (y *yamlTranslator) translateList(l []interface{}) string {
+func (y *yamlTranslator) translateList(l []any) string {
 	values := []string{}
 	for _, i := range l {
 		values = append(values, y.translateValue(i, ""))
@@ -131,7 +131,7 @@ func (y *yamlTranslator) translateList(l []interface{}) string {
 	return strings.Join(values, commaSeparator)
 }
 
-func (y *yamlTranslator) translateValue(v interface{}, ruleName string) string {
+func (y *yamlTranslator) translateValue(v any, ruleName string) string {
 	switch i := v.(type) {
 	case yaml.MapSlice:
 		m := y.translateMap(i)
@@ -139,7 +139,7 @@ func (y *yamlTranslator) translateValue(v interface{}, ruleName string) string {
 			return fmt.Sprintf("%s(%s)", ruleName, m)
 		}
 		return fmt.Sprintf("{%s}", m)
-	case []interface{}:
+	case []any:
 		if ruleName != "" {
 			s := []string{}
 			for _, i := range i {
@@ -176,7 +176,7 @@ func (y *yamlTranslator) translateLoad(m yaml.MapSlice) string {
 	for _, i := range m {
 		value := ""
 		switch i := i.Value.(type) {
-		case []interface{}:
+		case []any:
 			value = y.translateList(i)
 			y.loadList = append(y.loadList, strings.Split(value, commaSeparator)...)
 		case string:
@@ -192,7 +192,7 @@ func (y *yamlTranslator) translateLoad(m yaml.MapSlice) string {
 	return strings.Join(values, newLineSeparator)
 }
 
-func (y *yamlTranslator) translateDeps(m []interface{}, isModule bool) string {
+func (y *yamlTranslator) translateDeps(m []any, isModule bool) string {
 	var output strings.Builder
 	for _, dep := range m {
 		depString, ok := dep.(string)
@@ -254,7 +254,7 @@ func (y *yamlTranslator) translateTemplateMap(m yaml.MapSlice) {
 	}
 }
 
-func (y *yamlTranslator) translateTemplate(m []interface{}) {
+func (y *yamlTranslator) translateTemplate(m []any) {
 	for _, s := range m {
 		from := ""
 		into := ""

--- a/enterprise/server/auth_service/auth_service_test.go
+++ b/enterprise/server/auth_service/auth_service_test.go
@@ -74,7 +74,7 @@ func TestAuthenticate_ES256SigningMethod(t *testing.T) {
 	require.Len(t, keysResp.PublicKeys, 1)
 	es256PublicKey, err := jwt.ParseECPublicKeyFromPEM([]byte(keysResp.PublicKeys[0].GetKey()))
 	require.NoError(t, err)
-	token, err := jwt.Parse(authResp.GetJwt(), func(token *jwt.Token) (interface{}, error) {
+	token, err := jwt.Parse(authResp.GetJwt(), func(token *jwt.Token) (any, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodECDSA); !ok {
 			t.Fatalf("unexpected signing method: %v", token.Header["alg"])
 		}

--- a/enterprise/server/backends/pubsub/pubsub.go
+++ b/enterprise/server/backends/pubsub/pubsub.go
@@ -340,7 +340,7 @@ func (p *StreamPubSub) Publish(ctx context.Context, channel *Channel, message st
 	pipe := p.rdb.TxPipeline()
 	pipe.XAdd(ctx, &redis.XAddArgs{
 		Stream: channel.name,
-		Values: map[string]interface{}{streamDataField: message},
+		Values: map[string]any{streamDataField: message},
 	})
 	pipe.Expire(ctx, channel.name, listTTL)
 	_, err := pipe.Exec(ctx)

--- a/enterprise/server/backends/redis_metrics_collector/redis_metrics_collector.go
+++ b/enterprise/server/backends/redis_metrics_collector/redis_metrics_collector.go
@@ -68,7 +68,7 @@ func (c *collector) IncrementCount(ctx context.Context, key, field string, n int
 }
 
 func (c *collector) SetAddWithExpiry(ctx context.Context, key string, expiry time.Duration, members ...string) error {
-	membersIface := make([]interface{}, len(members))
+	membersIface := make([]any, len(members))
 	for i, member := range members {
 		membersIface[i] = member
 	}
@@ -116,7 +116,7 @@ func (c *collector) GetAll(ctx context.Context, keys ...string) ([]string, error
 }
 
 func (c *collector) ListAppend(ctx context.Context, key string, values ...string) error {
-	ifaces := make([]interface{}, 0, len(values))
+	ifaces := make([]any, 0, len(values))
 	for _, value := range values {
 		ifaces = append(ifaces, value)
 	}

--- a/enterprise/server/backends/s3_cache/s3_cache.go
+++ b/enterprise/server/backends/s3_cache/s3_cache.go
@@ -106,7 +106,7 @@ func NewS3Cache() (*S3Cache, error) {
 	if *endpoint != "" {
 		configOptions = append(configOptions, config.WithEndpointResolverWithOptions(
 			aws.EndpointResolverWithOptionsFunc(
-				func(_, _ string, _ ...interface{}) (aws.Endpoint, error) {
+				func(_, _ string, _ ...any) (aws.Endpoint, error) {
 					return aws.Endpoint{
 						URL:               *endpoint,
 						SigningRegion:     *region,

--- a/enterprise/server/batch_operator/batch_operator.go
+++ b/enterprise/server/batch_operator/batch_operator.go
@@ -494,7 +494,7 @@ func (u *batchOperator) flushBatches(ctx context.Context) int {
 	// Remove batches to flush and release the mutex before sending RPCs.
 	batchesToFlush := map[string]*DigestBatch{}
 	authHeaders := map[string]map[string][]string{}
-	u.batchesByGroupID.Range(func(key, value interface{}) bool {
+	u.batchesByGroupID.Range(func(key, value any) bool {
 		groupID, ok := key.(string)
 		if !ok {
 			alert.UnexpectedEvent("batch-operator-unexpected-key-type", "[%s] batchesByGroupID contains key with unexpected type. actual type: %T", u.name, key)

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -355,7 +355,7 @@ type casRPCRecorder struct {
 }
 
 func recordCASUnaryInterceptor(rec *casRPCRecorder) grpc.UnaryClientInterceptor {
-	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		rec.mu.Lock()
 		switch {
 		case strings.HasSuffix(method, "/FindMissingBlobs"):
@@ -386,7 +386,7 @@ func recordCASUnaryInterceptor(rec *casRPCRecorder) grpc.UnaryClientInterceptor 
 }
 
 func requestCountingUnaryInterceptor(count *atomic.Int32) grpc.UnaryClientInterceptor {
-	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		count.Add(1)
 		return invoker(ctx, method, req, reply, cc, opts...)
 	}
@@ -1585,7 +1585,7 @@ func TestReadChunkedFastPathSkipsSplitBlob(t *testing.T) {
 
 	var splitBlobCalls atomic.Int32
 	remoteConn, err := testenv.LocalGRPCConn(ctx, remoteLis, grpc.WithUnaryInterceptor(func(
-		ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
+		ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
 	) error {
 		if strings.HasSuffix(method, "/SplitBlob") {
 			splitBlobCalls.Add(1)
@@ -1747,7 +1747,7 @@ func TestReadChunkedEncryptedRemoteOnly(t *testing.T) {
 
 	var splitBlobCalls atomic.Int32
 	remoteConn, err := testenv.LocalGRPCConn(ctx, remoteLis, grpc.WithUnaryInterceptor(func(
-		ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
+		ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
 	) error {
 		if strings.HasSuffix(method, "/SplitBlob") {
 			splitBlobCalls.Add(1)
@@ -1903,7 +1903,7 @@ func TestReadChunkedEncryptedRemoteOnlyFallsBackToFullBlob(t *testing.T) {
 
 	var splitBlobCalls atomic.Int32
 	remoteConn, err := testenv.LocalGRPCConn(ctx, remoteLis, grpc.WithUnaryInterceptor(func(
-		ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
+		ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
 	) error {
 		if strings.HasSuffix(method, "/SplitBlob") {
 			splitBlobCalls.Add(1)
@@ -2028,7 +2028,7 @@ func TestReadChunkedCompressedWarmLocal(t *testing.T) {
 	go remoteRun()
 	var splitBlobCalls atomic.Int32
 	remoteConn, err := testenv.LocalGRPCConn(ctx, remoteLis, grpc.WithUnaryInterceptor(func(
-		ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
+		ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
 	) error {
 		if strings.HasSuffix(method, "/SplitBlob") {
 			splitBlobCalls.Add(1)
@@ -2460,7 +2460,7 @@ func TestReadChunkedFallsBackToLocalBlob(t *testing.T) {
 
 	var splitBlobCalls atomic.Int32
 	remoteConn, err := testenv.LocalGRPCConn(ctx, remoteLis, grpc.WithUnaryInterceptor(func(
-		ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
+		ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
 	) error {
 		if strings.HasSuffix(method, "/SplitBlob") {
 			splitBlobCalls.Add(1)
@@ -3305,7 +3305,7 @@ func TestWriteChunkedFallbackBelowThreshold(t *testing.T) {
 	require.Equal(t, originalData, downloadedData)
 }
 
-func networkLatencyUnaryInterceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+func networkLatencyUnaryInterceptor(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 	time.Sleep(simulatedBenchRTT())
 	return invoker(ctx, method, req, reply, cc, opts...)
 }
@@ -3316,7 +3316,7 @@ type delayedRecvClientStream struct {
 	recvCount int
 }
 
-func (s *delayedRecvClientStream) RecvMsg(m interface{}) error {
+func (s *delayedRecvClientStream) RecvMsg(m any) error {
 	if strings.HasSuffix(s.method, "/Read") {
 		if s.recvCount == 0 {
 			time.Sleep(simulatedBenchRTT())

--- a/enterprise/server/clientidentity/clientidentity.go
+++ b/enterprise/server/clientidentity/clientidentity.go
@@ -201,7 +201,7 @@ func (s *Service) ValidateIncomingIdentity(ctx context.Context) (context.Context
 	var verifyErr error
 	for _, key := range s.verificationKeys {
 		c := &claims{}
-		_, err := jwt.ParseWithClaims(headerValue, c, func(token *jwt.Token) (interface{}, error) {
+		_, err := jwt.ParseWithClaims(headerValue, c, func(token *jwt.Token) (any, error) {
 			return key, nil
 		})
 		if err == nil {

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1002,10 +1002,10 @@ func (r *buildEventReporter) Write(b []byte) (int, error) {
 	return r.log.Write(b)
 }
 
-func (r *buildEventReporter) Println(vals ...interface{}) {
+func (r *buildEventReporter) Println(vals ...any) {
 	r.log.Println(vals...)
 }
-func (r *buildEventReporter) Printf(format string, vals ...interface{}) {
+func (r *buildEventReporter) Printf(format string, vals ...any) {
 	r.log.Printf(format, vals...)
 }
 
@@ -1038,10 +1038,10 @@ func (invLog *invocationLog) Write(b []byte) (int, error) {
 	return len(b), err
 }
 
-func (invLog *invocationLog) Println(vals ...interface{}) {
+func (invLog *invocationLog) Println(vals ...any) {
 	invLog.Write([]byte(fmt.Sprintln(vals...)))
 }
-func (invLog *invocationLog) Printf(format string, vals ...interface{}) {
+func (invLog *invocationLog) Printf(format string, vals ...any) {
 	invLog.Write([]byte(fmt.Sprintf(format+"\n", vals...)))
 }
 
@@ -2667,7 +2667,7 @@ func formatNowUTC() string {
 	return time.Now().UTC().Format("2006-01-02 15:04:05.000 UTC")
 }
 
-func writeCommandSummary(out io.Writer, format string, args ...interface{}) {
+func writeCommandSummary(out io.Writer, format string, args ...any) {
 	io.WriteString(out, ansiGray+formatNowUTC()+ansiReset+" ")
 	io.WriteString(out, fmt.Sprintf(format, args...))
 	io.WriteString(out, "\n")

--- a/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy_test.go
+++ b/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy_test.go
@@ -54,7 +54,7 @@ const (
 )
 
 func requestCountingUnaryInterceptor(count *atomic.Int32) grpc.UnaryClientInterceptor {
-	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		count.Add(1)
 		return invoker(ctx, method, req, reply, cc, opts...)
 	}

--- a/enterprise/server/crypter_service/crypter_service.go
+++ b/enterprise/server/crypter_service/crypter_service.go
@@ -146,7 +146,7 @@ func derivedKey(groupID string, key *tables.EncryptionKeyVersion, kms interfaces
 
 func refreshKey(ctx context.Context, ck crypter_key_cache.CacheKey, dbh interfaces.DBHandle, kms interfaces.KMS) ([]byte, *sgpb.EncryptionMetadata, error) {
 	var query string
-	var args []interface{}
+	var args []any
 	if ck.KeyID != "" {
 		query = `
 			SELECT * FROM "EncryptionKeyVersions" ekv
@@ -154,14 +154,14 @@ func refreshKey(ctx context.Context, ck crypter_key_cache.CacheKey, dbh interfac
 			WHERE ek.group_id = ? 
 			AND ekv.encryption_key_id = ? AND ekv.version = ?
 		`
-		args = []interface{}{ck.GroupID, ck.KeyID, ck.Version}
+		args = []any{ck.GroupID, ck.KeyID, ck.Version}
 	} else {
 		query = `
 			SELECT * FROM "EncryptionKeyVersions" ekv
 			JOIN "EncryptionKeys" ek ON ekv.encryption_key_id = ek.encryption_key_id
 			WHERE ek.group_id = ?
 		`
-		args = []interface{}{ck.GroupID}
+		args = []any{ck.GroupID}
 	}
 
 	ekv := &tables.EncryptionKeyVersion{}
@@ -264,7 +264,7 @@ func (c *Crypter) reencryptKey(ctx context.Context, ekv *encryptionKeyVersionWit
 		WHERE encryption_key_id = ? AND version = ?
 	`
 	now := c.clock.Now()
-	args := []interface{}{encMasterKeyPortion, encGroupKeyPortion, now.UnixMicro(), now.UnixMicro(), ekv.EncryptionKeyID, ekv.Version}
+	args := []any{encMasterKeyPortion, encGroupKeyPortion, now.UnixMicro(), now.UnixMicro(), ekv.EncryptionKeyID, ekv.Version}
 	if err := c.dbh.NewQuery(ctx, "crypter_update_key_version").Raw(q, args...).Exec().Error; err != nil {
 		return err
 	}
@@ -329,7 +329,7 @@ func (c *Crypter) keyReencryptorIteration(cutoff time.Time) error {
 				WHERE encryption_key_id = ? AND version = ?
 			`
 		now := c.clock.Now()
-		args := []interface{}{now.UnixMicro(), ekv.EncryptionKeyID, ekv.Version}
+		args := []any{now.UnixMicro(), ekv.EncryptionKeyID, ekv.Version}
 		if err := c.dbh.NewQuery(uCtx, "crypter_update_encryption_timestamp").Raw(q, args...).Exec().Error; err != nil {
 			log.Warningf("could not update attempt timestamp: %s", err)
 		}

--- a/enterprise/server/execution_search_service/execution_search_service.go
+++ b/enterprise/server/execution_search_service/execution_search_service.go
@@ -42,7 +42,7 @@ func NewExecutionSearchService(env environment.Env, h interfaces.DBHandle, oh in
 	}
 }
 
-func (s *ExecutionSearchService) rawQueryExecutions(ctx context.Context, query string, queryArgs ...interface{}) ([]*schema.Execution, error) {
+func (s *ExecutionSearchService) rawQueryExecutions(ctx context.Context, query string, queryArgs ...any) ([]*schema.Execution, error) {
 	rq := s.oh.NewQuery(ctx, "execution_search_service_search").Raw(query, queryArgs...)
 	return db.ScanAll(rq, &schema.Execution{})
 }

--- a/enterprise/server/experiments/experiments.go
+++ b/enterprise/server/experiments/experiments.go
@@ -132,7 +132,7 @@ func (fp *FlagProvider) Statusz(ctx context.Context) string {
 // Options is evaluated by a set of Option functions, which configure it.
 type Options struct {
 	targetingKey string
-	attributes   map[string]interface{}
+	attributes   map[string]any
 }
 type Option func(*Options)
 
@@ -156,7 +156,7 @@ type Option func(*Options)
 func (fp *FlagProvider) getEvaluationContext(ctx context.Context, opts ...any) openfeature.EvaluationContext {
 	options := &Options{
 		targetingKey: interfaces.AuthAnonymousUser,
-		attributes:   make(map[string]interface{}, 0),
+		attributes:   make(map[string]any, 0),
 	}
 
 	if claims, err := claims.ClaimsFromContext(ctx); err == nil {
@@ -235,7 +235,7 @@ func ObjectToProto(object map[string]any, dest proto.Message) error {
 // the flag is evaluated. This allows selectively enabling flags only when they
 // make sense. For example, you might want to only enable a certain performance
 // optimization if the platform is linux, etc.
-func WithContext(key string, value interface{}) Option {
+func WithContext(key string, value any) Option {
 	return func(o *Options) {
 		o.attributes[key] = value
 	}

--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -2517,7 +2517,7 @@ func (a *GitHubApp) GetGithubPullRequestDetails(ctx context.Context, req *ghpb.G
 	eg, gCtx := errgroup.WithContext(ctx)
 
 	graph := &prDetailsQuery{}
-	vars := map[string]interface{}{
+	vars := map[string]any{
 		"repoOwner":  githubv4.String(req.GetOwner()),
 		"repoName":   githubv4.String(req.GetRepo()),
 		"pullNumber": githubv4.Int(req.GetPull()),
@@ -2769,10 +2769,10 @@ func (a *GitHubApp) getIncomingAndOutgoingPRs(ctx context.Context, username stri
 	eg, gCtx := errgroup.WithContext(ctx)
 	incomingGraph := &prSearchQuery{}
 	outgoingGraph := &prSearchQuery{}
-	incomingVars := map[string]interface{}{
+	incomingVars := map[string]any{
 		"searchQuery": githubv4.String(fmt.Sprintf("is:open is:pr user-review-requested:%s archived:false draft:false", username)),
 	}
-	outgoingVars := map[string]interface{}{
+	outgoingVars := map[string]any{
 		"searchQuery": githubv4.String(fmt.Sprintf("is:open is:pr author:%s archived:false draft:false", username)),
 	}
 

--- a/enterprise/server/githubauth/githubauth.go
+++ b/enterprise/server/githubauth/githubauth.go
@@ -323,7 +323,7 @@ func (a *githubAuthenticator) renewToken(ctx context.Context, authToken string) 
 	return &token{GithubUser: resp, Expiry: time.Now().Add(jwtDuration).Unix()}, nil
 }
 
-func jwtKeyFunc(token *jwt.Token) (interface{}, error) {
+func jwtKeyFunc(token *jwt.Token) (any, error) {
 	return []byte(*github.JwtKey), nil
 }
 

--- a/enterprise/server/invocation_search_service/invocation_search_service.go
+++ b/enterprise/server/invocation_search_service/invocation_search_service.go
@@ -146,7 +146,7 @@ func (s *InvocationSearchService) IndexInvocation(ctx context.Context, invocatio
 func addPermissionsCheckToQuery(u interfaces.UserInfo, q *query_builder.Query) {
 	o := query_builder.OrClauses{}
 	o.AddOr("(perms & ? != 0)", perms.OTHERS_READ)
-	groupArgs := []interface{}{
+	groupArgs := []any{
 		perms.GROUP_READ,
 	}
 	groupParams := make([]string, 0)
@@ -231,7 +231,7 @@ func addOrderBy(sort *inpb.InvocationSort, q *query_builder.Query) {
 	}
 }
 
-func (s *InvocationSearchService) buildPrimaryQuery(ctx context.Context, fields string, offset int64, limit int64, req *inpb.SearchInvocationRequest, isOlapQuery bool) (string, []interface{}, error) {
+func (s *InvocationSearchService) buildPrimaryQuery(ctx context.Context, fields string, offset int64, limit int64, req *inpb.SearchInvocationRequest, isOlapQuery bool) (string, []any, error) {
 	if req.GetQuery().GetRepoUrl() != "" {
 		norm, err := git.NormalizeRepoURL(req.GetQuery().GetRepoUrl())
 		if err == nil { // if we normalized successfully

--- a/enterprise/server/invocation_stat_service/invocation_stat_query_test.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_query_test.go
@@ -22,9 +22,9 @@ func TestGetDrilldownSubquery_ExitCode(t *testing.T) {
 		},
 	}
 	where := "WHERE group_id = 'GR1'"
-	whereArgs := []interface{}{}
+	whereArgs := []any{}
 	drilldown := "success = true"
-	drilldownArgs := []interface{}{}
+	drilldownArgs := []any{}
 	col := "exit_code"
 
 	query, args := iss.getDrilldownSubquery(ctx, drilldownFields, req, where, whereArgs, drilldown, drilldownArgs, col)
@@ -46,9 +46,9 @@ func TestGetDrilldownSubquery_NonExitCode(t *testing.T) {
 		},
 	}
 	where := "WHERE group_id = 'GR1'"
-	whereArgs := []interface{}{}
+	whereArgs := []any{}
 	drilldown := "success = true"
-	drilldownArgs := []interface{}{}
+	drilldownArgs := []any{}
 	col := "worker"
 
 	query, _ := iss.getDrilldownSubquery(ctx, drilldownFields, req, where, whereArgs, drilldown, drilldownArgs, col)

--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -237,9 +237,9 @@ func (i *InvocationStatService) getTrendTimeSettings(tq *stpb.TrendQuery, timezo
 	}
 }
 
-func (i *InvocationStatService) getTrendBasicQuery(tq *stpb.TrendQuery, timeSettings *trendTimeSettings, timezoneOffsetMinutes int32) (string, []interface{}) {
+func (i *InvocationStatService) getTrendBasicQuery(tq *stpb.TrendQuery, timeSettings *trendTimeSettings, timezoneOffsetMinutes int32) (string, []any) {
 	var q string
-	var qArgs []interface{}
+	var qArgs []any
 	if i.isOLAPDBEnabled() {
 		if i.finerTimeBucketsEnabled() {
 			bucketStr, bucketArgs := i.olapdbh.BucketFromUsecTimestamp("updated_at_usec", timeSettings.location, timeSettings.interval.ClickhouseInterval())
@@ -510,12 +510,12 @@ func (i *InvocationStatService) getInvocationTrend(ctx context.Context, req *stp
 	return res, nil
 }
 
-func (i *InvocationStatService) getExecutionTrendQuery(timeSettings *trendTimeSettings, timezoneOffsetMinutes int32) (string, []interface{}) {
+func (i *InvocationStatService) getExecutionTrendQuery(timeSettings *trendTimeSettings, timezoneOffsetMinutes int32) (string, []any) {
 	if !i.finerTimeBucketsEnabled() {
 		return fmt.Sprintf("SELECT %s as name,", i.olapdbh.DateFromUsecTimestamp("updated_at_usec", timezoneOffsetMinutes)) + `
 		quantilesExactExclusive(0.5, 0.75, 0.9, 0.95, 0.99)(IF(worker_start_timestamp_usec > queued_timestamp_usec AND queued_timestamp_usec > 0, worker_start_timestamp_usec - queued_timestamp_usec, 0)) AS queue_duration_usec_quantiles,
 		SUM(GREATEST(COALESCE(worker_completed_timestamp_usec - worker_start_timestamp_usec, 0), 0)) as total_build_time_usec
-		FROM "Executions"`, make([]interface{}, 0)
+		FROM "Executions"`, make([]any, 0)
 	}
 
 	bucketStr, bucketArgs := i.olapdbh.BucketFromUsecTimestamp("updated_at_usec", timeSettings.location, timeSettings.interval.ClickhouseInterval())
@@ -710,7 +710,7 @@ var coarseLogStepMultipliers = []int64{1, 2, 4, 6, 8}
 
 // getMetricMinMax returns the smallest and largest values of the given metric
 // matching the where clause. found is false when there are no matching rows.
-func (i *InvocationStatService) getMetricMinMax(ctx context.Context, table string, metric string, whereClauseStr string, whereClauseArgs []interface{}) (low int64, high int64, found bool, err error) {
+func (i *InvocationStatService) getMetricMinMax(ctx context.Context, table string, metric string, whereClauseStr string, whereClauseArgs []any) (low int64, high int64, found bool, err error) {
 	rangeQuery := fmt.Sprintf(`SELECT min(%s) as low, max(%s) as high FROM "%s" %s`, metric, metric, table, whereClauseStr)
 	rq := i.olapdbh.NewQuery(ctx, "invocation_stat_service_metric_range").Raw(rangeQuery, whereClauseArgs...)
 	valueRange := struct {
@@ -847,7 +847,7 @@ func subdivideLogBuckets(buckets []int64, stepMultipliers []int64) []int64 {
 	return subdivided
 }
 
-func (i *InvocationStatService) getMetricBuckets(ctx context.Context, table string, metric string, whereClauseStr string, whereClauseArgs []interface{}, logScale bool) (buckets []int64, arrayStr string, hadNegative bool, err error) {
+func (i *InvocationStatService) getMetricBuckets(ctx context.Context, table string, metric string, whereClauseStr string, whereClauseArgs []any, logScale bool) (buckets []int64, arrayStr string, hadNegative bool, err error) {
 	low, high, found, err := i.getMetricMinMax(ctx, table, metric, whereClauseStr, whereClauseArgs)
 	if err != nil {
 		return nil, "", false, err
@@ -971,7 +971,7 @@ type HeatmapQueryInputs = struct {
 	HadNegativeMetricValues bool
 }
 
-func (i *InvocationStatService) generateQueryInputs(ctx context.Context, table string, metric string, q *stpb.TrendQuery, whereClauseStr string, whereClauseArgs []interface{}, requestContext *ctxpb.RequestContext, logScale bool) (*HeatmapQueryInputs, error) {
+func (i *InvocationStatService) generateQueryInputs(ctx context.Context, table string, metric string, q *stpb.TrendQuery, whereClauseStr string, whereClauseArgs []any, requestContext *ctxpb.RequestContext, logScale bool) (*HeatmapQueryInputs, error) {
 	timestampBuckets, timestampArrayStr, err := i.getTimestampBuckets(q, requestContext)
 	if err != nil {
 		return nil, err
@@ -1001,7 +1001,7 @@ func (i *InvocationStatService) generateQueryInputs(ctx context.Context, table s
 		HadNegativeMetricValues: hadNegative}, nil
 }
 
-func (i *InvocationStatService) getWhereClauseForHeatmapQuery(m *sfpb.Metric, q *stpb.TrendQuery, reqCtx *ctxpb.RequestContext) (string, []interface{}, error) {
+func (i *InvocationStatService) getWhereClauseForHeatmapQuery(m *sfpb.Metric, q *stpb.TrendQuery, reqCtx *ctxpb.RequestContext) (string, []any, error) {
 	placeholderQuery := query_builder.NewQuery("")
 	if err := i.addWhereClauses(placeholderQuery, q, m.Execution != nil, reqCtx); err != nil {
 		return "", nil, err
@@ -1015,7 +1015,7 @@ func (i *InvocationStatService) getWhereClauseForHeatmapQuery(m *sfpb.Metric, q 
 
 type QueryAndBuckets = struct {
 	Query                   string
-	QueryArgs               []interface{}
+	QueryArgs               []any
 	TimestampBuckets        []int64
 	MetricBuckets           []int64
 	HadNegativeMetricValues bool
@@ -1269,7 +1269,7 @@ func (i *InvocationStatService) GetInvocationStat(ctx context.Context, req *inpb
 	return rsp, err
 }
 
-func (i *InvocationStatService) getDrilldownSubquery(ctx context.Context, drilldownFields []string, req *stpb.GetStatDrilldownRequest, where string, whereArgs []interface{}, drilldown string, drilldownArgs []interface{}, col string) (string, []interface{}) {
+func (i *InvocationStatService) getDrilldownSubquery(ctx context.Context, drilldownFields []string, req *stpb.GetStatDrilldownRequest, where string, whereArgs []any, drilldown string, drilldownArgs []any, col string) (string, []any) {
 	// This is really ugly--the clickhouse SQL engine doesn't play nice with GORM
 	// when you set a field name to NULL that matches a field in the table you are
 	// selecting--it blows away the type info and turns it into Sql.RawBytes.  To
@@ -1321,12 +1321,12 @@ func (i *InvocationStatService) getDrilldownSubquery(ctx context.Context, drilld
 		nulledOutFieldList, drilldown, drilldown, table, where, groupByCol), args
 }
 
-func getDrilldownQueryFilter(filters []*sfpb.StatFilter) (string, []interface{}, error) {
+func getDrilldownQueryFilter(filters []*sfpb.StatFilter) (string, []any, error) {
 	if len(filters) == 0 {
-		return "FALSE", []interface{}{}, nil
+		return "FALSE", []any{}, nil
 	}
 	var result []string
-	var resultArgs []interface{}
+	var resultArgs []any
 	for _, f := range filters[:] {
 		str, args, err := filter.GenerateFilterStringAndArgs(f)
 		if err != nil {
@@ -1341,7 +1341,7 @@ func getDrilldownQueryFilter(filters []*sfpb.StatFilter) (string, []interface{},
 // TODO(jdhollen): This can be made much efficient using GROUPING SETS when we
 // are able to upgrade to clickhouse 22.6 or later.  The release date for 22.8
 // from Altinity is supposed to be 2023-02-15.
-func (i *InvocationStatService) getDrilldownQuery(ctx context.Context, req *stpb.GetStatDrilldownRequest) (string, []interface{}, error) {
+func (i *InvocationStatService) getDrilldownQuery(ctx context.Context, req *stpb.GetStatDrilldownRequest) (string, []any, error) {
 	if req.GetDrilldownMetric() == nil {
 		return "", nil, status.InvalidArgumentError("Missing metric for drilldown request.")
 	}
@@ -1366,7 +1366,7 @@ func (i *InvocationStatService) getDrilldownQuery(ctx context.Context, req *stpb
 
 	whereString, whereArgs := placeholderQuery.Build()
 
-	args := make([]interface{}, 0)
+	args := make([]any, 0)
 	queries := make([]string, 0)
 	subQStr, subQArgs := i.getDrilldownSubquery(ctx, drilldownFields, req, whereString, whereArgs, drilldownStr, drilldownArgs, "")
 	queries = append(queries, subQStr)

--- a/enterprise/server/oidc/oidc_test.go
+++ b/enterprise/server/oidc/oidc_test.go
@@ -71,7 +71,7 @@ func (f fakeOidcAuthenticator) checkAccessToken(ctx context.Context, jwt, access
 
 func (f fakeOidcAuthenticator) renewToken(ctx context.Context, refreshToken string) (*oauth2.Token, error) {
 	if refreshToken == validRefreshToken {
-		t := (&oauth2.Token{}).WithExtra(map[string]interface{}{"id_token": refreshedJWT})
+		t := (&oauth2.Token{}).WithExtra(map[string]any{"id_token": refreshedJWT})
 		return t, nil
 	}
 	return nil, status.PermissionDeniedError("invalid refresh token")

--- a/enterprise/server/quota/quota_manager.go
+++ b/enterprise/server/quota/quota_manager.go
@@ -245,7 +245,7 @@ func (qm *QuotaManager) parseFlagdBucketConfig(ctx context.Context, nsString str
 		return nil, nil
 	}
 
-	bucketMap, ok := keySpecificFlagdNamespaceConfig.(map[string]interface{})
+	bucketMap, ok := keySpecificFlagdNamespaceConfig.(map[string]any)
 	if !ok {
 		return nil, status.InvalidArgumentErrorf("invalid quota.buckets config for namespace %q: expected object, got %T", nsString, keySpecificFlagdNamespaceConfig)
 	}
@@ -265,7 +265,7 @@ func (qm *QuotaManager) mergeIntoNamespace(ns *namespace) {
 	}
 
 	existing := existingInterface.(*namespace)
-	ns.bucketsByKey.Range(func(k, v interface{}) bool {
+	ns.bucketsByKey.Range(func(k, v any) bool {
 		existing.bucketsByKey.Store(k, v)
 		return true
 	})
@@ -286,7 +286,7 @@ func (qm *QuotaManager) findBucket(nsName string, key string) Bucket {
 }
 
 func (qm *QuotaManager) reloadNamespaces() {
-	qm.namespaces.Range(func(key, value interface{}) bool {
+	qm.namespaces.Range(func(key, value any) bool {
 		qm.namespaces.Delete(key)
 		return true
 	})
@@ -328,12 +328,12 @@ func (qm *QuotaManager) listenForUpdates(ctx context.Context) {
 	}
 }
 
-func bucketConfigFromMap(namespace string, bucketMap map[string]interface{}) (*bucketConfig, error) {
+func bucketConfigFromMap(namespace string, bucketMap map[string]any) (*bucketConfig, error) {
 	maxRateInterface, ok := bucketMap["maxRate"]
 	if !ok {
 		return nil, status.InvalidArgumentError("bucket.maxRate is required")
 	}
-	maxRateMap, ok := maxRateInterface.(map[string]interface{})
+	maxRateMap, ok := maxRateInterface.(map[string]any)
 	if !ok {
 		return nil, status.InvalidArgumentError("bucket.maxRate must be an object")
 	}
@@ -367,7 +367,7 @@ func bucketConfigFromMap(namespace string, bucketMap map[string]interface{}) (*b
 	return config, nil
 }
 
-func interfaceToInt64(v interface{}) (int64, error) {
+func interfaceToInt64(v any) (int64, error) {
 	switch val := v.(type) {
 	case int64:
 		return val, nil

--- a/enterprise/server/quota/quota_manager_test.go
+++ b/enterprise/server/quota/quota_manager_test.go
@@ -248,14 +248,14 @@ func TestBucketRowFromMap(t *testing.T) {
 	testCases := []struct {
 		name       string
 		namespace  string
-		bucketMap  map[string]interface{}
+		bucketMap  map[string]any
 		wantBucket *bucketConfig
 		wantError  bool
 	}{
 		{
 			name:      "valid bucket",
 			namespace: "rpc:/google.bytestream.ByteStream/Read",
-			bucketMap: map[string]interface{}{
+			bucketMap: map[string]any{
 				"maxRate": map[string]any{
 					"numRequests": float64(10),
 					"periodUsec":  float64(60 * 1000 * 1000),
@@ -274,7 +274,7 @@ func TestBucketRowFromMap(t *testing.T) {
 		{
 			name:      "missing maxRate",
 			namespace: "test",
-			bucketMap: map[string]interface{}{
+			bucketMap: map[string]any{
 				"maxBurst": int64(5),
 			},
 			wantError: true,
@@ -282,8 +282,8 @@ func TestBucketRowFromMap(t *testing.T) {
 		{
 			name:      "invalid numRequests",
 			namespace: "test",
-			bucketMap: map[string]interface{}{
-				"maxRate": map[string]interface{}{
+			bucketMap: map[string]any{
+				"maxRate": map[string]any{
 					"numRequests": int64(-1),
 					"periodUsec":  int64(60 * 1000 * 1000),
 				},
@@ -294,8 +294,8 @@ func TestBucketRowFromMap(t *testing.T) {
 		{
 			name:      "zero periodUsec",
 			namespace: "test",
-			bucketMap: map[string]interface{}{
-				"maxRate": map[string]interface{}{
+			bucketMap: map[string]any{
+				"maxRate": map[string]any{
 					"numRequests": int64(10),
 					"periodUsec":  int64(0),
 				},

--- a/enterprise/server/raft/client/client.go
+++ b/enterprise/server/raft/client/client.go
@@ -55,10 +55,10 @@ type NodeHost interface {
 	ID() string
 	GetNoOPSession(rangeID uint64) *client.Session
 	SyncPropose(ctx context.Context, session *client.Session, cmd []byte) (dbsm.Result, error)
-	SyncRead(ctx context.Context, rangeID uint64, query interface{}) (interface{}, error)
+	SyncRead(ctx context.Context, rangeID uint64, query any) (any, error)
 	ReadIndex(rangeID uint64, timeout time.Duration) (*dragonboat.RequestState, error)
-	ReadLocalNode(rs *dragonboat.RequestState, query interface{}) (interface{}, error)
-	StaleRead(rangeID uint64, query interface{}) (interface{}, error)
+	ReadLocalNode(rs *dragonboat.RequestState, query any) (any, error)
+	StaleRead(rangeID uint64, query any) (any, error)
 }
 
 type IRegistry interface {
@@ -408,7 +408,7 @@ func SyncReadLocal(ctx context.Context, nodehost NodeHost, rangeID uint64, batch
 	if batch.Header == nil {
 		return nil, status.FailedPreconditionError("Header must be set")
 	}
-	var raftResponseIface interface{}
+	var raftResponseIface any
 	err = RunNodehostFn(ctx, maxSingleOpTimeout, func(ctx context.Context) error {
 		switch batch.GetHeader().GetConsistencyMode() {
 		case rfpb.Header_LINEARIZABLE:

--- a/enterprise/server/raft/logger/logger.go
+++ b/enterprise/server/raft/logger/logger.go
@@ -14,7 +14,7 @@ type dbCompatibleLogger struct {
 }
 
 // Don't panic in server code.
-func (l *dbCompatibleLogger) Panicf(format string, args ...interface{}) {
+func (l *dbCompatibleLogger) Panicf(format string, args ...any) {
 	l.Errorf(format, args...)
 }
 

--- a/enterprise/server/raft/rbuilder/rbuilder.go
+++ b/enterprise/server/raft/rbuilder/rbuilder.go
@@ -230,7 +230,7 @@ func (br *BatchResponse) setErr(err error) {
 	br.err = err
 }
 
-func NewBatchResponse(val interface{}) *BatchResponse {
+func NewBatchResponse(val any) *BatchResponse {
 	br := &BatchResponse{
 		cmd: &rfpb.BatchCmdResponse{},
 	}

--- a/enterprise/server/raft/registry/registry.go
+++ b/enterprise/server/raft/registry/registry.go
@@ -279,7 +279,7 @@ func (n *StaticRegistry) AddNode(target, raftAddress, grpcAddress string) {
 // registry.
 func (n *StaticRegistry) ListNodes() []*rfpb.ConnectionInfo {
 	results := make([]*rfpb.ConnectionInfo, 0)
-	n.targetAddresses.Range(func(k, v interface{}) bool {
+	n.targetAddresses.Range(func(k, v any) bool {
 		nhid := k.(string)
 		a := v.(addresses)
 		results = append(results, &rfpb.ConnectionInfo{
@@ -293,7 +293,7 @@ func (n *StaticRegistry) ListNodes() []*rfpb.ConnectionInfo {
 }
 
 func (n *StaticRegistry) Close() error {
-	n.raftWatchCancels.Range(func(key, value interface{}) bool {
+	n.raftWatchCancels.Range(func(key, value any) bool {
 		if cancel, ok := value.(func()); ok && cancel != nil {
 			cancel()
 		}

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -1769,7 +1769,7 @@ func (sm *Replica) Update(entries []dbsm.Entry) ([]dbsm.Entry, error) {
 //
 // The Lookup method is a read only method, it should never change the state
 // of IOnDiskStateMachine.
-func (sm *Replica) Lookup(key interface{}) (interface{}, error) {
+func (sm *Replica) Lookup(key any) (any, error) {
 	reqBuf, ok := key.([]byte)
 	if !ok {
 		return nil, status.FailedPreconditionError("Cannot convert key to []byte")
@@ -1852,7 +1852,7 @@ func (sm *Replica) Sync() error {
 //
 // PrepareSnapshot returns an error when there is unrecoverable error for
 // preparing the snapshot.
-func (sm *Replica) PrepareSnapshot() (interface{}, error) {
+func (sm *Replica) PrepareSnapshot() (any, error) {
 	db, err := sm.leaser.DB()
 	if err != nil {
 		return nil, err
@@ -2071,7 +2071,7 @@ func (sm *Replica) applySnapshotFromReader(r io.Reader, db ReplicaWriter) error 
 // e.g. disk error preventing you from saving the snapshot.
 //
 // Note: we assume that local range will be saved before data in the [start, end).
-func (sm *Replica) SaveSnapshot(preparedSnap interface{}, w io.Writer, quit <-chan struct{}) error {
+func (sm *Replica) SaveSnapshot(preparedSnap any, w io.Writer, quit <-chan struct{}) error {
 	snap, ok := preparedSnap.(*pebble.Snapshot)
 	if !ok {
 		return status.FailedPreconditionError("unable to coerce snapshot to *pebble.Snapshot")

--- a/enterprise/server/raft/testutil/testutil.go
+++ b/enterprise/server/raft/testutil/testutil.go
@@ -347,16 +347,16 @@ func (tp *TestingProposer) SyncPropose(ctx context.Context, session *dbcl.Sessio
 	return entries[0].Result, nil
 }
 
-func (tp *TestingProposer) SyncRead(ctx context.Context, rangeID uint64, query interface{}) (interface{}, error) {
+func (tp *TestingProposer) SyncRead(ctx context.Context, rangeID uint64, query any) (any, error) {
 	return nil, status.UnimplementedError("not implemented in testingProposer")
 }
 func (tp *TestingProposer) ReadIndex(rangeID uint64, timeout time.Duration) (*dragonboat.RequestState, error) {
 	return nil, status.UnimplementedError("not implemented in testingProposer")
 }
-func (tp *TestingProposer) ReadLocalNode(rs *dragonboat.RequestState, query interface{}) (interface{}, error) {
+func (tp *TestingProposer) ReadLocalNode(rs *dragonboat.RequestState, query any) (any, error) {
 	return nil, status.UnimplementedError("not implemented in testingProposer")
 }
-func (tp *TestingProposer) StaleRead(rangeID uint64, query interface{}) (interface{}, error) {
+func (tp *TestingProposer) StaleRead(rangeID uint64, query any) (any, error) {
 	return nil, status.UnimplementedError("not implemented in testingProposer")
 }
 

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2293,7 +2293,7 @@ func (c *FirecrackerContainer) Create(ctx context.Context, actionWorkingDir stri
 	return err
 }
 
-func withMetadata(metadata interface{}) fcclient.Opt {
+func withMetadata(metadata any) fcclient.Opt {
 	return func(m *fcclient.Machine) {
 		// Set metadata during init, before the VM instance is created,
 		// since goinit expects metadata to be available on startup.

--- a/enterprise/server/routing/migration_operators/migration_operators_test.go
+++ b/enterprise/server/routing/migration_operators/migration_operators_test.go
@@ -58,11 +58,11 @@ func (m *mockBSReadClient) Context() context.Context {
 	return context.Background()
 }
 
-func (m *mockBSReadClient) SendMsg(interface{}) error {
+func (m *mockBSReadClient) SendMsg(any) error {
 	return nil
 }
 
-func (m *mockBSReadClient) RecvMsg(interface{}) error {
+func (m *mockBSReadClient) RecvMsg(any) error {
 	return nil
 }
 
@@ -110,11 +110,11 @@ func (m *mockBSWriteClient) Context() context.Context {
 	return context.Background()
 }
 
-func (m *mockBSWriteClient) SendMsg(interface{}) error {
+func (m *mockBSWriteClient) SendMsg(any) error {
 	return nil
 }
 
-func (m *mockBSWriteClient) RecvMsg(interface{}) error {
+func (m *mockBSWriteClient) RecvMsg(any) error {
 	return nil
 }
 
@@ -192,11 +192,11 @@ func (m *mockGetTreeClient) Context() context.Context {
 	return context.Background()
 }
 
-func (m *mockGetTreeClient) SendMsg(interface{}) error {
+func (m *mockGetTreeClient) SendMsg(any) error {
 	return nil
 }
 
-func (m *mockGetTreeClient) RecvMsg(interface{}) error {
+func (m *mockGetTreeClient) RecvMsg(any) error {
 	return nil
 }
 

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -1693,7 +1693,7 @@ func (s *SchedulerServer) insertTask(ctx context.Context, taskID string, metadat
 		return status.InternalErrorf("unable to serialize scheduling metadata: %v", err)
 	}
 
-	props := map[string]interface{}{
+	props := map[string]any{
 		redisTaskProtoField:       serializedTask,
 		redisTaskMetadataField:    serializedMetadata,
 		redisTaskQueuedAtUsec:     time.Now().UnixMicro(),

--- a/enterprise/server/scim/scim.go
+++ b/enterprise/server/scim/scim.go
@@ -201,7 +201,7 @@ func NewSCIMServer(env environment.Env) *SCIMServer {
 	}
 }
 
-type handlerFunc func(ctx context.Context, r *http.Request, g *tables.Group) (interface{}, error)
+type handlerFunc func(ctx context.Context, r *http.Request, g *tables.Group) (any, error)
 
 func isV2Path(urlPath string) bool {
 	return strings.HasPrefix(urlPath, "/scim/v2/")
@@ -364,7 +364,7 @@ func (s *SCIMServer) getFilteredUsers(ctx context.Context, g *tables.Group, filt
 	return nil, nil
 }
 
-func (s *SCIMServer) getUsers(ctx context.Context, r *http.Request, g *tables.Group) (interface{}, error) {
+func (s *SCIMServer) getUsers(ctx context.Context, r *http.Request, g *tables.Group) (any, error) {
 	startIndex := 0
 	startIndexParam := r.URL.Query().Get("startIndex")
 	if startIndexParam != "" {
@@ -453,7 +453,7 @@ func (s *SCIMServer) getUsers(ctx context.Context, r *http.Request, g *tables.Gr
 	}, nil
 }
 
-func (s *SCIMServer) getUser(ctx context.Context, r *http.Request, g *tables.Group) (interface{}, error) {
+func (s *SCIMServer) getUser(ctx context.Context, r *http.Request, g *tables.Group) (any, error) {
 	id := path.Base(r.URL.Path)
 	u, err := s.env.GetUserDB().GetUserByID(ctx, id, &interfaces.GetUserOpts{DirectMembershipsOnly: true})
 	if err != nil {
@@ -511,7 +511,7 @@ func fillUserFromResource(u *tables.User, ur UserResource, g *tables.Group, defa
 	return nil
 }
 
-func (s *SCIMServer) createUser(ctx context.Context, r *http.Request, g *tables.Group) (interface{}, error) {
+func (s *SCIMServer) createUser(ctx context.Context, r *http.Request, g *tables.Group) (any, error) {
 	req, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
@@ -606,7 +606,7 @@ func getBooleanValue(v any) (bool, error) {
 	return false, status.InvalidArgumentErrorf("boolean field has unexpected value %v of type %T", v, v)
 }
 
-func (s *SCIMServer) patchUser(ctx context.Context, r *http.Request, g *tables.Group) (interface{}, error) {
+func (s *SCIMServer) patchUser(ctx context.Context, r *http.Request, g *tables.Group) (any, error) {
 	req, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
@@ -725,7 +725,7 @@ func (s *SCIMServer) patchUser(ctx context.Context, r *http.Request, g *tables.G
 	return ur, nil
 }
 
-func (s *SCIMServer) updateUser(ctx context.Context, r *http.Request, g *tables.Group) (interface{}, error) {
+func (s *SCIMServer) updateUser(ctx context.Context, r *http.Request, g *tables.Group) (any, error) {
 	req, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
@@ -775,7 +775,7 @@ func (s *SCIMServer) updateUser(ctx context.Context, r *http.Request, g *tables.
 	return updatedUser, nil
 }
 
-func (s *SCIMServer) deleteUser(ctx context.Context, r *http.Request, g *tables.Group) (interface{}, error) {
+func (s *SCIMServer) deleteUser(ctx context.Context, r *http.Request, g *tables.Group) (any, error) {
 	id := path.Base(r.URL.Path)
 	if err := s.env.GetUserDB().DeleteUser(ctx, id); err != nil {
 		return nil, err
@@ -783,7 +783,7 @@ func (s *SCIMServer) deleteUser(ctx context.Context, r *http.Request, g *tables.
 	return nil, nil
 }
 
-func logGroupOperationResponse(ctx context.Context, label string, v interface{}) {
+func logGroupOperationResponse(ctx context.Context, label string, v any) {
 	out, err := json.Marshal(v)
 	if err != nil {
 		log.CtxWarningf(ctx, "SCIM %s response: failed to marshal: %s", label, err)
@@ -792,7 +792,7 @@ func logGroupOperationResponse(ctx context.Context, label string, v interface{})
 	log.CtxInfof(ctx, "SCIM %s response:\n%s", label, string(out))
 }
 
-func (s *SCIMServer) createGroup(ctx context.Context, r *http.Request, g *tables.Group) (interface{}, error) {
+func (s *SCIMServer) createGroup(ctx context.Context, r *http.Request, g *tables.Group) (any, error) {
 	req, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
@@ -835,7 +835,7 @@ func (s *SCIMServer) createGroup(ctx context.Context, r *http.Request, g *tables
 	return res, nil
 }
 
-func (s *SCIMServer) getGroup(ctx context.Context, r *http.Request, g *tables.Group) (interface{}, error) {
+func (s *SCIMServer) getGroup(ctx context.Context, r *http.Request, g *tables.Group) (any, error) {
 	log.CtxInfof(ctx, "SCIM get group request: %s %s", r.Method, r.URL.RequestURI())
 	id := path.Base(r.URL.Path)
 	ul, err := s.env.GetUserDB().GetUserList(ctx, id)
@@ -847,7 +847,7 @@ func (s *SCIMServer) getGroup(ctx context.Context, r *http.Request, g *tables.Gr
 	return res, nil
 }
 
-func (s *SCIMServer) updateGroup(ctx context.Context, r *http.Request, g *tables.Group) (interface{}, error) {
+func (s *SCIMServer) updateGroup(ctx context.Context, r *http.Request, g *tables.Group) (any, error) {
 	req, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
@@ -917,7 +917,7 @@ func (s *SCIMServer) updateGroup(ctx context.Context, r *http.Request, g *tables
 	return res, nil
 }
 
-func (s *SCIMServer) deleteGroup(ctx context.Context, r *http.Request, g *tables.Group) (interface{}, error) {
+func (s *SCIMServer) deleteGroup(ctx context.Context, r *http.Request, g *tables.Group) (any, error) {
 	log.CtxInfof(ctx, "SCIM delete group request: %s %s", r.Method, r.URL.RequestURI())
 	id := path.Base(r.URL.Path)
 	if err := s.env.GetUserDB().DeleteUserList(ctx, id); err != nil {
@@ -927,7 +927,7 @@ func (s *SCIMServer) deleteGroup(ctx context.Context, r *http.Request, g *tables
 	return nil, nil
 }
 
-func (s *SCIMServer) patchGroup(ctx context.Context, r *http.Request, g *tables.Group) (interface{}, error) {
+func (s *SCIMServer) patchGroup(ctx context.Context, r *http.Request, g *tables.Group) (any, error) {
 	req, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
@@ -1038,7 +1038,7 @@ func parseMemberValues(v any) ([]string, error) {
 	return ids, nil
 }
 
-func (s *SCIMServer) getGroups(ctx context.Context, r *http.Request, g *tables.Group) (interface{}, error) {
+func (s *SCIMServer) getGroups(ctx context.Context, r *http.Request, g *tables.Group) (any, error) {
 	log.CtxInfof(ctx, "SCIM get groups request: %s %s", r.Method, r.URL.RequestURI())
 	startIndex := 0
 	startIndexParam := r.URL.Query().Get("startIndex")

--- a/enterprise/server/selfauth/selfauth.go
+++ b/enterprise/server/selfauth/selfauth.go
@@ -207,7 +207,7 @@ func (o *selfAuth) Authorize(w http.ResponseWriter, r *http.Request) {
 
 }
 
-func writeJSONResponse(w http.ResponseWriter, r *http.Request, v interface{}) {
+func writeJSONResponse(w http.ResponseWriter, r *http.Request, v any) {
 	rsp, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/enterprise/server/util/fieldgetter/fieldgetter.go
+++ b/enterprise/server/util/fieldgetter/fieldgetter.go
@@ -22,7 +22,7 @@ var (
 // If a nil pointer is encountered the access path, an error is returned.
 //
 // Number-valued field names refer to slice indexes.
-func ExtractValues(obj interface{}, fieldPaths ...string) (map[string]string, error) {
+func ExtractValues(obj any, fieldPaths ...string) (map[string]string, error) {
 	values := map[string]string{}
 	objVal := reflect.Indirect(reflect.ValueOf(obj))
 	if !objVal.IsValid() {

--- a/enterprise/server/util/redisutil/redisutil.go
+++ b/enterprise/server/util/redisutil/redisutil.go
@@ -483,7 +483,7 @@ func (r *redlock) Unlock(ctx context.Context) error {
 }
 
 type valueExpiration struct {
-	value      interface{}
+	value      any
 	expiration time.Duration
 }
 
@@ -522,9 +522,9 @@ type CommandBuffer struct {
 	// Buffer for HINCRBY commands.
 	hincr map[string]map[string]int64
 	// Buffer for RPUSH commands.
-	rpush map[string][]interface{}
+	rpush map[string][]any
 	// Buffer for SADD commands.
-	sadd map[string]map[interface{}]struct{}
+	sadd map[string]map[any]struct{}
 	// Buffer for EXPIRE commands.
 	expire map[string]time.Duration
 	// Whether the server is shutting down.
@@ -542,8 +542,8 @@ func (c *CommandBuffer) init() {
 	c.set = map[string]valueExpiration{}
 	c.incr = map[string]int64{}
 	c.hincr = map[string]map[string]int64{}
-	c.rpush = map[string][]interface{}{}
-	c.sadd = map[string]map[interface{}]struct{}{}
+	c.rpush = map[string][]any{}
+	c.sadd = map[string]map[any]struct{}{}
 	c.expire = map[string]time.Duration{}
 }
 
@@ -595,7 +595,7 @@ func (c *CommandBuffer) HIncrBy(ctx context.Context, key, field string, incremen
 // If the server is shutting down, the command will be issued to Redis
 // synchronously using the given context. Otherwise, the command is added to
 // the buffer and the context is ignored.
-func (c *CommandBuffer) Set(ctx context.Context, key string, value interface{}, expiration time.Duration) error {
+func (c *CommandBuffer) Set(ctx context.Context, key string, value any, expiration time.Duration) error {
 	c.mu.Lock()
 	if c.shouldFlushSynchronously() {
 		c.mu.Unlock()
@@ -613,7 +613,7 @@ func (c *CommandBuffer) Set(ctx context.Context, key string, value interface{}, 
 // If the server is shutting down, the command will be issued to Redis
 // synchronously using the given context. Otherwise, the command is added to
 // the buffer and the context is ignored.
-func (c *CommandBuffer) SAdd(ctx context.Context, key string, members ...interface{}) error {
+func (c *CommandBuffer) SAdd(ctx context.Context, key string, members ...any) error {
 	c.mu.Lock()
 	if c.shouldFlushSynchronously() {
 		c.mu.Unlock()
@@ -623,7 +623,7 @@ func (c *CommandBuffer) SAdd(ctx context.Context, key string, members ...interfa
 
 	set, ok := c.sadd[key]
 	if !ok {
-		set = make(map[interface{}]struct{}, len(members))
+		set = make(map[any]struct{}, len(members))
 		c.sadd[key] = set
 	}
 	for _, m := range members {
@@ -637,7 +637,7 @@ func (c *CommandBuffer) SAdd(ctx context.Context, key string, members ...interfa
 // If the server is shutting down, the command will be issued to Redis
 // synchronously using the given context. Otherwise, the command is added to
 // the buffer and the context is ignored.
-func (c *CommandBuffer) RPush(ctx context.Context, key string, values ...interface{}) error {
+func (c *CommandBuffer) RPush(ctx context.Context, key string, values ...any) error {
 	c.mu.Lock()
 	if c.shouldFlushSynchronously() {
 		c.mu.Unlock()
@@ -714,7 +714,7 @@ func (c *CommandBuffer) Flush(ctx context.Context) error {
 		pipe.RPush(ctx, key, values...)
 	}
 	for key, set := range sadd {
-		members := []interface{}{}
+		members := []any{}
 		for member := range set {
 			members = append(members, member)
 		}

--- a/enterprise/server/webhooks/bitbucket/bitbucket.go
+++ b/enterprise/server/webhooks/bitbucket/bitbucket.go
@@ -135,7 +135,7 @@ func (*bitbucketGitProvider) CreateStatus(ctx context.Context, accessToken, grou
 	return status.UnimplementedError("Not implemented")
 }
 
-func unmarshalBody(r *http.Request, payload interface{}) error {
+func unmarshalBody(r *http.Request, payload any) error {
 	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		return err

--- a/enterprise/server/webhooks/github/github.go
+++ b/enterprise/server/webhooks/github/github.go
@@ -56,7 +56,7 @@ func (*githubGitProvider) RegisterWebhook(ctx context.Context, accessToken, repo
 	hook, _, err := client.Repositories.CreateHook(ctx, owner, repo, &gh.Hook{
 		Name:   &name,
 		Events: eventsToReceive,
-		Config: map[string]interface{}{
+		Config: map[string]any{
 			"url":    webhookURL,
 			"events": eventsToReceive,
 		},
@@ -116,7 +116,7 @@ func (*githubGitProvider) ParseWebhookData(r *http.Request) (*interfaces.Webhook
 	return ParseWebhookData(event)
 }
 
-func ParseWebhookData(event interface{}) (*interfaces.WebhookData, error) {
+func ParseWebhookData(event any) (*interfaces.WebhookData, error) {
 	switch event := event.(type) {
 	case *gh.PushEvent:
 		// Ignore deletion events (both branch and tag deletions).

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -244,13 +244,13 @@ type ScheduleTrigger struct {
 type ResourceRequests struct {
 	// Memory is a numeric quantity of memory in bytes, or human-readable IEC
 	// byte notation like "1GB" = 1024^3 bytes.
-	Memory interface{} `yaml:"memory"`
+	Memory any `yaml:"memory"`
 	// CPU is a numeric quantity of CPU cores, or a string with a numeric
 	// quantity followed by an "m"-suffix for milli-CPU.
-	CPU interface{} `yaml:"cpu"`
+	CPU any `yaml:"cpu"`
 	// Disk is a numeric quantity of disk size in bytes, or human-readable
 	// IEC byte notation like "1GB" = 1024^3 bytes.
-	Disk interface{} `yaml:"disk"`
+	Disk any `yaml:"disk"`
 }
 
 // GetEstimatedMemory converts the memory resource request to a value compatible
@@ -416,7 +416,7 @@ func matchesAnyPattern(haystack []string, needle string) bool {
 	return matched
 }
 
-func yamlNumberToString(num interface{}) (str string, ok bool) {
+func yamlNumberToString(num any) (str string, ok bool) {
 	if i, ok := num.(int); ok {
 		return strconv.Itoa(i), true
 	}

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -896,7 +896,7 @@ func (ws *workflowService) GetWorkflowHistory(ctx context.Context) (*wfpb.GetWor
 	qStr, qArgs := q.Build()
 	rq := ws.env.GetOLAPDBHandle().NewQuery(ctx, "workflow_service_get_actions").Raw(qStr, qArgs...)
 
-	actionHistoryQArgs := make([]interface{}, 0)
+	actionHistoryQArgs := make([]any, 0)
 	actionHistoryQStrs := make([]string, 0)
 	workflows := make(map[string]map[string]*wfpb.ActionHistory)
 

--- a/rules/go/analyzer/def.bzl
+++ b/rules/go/analyzer/def.bzl
@@ -1,5 +1,5 @@
 ANALYZERS = [
-    # "any",
+    "any",
     # "bloop", # DO NOT ENABLE, see golang/go#74967
     # "fmtappendf",
     # "forvar",

--- a/server/backends/blobstore/aws/aws.go
+++ b/server/backends/blobstore/aws/aws.go
@@ -81,7 +81,7 @@ func NewAwsS3BlobStore(ctx context.Context) (*AwsS3BlobStore, error) {
 		log.Debugf("AWS blobstore endpoint found: %q", *awsS3Endpoint)
 		configOptions = append(configOptions, config.WithEndpointResolverWithOptions(
 			aws.EndpointResolverWithOptionsFunc(
-				func(_, _ string, _ ...interface{}) (aws.Endpoint, error) {
+				func(_, _ string, _ ...any) (aws.Endpoint, error) {
 					return aws.Endpoint{
 						URL:               *awsS3Endpoint,
 						SigningRegion:     *awsS3Region,

--- a/server/build_event_protocol/invocation_format/invocation_format.go
+++ b/server/build_event_protocol/invocation_format/invocation_format.go
@@ -101,9 +101,9 @@ func ConvertDBTagsToOLAP(tags string) []string {
 	return strings.Split(tags, ",")
 }
 
-func GetTagsAsClickhouseWhereClause(fieldName string, tags []string) (string, []interface{}) {
+func GetTagsAsClickhouseWhereClause(fieldName string, tags []string) (string, []any) {
 	outStrings := []string{}
-	outArgs := []interface{}{}
+	outArgs := []any{}
 	for _, tag := range tags {
 		outStrings = append(outStrings, "?")
 		outArgs = append(outArgs, tag)

--- a/server/build_event_protocol/target_tracker/target_tracker.go
+++ b/server/build_event_protocol/target_tracker/target_tracker.go
@@ -551,7 +551,7 @@ func insertTargets(ctx context.Context, env environment.Env, targets []*tables.T
 	chunkList := chunkTargetsBy(targets, 100)
 	for _, chunk := range chunkList {
 		valueStrings := []string{}
-		valueArgs := []interface{}{}
+		valueArgs := []any{}
 		for _, t := range chunk {
 			nowUsec := time.Now().UnixMicro()
 			valueStrings = append(valueStrings, "(?, ?, ?, ?, ?, ?, ?, ?, ?)")
@@ -591,7 +591,7 @@ func insertOrUpdateTargetStatuses(ctx context.Context, env environment.Env, stat
 	chunkList := chunkStatusesBy(statuses, 100)
 	for _, chunk := range chunkList {
 		valueStrings := []string{}
-		valueArgs := []interface{}{}
+		valueArgs := []any{}
 		for _, t := range chunk {
 			nowUsec := time.Now().UnixMicro()
 			valueStrings = append(valueStrings, "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")

--- a/server/http/interceptors/interceptors.go
+++ b/server/http/interceptors/interceptors.go
@@ -190,7 +190,7 @@ func RedirectIfNotForwardedHTTPS(next http.Handler) http.Handler {
 
 // gzip, courtesy of https://gist.github.com/CJEnright/bc2d8b8dc0c1389a9feeddb110f822d7
 var gzPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		w := gzip.NewWriter(io.Discard)
 		return w
 	},

--- a/server/http/protolet/protolet.go
+++ b/server/http/protolet/protolet.go
@@ -148,7 +148,7 @@ type HTTPHandlers struct {
 	RequestHandler http.Handler
 }
 
-func GenerateHTTPHandlers(servicePrefix, serviceName string, server interface{}, grpcServer *grpc.Server) (*HTTPHandlers, error) {
+func GenerateHTTPHandlers(servicePrefix, serviceName string, server any, grpcServer *grpc.Server) (*HTTPHandlers, error) {
 	if reflect.ValueOf(server).Type().Kind() != reflect.Ptr {
 		return nil, fmt.Errorf("GenerateHTTPHandlers must be called with a pointer to an RPC service implementation")
 	}

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -392,7 +392,7 @@ type DBRawQuery interface {
 	// Take executes the query and scans the resulting row into the target
 	// struct. An error is returned if no records match. To check for this
 	// error use db.IsRecordNotFound.
-	Take(dest interface{}) error
+	Take(dest any) error
 	// Exec executes the raw modification query and returns the result.
 	Exec() DBResult
 	// IterateRaw executes the select query and iterates over the raw result
@@ -403,13 +403,13 @@ type DBRawQuery interface {
 
 type DBQuery interface {
 	// Create inserts a new row using the passed GORM-annotated struct.
-	Create(val interface{}) error
+	Create(val any) error
 	// Update updates an existing row using the primary key of the given
 	// GORM-annotated struct. Returns gorm.ErrRecordNotFound if a matching
 	// row does not exist.
-	Update(val interface{}) error
+	Update(val any) error
 	// Raw prepares a raw query.
-	Raw(sql string, values ...interface{}) DBRawQuery
+	Raw(sql string, values ...any) DBRawQuery
 }
 
 type DB interface {
@@ -487,7 +487,7 @@ type OLAPDBHandle interface {
 	FlushTestTargetStatuses(ctx context.Context, entries []*schema.TestTargetStatus) error
 	FlushUsages(ctx context.Context, entries []*schema.RawUsage) error
 	InsertAuditLog(ctx context.Context, entry *schema.AuditLog) error
-	BucketFromUsecTimestamp(fieldName string, loc *time.Location, interval string) (string, []interface{})
+	BucketFromUsecTimestamp(fieldName string, loc *time.Location, interval string) (string, []any)
 }
 
 type InvocationDB interface {

--- a/server/janitor/janitor.go
+++ b/server/janitor/janitor.go
@@ -89,13 +89,13 @@ func NewInvocationJanitor(env environment.Env) *Janitor {
 	}
 }
 
-func lookupExpiredExecutionIDs(ctx context.Context, c *JanitorConfig) ([]interface{}, error) {
+func lookupExpiredExecutionIDs(ctx context.Context, c *JanitorConfig) ([]any, error) {
 	dbh := c.env.GetDBHandle()
 	cutoff := time.Now().Add(-1 * c.ttl)
 
 	stmt := `SELECT execution_id FROM "Executions" WHERE created_at_usec < ? LIMIT ?`
 	rq := dbh.NewQuery(ctx, "janitor_lookup_expired_executions").Raw(stmt, cutoff.UnixMicro(), c.batchSize)
-	executionIDs := make([]interface{}, 0, c.batchSize)
+	executionIDs := make([]any, 0, c.batchSize)
 	err := rq.IterateRaw(func(ctx context.Context, row *sql.Rows) error {
 		var executionID *string
 		if err := row.Scan(&executionID); err != nil {

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -730,7 +730,7 @@ func MissingDigestError(d *repb.Digest) error {
 	return MissingDigestErrorf(d, "Digest %v not found", d)
 }
 
-func MissingDigestErrorf(d *repb.Digest, format string, args ...interface{}) error {
+func MissingDigestErrorf(d *repb.Digest, format string, args ...any) error {
 	if d == nil {
 		log.Infof("MissingDigestErrorf called with nil digest. Stack trace:\n%s", string(debug.Stack()))
 	}

--- a/server/rpc/interceptors/interceptors.go
+++ b/server/rpc/interceptors/interceptors.go
@@ -64,14 +64,14 @@ func (w *wrappedServerStreamWithContext) Context() context.Context {
 
 // ContextReplacingStreamServerInterceptor is a helper to make a stream interceptor that modifies a context.
 func contextReplacingStreamServerInterceptor(ctxFn func(ctx context.Context) context.Context) grpc.StreamServerInterceptor {
-	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		return handler(srv, &wrappedServerStreamWithContext{stream, ctxFn(stream.Context())})
 	}
 }
 
 // ContextReplacingStreamServerInterceptor is a helper to make a unary interceptor that modifies a context.
 func contextReplacingUnaryServerInterceptor(ctxFn func(ctx context.Context) context.Context) grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		return handler(ctxFn(ctx), req)
 	}
 }
@@ -85,7 +85,7 @@ func contextReplacingStreamClientInterceptor(ctxFn func(ctx context.Context) con
 
 // contextReplacingUnaryClientInterceptor is a helper to make a unary interceptor that modifies a context.
 func contextReplacingUnaryClientInterceptor(ctxFn func(ctx context.Context) context.Context) grpc.UnaryClientInterceptor {
-	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		return invoker(ctxFn(ctx), method, req, reply, cc, opts...)
 	}
 }
@@ -235,7 +235,7 @@ func authUnaryServerInterceptor(env environment.Env) grpc.UnaryServerInterceptor
 }
 
 func roleAuthStreamServerInterceptor(env environment.Env) grpc.StreamServerInterceptor {
-	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if strings.HasPrefix(info.FullMethod, buildBuddyServicePrefix) {
 			if err := capabilities_filter.AuthorizeRPC(stream.Context(), env, info.FullMethod); err != nil {
 				return err
@@ -246,7 +246,7 @@ func roleAuthStreamServerInterceptor(env environment.Env) grpc.StreamServerInter
 }
 
 func roleAuthUnaryServerInterceptor(env environment.Env) grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		if strings.HasPrefix(info.FullMethod, buildBuddyServicePrefix) {
 			if err := capabilities_filter.AuthorizeRPC(ctx, env, info.FullMethod); err != nil {
 				return nil, err
@@ -257,7 +257,7 @@ func roleAuthUnaryServerInterceptor(env environment.Env) grpc.UnaryServerInterce
 }
 
 func ipAuthUnaryServerInterceptor(env environment.Env) grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		if irs := env.GetIPRulesEnforcer(); irs != nil {
 			newCtx, err := irs.Authorize(ctx)
 			if err != nil {
@@ -270,7 +270,7 @@ func ipAuthUnaryServerInterceptor(env environment.Env) grpc.UnaryServerIntercept
 }
 
 func ipAuthStreamServerInterceptor(env environment.Env) grpc.StreamServerInterceptor {
-	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if irs := env.GetIPRulesEnforcer(); irs != nil {
 			newCtx, err := irs.Authorize(stream.Context())
 			if err != nil {
@@ -283,7 +283,7 @@ func ipAuthStreamServerInterceptor(env environment.Env) grpc.StreamServerInterce
 }
 
 func identityUnaryServerInterceptor(env environment.Env) grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		if cis := env.GetClientIdentityService(); cis != nil {
 			newCtx, err := cis.ValidateIncomingIdentity(ctx)
 			if err != nil {
@@ -296,7 +296,7 @@ func identityUnaryServerInterceptor(env environment.Env) grpc.UnaryServerInterce
 }
 
 func identityStreamServerInterceptor(env environment.Env) grpc.StreamServerInterceptor {
-	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if cis := env.GetClientIdentityService(); cis != nil {
 			newCtx, err := cis.ValidateIncomingIdentity(stream.Context())
 			if err != nil {
@@ -445,7 +445,7 @@ func invocationIDLoggerUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 // requestContextProtoUnaryServerInterceptor is a server interceptor that
 // copies the request context from the request message into the context.
 func requestContextProtoUnaryServerInterceptor() grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		msg, ok := req.(proto.Message)
 		if ok {
 			protoCtx := requestcontext.GetProtoRequestContext(msg)
@@ -457,7 +457,7 @@ func requestContextProtoUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 
 // logRequestUnaryServerInterceptor defers a call to log the GRPC request.
 func logRequestUnaryServerInterceptor() grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		start := time.Now()
 		r, err := handler(ctx, req)
 		log.LogGRPCRequest(ctx, info.FullMethod, time.Since(start), err)
@@ -467,7 +467,7 @@ func logRequestUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 
 // logRequestUnaryServerInterceptor defers a call to log the GRPC request.
 func logRequestStreamServerInterceptor() grpc.StreamServerInterceptor {
-	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		start := time.Now()
 		err := handler(srv, stream)
 		log.LogGRPCRequest(stream.Context(), info.FullMethod, time.Since(start), err)
@@ -476,7 +476,7 @@ func logRequestStreamServerInterceptor() grpc.StreamServerInterceptor {
 }
 
 func groupStatusUnaryServerInterceptor(env environment.Env) grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		if gs := env.GetGroupStatusChecker(); gs != nil {
 			if err := gs.CheckAllowed(ctx); err != nil {
 				return nil, err
@@ -487,7 +487,7 @@ func groupStatusUnaryServerInterceptor(env environment.Env) grpc.UnaryServerInte
 }
 
 func groupStatusStreamServerInterceptor(env environment.Env) grpc.StreamServerInterceptor {
-	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if gs := env.GetGroupStatusChecker(); gs != nil {
 			if err := gs.CheckAllowed(stream.Context()); err != nil {
 				return err
@@ -498,7 +498,7 @@ func groupStatusStreamServerInterceptor(env environment.Env) grpc.StreamServerIn
 }
 
 func quotaUnaryServerInterceptor(env environment.Env) grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		if qm := env.GetQuotaManager(); qm != nil {
 			err := qm.Allow(ctx, rpcQuotaPrefix+info.FullMethod, 1)
 			if err != nil {
@@ -510,7 +510,7 @@ func quotaUnaryServerInterceptor(env environment.Env) grpc.UnaryServerIntercepto
 }
 
 func quotaStreamServerInterceptor(env environment.Env) grpc.StreamServerInterceptor {
-	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if qm := env.GetQuotaManager(); qm != nil {
 			err := qm.Allow(stream.Context(), rpcQuotaPrefix+info.FullMethod, 1)
 			if err != nil {
@@ -528,7 +528,7 @@ func alertOnPanic(err any) {
 }
 
 func unaryRecoveryInterceptor() grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (rsp interface{}, err error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (rsp any, err error) {
 		defer func() {
 			if panicErr := recover(); panicErr != nil {
 				rsp = nil
@@ -542,7 +542,7 @@ func unaryRecoveryInterceptor() grpc.UnaryServerInterceptor {
 }
 
 func streamRecoveryInterceptor() grpc.StreamServerInterceptor {
-	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (err error) {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (err error) {
 		defer func() {
 			if panicErr := recover(); panicErr != nil {
 				err = status.InternalError("A panic occurred")
@@ -661,14 +661,14 @@ func propagateBazelRequestMetadataToSpan(ctx context.Context) {
 }
 
 func propagateRequestMetadataToSpanUnaryServerInterceptor() grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
 		propagateBazelRequestMetadataToSpan(ctx)
 		return handler(ctx, req)
 	}
 }
 
 func propagateRequestMetadataToSpanStreamServerInterceptor() grpc.StreamServerInterceptor {
-	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		ctx := stream.Context()
 		propagateBazelRequestMetadataToSpan(ctx)
 		return handler(srv, stream)

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -32,7 +32,7 @@ const (
 )
 
 type tableDescriptor struct {
-	table interface{}
+	table any
 	// 2-letter table prefix
 	prefix string
 	// Table name (must match struct name).
@@ -49,8 +49,8 @@ var (
 	allTables []tableDescriptor
 )
 
-func GetAllTables() []interface{} {
-	tableSlice := make([]interface{}, 0)
+func GetAllTables() []any {
+	tableSlice := make([]any, 0)
 	for _, d := range allTables {
 		tableSlice = append(tableSlice, d.table)
 	}

--- a/server/target/target.go
+++ b/server/target/target.go
@@ -749,7 +749,7 @@ func readPaginatedTargetsFromPrimaryDB(ctx context.Context, env environment.Env,
 	return fetchTargetsFromPrimaryDB(ctx, env, q, repo)
 }
 
-func getTimeFilters(startedAfter *timestamppb.Timestamp, startedBefore *timestamppb.Timestamp) (string, []interface{}) {
+func getTimeFilters(startedAfter *timestamppb.Timestamp, startedBefore *timestamppb.Timestamp) (string, []any) {
 	startedAfterMicros := time.Now().Add(-7 * 24 * time.Hour).UnixMicro()
 	if startedAfter != nil {
 		if reqUpdatedAfterMicros := startedAfter.AsTime().UnixMicro(); reqUpdatedAfterMicros > 0 {
@@ -757,7 +757,7 @@ func getTimeFilters(startedAfter *timestamppb.Timestamp, startedBefore *timestam
 		}
 	}
 	out := " (invocation_start_time_usec > ?) "
-	outArgs := []interface{}{startedAfterMicros}
+	outArgs := []any{startedAfterMicros}
 
 	if startedBefore != nil {
 		if startedBeforeMicros := startedBefore.AsTime().UnixMicro(); startedBeforeMicros > startedAfterMicros {
@@ -778,7 +778,7 @@ func GetDailyTargetStats(ctx context.Context, env environment.Env, req *trpb.Get
 	}
 
 	innerWhereClause := "group_id = ? AND cached = 0"
-	qArgs := []interface{}{u.GetGroupID()}
+	qArgs := []any{u.GetGroupID()}
 
 	timeQStr, timeQArgs := getTimeFilters(req.GetStartedAfter(), req.GetStartedBefore())
 	innerWhereClause += " AND " + timeQStr
@@ -870,7 +870,7 @@ func GetTargetStats(ctx context.Context, env environment.Env, req *trpb.GetTarge
 	}
 
 	innerWhereClause := "group_id = ? AND cached = 0"
-	qArgs := []interface{}{u.GetGroupID()}
+	qArgs := []any{u.GetGroupID()}
 
 	timeQStr, timeQArgs := getTimeFilters(req.GetStartedAfter(), req.GetStartedBefore())
 	innerWhereClause += " AND " + timeQStr
@@ -966,7 +966,7 @@ func GetTargetFlakeSamples(ctx context.Context, env environment.Env, req *trpb.G
 	pg.Limit = 5
 
 	innerWhereClause := "group_id = ? AND label = ? AND cached = 0"
-	qArgs := []interface{}{u.GetGroupID(), req.GetLabel()}
+	qArgs := []any{u.GetGroupID(), req.GetLabel()}
 
 	timeQStr, timeQArgs := getTimeFilters(req.GetStartedAfter(), req.GetStartedBefore())
 	innerWhereClause += " AND " + timeQStr

--- a/server/test/integration/build_event_protocol/build_event_protocol_test.go
+++ b/server/test/integration/build_event_protocol/build_event_protocol_test.go
@@ -60,7 +60,7 @@ func TestBuildWithRetry_InjectFailureAfterBuildFinished(t *testing.T) {
 	testInjectFailureAfterBazelEvent(t, &bespb.BuildEvent_Finished{})
 }
 
-func testInjectFailureAfterBazelEvent(t *testing.T, payloadMsg interface{}) {
+func testInjectFailureAfterBazelEvent(t *testing.T, payloadMsg any) {
 	app := buildbuddy.Run(t)
 	bepClient := app.PublishBuildEventClient(t)
 	proxy := StartBEPProxy(t, bepClient)
@@ -136,7 +136,7 @@ type StreamErrorInjector func(*StreamEvent) error
 // a Bazel event with the same payload type as the given message is successfully
 // forwarded to the build event server. The given message must be assignable to
 // BuildEvent.Payload, otherwise the test immediately fails.
-func AfterForwardBazelEvent(t *testing.T, payloadMsg interface{}) StreamErrorInjector {
+func AfterForwardBazelEvent(t *testing.T, payloadMsg any) StreamErrorInjector {
 	payloadType := reflect.TypeOf(payloadMsg)
 	payloadSuperType := reflect.TypeOf(&(&bespb.BuildEvent{}).Payload).Elem()
 	if !payloadType.AssignableTo(payloadSuperType) {

--- a/server/testutil/mockstore/mockstore.go
+++ b/server/testutil/mockstore/mockstore.go
@@ -26,7 +26,7 @@ func (m *Context) Err() error {
 	return nil
 }
 
-func (m *Context) Value(key interface{}) interface{} {
+func (m *Context) Value(key any) any {
 	return nil
 }
 

--- a/server/testutil/testmysql/testmysql.go
+++ b/server/testutil/testmysql/testmysql.go
@@ -114,7 +114,7 @@ func Start(t testing.TB, reuseServer bool) string {
 
 type discardLogger struct{}
 
-func (d *discardLogger) Print(args ...interface{}) {}
+func (d *discardLogger) Print(args ...any) {}
 
 type logWriter struct {
 	tag string

--- a/server/testutil/testolapdb/testolapdb.go
+++ b/server/testutil/testolapdb/testolapdb.go
@@ -45,7 +45,7 @@ func NewHandle() *Handle {
 	}
 }
 
-func (h *Handle) BucketFromUsecTimestamp(fieldName string, loc *time.Location, interval string) (string, []interface{}) {
+func (h *Handle) BucketFromUsecTimestamp(fieldName string, loc *time.Location, interval string) (string, []any) {
 	return "", nil
 }
 
@@ -98,7 +98,7 @@ func (h *Handle) GetExecutionIDsByInvID(t *testing.T, invID string) []string {
 
 func (h *Handle) GetInvocationIDs() []string {
 	res := []string{}
-	h.executionIDsByInvID.Range(func(k, v interface{}) bool {
+	h.executionIDsByInvID.Range(func(k, v any) bool {
 		invID := k.(string)
 		res = append(res, invID)
 		return true

--- a/server/util/alert/alert.go
+++ b/server/util/alert/alert.go
@@ -20,13 +20,13 @@ import (
 //
 //	alert.UnexpectedEvent("cannot_unmarshal_proto")
 //	alert.UnexpectedEvent("cannot_unmarshal_proto", "invocation_id %s err: %s", invocation_id, err)
-func UnexpectedEvent(name string, msgAndArgs ...interface{}) {
+func UnexpectedEvent(name string, msgAndArgs ...any) {
 	CtxUnexpectedEvent(context.Background(), name, msgAndArgs...)
 }
 
 // CtxUnexpectedEvent is the same as UnexpectedEvent, but takes a context
 // which is used when logging the event.
-func CtxUnexpectedEvent(ctx context.Context, name string, msgAndArgs ...interface{}) {
+func CtxUnexpectedEvent(ctx context.Context, name string, msgAndArgs ...any) {
 	metrics.UnexpectedEvent.With(prometheus.Labels{metrics.EventName: name}).Inc()
 	logMsg := fmt.Sprintf("Unexpected event %q", name)
 	if len(msgAndArgs) == 1 {

--- a/server/util/background/background.go
+++ b/server/util/background/background.go
@@ -51,7 +51,7 @@ func (ctx *disconnectedContext) cancel(err error) {
 	ctx.err = err
 	close(ctx.done)
 }
-func (ctx *disconnectedContext) Value(key interface{}) interface{} {
+func (ctx *disconnectedContext) Value(key any) any {
 	return ctx.parent.Value(key)
 }
 

--- a/server/util/claims/claims.go
+++ b/server/util/claims/claims.go
@@ -252,7 +252,7 @@ func parseClaimsInternal(ctx context.Context, token string, keyProvider KeyProvi
 	var lastErr error
 	claims := &Claims{}
 	for _, key := range keys {
-		_, err := jwt.ParseWithClaims(token, claims, func(token *jwt.Token) (interface{}, error) {
+		_, err := jwt.ParseWithClaims(token, claims, func(token *jwt.Token) (any, error) {
 			method = token.Method.Alg()
 			if token.Method != key.SigningMethod {
 				return nil, fmt.Errorf("incorrect key signing method: %v", token.Method.Alg())

--- a/server/util/claims/claims_test.go
+++ b/server/util/claims/claims_test.go
@@ -357,7 +357,7 @@ func TestAssembleJWT_ES256_UsesNewKeyWhenSet(t *testing.T) {
 	require.NoError(t, err)
 
 	parsedClaims := &claims.Claims{}
-	_, err = jwt.ParseWithClaims(tokenString, parsedClaims, func(token *jwt.Token) (interface{}, error) {
+	_, err = jwt.ParseWithClaims(tokenString, parsedClaims, func(token *jwt.Token) (any, error) {
 		return pubKey, nil
 	})
 	require.NoError(t, err)

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -136,11 +136,11 @@ type query struct {
 	name string
 }
 
-func (q *query) Create(val interface{}) error {
+func (q *query) Create(val any) error {
 	return status.UnimplementedError("Create is not supported for clickhouse")
 }
 
-func (q *query) Update(val interface{}) error {
+func (q *query) Update(val any) error {
 	return status.UnimplementedError("Update is not supported for clickhouse")
 }
 
@@ -148,7 +148,7 @@ type rawQuery struct {
 	db     *gorm.DB
 	ctx    context.Context
 	sql    string
-	values []interface{}
+	values []any
 }
 
 func (r *rawQuery) Exec() interfaces.DBResult {
@@ -156,11 +156,11 @@ func (r *rawQuery) Exec() interfaces.DBResult {
 	return interfaces.DBResult{Error: rb.Error, RowsAffected: rb.RowsAffected}
 }
 
-func (r *rawQuery) Take(dest interface{}) error {
+func (r *rawQuery) Take(dest any) error {
 	return r.db.Raw(r.sql, r.values...).Take(dest).Error
 }
 
-func (r *rawQuery) Scan(dest interface{}) error {
+func (r *rawQuery) Scan(dest any) error {
 	return r.db.Raw(r.sql, r.values...).Scan(dest).Error
 }
 
@@ -185,7 +185,7 @@ func (r *rawQuery) DB() *gorm.DB {
 	return r.db
 }
 
-func (q *query) Raw(sql string, values ...interface{}) interfaces.DBRawQuery {
+func (q *query) Raw(sql string, values ...any) interfaces.DBRawQuery {
 	db := q.db.WithContext(q.ctx).Set(gormQueryNameKey, q.name)
 	return &rawQuery{db: db, ctx: q.ctx, sql: sql, values: values}
 }
@@ -199,8 +199,8 @@ func (dbh *DBHandle) NewQuery(ctx context.Context, name string) interfaces.DBQue
 // another epoch in micros rounded down to the supplied clickhouse interval
 // string (e.g., "1 HOUR", "30 MINUTE").  More about clickhouse intervals:
 // https://clickhouse.com/docs/en/sql-reference/data-types/special-data-types/interval
-func (h *DBHandle) BucketFromUsecTimestamp(fieldName string, loc *time.Location, interval string) (string, []interface{}) {
-	return fmt.Sprintf("toUnixTimestamp(toStartOfInterval(toDateTime64(%s / 1000000, 6, ?), INTERVAL %s)) * 1000000", fieldName, interval), []interface{}{loc.String()}
+func (h *DBHandle) BucketFromUsecTimestamp(fieldName string, loc *time.Location, interval string) (string, []any) {
+	return fmt.Sprintf("toUnixTimestamp(toStartOfInterval(toDateTime64(%s / 1000000, 6, ?), INTERVAL %s)) * 1000000", fieldName, interval), []any{loc.String()}
 }
 
 // DateFromUsecTimestamp returns an SQL expression compatible with clickhouse
@@ -251,7 +251,7 @@ func withAsyncBusyTimeout(minMs, maxMs int) InsertOpt {
 	}
 }
 
-func (h *DBHandle) insertWithRetrier(ctx context.Context, tableName string, numEntries int, value interface{}, opts ...InsertOpt) error {
+func (h *DBHandle) insertWithRetrier(ctx context.Context, tableName string, numEntries int, value any, opts ...InsertOpt) error {
 	o := defaultInsertOpts()
 	o.apply(opts...)
 	retrier := retry.DefaultWithContext(ctx)

--- a/server/util/clickhouse/schema/schema_test.go
+++ b/server/util/clickhouse/schema/schema_test.go
@@ -16,7 +16,7 @@ import (
 func TestSchemaInSync(t *testing.T) {
 	tests := []struct {
 		clickhouseTable Table
-		primaryDBTable  interface{}
+		primaryDBTable  any
 	}{
 		{
 			clickhouseTable: &Invocation{},

--- a/server/util/compression/compression.go
+++ b/server/util/compression/compression.go
@@ -447,7 +447,7 @@ type ZstdDecoderPool struct {
 func NewZstdDecoderPool() *ZstdDecoderPool {
 	return &ZstdDecoderPool{
 		pool: sync.Pool{
-			New: func() interface{} {
+			New: func() any {
 				dc, err := zstd.NewReader(nil, zstd.WithDecoderConcurrency(1))
 				if err != nil {
 					return err

--- a/server/util/db/db.go
+++ b/server/util/db/db.go
@@ -951,7 +951,7 @@ type rawQuery struct {
 	db     *gorm.DB
 	ctx    context.Context
 	sql    string
-	values []interface{}
+	values []any
 }
 
 func (r *rawQuery) Exec() interfaces.DBResult {
@@ -959,11 +959,11 @@ func (r *rawQuery) Exec() interfaces.DBResult {
 	return interfaces.DBResult{Error: rb.Error, RowsAffected: rb.RowsAffected}
 }
 
-func (r *rawQuery) Take(dest interface{}) error {
+func (r *rawQuery) Take(dest any) error {
 	return r.db.Raw(r.sql, r.values...).Take(dest).Error
 }
 
-func (r *rawQuery) Scan(dest interface{}) error {
+func (r *rawQuery) Scan(dest any) error {
 	return r.db.Raw(r.sql, r.values...).Scan(dest).Error
 }
 
@@ -995,12 +995,12 @@ type query struct {
 	name string
 }
 
-func (q *query) Create(val interface{}) error {
+func (q *query) Create(val any) error {
 	db := q.db.WithContext(q.ctx).Set(gormQueryNameKey, q.name)
 	return db.Create(val).Error
 }
 
-func (q *query) Update(val interface{}) error {
+func (q *query) Update(val any) error {
 	db := q.db.WithContext(q.ctx).Set(gormQueryNameKey, q.name)
 	res := db.Updates(val)
 	if res.RowsAffected == 0 {
@@ -1009,7 +1009,7 @@ func (q *query) Update(val interface{}) error {
 	return nil
 }
 
-func (q *query) Raw(sql string, values ...interface{}) interfaces.DBRawQuery {
+func (q *query) Raw(sql string, values ...any) interfaces.DBRawQuery {
 	db := q.db.WithContext(q.ctx).Set(gormQueryNameKey, q.name)
 	return &rawQuery{db: db, ctx: q.ctx, sql: sql, values: values}
 }

--- a/server/util/filter/filter.go
+++ b/server/util/filter/filter.go
@@ -113,7 +113,7 @@ func MetricToDbField(m *stat_filter.Metric) (string, error) {
 	return "", status.InvalidArgumentErrorf("Invalid filter: %v", m)
 }
 
-func GenerateFilterStringAndArgs(f *stat_filter.StatFilter) (string, []interface{}, error) {
+func GenerateFilterStringAndArgs(f *stat_filter.StatFilter) (string, []any, error) {
 	metric, err := MetricToDbField(f.GetMetric())
 	if err != nil {
 		return "", nil, err
@@ -122,12 +122,12 @@ func GenerateFilterStringAndArgs(f *stat_filter.StatFilter) (string, []interface
 		return "", nil, status.InvalidArgumentErrorf("No filter bounds specified: %v", f)
 	}
 	if f.Max != nil && f.Min != nil {
-		return fmt.Sprintf("(%s BETWEEN ? AND ?)", metric), []interface{}{f.GetMin(), f.GetMax()}, nil
+		return fmt.Sprintf("(%s BETWEEN ? AND ?)", metric), []any{f.GetMin(), f.GetMax()}, nil
 	}
 	if f.Max != nil {
-		return fmt.Sprintf("(%s <= ?)", metric), []interface{}{f.GetMax()}, nil
+		return fmt.Sprintf("(%s <= ?)", metric), []any{f.GetMax()}, nil
 	}
-	return fmt.Sprintf("(%s >= ?)", metric), []interface{}{f.GetMin()}, nil
+	return fmt.Sprintf("(%s >= ?)", metric), []any{f.GetMin()}, nil
 }
 
 func DimensionToDbField(m *stat_filter.Dimension) (string, error) {
@@ -142,17 +142,17 @@ func DimensionToDbField(m *stat_filter.Dimension) (string, error) {
 	return "", status.InvalidArgumentErrorf("Invalid filter: %v", m)
 }
 
-func GenerateDimensionFilterStringAndArgs(f *stat_filter.DimensionFilter) (string, []interface{}, error) {
+func GenerateDimensionFilterStringAndArgs(f *stat_filter.DimensionFilter) (string, []any, error) {
 	metric, err := DimensionToDbField(f.GetDimension())
 	if err != nil {
 		return "", nil, err
 	}
-	return fmt.Sprintf("(%s = ?)", metric), []interface{}{f.GetValue()}, nil
+	return fmt.Sprintf("(%s = ?)", metric), []any{f.GetValue()}, nil
 }
 
-func getStringAndArgs(databaseQueryTemplate string, v interface{}, columnName string) (string, []interface{}) {
+func getStringAndArgs(databaseQueryTemplate string, v any, columnName string) (string, []any) {
 	str := strings.ReplaceAll(databaseQueryTemplate, "?field", columnName)
-	var args []interface{}
+	var args []any
 	for strings.Contains(str, "?value") {
 		str = strings.Replace(str, "?value", "?", 1)
 		args = append(args, v)
@@ -160,7 +160,7 @@ func getStringAndArgs(databaseQueryTemplate string, v interface{}, columnName st
 	return str, args
 }
 
-func generateStatusFilterQueryStringAndArgs(f *stat_filter.GenericFilter) (string, []interface{}, error) {
+func generateStatusFilterQueryStringAndArgs(f *stat_filter.GenericFilter) (string, []any, error) {
 	// Currently, we only support IN queries for status.
 	if f.GetOperand() != stat_filter.FilterOperand_IN_OPERAND {
 		return "", nil, status.InvalidArgumentErrorf("Status filters only support the IN operand.")
@@ -190,7 +190,7 @@ func generateStatusFilterQueryStringAndArgs(f *stat_filter.GenericFilter) (strin
 	return out, outArgs, nil
 }
 
-func generateArrayContainsQueryStringAndArgs(column string, args []string, dialect string) (string, []interface{}, error) {
+func generateArrayContainsQueryStringAndArgs(column string, args []string, dialect string) (string, []any, error) {
 	if dialect == "clickhouse" {
 		qStr, qArgs := getStringAndArgs("hasAny(?field, array(?value))", args, column)
 		return qStr, qArgs, nil
@@ -207,7 +207,7 @@ func generateArrayContainsQueryStringAndArgs(column string, args []string, diale
 	return out, outArgs, nil
 }
 
-func ValidateAndGenerateGenericFilterQueryStringAndArgs(f *stat_filter.GenericFilter, qType stat_filter.ObjectTypes, dialect string) (string, []interface{}, error) {
+func ValidateAndGenerateGenericFilterQueryStringAndArgs(f *stat_filter.GenericFilter, qType stat_filter.ObjectTypes, dialect string) (string, []any, error) {
 	if f == nil {
 		return "", nil, status.InvalidArgumentError("invalid nil entry in filter list")
 	}
@@ -244,12 +244,12 @@ func ValidateAndGenerateGenericFilterQueryStringAndArgs(f *stat_filter.GenericFi
 
 	v := f.GetValue()
 	var qStr string
-	var qArgs []interface{}
+	var qArgs []any
 	var err error
 
 	// Normal cases (ints, strings).
 	if typeOptions.GetCategory() == stat_filter.FilterCategory_INT_FILTER_CATEGORY {
-		var arg interface{}
+		var arg any
 		if operandOptions.GetArgumentCount() == stat_filter.FilterArgumentCount_ONE_FILTER_ARGUMENT_COUNT && len(v.GetIntValue()) == 1 {
 			arg = v.GetIntValue()[0]
 		} else if operandOptions.GetArgumentCount() == stat_filter.FilterArgumentCount_MANY_FILTER_ARGUMENT_COUNT && len(v.GetIntValue()) > 0 {
@@ -259,7 +259,7 @@ func ValidateAndGenerateGenericFilterQueryStringAndArgs(f *stat_filter.GenericFi
 		}
 		qStr, qArgs = getStringAndArgs(operandOptions.GetDatabaseQueryString(), arg, typeOptions.GetDatabaseColumnName())
 	} else if typeOptions.GetCategory() == stat_filter.FilterCategory_STRING_FILTER_CATEGORY {
-		var arg interface{}
+		var arg any
 		if operandOptions.GetArgumentCount() == stat_filter.FilterArgumentCount_ONE_FILTER_ARGUMENT_COUNT && len(v.GetStringValue()) == 1 {
 			arg = v.GetStringValue()[0]
 		} else if operandOptions.GetArgumentCount() == stat_filter.FilterArgumentCount_MANY_FILTER_ARGUMENT_COUNT && len(v.GetStringValue()) > 0 {
@@ -269,7 +269,7 @@ func ValidateAndGenerateGenericFilterQueryStringAndArgs(f *stat_filter.GenericFi
 		}
 		qStr, qArgs = getStringAndArgs(operandOptions.GetDatabaseQueryString(), arg, typeOptions.GetDatabaseColumnName())
 	} else if typeOptions.GetCategory() == stat_filter.FilterCategory_STRING_ARRAY_FILTER_CATEGORY {
-		var arg interface{}
+		var arg any
 		if operandOptions.GetArgumentCount() == stat_filter.FilterArgumentCount_ONE_FILTER_ARGUMENT_COUNT && len(v.GetStringValue()) == 1 {
 			arg = v.GetStringValue()[0]
 		} else if operandOptions.GetArgumentCount() == stat_filter.FilterArgumentCount_MANY_FILTER_ARGUMENT_COUNT && len(v.GetStringValue()) > 0 {

--- a/server/util/filter/filter_test.go
+++ b/server/util/filter/filter_test.go
@@ -17,7 +17,7 @@ func TestValidGenericFilters(t *testing.T) {
 		filter        *stat_filter.GenericFilter
 		filterType    stat_filter.ObjectTypes
 		expectedQStr  string
-		expectedQArgs []interface{}
+		expectedQArgs []any
 	}{
 		{
 			filter: &stat_filter.GenericFilter{
@@ -29,7 +29,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_INVOCATION_OBJECTS,
 			expectedQStr:  "duration_usec > ?",
-			expectedQArgs: []interface{}{int64(10000)},
+			expectedQArgs: []any{int64(10000)},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -41,7 +41,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_INVOCATION_OBJECTS,
 			expectedQStr:  "repo_url IN ?",
-			expectedQArgs: []interface{}{[]string{"http://github.com/buildbuddy-io/buildbuddy"}},
+			expectedQArgs: []any{[]string{"http://github.com/buildbuddy-io/buildbuddy"}},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -53,7 +53,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_INVOCATION_OBJECTS,
 			expectedQStr:  "\"user\" IN ?",
-			expectedQArgs: []interface{}{[]string{"siggisim", "tylerw"}},
+			expectedQArgs: []any{[]string{"siggisim", "tylerw"}},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -65,7 +65,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_INVOCATION_OBJECTS,
 			expectedQStr:  "INSTR(\"user\", ?) > 0",
-			expectedQArgs: []interface{}{"sigg"},
+			expectedQArgs: []any{"sigg"},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -77,7 +77,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
 			expectedQStr:  "created_at_usec < ?",
-			expectedQArgs: []interface{}{int64(10001)},
+			expectedQArgs: []any{int64(10001)},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -89,7 +89,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
 			expectedQStr:  " (invocation_status = ? AND success = ?) OR (invocation_status = ? AND success = ?) ",
-			expectedQArgs: []interface{}{1, 1, 1, 0},
+			expectedQArgs: []any{1, 1, 1, 0},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -102,7 +102,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_INVOCATION_OBJECTS,
 			expectedQStr:  "NOT( invocation_status = ? OR invocation_status = ? )",
-			expectedQArgs: []interface{}{2, 3},
+			expectedQArgs: []any{2, 3},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -114,7 +114,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_INVOCATION_OBJECTS,
 			expectedQStr:  "cas_cache_misses > ?",
-			expectedQArgs: []interface{}{int64(0)},
+			expectedQArgs: []any{int64(0)},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -126,7 +126,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_INVOCATION_OBJECTS,
 			expectedQStr:  "action_cache_misses > ?",
-			expectedQArgs: []interface{}{int64(0)},
+			expectedQArgs: []any{int64(0)},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -138,7 +138,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_INVOCATION_OBJECTS,
 			expectedQStr:  "total_download_size_bytes < ?",
-			expectedQArgs: []interface{}{int64(2001)},
+			expectedQArgs: []any{int64(2001)},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -150,7 +150,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_INVOCATION_OBJECTS,
 			expectedQStr:  "download_throughput_bytes_per_second > ?",
-			expectedQArgs: []interface{}{int64(10_000)},
+			expectedQArgs: []any{int64(10_000)},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -162,7 +162,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_INVOCATION_OBJECTS,
 			expectedQStr:  "total_upload_size_bytes < ?",
-			expectedQArgs: []interface{}{int64(2001)},
+			expectedQArgs: []any{int64(2001)},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -174,7 +174,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_INVOCATION_OBJECTS,
 			expectedQStr:  "upload_throughput_bytes_per_second > ?",
-			expectedQArgs: []interface{}{int64(10_000)},
+			expectedQArgs: []any{int64(10_000)},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -186,7 +186,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_INVOCATION_OBJECTS,
 			expectedQStr:  "total_cached_action_exec_usec > ?",
-			expectedQArgs: []interface{}{int64(456)},
+			expectedQArgs: []any{int64(456)},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -198,7 +198,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
 			expectedQStr:  "IF(worker_start_timestamp_usec < queued_timestamp_usec, 0, (worker_start_timestamp_usec - queued_timestamp_usec)) < ?",
-			expectedQArgs: []interface{}{int64(500)},
+			expectedQArgs: []any{int64(500)},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -210,7 +210,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
 			expectedQStr:  "(input_fetch_completed_timestamp_usec - input_fetch_start_timestamp_usec) < ?",
-			expectedQArgs: []interface{}{int64(1000)},
+			expectedQArgs: []any{int64(1000)},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -222,7 +222,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
 			expectedQStr:  "(execution_completed_timestamp_usec - execution_start_timestamp_usec) < ?",
-			expectedQArgs: []interface{}{int64(9090)},
+			expectedQArgs: []any{int64(9090)},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -234,7 +234,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
 			expectedQStr:  "(output_upload_completed_timestamp_usec - output_upload_start_timestamp_usec) > ?",
-			expectedQArgs: []interface{}{int64(100)},
+			expectedQArgs: []any{int64(100)},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -246,7 +246,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
 			expectedQStr:  "peak_memory_bytes > ?",
-			expectedQArgs: []interface{}{int64(250)},
+			expectedQArgs: []any{int64(250)},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -258,7 +258,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
 			expectedQStr:  "file_download_size_bytes > ?",
-			expectedQArgs: []interface{}{int64(400)},
+			expectedQArgs: []any{int64(400)},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -270,7 +270,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
 			expectedQStr:  "file_upload_size_bytes > ?",
-			expectedQArgs: []interface{}{int64(500)},
+			expectedQArgs: []any{int64(500)},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -282,7 +282,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
 			expectedQStr:  "IF(worker_completed_timestamp_usec < queued_timestamp_usec, 0, (worker_completed_timestamp_usec - queued_timestamp_usec)) > ?",
-			expectedQArgs: []interface{}{int64(7500)},
+			expectedQArgs: []any{int64(7500)},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -294,7 +294,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
 			expectedQStr:  "cpu_nanos > ?",
-			expectedQArgs: []interface{}{int64(10_000)},
+			expectedQArgs: []any{int64(10_000)},
 		},
 		{
 			filter: &stat_filter.GenericFilter{
@@ -306,7 +306,7 @@ func TestValidGenericFilters(t *testing.T) {
 			},
 			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
 			expectedQStr:  "IF(cpu_nanos <= 0 OR (execution_completed_timestamp_usec - execution_start_timestamp_usec) <= 0, 0, intDivOrZero(cpu_nanos*1000, (execution_completed_timestamp_usec - execution_start_timestamp_usec) * 1000)) > ?",
-			expectedQArgs: []interface{}{int64(4000)},
+			expectedQArgs: []any{int64(4000)},
 		},
 	}
 	for _, tc := range cases {
@@ -333,11 +333,11 @@ func TestTagGenericFilters(t *testing.T) {
 	qStr, qArgs, err := filter.ValidateAndGenerateGenericFilterQueryStringAndArgs(f, stat_filter.ObjectTypes_INVOCATION_OBJECTS, "clickhouse")
 	assert.Nil(t, err)
 	assert.Equal(t, "hasAny(tags, array(?))", qStr)
-	assert.ElementsMatch(t, []interface{}{[]string{"tag_one", "tag_two"}}, qArgs)
+	assert.ElementsMatch(t, []any{[]string{"tag_one", "tag_two"}}, qArgs)
 	qStr, qArgs, err = filter.ValidateAndGenerateGenericFilterQueryStringAndArgs(f, stat_filter.ObjectTypes_INVOCATION_OBJECTS, "mysql")
 	assert.Nil(t, err)
 	assert.Equal(t, " INSTR(tags, ?) OR INSTR(tags, ?) ", qStr)
-	assert.ElementsMatch(t, []interface{}{"tag_one", "tag_two"}, qArgs)
+	assert.ElementsMatch(t, []any{"tag_one", "tag_two"}, qArgs)
 }
 
 func TestInvalidGenericFilters(t *testing.T) {

--- a/server/util/gormutil/gormutil.go
+++ b/server/util/gormutil/gormutil.go
@@ -116,6 +116,6 @@ func (l *Logger) LogMode(level logger.LogLevel) logger.Interface {
 
 // ParamsFilter implements gorm's ParamsFilter interface, ensuring that queries
 // are logged without parameter values showing up in the logs.
-func (l *Logger) ParamsFilter(ctx context.Context, sql string, params ...interface{}) (string, []interface{}) {
+func (l *Logger) ParamsFilter(ctx context.Context, sql string, params ...any) (string, []any) {
 	return sql, nil
 }

--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -116,7 +116,7 @@ func init() {
 func LocalWriter() io.Writer {
 	zerolog.TimeFieldFormat = time.RFC3339Nano
 	output := &zerolog.ConsoleWriter{Out: os.Stderr}
-	output.FormatCaller = func(i interface{}) string {
+	output.FormatCaller = func(i any) string {
 		s, ok := i.(string)
 		if !ok {
 			return ""
@@ -196,7 +196,7 @@ func (l *Logger) Debug(message string) {
 }
 
 // Debugf logs to the DEBUG log. Arguments are handled in the manner of fmt.Printf.
-func (l *Logger) Debugf(format string, args ...interface{}) {
+func (l *Logger) Debugf(format string, args ...any) {
 	l.zl.Debug().Msgf(format, args...)
 }
 
@@ -204,7 +204,7 @@ func (l *Logger) Debugf(format string, args ...interface{}) {
 // fmt.Printf.
 // Logs are enriched with information from the context
 // (e.g. invocation_id, request_id)
-func (l *Logger) CtxDebugf(ctx context.Context, format string, args ...interface{}) {
+func (l *Logger) CtxDebugf(ctx context.Context, format string, args ...any) {
 	e := l.zl.Debug()
 	if e == nil {
 		return
@@ -219,7 +219,7 @@ func (l *Logger) Info(message string) {
 }
 
 // Infof logs to the INFO log. Arguments are handled in the manner of fmt.Printf.
-func (l *Logger) Infof(format string, args ...interface{}) {
+func (l *Logger) Infof(format string, args ...any) {
 	l.zl.Info().Msgf(format, args...)
 }
 
@@ -227,7 +227,7 @@ func (l *Logger) Infof(format string, args ...interface{}) {
 // fmt.Printf.
 // Logs are enriched with information from the context
 // (e.g. invocation_id, request_id)
-func (l *Logger) CtxInfof(ctx context.Context, format string, args ...interface{}) {
+func (l *Logger) CtxInfof(ctx context.Context, format string, args ...any) {
 	e := l.zl.Info()
 	enrichEventFromContext(ctx, e)
 	e.Msgf(format, args...)
@@ -242,7 +242,7 @@ func (l *Logger) Warning(message string) {
 }
 
 // Warningf logs to the WARNING log. Arguments are handled in the manner of fmt.Printf.
-func (l *Logger) Warningf(format string, args ...interface{}) {
+func (l *Logger) Warningf(format string, args ...any) {
 	l.zl.Warn().Msgf(format, args...)
 	metrics.Logs.With(prometheus.Labels{
 		metrics.StatusHumanReadableLabel: "warning",
@@ -253,7 +253,7 @@ func (l *Logger) Warningf(format string, args ...interface{}) {
 // fmt.Printf.
 // Logs are enriched with information from the context
 // (e.g. invocation_id, request_id)
-func (l *Logger) CtxWarningf(ctx context.Context, format string, args ...interface{}) {
+func (l *Logger) CtxWarningf(ctx context.Context, format string, args ...any) {
 	e := l.zl.Warn()
 	enrichEventFromContext(ctx, e)
 	e.Msgf(format, args...)
@@ -271,7 +271,7 @@ func (l *Logger) Error(message string) {
 }
 
 // Errorf logs to the ERROR log. Arguments are handled in the manner of fmt.Printf.
-func (l *Logger) Errorf(format string, args ...interface{}) {
+func (l *Logger) Errorf(format string, args ...any) {
 	l.zl.Error().Msgf(format, args...)
 	metrics.Logs.With(prometheus.Labels{
 		metrics.StatusHumanReadableLabel: "error",
@@ -282,7 +282,7 @@ func (l *Logger) Errorf(format string, args ...interface{}) {
 // fmt.Printf.
 // Logs are enriched with information from the context
 // (e.g. invocation_id, request_id)
-func (l *Logger) CtxErrorf(ctx context.Context, format string, args ...interface{}) {
+func (l *Logger) CtxErrorf(ctx context.Context, format string, args ...any) {
 	e := l.zl.Error()
 	enrichEventFromContext(ctx, e)
 	e.Msgf(format, args...)
@@ -311,7 +311,7 @@ func (l *Logger) Fatal(message string) {
 
 // Fatalf logs to the FATAL log. Arguments are handled in the manner of fmt.Printf.
 // It calls os.Exit() with exit code 1.
-func (l *Logger) Fatalf(format string, args ...interface{}) {
+func (l *Logger) Fatalf(format string, args ...any) {
 	log.Fatal().Msgf(format, args...)
 	metrics.Logs.With(prometheus.Labels{
 		metrics.StatusHumanReadableLabel: "fatal",
@@ -414,7 +414,7 @@ func Print(message string) {
 }
 
 // DEPRECATED: use log.Infof instead!
-func Printf(format string, v ...interface{}) {
+func Printf(format string, v ...any) {
 	log.Info().Msgf(format, v...)
 }
 
@@ -424,7 +424,7 @@ func Debug(message string) {
 }
 
 // Debugf logs to the DEBUG log. Arguments are handled in the manner of fmt.Printf.
-func Debugf(format string, args ...interface{}) {
+func Debugf(format string, args ...any) {
 	log.Debug().Msgf(format, args...)
 }
 
@@ -444,7 +444,7 @@ func CtxDebug(ctx context.Context, message string) {
 // fmt.Printf.
 // Logs are enriched with information from the context
 // (e.g. invocation_id, request_id)
-func CtxDebugf(ctx context.Context, format string, args ...interface{}) {
+func CtxDebugf(ctx context.Context, format string, args ...any) {
 	e := log.Debug()
 	if e == nil {
 		return
@@ -459,7 +459,7 @@ func Info(message string) {
 }
 
 // Infof logs to the INFO log. Arguments are handled in the manner of fmt.Printf.
-func Infof(format string, args ...interface{}) {
+func Infof(format string, args ...any) {
 	log.Info().Msgf(format, args...)
 }
 
@@ -476,7 +476,7 @@ func CtxInfo(ctx context.Context, message string) {
 // fmt.Printf.
 // Logs are enriched with information from the context
 // (e.g. invocation_id, request_id)
-func CtxInfof(ctx context.Context, format string, args ...interface{}) {
+func CtxInfof(ctx context.Context, format string, args ...any) {
 	e := log.Info()
 	enrichEventFromContext(ctx, e)
 	e.Msgf(format, args...)
@@ -491,7 +491,7 @@ func Warning(message string) {
 }
 
 // Warningf logs to the WARNING log. Arguments are handled in the manner of fmt.Printf.
-func Warningf(format string, args ...interface{}) {
+func Warningf(format string, args ...any) {
 	log.Warn().Msgf(format, args...)
 	metrics.Logs.With(prometheus.Labels{
 		metrics.StatusHumanReadableLabel: "warning",
@@ -514,7 +514,7 @@ func CtxWarning(ctx context.Context, message string) {
 // fmt.Printf.
 // Logs are enriched with information from the context
 // (e.g. invocation_id, request_id)
-func CtxWarningf(ctx context.Context, format string, args ...interface{}) {
+func CtxWarningf(ctx context.Context, format string, args ...any) {
 	e := log.Warn()
 	enrichEventFromContext(ctx, e)
 	e.Msgf(format, args...)
@@ -532,7 +532,7 @@ func Error(message string) {
 }
 
 // Errorf logs to the ERROR log. Arguments are handled in the manner of fmt.Printf.
-func Errorf(format string, args ...interface{}) {
+func Errorf(format string, args ...any) {
 	log.Error().Msgf(format, args...)
 	metrics.Logs.With(prometheus.Labels{
 		metrics.StatusHumanReadableLabel: "error",
@@ -555,7 +555,7 @@ func CtxError(ctx context.Context, message string) {
 // fmt.Printf.
 // Logs are enriched with information from the context
 // (e.g. invocation_id, request_id)
-func CtxErrorf(ctx context.Context, format string, args ...interface{}) {
+func CtxErrorf(ctx context.Context, format string, args ...any) {
 	e := log.Error()
 	enrichEventFromContext(ctx, e)
 	e.Msgf(format, args...)
@@ -577,7 +577,7 @@ func Fatal(message string) {
 
 // Fatalf logs to the FATAL log. Arguments are handled in the manner of fmt.Printf.
 // It calls os.Exit() with exit code 1.
-func Fatalf(format string, args ...interface{}) {
+func Fatalf(format string, args ...any) {
 	log.Fatal().Msgf(format, args...)
 	metrics.Logs.With(prometheus.Labels{
 		metrics.StatusHumanReadableLabel: "fatal",
@@ -591,7 +591,7 @@ func Fatalf(format string, args ...interface{}) {
 // Logs are enriched with information from the context
 // (e.g. invocation_id, request_id)
 // It calls os.Exit() with exit code 1.
-func CtxFatalf(ctx context.Context, format string, args ...interface{}) {
+func CtxFatalf(ctx context.Context, format string, args ...any) {
 	e := log.Fatal()
 	enrichEventFromContext(ctx, e)
 	e.Msgf(format, args...)

--- a/server/util/perms/perms.go
+++ b/server/util/perms/perms.go
@@ -187,7 +187,7 @@ func GetPermissionsCheckClauses(ctx context.Context, env environment.Env, q *que
 	if u, err := auth.AuthenticatedUser(ctx); err == nil {
 		hasUser = true
 		if u.GetUserID() != "" {
-			groupArgs := []interface{}{
+			groupArgs := []any{
 				GROUP_READ,
 			}
 			groupParams := make([]string, 0)
@@ -200,7 +200,7 @@ func GetPermissionsCheckClauses(ctx context.Context, env environment.Env, q *que
 			o.AddOr(groupQueryStr, groupArgs...)
 			o.AddOr(fmt.Sprintf("(%sperms & ? != 0 AND %suser_id = ?)", tablePrefix, tablePrefix), OWNER_READ, u.GetUserID())
 		} else if u.GetGroupID() != "" {
-			groupArgs := []interface{}{
+			groupArgs := []any{
 				GROUP_READ,
 				u.GetGroupID(),
 			}

--- a/server/util/query_builder/query_builder.go
+++ b/server/util/query_builder/query_builder.go
@@ -39,7 +39,7 @@ type joinClause struct {
 	onClause      string
 }
 
-func (j *joinClause) Build() (string, []interface{}) {
+func (j *joinClause) Build() (string, []any) {
 	subQuery, args := j.tableSubquery.Build()
 	q := pad(joinSQLKeyword) + "(" + subQuery + ") AS" + pad(j.alias) + pad(onSQLKeyword) + pad(j.onClause)
 	return q, args
@@ -51,7 +51,7 @@ type Query struct {
 	orderBy      string
 	groupBy      string
 	baseQuery    string
-	arguments    []interface{}
+	arguments    []any
 	whereClauses []string
 	joinClauses  []joinClause
 	fromClause   *Query
@@ -62,12 +62,12 @@ func NewQuery(baseQuery string) *Query {
 	return &Query{
 		baseQuery:    baseQuery,
 		whereClauses: make([]string, 0),
-		arguments:    make([]interface{}, 0),
+		arguments:    make([]any, 0),
 	}
 }
 
 // For those who simply can't help but use args in SELECT clauses
-func NewQueryWithArgs(baseQuery string, baseArgs []interface{}) *Query {
+func NewQueryWithArgs(baseQuery string, baseArgs []any) *Query {
 	return &Query{
 		baseQuery:    baseQuery,
 		whereClauses: make([]string, 0),
@@ -75,7 +75,7 @@ func NewQueryWithArgs(baseQuery string, baseArgs []interface{}) *Query {
 	}
 }
 
-func (q *Query) AddWhereClause(clause string, args ...interface{}) *Query {
+func (q *Query) AddWhereClause(clause string, args ...any) *Query {
 	clause = pad(clause)
 	q.whereClauses = append(q.whereClauses, clause)
 	q.arguments = append(q.arguments, args...)
@@ -128,7 +128,7 @@ func (q *Query) SetOffset(offset int64) *Query {
 	q.offset = &offset
 	return q
 }
-func (q *Query) Build() (string, []interface{}) {
+func (q *Query) Build() (string, []any) {
 	// Reference: SELECT foo FROM TABLE [JOIN TABLE2 ON a = b] WHERE bar = baz ORDER BY ack ASC LIMIT 10
 	var fullQuery strings.Builder
 	fullQuery.WriteString(q.baseQuery)
@@ -138,7 +138,7 @@ func (q *Query) Build() (string, []interface{}) {
 		fromClauseStr = " FROM (" + fromClauseStr + ")"
 		fullQuery.WriteString(fromClauseStr)
 	}
-	var argsInJoinClauses []interface{}
+	var argsInJoinClauses []any
 	for _, j := range q.joinClauses {
 		joinClause, args := j.Build()
 		argsInJoinClauses = append(argsInJoinClauses, args...)
@@ -175,16 +175,16 @@ func (q *Query) Build() (string, []interface{}) {
 
 type OrClauses struct {
 	whereClauses []string
-	arguments    []interface{}
+	arguments    []any
 }
 
-func (o *OrClauses) AddOr(clause string, args ...interface{}) *OrClauses {
+func (o *OrClauses) AddOr(clause string, args ...any) *OrClauses {
 	o.whereClauses = append(o.whereClauses, pad(clause))
 	o.arguments = append(o.arguments, args...)
 	return o
 }
 
-func (o *OrClauses) Build() (string, []interface{}) {
+func (o *OrClauses) Build() (string, []any) {
 	fullQuery := ""
 	if len(o.whereClauses) > 0 {
 		whereRestrict := strings.Join(o.whereClauses, orQueryJoiner)

--- a/server/util/query_builder/query_builder_test.go
+++ b/server/util/query_builder/query_builder_test.go
@@ -57,7 +57,7 @@ func TestOrClauses_Single(t *testing.T) {
 	qStr, qArgs := q.Build()
 
 	assert.Equal(t, "a = ?", strings.TrimSpace(qStr))
-	assert.Equal(t, []interface{}{1}, qArgs)
+	assert.Equal(t, []any{1}, qArgs)
 }
 
 func TestOrClauses_Multiple(t *testing.T) {
@@ -68,7 +68,7 @@ func TestOrClauses_Multiple(t *testing.T) {
 	qStr, qArgs := q.Build()
 
 	assert.Equal(t, "a = ? OR b = ?", strings.TrimSpace(qStr))
-	assert.Equal(t, []interface{}{1, 2}, qArgs)
+	assert.Equal(t, []any{1, 2}, qArgs)
 }
 
 func TestJoinClause(t *testing.T) {
@@ -98,7 +98,7 @@ func TestJoinClause(t *testing.T) {
 		WHERE (t.t1 > ?)
 	`
 	assert.Equal(t, normalize(t, expectedQueryStr), normalize(t, qStr))
-	assert.Equal(t, []interface{}{4, 6, 10}, qArgs)
+	assert.Equal(t, []any{4, 6, 10}, qArgs)
 }
 
 func TestJoinInOriginalQuery(t *testing.T) {
@@ -114,7 +114,7 @@ func TestJoinInOriginalQuery(t *testing.T) {
 	`
 
 	assert.Equal(t, normalize(t, expectedQueryStr), normalize(t, q))
-	assert.Equal(t, []interface{}{"GR1"}, args)
+	assert.Equal(t, []any{"GR1"}, args)
 }
 
 func TestFromClause(t *testing.T) {
@@ -140,7 +140,7 @@ func TestFromClause(t *testing.T) {
 		LIMIT 5
 	`
 	assert.Equal(t, normalize(t, expectedQueryStr), normalize(t, qStr))
-	assert.Equal(t, []interface{}{10, 5}, qArgs)
+	assert.Equal(t, []any{10, 5}, qArgs)
 }
 
 func TestWhereInClause(t *testing.T) {
@@ -172,5 +172,5 @@ func TestWhereInClause(t *testing.T) {
 		AND (d = ?)
 	`
 	assert.Equal(t, normalize(t, expectedQueryStr), normalize(t, qStr))
-	assert.Equal(t, []interface{}{1, 2, 3, 4}, qArgs)
+	assert.Equal(t, []any{1, 2, 3, 4}, qArgs)
 }

--- a/server/util/relayauth/relayauth.go
+++ b/server/util/relayauth/relayauth.go
@@ -190,7 +190,7 @@ func (v *Verifier) Verify(credential string) (*Identity, error) {
 	var leaf *x509.Certificate
 	c := &claims{}
 	parser := jwt.NewParser(jwt.WithValidMethods(allowedMethods), jwt.WithoutClaimsValidation())
-	token, err := parser.ParseWithClaims(credential, c, func(t *jwt.Token) (interface{}, error) {
+	token, err := parser.ParseWithClaims(credential, c, func(t *jwt.Token) (any, error) {
 		cert, err := v.leafCertificate(t.Header)
 		if err != nil {
 			return nil, err
@@ -250,8 +250,8 @@ func (v *Verifier) Verify(credential string) (*Identity, error) {
 
 // leafCertificate reads the user certificate out of a JWT's x5c header and
 // verifies it against the pinned CA for client authentication.
-func (v *Verifier) leafCertificate(header map[string]interface{}) (*x509.Certificate, error) {
-	x5c, _ := header["x5c"].([]interface{})
+func (v *Verifier) leafCertificate(header map[string]any) (*x509.Certificate, error) {
+	x5c, _ := header["x5c"].([]any)
 	if len(x5c) != 1 {
 		return nil, fmt.Errorf("credential must carry exactly one certificate in x5c, has %d", len(x5c))
 	}

--- a/server/util/relayauth/relayauth_test.go
+++ b/server/util/relayauth/relayauth_test.go
@@ -422,7 +422,7 @@ func TestSignerRejectsIncompleteArguments(t *testing.T) {
 // certDER in x5c when non-nil.
 func headerSegment(t *testing.T, alg string, certDER []byte) string {
 	t.Helper()
-	h := map[string]interface{}{"alg": alg, "typ": credentialType}
+	h := map[string]any{"alg": alg, "typ": credentialType}
 	if certDER != nil {
 		h["x5c"] = []string{base64.StdEncoding.EncodeToString(certDER)}
 	}
@@ -450,7 +450,7 @@ func TestHostileHeadersAreRejected(t *testing.T) {
 	key, err := parsePrivateKey(keyBlock.Bytes)
 	require.NoError(t, err)
 
-	withHeader := func(alg string, extra map[string]interface{}) string {
+	withHeader := func(alg string, extra map[string]any) string {
 		t.Helper()
 		token := jwt.NewWithClaims(jwt.GetSigningMethod(alg), &claims{
 			RegisteredClaims: jwt.RegisteredClaims{
@@ -464,7 +464,7 @@ func TestHostileHeadersAreRejected(t *testing.T) {
 		for k, v := range extra {
 			token.Header[k] = v
 		}
-		var signingKey interface{} = key
+		var signingKey any = key
 		switch alg {
 		case "none":
 			signingKey = jwt.UnsafeAllowNoneSignatureType
@@ -528,7 +528,7 @@ func TestHostileHeadersAreRejected(t *testing.T) {
 			want: "exactly one",
 		},
 		"wrong type": {
-			cred: withHeader("ES256", map[string]interface{}{"typ": "JWT"}),
+			cred: withHeader("ES256", map[string]any{"typ": "JWT"}),
 			want: "type",
 		},
 		// A jwk/jku header naming the attacker's key must be ignored in
@@ -556,7 +556,7 @@ func headerWithX5C(t *testing.T, certs ...[]byte) string {
 	for _, c := range certs {
 		x5c = append(x5c, base64.StdEncoding.EncodeToString(c))
 	}
-	b, err := json.Marshal(map[string]interface{}{"alg": "ES256", "typ": credentialType, "x5c": x5c})
+	b, err := json.Marshal(map[string]any{"alg": "ES256", "typ": credentialType, "x5c": x5c})
 	require.NoError(t, err)
 	return base64.RawURLEncoding.EncodeToString(b)
 }

--- a/server/util/status/status.go
+++ b/server/util/status/status.go
@@ -133,7 +133,7 @@ func CanceledError(msg string) error {
 func IsCanceledError(err error) bool {
 	return status.Code(err) == codes.Canceled
 }
-func CanceledErrorf(format string, a ...interface{}) error {
+func CanceledErrorf(format string, a ...any) error {
 	return makeStatusError(codes.Canceled, fmt.Errorf(format, a...))
 }
 func UnknownError(msg string) error {
@@ -142,7 +142,7 @@ func UnknownError(msg string) error {
 func IsUnknownError(err error) bool {
 	return status.Code(err) == codes.Unknown
 }
-func UnknownErrorf(format string, a ...interface{}) error {
+func UnknownErrorf(format string, a ...any) error {
 	return makeStatusError(codes.Unknown, fmt.Errorf(format, a...))
 }
 func InvalidArgumentError(msg string) error {
@@ -151,7 +151,7 @@ func InvalidArgumentError(msg string) error {
 func IsInvalidArgumentError(err error) bool {
 	return status.Code(err) == codes.InvalidArgument
 }
-func InvalidArgumentErrorf(format string, a ...interface{}) error {
+func InvalidArgumentErrorf(format string, a ...any) error {
 	return makeStatusError(codes.InvalidArgument, fmt.Errorf(format, a...))
 }
 func DeadlineExceededError(msg string) error {
@@ -160,7 +160,7 @@ func DeadlineExceededError(msg string) error {
 func IsDeadlineExceededError(err error) bool {
 	return status.Code(err) == codes.DeadlineExceeded
 }
-func DeadlineExceededErrorf(format string, a ...interface{}) error {
+func DeadlineExceededErrorf(format string, a ...any) error {
 	return makeStatusError(codes.DeadlineExceeded, fmt.Errorf(format, a...))
 }
 func NotFoundError(msg string) error {
@@ -169,7 +169,7 @@ func NotFoundError(msg string) error {
 func IsNotFoundError(err error) bool {
 	return status.Code(err) == codes.NotFound
 }
-func NotFoundErrorf(format string, a ...interface{}) error {
+func NotFoundErrorf(format string, a ...any) error {
 	return makeStatusError(codes.NotFound, fmt.Errorf(format, a...))
 }
 func AlreadyExistsError(msg string) error {
@@ -178,7 +178,7 @@ func AlreadyExistsError(msg string) error {
 func IsAlreadyExistsError(err error) bool {
 	return status.Code(err) == codes.AlreadyExists
 }
-func AlreadyExistsErrorf(format string, a ...interface{}) error {
+func AlreadyExistsErrorf(format string, a ...any) error {
 	return makeStatusError(codes.AlreadyExists, fmt.Errorf(format, a...))
 }
 func PermissionDeniedError(msg string) error {
@@ -187,7 +187,7 @@ func PermissionDeniedError(msg string) error {
 func IsPermissionDeniedError(err error) bool {
 	return status.Code(err) == codes.PermissionDenied
 }
-func PermissionDeniedErrorf(format string, a ...interface{}) error {
+func PermissionDeniedErrorf(format string, a ...any) error {
 	return makeStatusError(codes.PermissionDenied, fmt.Errorf(format, a...))
 }
 func ResourceExhaustedError(msg string) error {
@@ -196,7 +196,7 @@ func ResourceExhaustedError(msg string) error {
 func IsResourceExhaustedError(err error) bool {
 	return status.Code(err) == codes.ResourceExhausted
 }
-func ResourceExhaustedErrorf(format string, a ...interface{}) error {
+func ResourceExhaustedErrorf(format string, a ...any) error {
 	return makeStatusError(codes.ResourceExhausted, fmt.Errorf(format, a...))
 }
 func FailedPreconditionError(msg string) error {
@@ -205,7 +205,7 @@ func FailedPreconditionError(msg string) error {
 func IsFailedPreconditionError(err error) bool {
 	return status.Code(err) == codes.FailedPrecondition
 }
-func FailedPreconditionErrorf(format string, a ...interface{}) error {
+func FailedPreconditionErrorf(format string, a ...any) error {
 	return makeStatusError(codes.FailedPrecondition, fmt.Errorf(format, a...))
 }
 func AbortedError(msg string) error {
@@ -214,7 +214,7 @@ func AbortedError(msg string) error {
 func IsAbortedError(err error) bool {
 	return status.Code(err) == codes.Aborted
 }
-func AbortedErrorf(format string, a ...interface{}) error {
+func AbortedErrorf(format string, a ...any) error {
 	return makeStatusError(codes.Aborted, fmt.Errorf(format, a...))
 }
 func OutOfRangeError(msg string) error {
@@ -223,7 +223,7 @@ func OutOfRangeError(msg string) error {
 func IsOutOfRangeError(err error) bool {
 	return status.Code(err) == codes.OutOfRange
 }
-func OutOfRangeErrorf(format string, a ...interface{}) error {
+func OutOfRangeErrorf(format string, a ...any) error {
 	return makeStatusError(codes.OutOfRange, fmt.Errorf(format, a...))
 }
 func UnimplementedError(msg string) error {
@@ -232,7 +232,7 @@ func UnimplementedError(msg string) error {
 func IsUnimplementedError(err error) bool {
 	return status.Code(err) == codes.Unimplemented
 }
-func UnimplementedErrorf(format string, a ...interface{}) error {
+func UnimplementedErrorf(format string, a ...any) error {
 	return makeStatusError(codes.Unimplemented, fmt.Errorf(format, a...))
 }
 func InternalError(msg string) error {
@@ -241,7 +241,7 @@ func InternalError(msg string) error {
 func IsInternalError(err error) bool {
 	return status.Code(err) == codes.Internal
 }
-func InternalErrorf(format string, a ...interface{}) error {
+func InternalErrorf(format string, a ...any) error {
 	return makeStatusError(codes.Internal, fmt.Errorf(format, a...))
 }
 func UnavailableError(msg string) error {
@@ -250,7 +250,7 @@ func UnavailableError(msg string) error {
 func IsUnavailableError(err error) bool {
 	return status.Code(err) == codes.Unavailable
 }
-func UnavailableErrorf(format string, a ...interface{}) error {
+func UnavailableErrorf(format string, a ...any) error {
 	return makeStatusError(codes.Unavailable, fmt.Errorf(format, a...))
 }
 func DataLossError(msg string) error {
@@ -259,7 +259,7 @@ func DataLossError(msg string) error {
 func IsDataLossError(err error) bool {
 	return status.Code(err) == codes.DataLoss
 }
-func DataLossErrorf(format string, a ...interface{}) error {
+func DataLossErrorf(format string, a ...any) error {
 	return makeStatusError(codes.DataLoss, fmt.Errorf(format, a...))
 }
 func UnauthenticatedError(msg string) error {
@@ -268,7 +268,7 @@ func UnauthenticatedError(msg string) error {
 func IsUnauthenticatedError(err error) bool {
 	return status.Code(err) == codes.Unauthenticated
 }
-func UnauthenticatedErrorf(format string, a ...interface{}) error {
+func UnauthenticatedErrorf(format string, a ...any) error {
 	return makeStatusError(codes.Unauthenticated, fmt.Errorf(format, a...))
 }
 
@@ -309,7 +309,7 @@ func WrapError(err error, msg string) error {
 }
 
 // Wrapf is the "Printf" version of `Wrap`.
-func WrapErrorf(err error, format string, a ...interface{}) error {
+func WrapErrorf(err error, format string, a ...any) error {
 	return WrapError(err, fmt.Sprintf(format, a...))
 }
 

--- a/third_party/singleflight/singleflight.go
+++ b/third_party/singleflight/singleflight.go
@@ -18,7 +18,7 @@ import (
 // A panicError is an arbitrary value recovered from a panic
 // with the stack trace during the execution of given function.
 type panicError struct {
-	value interface{}
+	value any
 	stack []byte
 }
 


### PR DESCRIPTION
The repository already requires Go 1.27, so empty interface types
can use the predeclared any alias. Apply the type-aware modernizer
and enable the any check to keep new code consistent without changing
interface semantics.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>