### PR TITLE
go: simplify pointer construction

### DIFF
--- a/cli/parser/parsed/parsed_test.go
+++ b/cli/parser/parsed/parsed_test.go
@@ -16,10 +16,6 @@ func mustNewOption(t *testing.T, optName string, v *string, d *options.Definitio
 	return opt
 }
 
-func ptr[T any](v T) *T {
-	return &v
-}
-
 func TestExpandConfigsWithPolicy(t *testing.T) {
 	// The explain command supports the following options:
 	// - bb_config
@@ -50,8 +46,8 @@ func TestExpandConfigsWithPolicy(t *testing.T) {
 	// Args: explain --config=untouched --bb_config=detailed invocation-id
 	args := &parsed.OrderedArgs{Args: []arguments.Argument{
 		&arguments.PositionalArgument{Value: "explain"},
-		mustNewOption(t, "config", ptr("untouched"), bazelConfigDefinition),
-		mustNewOption(t, "bb_config", ptr("detailed"), bbConfigDefinition),
+		mustNewOption(t, "config", new("untouched"), bazelConfigDefinition),
+		mustNewOption(t, "bb_config", new("detailed"), bbConfigDefinition),
 		&arguments.PositionalArgument{Value: "invocation-id"},
 	}}
 
@@ -138,20 +134,20 @@ func TestRemoveAndAccumulateStartupOption(t *testing.T) {
 	args := &parsed.OrderedArgs{
 		Args: []arguments.Argument{
 			mustNewOption(t, "no"+startupOptionBoolName, nil, startupOptionBoolDefinition),
-			mustNewOption(t, startupOptionMultiName, ptr("foo"), startupOptionMultiDefinition),
+			mustNewOption(t, startupOptionMultiName, new("foo"), startupOptionMultiDefinition),
 			mustNewOption(t, startupOptionBoolName, nil, startupOptionBoolDefinition),
-			mustNewOption(t, startupOptionMultiName, ptr("bar"), startupOptionMultiDefinition),
-			mustNewOption(t, startupOptionRequiresValueName, ptr("foo"), startupOptionRequiresValueDefinition),
-			mustNewOption(t, startupOptionMultiName, ptr("bar"), startupOptionMultiDefinition),
-			mustNewOption(t, startupOptionRequiresValueName, ptr("bar"), startupOptionRequiresValueDefinition),
+			mustNewOption(t, startupOptionMultiName, new("bar"), startupOptionMultiDefinition),
+			mustNewOption(t, startupOptionRequiresValueName, new("foo"), startupOptionRequiresValueDefinition),
+			mustNewOption(t, startupOptionMultiName, new("bar"), startupOptionMultiDefinition),
+			mustNewOption(t, startupOptionRequiresValueName, new("bar"), startupOptionRequiresValueDefinition),
 			&arguments.PositionalArgument{Value: "command"},
 			mustNewOption(t, "no"+commandOptionBoolName, nil, commandOptionBoolDefinition),
-			mustNewOption(t, commandOptionMultiName, ptr("foo"), commandOptionMultiDefinition),
+			mustNewOption(t, commandOptionMultiName, new("foo"), commandOptionMultiDefinition),
 			mustNewOption(t, commandOptionBoolName, nil, commandOptionBoolDefinition),
-			mustNewOption(t, commandOptionMultiName, ptr("bar"), commandOptionMultiDefinition),
-			mustNewOption(t, commandOptionRequiresValueName, ptr("bar"), commandOptionRequiresValueDefinition),
-			mustNewOption(t, commandOptionMultiName, ptr("foo"), commandOptionMultiDefinition),
-			mustNewOption(t, commandOptionRequiresValueName, ptr("foo"), commandOptionRequiresValueDefinition),
+			mustNewOption(t, commandOptionMultiName, new("bar"), commandOptionMultiDefinition),
+			mustNewOption(t, commandOptionRequiresValueName, new("bar"), commandOptionRequiresValueDefinition),
+			mustNewOption(t, commandOptionMultiName, new("foo"), commandOptionMultiDefinition),
+			mustNewOption(t, commandOptionRequiresValueName, new("foo"), commandOptionRequiresValueDefinition),
 		},
 	}
 
@@ -224,20 +220,20 @@ func TestRemoveAndAccumulateCommandOption(t *testing.T) {
 	args := &parsed.OrderedArgs{
 		Args: []arguments.Argument{
 			mustNewOption(t, "no"+startupOptionBoolName, nil, startupOptionBoolDefinition),
-			mustNewOption(t, startupOptionMultiName, ptr("foo"), startupOptionMultiDefinition),
+			mustNewOption(t, startupOptionMultiName, new("foo"), startupOptionMultiDefinition),
 			mustNewOption(t, startupOptionBoolName, nil, startupOptionBoolDefinition),
-			mustNewOption(t, startupOptionMultiName, ptr("bar"), startupOptionMultiDefinition),
-			mustNewOption(t, startupOptionRequiresValueName, ptr("foo"), startupOptionRequiresValueDefinition),
-			mustNewOption(t, startupOptionMultiName, ptr("bar"), startupOptionMultiDefinition),
-			mustNewOption(t, startupOptionRequiresValueName, ptr("bar"), startupOptionRequiresValueDefinition),
+			mustNewOption(t, startupOptionMultiName, new("bar"), startupOptionMultiDefinition),
+			mustNewOption(t, startupOptionRequiresValueName, new("foo"), startupOptionRequiresValueDefinition),
+			mustNewOption(t, startupOptionMultiName, new("bar"), startupOptionMultiDefinition),
+			mustNewOption(t, startupOptionRequiresValueName, new("bar"), startupOptionRequiresValueDefinition),
 			&arguments.PositionalArgument{Value: "command"},
 			mustNewOption(t, "no"+commandOptionBoolName, nil, commandOptionBoolDefinition),
-			mustNewOption(t, commandOptionMultiName, ptr("foo"), commandOptionMultiDefinition),
+			mustNewOption(t, commandOptionMultiName, new("foo"), commandOptionMultiDefinition),
 			mustNewOption(t, commandOptionBoolName, nil, commandOptionBoolDefinition),
-			mustNewOption(t, commandOptionMultiName, ptr("bar"), commandOptionMultiDefinition),
-			mustNewOption(t, commandOptionRequiresValueName, ptr("bar"), commandOptionRequiresValueDefinition),
-			mustNewOption(t, commandOptionMultiName, ptr("foo"), commandOptionMultiDefinition),
-			mustNewOption(t, commandOptionRequiresValueName, ptr("foo"), commandOptionRequiresValueDefinition),
+			mustNewOption(t, commandOptionMultiName, new("bar"), commandOptionMultiDefinition),
+			mustNewOption(t, commandOptionRequiresValueName, new("bar"), commandOptionRequiresValueDefinition),
+			mustNewOption(t, commandOptionMultiName, new("foo"), commandOptionMultiDefinition),
+			mustNewOption(t, commandOptionRequiresValueName, new("foo"), commandOptionRequiresValueDefinition),
 		},
 	}
 
@@ -310,28 +306,28 @@ func TestPrepend(t *testing.T) {
 	args := &parsed.OrderedArgs{
 		Args: []arguments.Argument{
 			mustNewOption(t, "no"+startupOptionBoolName, nil, startupOptionBoolDefinition),
-			mustNewOption(t, startupOptionMultiName, ptr("foo"), startupOptionMultiDefinition),
+			mustNewOption(t, startupOptionMultiName, new("foo"), startupOptionMultiDefinition),
 			mustNewOption(t, startupOptionBoolName, nil, startupOptionBoolDefinition),
-			mustNewOption(t, startupOptionMultiName, ptr("bar"), startupOptionMultiDefinition),
-			mustNewOption(t, startupOptionRequiresValueName, ptr("foo"), startupOptionRequiresValueDefinition),
-			mustNewOption(t, startupOptionMultiName, ptr("bar"), startupOptionMultiDefinition),
-			mustNewOption(t, startupOptionRequiresValueName, ptr("bar"), startupOptionRequiresValueDefinition),
+			mustNewOption(t, startupOptionMultiName, new("bar"), startupOptionMultiDefinition),
+			mustNewOption(t, startupOptionRequiresValueName, new("foo"), startupOptionRequiresValueDefinition),
+			mustNewOption(t, startupOptionMultiName, new("bar"), startupOptionMultiDefinition),
+			mustNewOption(t, startupOptionRequiresValueName, new("bar"), startupOptionRequiresValueDefinition),
 			&arguments.PositionalArgument{Value: "command"},
 			mustNewOption(t, "no"+commandOptionBoolName, nil, commandOptionBoolDefinition),
-			mustNewOption(t, commandOptionMultiName, ptr("foo"), commandOptionMultiDefinition),
+			mustNewOption(t, commandOptionMultiName, new("foo"), commandOptionMultiDefinition),
 			mustNewOption(t, commandOptionBoolName, nil, commandOptionBoolDefinition),
-			mustNewOption(t, commandOptionMultiName, ptr("bar"), commandOptionMultiDefinition),
-			mustNewOption(t, commandOptionRequiresValueName, ptr("bar"), commandOptionRequiresValueDefinition),
-			mustNewOption(t, commandOptionMultiName, ptr("foo"), commandOptionMultiDefinition),
-			mustNewOption(t, commandOptionRequiresValueName, ptr("foo"), commandOptionRequiresValueDefinition),
+			mustNewOption(t, commandOptionMultiName, new("bar"), commandOptionMultiDefinition),
+			mustNewOption(t, commandOptionRequiresValueName, new("bar"), commandOptionRequiresValueDefinition),
+			mustNewOption(t, commandOptionMultiName, new("foo"), commandOptionMultiDefinition),
+			mustNewOption(t, commandOptionRequiresValueName, new("foo"), commandOptionRequiresValueDefinition),
 		},
 	}
 	args.Prepend(
 		mustNewOption(t, "no"+commandOptionBoolName, nil, commandOptionBoolDefinition),
-		mustNewOption(t, commandOptionMultiName, ptr("foofoo"), commandOptionMultiDefinition),
+		mustNewOption(t, commandOptionMultiName, new("foofoo"), commandOptionMultiDefinition),
 		mustNewOption(t, commandOptionBoolName, nil, commandOptionBoolDefinition),
 		mustNewOption(t, "no"+startupOptionBoolName, nil, startupOptionBoolDefinition),
-		mustNewOption(t, startupOptionMultiName, ptr("foobar"), startupOptionMultiDefinition),
+		mustNewOption(t, startupOptionMultiName, new("foobar"), startupOptionMultiDefinition),
 		mustNewOption(t, startupOptionBoolName, nil, startupOptionBoolDefinition),
 	)
 

--- a/enterprise/server/backends/kms/kms.go
+++ b/enterprise/server/backends/kms/kms.go
@@ -210,7 +210,7 @@ func createAWSClientWithCreds(arn *awsKMSARN) (registry.KMSClient, error) {
 	creds := awscreds.NewStaticCredentialsFromCreds(*credValue)
 	sess, err := awssession.NewSession(&aws.Config{
 		Credentials: creds,
-		Region:      aws.String(arn.region),
+		Region:      new(arn.region),
 	})
 	if err != nil {
 		return nil, status.UnknownErrorf("could not create session: %s", err)

--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -1068,10 +1068,10 @@ func (a *GitHubApp) CreateRepo(ctx context.Context, req *rppb.CreateRepoRequest)
 			organization = req.Owner
 		}
 		_, _, err := githubClient.Repositories.Create(ctx, organization, &github.Repository{
-			Name:        github.String(req.Name),
-			Description: github.String(req.Description),
-			Private:     github.Bool(req.Private),
-			AutoInit:    github.Bool(req.Template == ""),
+			Name:        new(req.Name),
+			Description: new(req.Description),
+			Private:     new(req.Private),
+			AutoInit:    new(req.Template == ""),
 		})
 		if err != nil {
 			return nil, err
@@ -2054,7 +2054,7 @@ func (a *GitHubApp) CreateGithubPullRequestComment(ctx context.Context, req *ghp
 			PullRequestID:       githubv4.NewID(req.GetPullId()),
 			PullRequestReviewID: githubv4.NewID(reviewId),
 			Path:                githubv4.String(req.GetPath()),
-			Line:                githubv4.NewInt(githubv4.Int(int(req.GetLine()))),
+			Line:                new(githubv4.Int(int(req.GetLine()))),
 			Side:                &side,
 			Body:                githubv4.String(req.GetBody()),
 		}
@@ -2354,7 +2354,7 @@ func (a *GitHubApp) SendGithubPullRequestReview(ctx context.Context, req *ghpb.S
 		}
 		input := githubv4.AddPullRequestReviewInput{
 			PullRequestID: req.GetPullRequestId(),
-			Body:          githubv4.NewString(githubv4.String(replyBody)),
+			Body:          new(githubv4.String(replyBody)),
 			Event:         &event,
 		}
 		err := graphqlClient.Mutate(ctx, &m, input, nil)
@@ -2372,7 +2372,7 @@ func (a *GitHubApp) SendGithubPullRequestReview(ctx context.Context, req *ghpb.S
 
 	input := githubv4.SubmitPullRequestReviewInput{
 		PullRequestReviewID: githubv4.NewID(reviewID),
-		Body:                githubv4.NewString(githubv4.String(replyBody)),
+		Body:                new(githubv4.String(replyBody)),
 		Event:               event,
 	}
 	err = graphqlClient.Mutate(ctx, &m, input, nil)

--- a/enterprise/server/githubapp/githubapp_test.go
+++ b/enterprise/server/githubapp/githubapp_test.go
@@ -43,7 +43,7 @@ type fakeAppClient struct {
 func (c *fakeAppClient) CreateInstallationToken(_ context.Context, installationID int64, opts *github.InstallationTokenOptions) (*github.InstallationToken, *github.Response, error) {
 	c.createTokenCalls++
 	require.Equal(c.t, c.wantInstallationID, installationID)
-	return &github.InstallationToken{Token: github.String(fakeToken)}, &github.Response{
+	return &github.InstallationToken{Token: new(fakeToken)}, &github.Response{
 		Response: &http.Response{StatusCode: http.StatusCreated},
 	}, nil
 }

--- a/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy_test.go
+++ b/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy_test.go
@@ -207,8 +207,8 @@ func TestFetchBlob_ForwardsRequestUnchanged(t *testing.T) {
 	}{
 		{name: "NoSizeOrMediaType"},
 		{name: "SizeOnly", size: gproto.Int64(12345)},
-		{name: "MediaTypeOnly", mediaType: gproto.String("application/vnd.example.layer.v1.tar+gzip")},
-		{name: "SizeAndMediaType", size: gproto.Int64(12345), mediaType: gproto.String("application/vnd.example.layer.v1.tar+gzip")},
+		{name: "MediaTypeOnly", mediaType: new("application/vnd.example.layer.v1.tar+gzip")},
+		{name: "SizeAndMediaType", size: gproto.Int64(12345), mediaType: new("application/vnd.example.layer.v1.tar+gzip")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1830,40 +1830,40 @@ func (c *FirecrackerContainer) getConfig(ctx context.Context, rootFS, containerF
 		},
 		JailerCfg: jailerCfg,
 		MachineCfg: fcmodels.MachineConfiguration{
-			VcpuCount:       fcclient.Int64(c.vmConfig.NumCpus),
-			MemSizeMib:      fcclient.Int64(c.vmConfig.MemSizeMb),
-			Smt:             fcclient.Bool(false),
-			TrackDirtyPages: fcclient.Bool(true),
+			VcpuCount:       new(c.vmConfig.NumCpus),
+			MemSizeMib:      new(c.vmConfig.MemSizeMb),
+			Smt:             new(false),
+			TrackDirtyPages: new(true),
 		},
 	}
 	if snaputil.IsChunkedSnapshotSharingEnabled() {
 		cfg.Drives = append(cfg.Drives, fcmodels.Drive{
-			DriveID:      fcclient.String(rootDriveID),
+			DriveID:      new(rootDriveID),
 			PathOnHost:   &rootFS,
-			IsRootDevice: fcclient.Bool(false),
-			IsReadOnly:   fcclient.Bool(false),
+			IsRootDevice: new(false),
+			IsReadOnly:   new(false),
 		})
 	} else {
 		cfg.Drives = append(cfg.Drives, fcmodels.Drive{
-			DriveID:      fcclient.String(containerDriveID),
+			DriveID:      new(containerDriveID),
 			PathOnHost:   &containerFS,
-			IsRootDevice: fcclient.Bool(false),
-			IsReadOnly:   fcclient.Bool(true),
+			IsRootDevice: new(false),
+			IsReadOnly:   new(true),
 		}, fcmodels.Drive{
-			DriveID:      fcclient.String(scratchDriveID),
+			DriveID:      new(scratchDriveID),
 			PathOnHost:   &scratchFS,
-			IsRootDevice: fcclient.Bool(false),
-			IsReadOnly:   fcclient.Bool(false),
+			IsRootDevice: new(false),
+			IsReadOnly:   new(false),
 		})
 	}
 	// Workspace drive will be /dev/vdb if merged rootfs is enabled, /dev/vdc
 	// otherwise.
 	cfg.Drives = append(cfg.Drives, []fcmodels.Drive{
 		{
-			DriveID:      fcclient.String(workspaceDriveID),
+			DriveID:      new(workspaceDriveID),
 			PathOnHost:   &workspaceFS,
-			IsRootDevice: fcclient.Bool(false),
-			IsReadOnly:   fcclient.Bool(false),
+			IsRootDevice: new(false),
+			IsReadOnly:   new(false),
 		},
 	}...)
 
@@ -1902,9 +1902,9 @@ func (c *FirecrackerContainer) getJailerConfig(ctx context.Context, kernelImageP
 		JailerBinary:   c.executorConfig.JailerBinaryPath,
 		ChrootBaseDir:  c.jailerRoot,
 		ID:             c.id,
-		UID:            fcclient.Int(unix.Geteuid()),
-		GID:            fcclient.Int(unix.Getegid()),
-		NumaNode:       fcclient.Int(numaNode),
+		UID:            new(unix.Geteuid()),
+		GID:            new(unix.Getegid()),
+		NumaNode:       new(numaNode),
 		ExecFile:       c.executorConfig.FirecrackerBinaryPath,
 		ChrootStrategy: fcclient.NewNaiveChrootStrategy(kernelImagePath),
 		Stdout:         c.vmLogWriter(),
@@ -1922,7 +1922,7 @@ func (c *FirecrackerContainer) getJailerConfig(ctx context.Context, kernelImageP
 		// 1. The cgroup FS root: "/sys/fs/cgroup"
 		// 2. This ParentCgroup setting
 		// 3. The ID setting
-		ParentCgroup: fcclient.String(c.cgroupParent),
+		ParentCgroup: new(c.cgroupParent),
 	}, nil
 }
 
@@ -3493,10 +3493,6 @@ func (c *FirecrackerContainer) updateBalloon(ctx context.Context, targetSizeMib 
 	return currentBalloonSize, ctx.Err()
 }
 
-func pointer[T any](val T) *T {
-	return &val
-}
-
 func toInt32s(in []int) []int32 {
 	out := make([]int32, len(in))
 	for i, l := range in {
@@ -3673,7 +3669,7 @@ func (c *FirecrackerContainer) setupCgroup(ctx context.Context) error {
 	log.CtxInfof(ctx, "Lease %s granted %+v cpus on numa node: %d", leaseID, leasedCPUs, numaNode)
 	c.releaseCPUs = cleanupFunc
 	c.cgroupSettings.CpusetCpus = toInt32s(leasedCPUs)
-	c.cgroupSettings.NumaNode = pointer(int32(numaNode))
+	c.cgroupSettings.NumaNode = new(int32(numaNode))
 
 	if *debugDisableCgroup {
 		return nil

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -1619,12 +1619,8 @@ func getUser(ctx context.Context, image *Image, rootfsPath string, dockerUserPro
 		UID:            uid,
 		GID:            gid,
 		AdditionalGids: gids,
-		Umask:          pointer(uint32(022)), // 0644 file perms by default
+		Umask:          new(uint32(022)), // 0644 file perms by default
 	}, nil
-}
-
-func pointer[T any](val T) *T {
-	return &val
 }
 
 func toInt32s(in []int) []int32 {

--- a/enterprise/server/test/integration/workflow/workflow_test.go
+++ b/enterprise/server/test/integration/workflow/workflow_test.go
@@ -749,16 +749,12 @@ func TestInvalidYAML(t *testing.T) {
 		RepoURL:     repoURL,
 		CommitSHA:   commitSHA,
 		Payload: &github.GithubStatusPayload{
-			Context:     pointer("BuildBuddy Workflows"),
+			Context:     new("BuildBuddy Workflows"),
 			Description: payload.Description,
-			TargetURL:   pointer("https://buildbuddy.io/docs/workflows-config"),
-			State:       pointer("error"),
+			TargetURL:   new("https://buildbuddy.io/docs/workflows-config"),
+			State:       new("error"),
 		},
 	}, s)
-}
-
-func pointer[T any](val T) *T {
-	return &val
 }
 
 func TestBazelUseCLI(t *testing.T) {

--- a/enterprise/server/webhooks/github/github_test.go
+++ b/enterprise/server/webhooks/github/github_test.go
@@ -143,22 +143,22 @@ func TestParseRequest_InvalidEvent_Error(t *testing.T) {
 
 func pullRequestEvent(action string) *gh.PullRequestEvent {
 	repo := &gh.Repository{
-		CloneURL:      gh.String("https://github.com/test/repo.git"),
-		DefaultBranch: gh.String("main"),
-		Private:       gh.Bool(false),
+		CloneURL:      new("https://github.com/test/repo.git"),
+		DefaultBranch: new("main"),
+		Private:       new(false),
 	}
 	return &gh.PullRequestEvent{
-		Action: gh.String(action),
+		Action: new(action),
 		PullRequest: &gh.PullRequest{
-			Number: gh.Int(7),
-			User:   &gh.User{Login: gh.String("author")},
+			Number: new(7),
+			User:   &gh.User{Login: new("author")},
 			Head: &gh.PullRequestBranch{
-				Ref:  gh.String("feature"),
-				SHA:  gh.String("deadbeef"),
+				Ref:  new("feature"),
+				SHA:  new("deadbeef"),
 				Repo: repo,
 			},
 			Base: &gh.PullRequestBranch{
-				Ref:  gh.String("main"),
+				Ref:  new("main"),
 				Repo: repo,
 			},
 		},

--- a/enterprise/tools/agent_review/main.go
+++ b/enterprise/tools/agent_review/main.go
@@ -276,10 +276,10 @@ func main() {
 	for _, c := range review.Comments {
 		if validLines[fileLine{c.File, c.Line}] {
 			inlineComments = append(inlineComments, &github.DraftReviewComment{
-				Path: github.String(c.File),
-				Line: github.Int(c.Line),
-				Side: github.String("RIGHT"),
-				Body: github.String(c.Body),
+				Path: new(c.File),
+				Line: new(c.Line),
+				Side: new("RIGHT"),
+				Body: new(c.Body),
 			})
 		} else {
 			overflowLines = append(overflowLines, fmt.Sprintf("- `%s:%d` — %s", c.File, c.Line, c.Body))
@@ -296,9 +296,9 @@ func main() {
 
 	if *dryRun {
 		req := &github.PullRequestReviewRequest{
-			CommitID: github.String(headSHA),
-			Event:    github.String("COMMENT"),
-			Body:     github.String(fullBody),
+			CommitID: new(headSHA),
+			Event:    new("COMMENT"),
+			Body:     new(fullBody),
 			Comments: inlineComments,
 		}
 		payloadBytes, _ := json.MarshalIndent(req, "", "  ")
@@ -338,9 +338,9 @@ func fetchRepoInfo(gh *github.Client) (owner, repo, branch string, err error) {
 func postReview(ctx context.Context, gh *github.Client, owner, repo string, prNumber int, headSHA, body string, comments []*github.DraftReviewComment) {
 	log.Info("Posting review to GitHub...")
 	req := &github.PullRequestReviewRequest{
-		CommitID: github.String(headSHA),
-		Event:    github.String("COMMENT"),
-		Body:     github.String(body),
+		CommitID: new(headSHA),
+		Event:    new("COMMENT"),
+		Body:     new(body),
 		Comments: comments,
 	}
 	posted, _, err := gh.PullRequests.CreateReview(ctx, owner, repo, prNumber, req)
@@ -353,7 +353,7 @@ func postReview(ctx context.Context, gh *github.Client, owner, repo string, prNu
 			fallbackBody.WriteString(fmt.Sprintf("- `%s:%d` — %s\n", c.GetPath(), c.GetLine(), c.GetBody()))
 		}
 		req.Comments = nil
-		req.Body = github.String(fallbackBody.String())
+		req.Body = new(fallbackBody.String())
 		posted, _, err = gh.PullRequests.CreateReview(ctx, owner, repo, prNumber, req)
 	}
 	if err != nil {

--- a/rules/go/analyzer/def.bzl
+++ b/rules/go/analyzer/def.bzl
@@ -7,7 +7,7 @@ ANALYZERS = [
     "forvar",
     "mapsloop",
     "minmax",
-    # "newexpr",
+    "newexpr",
     # "plusbuild",
     # "omitzero",
     "rangeint",

--- a/server/build_event_protocol/build_event_handler/build_event_handler_test.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler_test.go
@@ -1833,10 +1833,10 @@ func TestBuildStatusReporting(t *testing.T) {
 					OwnerRepo: "testowner/testrepo",
 					CommitSHA: "0c894fe31c2e91d59cb1a59bb25aaa78089919c2",
 					RepoStatus: &github.GithubStatusPayload{
-						TargetURL:   pointer("http://localhost:8080/invocation/" + seq.InvocationID),
-						State:       pointer("pending"),
-						Description: pointer("Running..."),
-						Context:     pointer(test.statusContext),
+						TargetURL:   new("http://localhost:8080/invocation/" + seq.InvocationID),
+						State:       new("pending"),
+						Description: new("Running..."),
+						Context:     new(test.statusContext),
 					},
 				},
 			}, client.ConsumeStatuses())
@@ -1858,10 +1858,10 @@ func TestBuildStatusReporting(t *testing.T) {
 					OwnerRepo: "testowner/testrepo",
 					CommitSHA: "0c894fe31c2e91d59cb1a59bb25aaa78089919c2",
 					RepoStatus: &github.GithubStatusPayload{
-						TargetURL:   pointer("http://localhost:8080/invocation/" + seq.InvocationID),
-						State:       pointer("success"),
-						Description: pointer("Success"),
-						Context:     pointer(test.statusContext),
+						TargetURL:   new("http://localhost:8080/invocation/" + seq.InvocationID),
+						State:       new("success"),
+						Description: new("Success"),
+						Context:     new(test.statusContext),
 					},
 				},
 			}, client.ConsumeStatuses())
@@ -2115,10 +2115,10 @@ func TestBuildStatusReporting_LegacyMethods(t *testing.T) {
 					OwnerRepo: "testowner/testrepo",
 					CommitSHA: "0c894fe31c2e91d59cb1a59bb25aaa78089919c2",
 					RepoStatus: &github.GithubStatusPayload{
-						TargetURL:   pointer("http://localhost:8080/invocation/" + seq.InvocationID),
-						State:       pointer("pending"),
-						Description: pointer("Running..."),
-						Context:     pointer("bazel build //..."),
+						TargetURL:   new("http://localhost:8080/invocation/" + seq.InvocationID),
+						State:       new("pending"),
+						Description: new("Running..."),
+						Context:     new("bazel build //..."),
 					},
 				},
 			}, client.ConsumeStatuses())
@@ -2140,10 +2140,10 @@ func TestBuildStatusReporting_LegacyMethods(t *testing.T) {
 					OwnerRepo: "testowner/testrepo",
 					CommitSHA: "0c894fe31c2e91d59cb1a59bb25aaa78089919c2",
 					RepoStatus: &github.GithubStatusPayload{
-						TargetURL:   pointer("http://localhost:8080/invocation/" + seq.InvocationID),
-						State:       pointer("success"),
-						Description: pointer("Success"),
-						Context:     pointer("bazel build //..."),
+						TargetURL:   new("http://localhost:8080/invocation/" + seq.InvocationID),
+						State:       new("success"),
+						Description: new("Success"),
+						Context:     new("bazel build //..."),
 					},
 				},
 			}, client.ConsumeStatuses())
@@ -2230,8 +2230,4 @@ func TestTruncateStringSlice(t *testing.T) {
 			assert.Equal(t, test.Truncated, truncated, "truncated should be %t", test.Truncated)
 		})
 	}
-}
-
-func pointer[T any](value T) *T {
-	return &value
 }

--- a/server/util/channelz_metrics/channelz_metrics_test.go
+++ b/server/util/channelz_metrics/channelz_metrics_test.go
@@ -86,8 +86,6 @@ func (f *fakeChannelz) GetChannel(ctx context.Context, in *channelzpb.GetChannel
 	return &channelzpb.GetChannelResponse{Channel: ch}, nil
 }
 
-func i64(v int64) *int64 { return &v }
-
 func socket(id int64, remote, local *int64, started, succeeded, failed int64) *channelzpb.Socket {
 	d := &channelzpb.SocketData{StreamsStarted: started, StreamsSucceeded: succeeded, StreamsFailed: failed}
 	if remote != nil {
@@ -159,13 +157,13 @@ func TestCollect(t *testing.T) {
 	const remote = "grpc://remote:443"
 	const other = "grpc://other:443"
 	// Blocked: remote window 0, 100 open streams.
-	f.addChannel(1, 11, 101, remote, socket(101, i64(0), i64(1000), 105, 5, 0))
+	f.addChannel(1, 11, 101, remote, socket(101, new(int64(0)), new(int64(1000)), 105, 5, 0))
 	// Healthy: remote window 500000, 1 open stream.
-	f.addChannel(2, 12, 102, remote, socket(102, i64(500_000), i64(2000), 10, 8, 1))
+	f.addChannel(2, 12, 102, remote, socket(102, new(int64(500_000)), new(int64(2000)), 10, 8, 1))
 	// Unknown remote window (nil wrapper), 0 open streams.
-	f.addChannel(3, 13, 103, remote, socket(103, nil, i64(3000), 3, 3, 0))
+	f.addChannel(3, 13, 103, remote, socket(103, nil, new(int64(3000)), 3, 3, 0))
 	// Different target.
-	f.addChannel(4, 14, 104, other, socket(104, i64(12345), i64(4000), 2, 2, 0))
+	f.addChannel(4, 14, 104, other, socket(104, new(int64(12345)), new(int64(4000)), 2, 2, 0))
 	// Socket that vanished mid-walk: should be skipped, not fail the pass.
 	f.addChannel(5, 15, 105, remote, nil)
 	f.missing[105] = true
@@ -209,7 +207,7 @@ func TestCollect_NestedChildChannels(t *testing.T) {
 	const target = "xds:///remote:443"
 	// The top channel (1) has no direct subchannel; its socket lives under child
 	// channel 2, reachable only via ChannelRef + GetChannel.
-	f.addNestedChannel(1, 2, 21, 201, target, socket(201, i64(0), i64(1000), 100, 0, 0))
+	f.addNestedChannel(1, 2, 21, 201, target, socket(201, new(int64(0)), new(int64(1000)), 100, 0, 0))
 
 	conns, err := collect(context.Background(), f)
 	require.NoError(t, err)
@@ -222,9 +220,9 @@ func TestCollect_NestedChildChannels(t *testing.T) {
 func TestSampleAggregates(t *testing.T) {
 	f := newFake()
 	const target = "grpc://sample-test:443"
-	f.addChannel(1, 11, 101, target, socket(101, i64(0), i64(1000), 100, 0, 0))     // blocked
-	f.addChannel(2, 12, 102, target, socket(102, i64(0), i64(1000), 50, 0, 0))      // blocked
-	f.addChannel(3, 13, 103, target, socket(103, i64(500_000), i64(1000), 5, 4, 0)) // healthy
+	f.addChannel(1, 11, 101, target, socket(101, new(int64(0)), new(int64(1000)), 100, 0, 0))     // blocked
+	f.addChannel(2, 12, 102, target, socket(102, new(int64(0)), new(int64(1000)), 50, 0, 0))      // blocked
+	f.addChannel(3, 13, 103, target, socket(103, new(int64(500_000)), new(int64(1000)), 5, 4, 0)) // healthy
 
 	require.NoError(t, sample(context.Background(), f))
 

--- a/tools/protoc-gen-go-vtproto-view/BUILD
+++ b/tools/protoc-gen-go-vtproto-view/BUILD
@@ -34,7 +34,6 @@ go_test(
         "//tools/protoc-gen-go-vtproto-view/testdata:viewtest_go_proto",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//compiler/protogen",
-        "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//reflect/protodesc",
         "@org_golang_google_protobuf//reflect/protoreflect",
         "@org_golang_google_protobuf//reflect/protoregistry",

--- a/tools/protoc-gen-go-vtproto-view/golden_test.go
+++ b/tools/protoc-gen-go-vtproto-view/golden_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/compiler/protogen"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
@@ -102,7 +101,7 @@ func codeGeneratorRequest(t *testing.T, path string) *pluginpb.CodeGeneratorRequ
 	add(fd)
 	return &pluginpb.CodeGeneratorRequest{
 		FileToGenerate: []string{path},
-		Parameter:      proto.String(strings.Join(params, ",")),
+		Parameter:      new(strings.Join(params, ",")),
 		ProtoFile:      files,
 	}
 }


### PR DESCRIPTION
Go 1.26 allows new to accept a value expression, avoiding temporary
variables and immediately invoked functions used only to take a
value's address. Apply the type-aware newexpr fixes and enable the
check for future pointer construction.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>