### PR TITLE
go: use modern slice and iterator helpers

### DIFF
--- a/cli/analyze/analyze.go
+++ b/cli/analyze/analyze.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -430,8 +431,7 @@ func (g *DependencyGraph) LongestPath() []string {
 
 	e := g.EdgeSet()
 	nodes := g.TopologicalSort()
-	for i := len(nodes) - 1; i >= 0; i-- {
-		n := nodes[i]
+	for _, n := range slices.Backward(nodes) {
 		for dep := range e.Outgoing[n] {
 			candidateLength := length[dep] + 1
 			if candidateLength > length[n] ||

--- a/cli/explain/compactgraph/input.go
+++ b/cli/explain/compactgraph/input.go
@@ -837,8 +837,10 @@ func iterateAsRunfiles(s depset, filter InputFilter) RunfilesSeq {
 // reverse order (generators can't).
 func depsetsBackward[T depset](depsets []T) DepsetSeq {
 	return func(yield func(depset) bool) {
-		for i := len(depsets) - 1; i >= 0; i-- {
-			if !yield(depsets[i]) {
+		// A nested slices.Backward iterator can allocate when this helper is
+		// inlined into a method returning DepsetSeq. Keep a direct countdown.
+		for i := len(depsets); i > 0; i-- {
+			if !yield(depsets[i-1]) {
 				return
 			}
 		}

--- a/cli/explain/compactgraph/input_test.go
+++ b/cli/explain/compactgraph/input_test.go
@@ -1,6 +1,7 @@
 package compactgraph
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -99,5 +100,73 @@ func TestRunfilesTree_ComputeMapping(t *testing.T) {
 
 			assert.Equal(t, tc.expected, tc.rt.ComputeMapping("_main", "SHA-256"))
 		})
+	}
+}
+
+func TestTransitiveRunfilesBackward(t *testing.T) {
+	inputs := []*InputSet{{}, {}, {}}
+	symlinks := []*SymlinkEntrySet{{}, {}, {}}
+	for _, tc := range []struct {
+		name string
+		set  depset
+		want []depset
+	}{
+		{name: "InputSet", set: &InputSet{TransitiveSets: inputs}, want: []depset{inputs[2], inputs[1], inputs[0]}},
+		{name: "SymlinkEntrySet", set: &SymlinkEntrySet{transitiveSets: symlinks}, want: []depset{symlinks[2], symlinks[1], symlinks[0]}},
+		{name: "empty InputSet", set: &InputSet{}},
+		{name: "empty SymlinkEntrySet", set: &SymlinkEntrySet{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got []depset
+			for child := range tc.set.TransitiveRunfilesBackward() {
+				got = append(got, child)
+			}
+			if !assert.Len(t, got, len(tc.want)) {
+				return
+			}
+			for i := range got {
+				assert.Same(t, tc.want[i], got[i])
+			}
+
+			calls := 0
+			tc.set.TransitiveRunfilesBackward()(func(child depset) bool {
+				calls++
+				if len(tc.want) > 0 {
+					assert.Same(t, tc.want[0], child)
+				}
+				return false
+			})
+			assert.Equal(t, min(1, len(tc.want)), calls)
+		})
+	}
+}
+
+func BenchmarkTransitiveRunfilesBackward(b *testing.B) {
+	for _, size := range []int{0, 1, 64, 1024} {
+		inputs := make([]*InputSet, size)
+		symlinks := make([]*SymlinkEntrySet, size)
+		for i := range size {
+			inputs[i] = &InputSet{}
+			symlinks[i] = &SymlinkEntrySet{}
+		}
+		b.Run(fmt.Sprintf("InputSet/%d", size), func(b *testing.B) {
+			benchmarkTransitiveRunfilesBackward(b, &InputSet{TransitiveSets: inputs}, size)
+		})
+		b.Run(fmt.Sprintf("SymlinkEntrySet/%d", size), func(b *testing.B) {
+			benchmarkTransitiveRunfilesBackward(b, &SymlinkEntrySet{transitiveSets: symlinks}, size)
+		})
+	}
+}
+
+func benchmarkTransitiveRunfilesBackward(b *testing.B, set depset, want int) {
+	b.ReportAllocs()
+	for range b.N {
+		count := 0
+		for range set.TransitiveRunfilesBackward() {
+			count++
+		}
+		if count != want {
+			b.Fatalf("visited %d transitive sets, want %d", count, want)
+		}
 	}
 }

--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -306,8 +306,7 @@ func dedupe(plugins []*Plugin) ([]*Plugin, error) {
 	var out []*Plugin
 	// Iterate in reverse order so that IDs appearing latest get the highest
 	// precedence.
-	for i := len(plugins) - 1; i >= 0; i-- {
-		p := plugins[i]
+	for _, p := range slices.Backward(plugins) {
 		id, err := p.NonVersionedID()
 		if err != nil {
 			return nil, err

--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -12,6 +12,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -233,10 +234,10 @@ func EnableController(path string, controller string) error {
 			break
 		}
 	}
-	for i := len(stack) - 1; i >= 0; i-- {
-		log.Infof("Enabling cgroup subtree controller %q for %q", controller, stack[i])
-		if err := WriteSubtreeControl(stack[i], map[string]bool{controller: true}); err != nil {
-			return fmt.Errorf("write subtree control for %q: %w", stack[i], err)
+	for _, s := range slices.Backward(stack) {
+		log.Infof("Enabling cgroup subtree controller %q for %q", controller, s)
+		if err := WriteSubtreeControl(s, map[string]bool{controller: true}); err != nil {
+			return fmt.Errorf("write subtree control for %q: %w", s, err)
 		}
 	}
 	return nil

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -1473,8 +1473,7 @@ func (p *pool) take(ctx context.Context, key *rnpb.RunnerKey) *taskRunner {
 		return nil
 	}
 
-	for i := len(p.runners) - 1; i >= 0; i-- {
-		r := p.runners[i]
+	for _, r := range slices.Backward(p.runners) {
 		if key.GroupId != r.key.GroupId || r.getState() != paused {
 			continue
 		}

--- a/enterprise/server/usage/usage_test.go
+++ b/enterprise/server/usage/usage_test.go
@@ -981,8 +981,8 @@ func TestUsageTracker_UsageLabels_UnrecognizedLabelsAreNotFlushed(t *testing.T) 
 func increasingCountsStartingAt(value int64) *tables.UsageCounts {
 	counts := &tables.UsageCounts{}
 	countsValue := reflect.ValueOf(counts).Elem()
-	for i := 0; i < countsValue.NumField(); i++ {
-		countsValue.Field(i).Set(reflect.ValueOf(value))
+	for _, field := range countsValue.Fields() {
+		field.Set(reflect.ValueOf(value))
 		value++
 	}
 	return counts

--- a/rules/go/analyzer/def.bzl
+++ b/rules/go/analyzer/def.bzl
@@ -1,4 +1,6 @@
 ANALYZERS = [
+    "slicesclip",
+    "slicesbackward",
     "any",
     # "bloop", # DO NOT ENABLE, see golang/go#74967
     # "fmtappendf",
@@ -11,8 +13,8 @@ ANALYZERS = [
     "rangeint",
     # "reflecttypefor",
     "slicescontains",
-    # "slicessort",
-    # "stditerators",
+    "slicessort",
+    "stditerators",
     "stringscut",
     "stringscutprefix",
     "stringsseq",

--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -151,9 +152,9 @@ func MigrateToV2Layout(rootDir string) error {
 	if err := filepath.WalkDir(rootDir, walkFn); err != nil {
 		return err
 	}
-	for i := len(dirsToDelete) - 1; i >= 0; i-- {
-		if err := os.Remove(dirsToDelete[i]); err != nil {
-			log.Warningf("Could not delete directory %q: %s", dirsToDelete[i], err)
+	for _, d := range slices.Backward(dirsToDelete) {
+		if err := os.Remove(d); err != nil {
+			log.Warningf("Could not delete directory %q: %s", d, err)
 		}
 	}
 	log.Infof("Migrated %d digests in %s.", numMigrated, time.Since(start))

--- a/server/capabilities_filter/capabilities_filter_test.go
+++ b/server/capabilities_filter/capabilities_filter_test.go
@@ -26,12 +26,12 @@ var (
 func TestAllRPCsHaveExplicitCapabilitiesSpecified(t *testing.T) {
 	serviceMethodNames := []string{}
 	buildbuddyServiceType := reflect.TypeOf((*bbspb.BuildBuddyServiceServer)(nil)).Elem()
-	for i := 0; i < buildbuddyServiceType.NumMethod(); i++ {
-		serviceMethodNames = append(serviceMethodNames, buildBuddyServicePrefix+buildbuddyServiceType.Method(i).Name)
+	for method := range buildbuddyServiceType.Methods() {
+		serviceMethodNames = append(serviceMethodNames, buildBuddyServicePrefix+method.Name)
 	}
 	apiServiceType := reflect.TypeOf((*apipb.ApiServiceServer)(nil)).Elem()
-	for i := 0; i < apiServiceType.NumMethod(); i++ {
-		serviceMethodNames = append(serviceMethodNames, apiServicePrefix+apiServiceType.Method(i).Name)
+	for method := range apiServiceType.Methods() {
+		serviceMethodNames = append(serviceMethodNames, apiServicePrefix+method.Name)
 	}
 
 	allDefinedMethods := capabilities_filter.AllRPCsForTestOnly()
@@ -55,9 +55,9 @@ func TestBuildBuddyServiceRPCsHaveRequestAndResponseContextFields(t *testing.T) 
 	ctxType := reflect.TypeOf((*context.Context)(nil)).Elem()
 
 	buildbuddyServiceType := reflect.TypeOf((*bbspb.BuildBuddyServiceServer)(nil)).Elem()
-	for i := 0; i < buildbuddyServiceType.NumMethod(); i++ {
-		methodFunc := buildbuddyServiceType.Method(i).Type
-		methodName := buildbuddyServiceType.Method(i).Name
+	for method := range buildbuddyServiceType.Methods() {
+		methodFunc := method.Type
+		methodName := method.Name
 
 		var actualReqType, actualResType reflect.Type
 		if methodFunc.In(0).Implements(ctxType) {

--- a/server/http/protolet/protolet.go
+++ b/server/http/protolet/protolet.go
@@ -155,8 +155,7 @@ func GenerateHTTPHandlers(servicePrefix, serviceName string, server any, grpcSer
 	handlerFns := make(map[string]reflect.Value)
 
 	serverType := reflect.TypeOf(server)
-	for i := 0; i < serverType.NumMethod(); i++ {
-		method := serverType.Method(i)
+	for method := range serverType.Methods() {
 		if !isRPCMethod(method) && !isStreamingRPCMethod(method) {
 			continue
 		}

--- a/server/util/approxlru/approxlru.go
+++ b/server/util/approxlru/approxlru.go
@@ -243,9 +243,7 @@ func (l *LRU[T]) evictSingleKey() (*Sample[T], error) {
 	if err := l.limiter.Wait(l.ctx); err != nil {
 		return nil, err
 	}
-	for i := len(l.samplePool) - 1; i >= 0; i-- {
-		sample := l.samplePool[i]
-
+	for i, sample := range slices.Backward(l.samplePool) {
 		l.mu.Lock()
 		oldLocalSizeBytes := l.localSizeBytes
 		oldGlobalSizeBytes := l.globalSizeBytes

--- a/server/util/flagutil/yaml/yaml.go
+++ b/server/util/flagutil/yaml/yaml.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -233,8 +234,7 @@ func (r *redactSecrets) Transform(in any, n *yaml.Node, flg *flag.Flag) (*yaml.N
 		for i := 0; i < len(n.Content)/2; i++ {
 			contentIndex[n.Content[2*i].Value] = 2*i + 1
 		}
-		for i := 0; i < t.NumField(); i++ {
-			ft := t.Field(i)
+		for ft := range t.Fields() {
 			name, _, _ := strings.Cut(ft.Tag.Get("yaml"), ",")
 			if name == "" {
 				name = strings.ToLower(ft.Name)
@@ -320,8 +320,8 @@ func DocumentNode(in any, n *yaml.Node, flg *flag.Flag, opts ...common.DocumentN
 				return DocumentNode(v.Elem().Interface(), n, flg, opts...)
 			} else {
 				exampleOpts := append(filterPassthrough(opts), AppendTypeToLineComment)
-				for i := len(exampleOpts) - 1; i >= 0; i-- {
-					if exampleOpts[i] == RedactSecrets {
+				for i, exampleOpt := range slices.Backward(exampleOpts) {
+					if exampleOpt == RedactSecrets {
 						exampleOpts = append(exampleOpts[:i], exampleOpts[i+1:]...)
 					}
 				}
@@ -392,8 +392,8 @@ func DocumentNode(in any, n *yaml.Node, flg *flag.Flag, opts ...common.DocumentN
 			}
 			if len(n.Content) == 0 {
 				exampleOpts := append(filterPassthrough(opts), AppendTypeToLineComment)
-				for i := len(exampleOpts) - 1; i >= 0; i-- {
-					if exampleOpts[i] == RedactSecrets {
+				for i, exampleOpt := range slices.Backward(exampleOpts) {
+					if exampleOpt == RedactSecrets {
 						exampleOpts = append(exampleOpts[:i], exampleOpts[i+1:]...)
 					}
 				}

--- a/server/util/histogram/histogram.go
+++ b/server/util/histogram/histogram.go
@@ -3,7 +3,7 @@ package histogram
 import (
 	"fmt"
 	"math"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -53,7 +53,7 @@ type Percentiles struct {
 }
 
 func (h *Histogram) Percentiles() Percentiles {
-	sort.Slice(h.data, func(i, j int) bool { return h.data[i] < h.data[j] })
+	slices.Sort(h.data)
 
 	percentile := func(p float64) int64 {
 		if len(h.data) == 0 {

--- a/server/util/redact/redact.go
+++ b/server/util/redact/redact.go
@@ -992,8 +992,7 @@ func typeContainsSecrets(t reflect.Type, seen map[reflect.Type]bool) bool {
 	case reflect.Map:
 		return typeContainsSecrets(t.Key(), seen) || typeContainsSecrets(t.Elem(), seen)
 	case reflect.Struct:
-		for i := 0; i < t.NumField(); i++ {
-			field := t.Field(i)
+		for field := range t.Fields() {
 			if slices.Contains(strings.Split(field.Tag.Get("config"), ","), "secret") {
 				return true
 			}


### PR DESCRIPTION
Standard slice and iterator helpers make common traversal, sorting,
and capacity operations explicit. Apply the eligible modernizer
fixes and enable their checks, including the newer slicesbackward
and slicesclip analyzers.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>