### PR TITLE
go: use built-in min and max

### DIFF
--- a/cli/ui/list.go
+++ b/cli/ui/list.go
@@ -123,10 +123,7 @@ func (m *listModel) clampCursorAndOffset() {
 	}
 
 	visibleRows := m.visibleRows()
-	maxOffset := len(m.invocations) - visibleRows
-	if maxOffset < 0 {
-		maxOffset = 0
-	}
+	maxOffset := max(len(m.invocations)-visibleRows, 0)
 	if m.offset < 0 {
 		m.offset = 0
 	}
@@ -219,20 +216,8 @@ func (m listModel) renderTable() string {
 	widths := m.columnWidths()
 	allRows := m.buildRows(widths)
 	tableHeight := m.tableAreaHeight()
-	start := m.offset
-	if start < 0 {
-		start = 0
-	}
-	if start > len(allRows) {
-		start = len(allRows)
-	}
-	end := start + (tableHeight - 2)
-	if end < start {
-		end = start
-	}
-	if end > len(allRows) {
-		end = len(allRows)
-	}
+	start := min(max(m.offset, 0), len(allRows))
+	end := min(max(start+(tableHeight-2), start), len(allRows))
 	visibleRows := allRows[start:end]
 
 	t := lgtable.New().

--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -587,10 +587,7 @@ func (w *Writer) AddDocument(doc types.Document) error {
 			s.tokens++
 		})
 		tfStats := tokenizer.TermFrequencyStats()
-		occurrences := tfStats.Occurrences
-		if occurrences < 0 {
-			occurrences = 0
-		}
+		occurrences := max(tfStats.Occurrences, 0)
 		fieldLengths[field.Name()] = uint32(min(occurrences, math.MaxUint32))
 		indexprofile.RecordTermFrequencyStats(field.Name(), tfStats)
 

--- a/codesearch/query/regexp_query.go
+++ b/codesearch/query/regexp_query.go
@@ -77,10 +77,7 @@ func match(re *dfa.Regexp, buf []byte) []region {
 			break
 		}
 		lineStart := bytes.LastIndex(buf[chunkStart:m1], nl) + 1 + chunkStart
-		lineEnd := m1 + 1
-		if lineEnd > end {
-			lineEnd = end
-		}
+		lineEnd := min(m1+1, end)
 		lineno += countNL(buf[chunkStart:lineStart])
 		results = append(results, region{
 			startOffset: lineStart,

--- a/enterprise/dns/server/server.go
+++ b/enterprise/dns/server/server.go
@@ -378,10 +378,7 @@ func attachClientSubnetScopeIfPresent(m, r *dns.Msg) {
 		if !ok {
 			continue
 		}
-		udpSize := reqOPT.UDPSize()
-		if udpSize < dns.MinMsgSize {
-			udpSize = dns.MinMsgSize
-		}
+		udpSize := max(reqOPT.UDPSize(), dns.MinMsgSize)
 		respOPT := &dns.OPT{Hdr: dns.RR_Header{Name: ".", Rrtype: dns.TypeOPT}}
 		respOPT.SetUDPSize(udpSize)
 		respOPT.Option = append(respOPT.Option, &dns.EDNS0_SUBNET{

--- a/enterprise/server/billing/metronome/metronome.go
+++ b/enterprise/server/billing/metronome/metronome.go
@@ -111,10 +111,7 @@ func (c *Client) ReportUsage(ctx context.Context, events []UsageEvent) error {
 		encoded = append(encoded, *ue)
 	}
 	for start := 0; start < len(encoded); start += MaxEventsPerIngestRequest {
-		end := start + MaxEventsPerIngestRequest
-		if end > len(encoded) {
-			end = len(encoded)
-		}
+		end := min(start+MaxEventsPerIngestRequest, len(encoded))
 		batch := encoded[start:end]
 		err := retry.DoVoid(ctx, c.retryOptions, func(ctx context.Context) error {
 			err := c.ingestToMetronome(ctx, batch)

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -2783,10 +2783,7 @@ func TestWriteChunked(t *testing.T) {
 	require.NoError(t, err)
 	remaining := compressedData
 	for len(remaining) > 0 {
-		chunkSize := 1_000_000
-		if chunkSize > len(remaining) {
-			chunkSize = len(remaining)
-		}
+		chunkSize := min(1_000_000, len(remaining))
 		err = uploadStream.Send(&bspb.WriteRequest{
 			ResourceName: blobRN.NewUploadString(),
 			WriteOffset:  int64(len(compressedData) - len(remaining)),
@@ -3266,10 +3263,7 @@ func TestWriteChunkedFallbackBelowThreshold(t *testing.T) {
 	require.NoError(t, err)
 	remaining := originalData
 	for len(remaining) > 0 {
-		chunkSize := 100_000
-		if chunkSize > len(remaining) {
-			chunkSize = len(remaining)
-		}
+		chunkSize := min(100_000, len(remaining))
 		err = uploadStream.Send(&bspb.WriteRequest{
 			ResourceName: uploadString,
 			WriteOffset:  int64(len(originalData) - len(remaining)),

--- a/enterprise/server/crypter/crypter.go
+++ b/enterprise/server/crypter/crypter.go
@@ -156,10 +156,7 @@ func (e *Encryptor) Write(p []byte) (n int, err error) {
 
 	readIdx := 0
 	for readIdx < len(p) {
-		readLen := e.bufCap - e.bufIdx
-		if readLen > len(p)-readIdx {
-			readLen = len(p) - readIdx
-		}
+		readLen := min(e.bufCap-e.bufIdx, len(p)-readIdx)
 		copy(e.buf[e.bufIdx:], p[readIdx:readIdx+readLen])
 		e.bufIdx += readLen
 		readIdx += readLen

--- a/enterprise/server/raft/usagetracker/usagetracker.go
+++ b/enterprise/server/raft/usagetracker/usagetracker.go
@@ -721,11 +721,8 @@ func (ut *Tracker) Start() {
 		pu.gcsDeleteCancel = gcsCancel
 		gcsEg, gcsGctx := errgroup.WithContext(gcsCtx)
 		pu.gcsDeleteEg = gcsEg
-		numGCSWorkers := pu.numGCSDeleteWorkers
-		if numGCSWorkers < 1 {
-			numGCSWorkers = 1
-		}
-		for i := 0; i < numGCSWorkers; i++ {
+		numGCSWorkers := max(pu.numGCSDeleteWorkers, 1)
+		for range numGCSWorkers {
 			pu.gcsDeleteEg.Go(func() error {
 				pu.processGCSDeletions(gcsGctx)
 				return nil

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -389,10 +389,7 @@ func (c *COWStore) ReadAt(p []byte, off int64) (int, error) {
 	for len(p) > 0 {
 		chunkRelativeOffset := off % c.chunkSizeBytes
 		chunkCalculatedSize := c.calculateChunkSize(chunkOffset)
-		readSize := int(chunkCalculatedSize - chunkRelativeOffset)
-		if readSize > len(p) {
-			readSize = len(p)
-		}
+		readSize := min(int(chunkCalculatedSize-chunkRelativeOffset), len(p))
 
 		if err := c.readChunk(p, chunkRelativeOffset, chunkOffset, readSize); err != nil {
 			return n, err
@@ -494,10 +491,7 @@ func (c *COWStore) WriteAt(p []byte, off int64) (int, error) {
 		chunkRelativeOffset := (off + int64(n)) % c.chunkSizeBytes
 		// Index of the chunk in the COWStore.
 		chunkIndex := writeOffset / c.chunkSizeBytes
-		writeSize := int(c.chunkSizeBytes - chunkRelativeOffset)
-		if writeSize > len(p) {
-			writeSize = len(p)
-		}
+		writeSize := min(int(c.chunkSizeBytes-chunkRelativeOffset), len(p))
 
 		nw, err := c.writeToChunk(p, chunkRelativeOffset, chunkStartOffset, writeSize)
 		n += nw

--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -483,11 +483,9 @@ func (h *Handler) handlePageFault(uffd uintptr, memoryStore *copy_on_write.COWSt
 	// address to a page boundary. In other words, get the address of the
 	// start of the page containing the faulting address.
 	guestPageAddr := pageStartAddress(uint64(faultingAddress), os.Getpagesize())
-	if guestPageAddr < mapping.BaseHostVirtAddr {
-		// Make sure we only try to map addresses that fall within the valid
-		// guest memory ranges
-		guestPageAddr = mapping.BaseHostVirtAddr
-	}
+	// Make sure we only try to map addresses that fall within the valid
+	// guest memory ranges.
+	guestPageAddr = max(guestPageAddr, mapping.BaseHostVirtAddr)
 
 	// If address had been previously removed, zero it.
 	if _, removed := h.removedAddresses[int64(guestPageAddr)]; removed {

--- a/enterprise/server/remote_execution/vbd/vbd.go
+++ b/enterprise/server/remote_execution/vbd/vbd.go
@@ -269,10 +269,7 @@ type reader struct {
 var _ fuse.ReadResult = (*reader)(nil)
 
 func (r *reader) Bytes(p []byte) ([]byte, fuse.Status) {
-	length := r.size
-	if len(p) < length {
-		length = len(p)
-	}
+	length := min(len(p), r.size)
 	_, err := r.file.ReadAt(p[:length], r.off)
 	if err != nil {
 		log.CtxErrorf(r.ctx, "VBD read failed: %s", err)

--- a/enterprise/server/remote_execution/vfs/vfs_unix.go
+++ b/enterprise/server/remote_execution/vfs/vfs_unix.go
@@ -916,10 +916,7 @@ type remoteFileReader struct {
 }
 
 func (r *remoteFileReader) Bytes(buf []byte) ([]byte, fuse.Status) {
-	numBytes := r.numBytes
-	if len(buf) < numBytes {
-		numBytes = len(buf)
-	}
+	numBytes := min(len(buf), r.numBytes)
 
 	// If the file contents was returned inline as part of the Open RPC, read from it directly instead of making
 	// additional RPCs.

--- a/enterprise/server/scim/scim.go
+++ b/enterprise/server/scim/scim.go
@@ -372,10 +372,7 @@ func (s *SCIMServer) getUsers(ctx context.Context, r *http.Request, g *tables.Gr
 		if err != nil {
 			return nil, status.InvalidArgumentErrorf("invalid startIndex value: %s", err)
 		}
-		startIndex = v - 1
-		if startIndex < 0 {
-			startIndex = 0
-		}
+		startIndex = max(v-1, 0)
 	}
 
 	count := 0
@@ -385,10 +382,7 @@ func (s *SCIMServer) getUsers(ctx context.Context, r *http.Request, g *tables.Gr
 		if err != nil {
 			return nil, status.InvalidArgumentErrorf("invalud count value: %s", err)
 		}
-		count = v
-		if count < 0 {
-			count = 0
-		}
+		count = max(v, 0)
 	}
 
 	users := []*UserResource{}
@@ -1047,10 +1041,7 @@ func (s *SCIMServer) getGroups(ctx context.Context, r *http.Request, g *tables.G
 		if err != nil {
 			return nil, status.InvalidArgumentErrorf("invalid startIndex value: %s", err)
 		}
-		startIndex = v - 1
-		if startIndex < 0 {
-			startIndex = 0
-		}
+		startIndex = max(v-1, 0)
 	}
 
 	count := 0
@@ -1060,10 +1051,7 @@ func (s *SCIMServer) getGroups(ctx context.Context, r *http.Request, g *tables.G
 		if err != nil {
 			return nil, status.InvalidArgumentErrorf("invalid count value: %s", err)
 		}
-		count = v
-		if count < 0 {
-			count = 0
-		}
+		count = max(v, 0)
 	}
 
 	userLists, err := s.env.GetUserDB().GetUserLists(ctx, g.GroupID)

--- a/enterprise/server/util/cpuset/cpuset.go
+++ b/enterprise/server/util/cpuset/cpuset.go
@@ -199,10 +199,7 @@ func computeNumCPUs(milliCPU int64, allowOverhead bool) int {
 		return rawNumCPUs
 	}
 
-	overheadCPUs := int(*cpuLeaserOverhead*float64(milliCPU)) / 1000
-	if overheadCPUs < *cpuLeaserMinOverhead {
-		overheadCPUs = *cpuLeaserMinOverhead
-	}
+	overheadCPUs := max(int(*cpuLeaserOverhead*float64(milliCPU))/1000, *cpuLeaserMinOverhead)
 	return rawNumCPUs + overheadCPUs
 }
 

--- a/enterprise/server/util/procstats/procstats.go
+++ b/enterprise/server/util/procstats/procstats.go
@@ -44,10 +44,7 @@ func Monitor(pid int, listener Listener, processTerminated <-chan struct{}) *rep
 			ts.Update() // ignore error
 			listener(ts.Total())
 		}
-		pollInterval = time.Duration(float64(pollInterval) * statsPollBackoff)
-		if pollInterval > statsMaxPollInterval {
-			pollInterval = statsMaxPollInterval
-		}
+		pollInterval = min(time.Duration(float64(pollInterval)*statsPollBackoff), statsMaxPollInterval)
 	}
 }
 

--- a/enterprise/server/util/vfs_server/vfs_server.go
+++ b/enterprise/server/util/vfs_server/vfs_server.go
@@ -1874,12 +1874,9 @@ func (p *Server) Statfs(ctx context.Context, request *vfspb.StatfsRequest) (*vfs
 
 	totalBlocks := reportedSizeBytes / p.backingBlockSize
 
-	free := totalBlocks - p.blocks
 	// We don't enforce a usage limit yet so used blocks may go over the
 	// total blocks.
-	if free < 0 {
-		free = 0
-	}
+	free := max(totalBlocks-p.blocks, 0)
 
 	return &vfspb.StatfsResponse{
 		BlockSize:       p.backingBlockSize,

--- a/rules/go/analyzer/def.bzl
+++ b/rules/go/analyzer/def.bzl
@@ -4,7 +4,7 @@ ANALYZERS = [
     # "fmtappendf",
     "forvar",
     # "mapsloop",
-    # "minmax",
+    "minmax",
     # "newexpr",
     # "plusbuild",
     # "omitzero",

--- a/server/remote_cache/byte_stream_client/byte_stream_client.go
+++ b/server/remote_cache/byte_stream_client/byte_stream_client.go
@@ -60,10 +60,7 @@ func (p *pooledByteStreamClient) FetchBytestreamZipManifest(ctx context.Context,
 	// Let's just read 64K and see if we can find the central directory in there.
 	// We probably don't want to be in the business of rendering 3000-file zips'
 	// contents anyway.
-	offset := r.GetDigest().GetSizeBytes() - 65536
-	if offset < 0 {
-		offset = 0
-	}
+	offset := max(r.GetDigest().GetSizeBytes()-65536, 0)
 
 	var buf bytes.Buffer
 	err = p.StreamBytestreamFileChunk(ctx, url, offset, r.GetDigest().GetSizeBytes()-offset, &buf)

--- a/server/remote_cache/chunking/chunking_test.go
+++ b/server/remote_cache/chunking/chunking_test.go
@@ -723,10 +723,7 @@ func BenchmarkStore(b *testing.B) {
 			const chunkSize = 512 * 1024
 			var chunkDigests []*repb.Digest
 			for i := 0; i < len(blobData); i += chunkSize {
-				end := i + chunkSize
-				if end > len(blobData) {
-					end = len(blobData)
-				}
+				end := min(i+chunkSize, len(blobData))
 				chunk := blobData[i:end]
 				d, err := digest.Compute(bytes.NewReader(chunk), repb.DigestFunction_SHA256)
 				require.NoError(b, err)

--- a/server/remote_cache/scorecard/scorecard.go
+++ b/server/remote_cache/scorecard/scorecard.go
@@ -70,14 +70,8 @@ func GetCacheScoreCard(ctx context.Context, env environment.Env, req *capb.GetCa
 		return nil, err
 	}
 
-	start := page.Offset
-	if start > int64(len(results)) {
-		start = int64(len(results))
-	}
-	end := start + page.Limit
-	if end > int64(len(results)) {
-		end = int64(len(results))
-	}
+	start := min(page.Offset, int64(len(results)))
+	end := min(start+page.Limit, int64(len(results)))
 
 	nextPageToken := ""
 	if end < int64(len(results)) {

--- a/server/testutil/byte_stream/byte_stream.go
+++ b/server/testutil/byte_stream/byte_stream.go
@@ -57,10 +57,7 @@ func MustUploadChunked(t *testing.T, ctx context.Context, bsClient bspb.ByteStre
 
 	remaining := blob
 	for len(remaining) > 0 {
-		chunkSize := 1_000_000
-		if chunkSize > len(remaining) {
-			chunkSize = len(remaining)
-		}
+		chunkSize := min(1_000_000, len(remaining))
 		err = uploadStream.Send(&bspb.WriteRequest{
 			ResourceName: uploadResourceName,
 			WriteOffset:  int64(len(blob) - len(remaining)),

--- a/server/testutil/testdata/testdata.go
+++ b/server/testutil/testdata/testdata.go
@@ -12,10 +12,7 @@ import (
 // randomly-sized chunks.
 func WriteInRandomChunks(t *testing.T, w interfaces.CommittedWriteCloser, data []byte) {
 	for len(data) > 0 {
-		n := rand.Intn(2048)
-		if n > len(data) {
-			n = len(data)
-		}
+		n := min(rand.Intn(2048), len(data))
 		_, err := w.Write(data[:n])
 		require.NoError(t, err)
 		data = data[n:]

--- a/server/testutil/testdigest/testdigest.go
+++ b/server/testutil/testdigest/testdigest.go
@@ -21,10 +21,7 @@ var (
 func compressibleBlobOfSize(sizeBytes int) []byte {
 	out := make([]byte, 0, sizeBytes)
 	for len(out) < sizeBytes {
-		runEnd := len(out) + 100 + rand.Intn(100)
-		if runEnd > sizeBytes {
-			runEnd = sizeBytes
-		}
+		runEnd := min(len(out)+100+rand.Intn(100), sizeBytes)
 
 		runChar := byte(rand.Intn('Z'-'A'+1)) + 'A'
 		for len(out) < runEnd {

--- a/server/util/channelz_metrics/channelz_metrics.go
+++ b/server/util/channelz_metrics/channelz_metrics.go
@@ -183,11 +183,8 @@ func collectSubchannel(ctx context.Context, client channelzpb.ChannelzClient, ta
 		if d == nil {
 			continue
 		}
-		numOpenStreams := d.GetStreamsStarted() - d.GetStreamsSucceeded() - d.GetStreamsFailed()
 		// The counters are not read from a consistent snapshot.
-		if numOpenStreams < 0 {
-			numOpenStreams = 0
-		}
+		numOpenStreams := max(d.GetStreamsStarted()-d.GetStreamsSucceeded()-d.GetStreamsFailed(), 0)
 		c := connState{
 			target:      target,
 			openStreams: numOpenStreams,

--- a/server/util/grpc_client/grpc_client_test.go
+++ b/server/util/grpc_client/grpc_client_test.go
@@ -46,14 +46,8 @@ func requireTraffic(t *testing.T, percent, numRequests, margin, actual int) {
 	} else if percent == 100 {
 		require.Equal(t, numRequests, actual, fmt.Sprintf("Expected server receiving 100%% of traffic to receive %d requests (actually received %d)", numRequests, actual))
 	} else {
-		lowerBound := int(math.Floor(float64(numRequests)*float64(percent)/100.0)) - margin
-		if lowerBound < 0 {
-			lowerBound = 0
-		}
-		upperBound := int(math.Ceil(float64(numRequests)*float64(percent)/100.0)) + margin
-		if upperBound > numRequests {
-			upperBound = numRequests
-		}
+		lowerBound := max(int(math.Floor(float64(numRequests)*float64(percent)/100.0))-margin, 0)
+		upperBound := min(int(math.Ceil(float64(numRequests)*float64(percent)/100.0))+margin, numRequests)
 		require.True(t, actual <= upperBound && actual >= lowerBound,
 			fmt.Sprintf("Expected server receiving %d%% of traffic to receive between [%d, %d] requests (actually received %d)", percent, lowerBound, upperBound, actual))
 	}


### PR DESCRIPTION
Conditional assignments that select the smaller or larger value
can use Go's built-in min and max functions. Apply the modernizer's
type-aware replacements and enable minmax so future code uses the
same concise expressions.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>