### PR TITLE
go: replace map-copy loops with maps helpers

### DIFF
--- a/cli/explain/compactgraph/input.go
+++ b/cli/explain/compactgraph/input.go
@@ -431,9 +431,7 @@ func (r *RunfilesTree) ComputeMapping(workspaceRunfilesDirectory, hashFunction s
 	// 2. Artifacts at canonical locations.
 	// Later artifacts override earlier ones, but only after removing duplicates. Bazel internally uses a NestedSet,
 	// which deduplicates artifacts and then maps them to their potentially duplicate runfiles paths).
-	for runfilesPath, artifact := range iterateAsRunfiles(r.Artifacts, newDuplicateFilter()) {
-		m[runfilesPath] = artifact
-	}
+	maps.Insert(m, iterateAsRunfiles(r.Artifacts, newDuplicateFilter()))
 	// 3. Empty files.
 	for _, emptyFilePath := range r.EmptyFiles {
 		// Empty file paths as contained in the log are not prefixed with the workspace runfiles directory.
@@ -443,9 +441,7 @@ func (r *RunfilesTree) ComputeMapping(workspaceRunfilesDirectory, hashFunction s
 		}, hashFunction)
 	}
 	// 4. Root symlinks.
-	for runfilesPath, artifact := range iterateAsRunfiles(r.RootSymlinks, noFilter) {
-		m[runfilesPath] = artifact
-	}
+	maps.Insert(m, iterateAsRunfiles(r.RootSymlinks, noFilter))
 	// 5. The repo mapping manifest at its fixed location.
 	if r.RepoMappingManifest != nil {
 		m["_repo_mapping"] = r.RepoMappingManifest

--- a/cli/explain/compactgraph/input_test.go
+++ b/cli/explain/compactgraph/input_test.go
@@ -97,11 +97,7 @@ func TestRunfilesTree_ComputeMapping(t *testing.T) {
 				tc.rt.RootSymlinks = &SymlinkEntrySet{}
 			}
 
-			actual := make(map[string]Input)
-			for runfilesPath, input := range tc.rt.ComputeMapping("_main", "SHA-256") {
-				actual[runfilesPath] = input
-			}
-			assert.Equal(t, tc.expected, actual)
+			assert.Equal(t, tc.expected, tc.rt.ComputeMapping("_main", "SHA-256"))
 		})
 	}
 }

--- a/enterprise/dns/watcher/watcher.go
+++ b/enterprise/dns/watcher/watcher.go
@@ -9,6 +9,7 @@ package watcher
 import (
 	"context"
 	"iter"
+	"maps"
 	"strings"
 	"time"
 
@@ -141,9 +142,7 @@ func (w *Watcher) Poll(ctx context.Context) {
 			removed = append(removed, name)
 		}
 	}
-	for name, gen := range newGens {
-		w.generations[name] = gen
-	}
+	maps.Copy(w.generations, newGens)
 	for _, name := range removed {
 		delete(w.generations, name)
 	}

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"slices"
 	"strings"
@@ -1000,9 +1001,7 @@ func (c *Cache) remoteGetMulti(ctx context.Context, peer string, rns []*rspb.Res
 		// ones, instead instead of copying into an empty map.
 		return remoteResults, nil
 	}
-	for k, v := range remoteResults {
-		results[k] = v
-	}
+	maps.Copy(results, remoteResults)
 	return results, nil
 }
 

--- a/enterprise/server/billing/metronome/metronome.go
+++ b/enterprise/server/billing/metronome/metronome.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"sort"
@@ -148,9 +149,7 @@ func encodeEvent(e UsageEvent) (*MetronomeEvent, error) {
 		"period_start": e.PeriodStart.UTC().Format(time.RFC3339),
 		"period_end":   e.PeriodEnd.UTC().Format(time.RFC3339),
 	}
-	for k, v := range e.Labels {
-		properties[k] = v
-	}
+	maps.Copy(properties, e.Labels)
 	return &MetronomeEvent{
 		TransactionID: transactionID(e),
 		CustomerID:    e.GroupID,

--- a/enterprise/server/composable_cache/composable_cache.go
+++ b/enterprise/server/composable_cache/composable_cache.go
@@ -3,6 +3,7 @@ package composable_cache
 import (
 	"context"
 	"io"
+	"maps"
 
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
@@ -105,9 +106,7 @@ func (c *ComposableCache) GetMulti(ctx context.Context, resources []*rspb.Resour
 
 	foundMap := make(map[*repb.Digest][]byte, len(resources))
 	if outerFoundMap, err := c.outer.GetMulti(ctx, resources); err == nil {
-		for d, data := range outerFoundMap {
-			foundMap[d] = data
-		}
+		maps.Copy(foundMap, outerFoundMap)
 	}
 	stillMissing := make([]*rspb.ResourceName, 0)
 	for _, r := range resources {
@@ -128,9 +127,7 @@ func (c *ComposableCache) GetMulti(ctx context.Context, resources []*rspb.Resour
 	if err != nil {
 		return nil, err
 	}
-	for d, data := range innerFoundMap {
-		foundMap[d] = data
-	}
+	maps.Copy(foundMap, innerFoundMap)
 	return foundMap, nil
 }
 

--- a/enterprise/server/raft/metadata/metadata.go
+++ b/enterprise/server/raft/metadata/metadata.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"sync"
@@ -639,9 +640,7 @@ func (rc *Server) Get(ctx context.Context, req *mdpb.GetRequest) (*mdpb.GetRespo
 			return nil, status.InternalError("response not of type getMetadataResult")
 		}
 
-		for k, v := range res.found {
-			allFound[k] = v
-		}
+		maps.Copy(allFound, res.found)
 
 		for _, p := range res.atimeUpdates {
 			rc.sendAccessTimeUpdate(p)
@@ -729,9 +728,7 @@ func (rc *Server) Find(ctx context.Context, req *mdpb.FindRequest) (*mdpb.FindRe
 			return nil, status.InternalError("response not of type findResult")
 		}
 
-		for k, v := range res.found {
-			allFound[k] = v
-		}
+		maps.Copy(allFound, res.found)
 
 		for _, p := range res.atimeUpdates {
 			rc.sendAccessTimeUpdate(p)

--- a/enterprise/server/util/vfs_server/vfs_server.go
+++ b/enterprise/server/util/vfs_server/vfs_server.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"os"
 	"path/filepath"
@@ -1154,9 +1155,7 @@ func (p *Server) materializeNode(ctx context.Context, node *fsNode, destination 
 	target := node.target
 	backingPath := node.backingPath
 	children := make(map[string]*fsNode, len(node.children))
-	for name, child := range node.children {
-		children[name] = child
-	}
+	maps.Copy(children, node.children)
 	node.mu.Unlock()
 
 	switch nodeType {

--- a/rules/go/analyzer/def.bzl
+++ b/rules/go/analyzer/def.bzl
@@ -3,7 +3,7 @@ ANALYZERS = [
     # "bloop", # DO NOT ENABLE, see golang/go#74967
     # "fmtappendf",
     "forvar",
-    # "mapsloop",
+    "mapsloop",
     "minmax",
     # "newexpr",
     # "plusbuild",

--- a/server/backends/memory_metrics_collector/memory_metrics_collector.go
+++ b/server/backends/memory_metrics_collector/memory_metrics_collector.go
@@ -2,6 +2,7 @@ package memory_metrics_collector
 
 import (
 	"context"
+	"maps"
 	"sync"
 	"time"
 
@@ -236,9 +237,7 @@ func (m *MemoryMetricsCollector) ReadCounts(ctx context.Context, key string) (ma
 	if existingValIface, ok := m.l.Get(key); ok {
 		if existingVal, ok := existingValIface.(map[string]int64); ok {
 			counts := make(map[string]int64, len(existingVal))
-			for k, v := range existingVal {
-				counts[k] = v
-			}
+			maps.Copy(counts, existingVal)
 			return counts, nil
 		}
 	}

--- a/server/gossip/gossip.go
+++ b/server/gossip/gossip.go
@@ -3,6 +3,7 @@ package gossip
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 	"sync"
@@ -125,9 +126,7 @@ func (gm *GossipManager) getTags() map[string]string {
 	gm.mu.Lock()
 	defer gm.mu.Unlock()
 	rmap := make(map[string]string, len(gm.tags))
-	for tagName, tagValue := range gm.tags {
-		rmap[tagName] = tagValue
-	}
+	maps.Copy(rmap, gm.tags)
 	return rmap
 }
 

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -4,6 +4,7 @@ package tables
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 
@@ -1369,9 +1370,7 @@ func PostAutoMigrate(db *gorm.DB) error {
 	}
 	prefixIndexes, ok := prefixIndicesByDialect[db.Dialector.Name()]
 	if ok {
-		for name, cols := range prefixIndexes {
-			invocationIndices[name] = cols
-		}
+		maps.Copy(invocationIndices, prefixIndexes)
 	}
 
 	executionIndices := map[string]string{

--- a/server/testutil/mockstore/mockstore.go
+++ b/server/testutil/mockstore/mockstore.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"sync"
 	"time"
@@ -65,9 +66,7 @@ func (m *Mockstore) GetBlobMap() map[string][]byte {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	r := make(map[string][]byte, len(m.BlobMap))
-	for k, v := range m.BlobMap {
-		r[k] = v
-	}
+	maps.Copy(r, m.BlobMap)
 	return r
 }
 

--- a/server/testutil/testhttp/testhttp.go
+++ b/server/testutil/testhttp/testhttp.go
@@ -2,6 +2,7 @@ package testhttp
 
 import (
 	"fmt"
+	"maps"
 	"net"
 	"net/http"
 	"net/url"
@@ -81,9 +82,7 @@ func (c *RequestCounter) Snapshot() map[string]int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	snap := make(map[string]int, len(c.counts))
-	for k, v := range c.counts {
-		snap[k] = v
-	}
+	maps.Copy(snap, c.counts)
 	return snap
 }
 

--- a/server/util/cache_metrics/cache_metrics.go
+++ b/server/util/cache_metrics/cache_metrics.go
@@ -3,6 +3,7 @@ package cache_metrics
 import (
 	"fmt"
 	"io"
+	"maps"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
@@ -42,12 +43,8 @@ func MakeCacheLabels(tier CacheTier, backend string) prometheus.Labels {
 
 func appendLabels(a prometheus.Labels, b prometheus.Labels) prometheus.Labels {
 	labels := prometheus.Labels{}
-	for k, v := range a {
-		labels[k] = v
-	}
-	for k, v := range b {
-		labels[k] = v
-	}
+	maps.Copy(labels, a)
+	maps.Copy(labels, b)
 	return labels
 }
 

--- a/server/util/healthcheck/healthcheck.go
+++ b/server/util/healthcheck/healthcheck.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"maps"
 	"net/http"
 	"os"
 	"os/signal"
@@ -220,9 +221,7 @@ func (h *HealthChecker) runHealthChecks(ctx context.Context) {
 
 	h.checkersMu.Lock()
 	checkers := make(map[string]interfaces.Checker, len(h.checkers))
-	for k, v := range h.checkers {
-		checkers[k] = v
-	}
+	maps.Copy(checkers, h.checkers)
 	h.checkersMu.Unlock()
 
 	eg, ctx := errgroup.WithContext(ctx)

--- a/server/util/relayauth/relayauth_test.go
+++ b/server/util/relayauth/relayauth_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"maps"
 	"math/big"
 	"strings"
 	"testing"
@@ -461,9 +462,7 @@ func TestHostileHeadersAreRejected(t *testing.T) {
 		})
 		token.Header["typ"] = credentialType
 		token.Header["x5c"] = []string{base64.StdEncoding.EncodeToString(certBlock.Bytes)}
-		for k, v := range extra {
-			token.Header[k] = v
-		}
+		maps.Copy(token.Header, extra)
 		var signingKey any = key
 		switch alg {
 		case "none":

--- a/server/util/tracing/tracing_test.go
+++ b/server/util/tracing/tracing_test.go
@@ -2,6 +2,7 @@ package tracing_test
 
 import (
 	"context"
+	"maps"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -57,9 +58,7 @@ func externalCarrier(extraHeaders map[string]string) propagation.MapCarrier {
 		"traceparent": externalTraceParent(),
 		"tracestate":  externalTraceState,
 	}
-	for k, v := range extraHeaders {
-		c[k] = v
-	}
+	maps.Copy(c, extraHeaders)
 	return c
 }
 

--- a/tools/protoc-gen-go-vtproto-view/main.go
+++ b/tools/protoc-gen-go-vtproto-view/main.go
@@ -38,6 +38,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 	"text/template"
@@ -136,9 +137,7 @@ func (p *viewGen) common(extra D) D {
 		"Skip":             p.helper("Skip"),
 		"EndGroupType":     int(protowire.EndGroupType),
 	}
-	for k, v := range extra {
-		d[k] = v
-	}
+	maps.Copy(d, extra)
 	return d
 }
 


### PR DESCRIPTION
The maps package expresses copy and collection operations
directly. Replace eligible loops with the modernizer's suggested
helpers, retaining its conservative treatment of nil maps, and enable
mapsloop to keep these operations consistent.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>