### PR TITLE
go: simplify typed error and reflection APIs

### DIFF
--- a/cli/ssh/ssh.go
+++ b/cli/ssh/ssh.go
@@ -607,8 +607,7 @@ func Run(ctx context.Context, opts Options) (int, error) {
 			if closed(connDead) {
 				return 1, status.UnavailableErrorf("connection to %s lost: no response from server", opts.Host)
 			}
-			var exitErr *gossh.ExitError
-			if errors.As(err, &exitErr) {
+			if exitErr, ok := errors.AsType[*gossh.ExitError](err); ok {
 				return exitErr.ExitStatus(), nil
 			}
 			return 1, status.WrapError(err, "running remote command")
@@ -640,8 +639,7 @@ func Run(ctx context.Context, opts Options) (int, error) {
 		return 1, nil
 	}
 	if err != nil {
-		var exitErr *gossh.ExitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[*gossh.ExitError](err); ok {
 			return exitErr.ExitStatus(), nil
 		}
 		// Server closed without an exit status (e.g. its idle timeout or

--- a/enterprise/server/mcp/mcpserver/mcpserver.go
+++ b/enterprise/server/mcp/mcpserver/mcpserver.go
@@ -214,8 +214,7 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		var maxBytesErr *http.MaxBytesError
-		if errors.As(err, &maxBytesErr) {
+		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
 			http.Error(w, "MCP request body is too large", http.StatusRequestEntityTooLarge)
 			return
 		}
@@ -412,7 +411,7 @@ func (s *Service) invokeAPITool(ctx context.Context, generatedTool mcptools.Tool
 	if results[0].IsNil() {
 		return nil, status.InternalErrorf("API method %s returned no response", generatedTool.RPCName)
 	}
-	responseProto, ok := results[0].Interface().(proto.Message)
+	responseProto, ok := reflect.TypeAssert[proto.Message](results[0])
 	if !ok {
 		return nil, status.InternalErrorf("API method %s returned a non-proto response", generatedTool.RPCName)
 	}

--- a/rules/go/analyzer/def.bzl
+++ b/rules/go/analyzer/def.bzl
@@ -1,4 +1,6 @@
 ANALYZERS = [
+    "reflecttypeassert",
+    "errorsastype",
     "embedlit",
     "slicesclip",
     "slicesbackward",
@@ -12,7 +14,7 @@ ANALYZERS = [
     # "plusbuild",
     # "omitzero",
     "rangeint",
-    # "reflecttypefor",
+    "reflecttypefor",
     "slicescontains",
     "slicessort",
     "stditerators",

--- a/server/backends/blobstore/aws/aws.go
+++ b/server/backends/blobstore/aws/aws.go
@@ -156,8 +156,7 @@ func (a *AwsS3BlobStore) bucketExists(ctx context.Context, bucketName string) (b
 	if err == nil {
 		return true, nil
 	}
-	var nf *s3types.NotFound
-	if errors.As(err, &nf) {
+	if _, ok := errors.AsType[*s3types.NotFound](err); ok {
 		return false, nil
 	}
 	return false, err
@@ -204,8 +203,7 @@ func (a *AwsS3BlobStore) download(ctx context.Context, blobName string) ([]byte,
 	spn.End()
 
 	if err != nil {
-		var nsk *s3types.NoSuchKey
-		if errors.As(err, &nsk) {
+		if _, ok := errors.AsType[*s3types.NoSuchKey](err); ok {
 			return nil, status.NotFoundError(err.Error())
 		}
 		return nil, err
@@ -280,8 +278,7 @@ func (a *AwsS3BlobStore) BlobExists(ctx context.Context, blobName string) (bool,
 	_, err := a.client.HeadObject(ctx, params)
 	util.RecordExistsMetrics(awsS3Label, start, err)
 	if err != nil {
-		var nf *s3types.NotFound
-		if errors.As(err, &nf) {
+		if _, ok := errors.AsType[*s3types.NotFound](err); ok {
 			return false, nil
 		}
 		return false, err

--- a/server/capabilities_filter/capabilities_filter_test.go
+++ b/server/capabilities_filter/capabilities_filter_test.go
@@ -25,11 +25,11 @@ var (
 
 func TestAllRPCsHaveExplicitCapabilitiesSpecified(t *testing.T) {
 	serviceMethodNames := []string{}
-	buildbuddyServiceType := reflect.TypeOf((*bbspb.BuildBuddyServiceServer)(nil)).Elem()
+	buildbuddyServiceType := reflect.TypeFor[bbspb.BuildBuddyServiceServer]()
 	for method := range buildbuddyServiceType.Methods() {
 		serviceMethodNames = append(serviceMethodNames, buildBuddyServicePrefix+method.Name)
 	}
-	apiServiceType := reflect.TypeOf((*apipb.ApiServiceServer)(nil)).Elem()
+	apiServiceType := reflect.TypeFor[apipb.ApiServiceServer]()
 	for method := range apiServiceType.Methods() {
 		serviceMethodNames = append(serviceMethodNames, apiServicePrefix+method.Name)
 	}
@@ -50,11 +50,11 @@ func TestAllRPCsHaveExplicitCapabilitiesSpecified(t *testing.T) {
 func TestBuildBuddyServiceRPCsHaveRequestAndResponseContextFields(t *testing.T) {
 	type Req interface{ GetRequestContext() *ctxpb.RequestContext }
 	type Res interface{ GetResponseContext() *ctxpb.ResponseContext }
-	expectedReqType := reflect.TypeOf((*Req)(nil)).Elem()
-	expectedResType := reflect.TypeOf((*Res)(nil)).Elem()
-	ctxType := reflect.TypeOf((*context.Context)(nil)).Elem()
+	expectedReqType := reflect.TypeFor[Req]()
+	expectedResType := reflect.TypeFor[Res]()
+	ctxType := reflect.TypeFor[context.Context]()
 
-	buildbuddyServiceType := reflect.TypeOf((*bbspb.BuildBuddyServiceServer)(nil)).Elem()
+	buildbuddyServiceType := reflect.TypeFor[bbspb.BuildBuddyServiceServer]()
 	for method := range buildbuddyServiceType.Methods() {
 		methodFunc := method.Type
 		methodName := method.Name

--- a/server/http/protolet/protolet.go
+++ b/server/http/protolet/protolet.go
@@ -48,16 +48,16 @@ func isRPCMethod(m reflect.Method) bool {
 		return false
 	}
 	// Check signature is about right: (rcvr??, context, proto) (proto, error)
-	if !t.In(1).Implements(reflect.TypeOf((*context.Context)(nil)).Elem()) {
+	if !t.In(1).Implements(reflect.TypeFor[context.Context]()) {
 		return false
 	}
-	if !t.In(2).Implements(reflect.TypeOf((*proto.Message)(nil)).Elem()) {
+	if !t.In(2).Implements(reflect.TypeFor[proto.Message]()) {
 		return false
 	}
-	if !t.Out(0).Implements(reflect.TypeOf((*proto.Message)(nil)).Elem()) {
+	if !t.Out(0).Implements(reflect.TypeFor[proto.Message]()) {
 		return false
 	}
-	if !t.Out(1).Implements(reflect.TypeOf((*error)(nil)).Elem()) {
+	if !t.Out(1).Implements(reflect.TypeFor[error]()) {
 		return false
 	}
 	return true
@@ -71,13 +71,13 @@ func isStreamingRPCMethod(m reflect.Method) bool {
 	if t.NumIn() != 3 || t.NumOut() != 1 {
 		return false
 	}
-	if !t.In(1).Implements(reflect.TypeOf((*proto.Message)(nil)).Elem()) {
+	if !t.In(1).Implements(reflect.TypeFor[proto.Message]()) {
 		return false
 	}
-	if !t.In(2).Implements(reflect.TypeOf((*grpc.ServerStream)(nil)).Elem()) {
+	if !t.In(2).Implements(reflect.TypeFor[grpc.ServerStream]()) {
 		return false
 	}
-	if !t.Out(0).Implements(reflect.TypeOf((*error)(nil)).Elem()) {
+	if !t.Out(0).Implements(reflect.TypeFor[error]()) {
 		return false
 	}
 	return true
@@ -173,7 +173,7 @@ func GenerateHTTPHandlers(servicePrefix, serviceName string, server any, grpcSer
 			methodType := method.Type()
 			requestIndex := 2
 			// If we're dealing with a streaming method, the request proto is the first input
-			if method.Type().In(1).Implements(reflect.TypeOf((*proto.Message)(nil)).Elem()) {
+			if method.Type().In(1).Implements(reflect.TypeFor[proto.Message]()) {
 				requestIndex = 1
 			}
 
@@ -232,7 +232,7 @@ func GenerateHTTPHandlers(servicePrefix, serviceName string, server any, grpcSer
 		args := []reflect.Value{reflect.ValueOf(server), reflect.ValueOf(ctx), reqVal}
 		rspArr := method.Call(args)
 		if rspArr[1].Interface() != nil {
-			err, _ := rspArr[1].Interface().(error)
+			err, _ := reflect.TypeAssert[error](rspArr[1])
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/server/util/flagutil/common/common.go
+++ b/server/util/flagutil/common/common.go
@@ -13,14 +13,14 @@ import (
 var (
 	// Used for type conversions between flags and normal go types
 	flagTypeToGoTypeMap = map[reflect.Type]reflect.Type{
-		flagTypeFromFlagFuncName("Bool"):     reflect.TypeOf((*bool)(nil)),
-		flagTypeFromFlagFuncName("Duration"): reflect.TypeOf((*time.Duration)(nil)),
-		flagTypeFromFlagFuncName("Float64"):  reflect.TypeOf((*float64)(nil)),
-		flagTypeFromFlagFuncName("Int"):      reflect.TypeOf((*int)(nil)),
-		flagTypeFromFlagFuncName("Int64"):    reflect.TypeOf((*int64)(nil)),
-		flagTypeFromFlagFuncName("Uint"):     reflect.TypeOf((*uint)(nil)),
-		flagTypeFromFlagFuncName("Uint64"):   reflect.TypeOf((*uint64)(nil)),
-		flagTypeFromFlagFuncName("String"):   reflect.TypeOf((*string)(nil)),
+		flagTypeFromFlagFuncName("Bool"):     reflect.TypeFor[*bool](),
+		flagTypeFromFlagFuncName("Duration"): reflect.TypeFor[*time.Duration](),
+		flagTypeFromFlagFuncName("Float64"):  reflect.TypeFor[*float64](),
+		flagTypeFromFlagFuncName("Int"):      reflect.TypeFor[*int](),
+		flagTypeFromFlagFuncName("Int64"):    reflect.TypeFor[*int64](),
+		flagTypeFromFlagFuncName("Uint"):     reflect.TypeFor[*uint](),
+		flagTypeFromFlagFuncName("Uint64"):   reflect.TypeFor[*uint64](),
+		flagTypeFromFlagFuncName("String"):   reflect.TypeFor[*string](),
 	}
 	goTypeToFlagTypeMap = invertMap(flagTypeToGoTypeMap)
 
@@ -54,7 +54,7 @@ func ZeroFlagValueFromType[T any]() flag.Value {
 	if !ok || t.Kind() != reflect.Pointer {
 		return nil
 	}
-	zero, ok := reflect.New(t.Elem()).Interface().(flag.Value)
+	zero, ok := reflect.TypeAssert[flag.Value](reflect.New(t.Elem()))
 	if !ok {
 		return nil
 	}
@@ -150,8 +150,8 @@ func ConvertFlagValue(value flag.Value) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	if addr.CanConvert(reflect.TypeOf((*reflect.Value)(nil))) {
-		addr = *addr.Convert(reflect.TypeOf((*reflect.Value)(nil))).Interface().(*reflect.Value)
+	if addr.CanConvert(reflect.TypeFor[*reflect.Value]()) {
+		addr = *addr.Convert(reflect.TypeFor[*reflect.Value]()).Interface().(*reflect.Value)
 		if !addr.CanConvert(t) {
 			return nil, status.InternalErrorf("Flag of type %T with concrete type *reflect.Value wrapping type %T could not be converted to %s.", value, addr.Interface(), t)
 		}
@@ -263,8 +263,8 @@ func getDereferencedValueFrom[T any](flagset *flag.FlagSet, value flag.Value, na
 	if err != nil {
 		return Zero[T](), status.InternalErrorf("Error dereferencing flag %s: %v", name, err)
 	}
-	t := reflect.TypeOf((*T)(nil))
-	if t == reflect.TypeOf((*any)(nil)) {
+	t := reflect.TypeFor[*T]()
+	if t == reflect.TypeFor[*any]() {
 		return reflect.ValueOf(converted).Elem().Interface().(T), nil
 	}
 	v, ok := converted.(*T)
@@ -276,7 +276,7 @@ func getDereferencedValueFrom[T any](flagset *flag.FlagSet, value flag.Value, na
 
 // Zero returns a zero-value of the provided type.
 func Zero[T any]() T {
-	return *reflect.New(reflect.TypeOf((*T)(nil)).Elem()).Interface().(*T)
+	return *reflect.New(reflect.TypeFor[T]()).Interface().(*T)
 }
 
 // ResetFlags resets all flags to their default values, as specified by
@@ -319,7 +319,7 @@ func setWithOverride(flagset *flag.FlagSet, flagValue flag.Value, name, newValue
 	// flag.Value interface's Set method, so it can be set with newValueString.
 	blankFlagValue := reflect.New(reflect.TypeOf(unwrapped).Elem()).Interface().(flag.Value)
 
-	if reflect.ValueOf(blankFlagValue).CanConvert(reflect.TypeOf((*reflect.Value)(nil))) {
+	if reflect.ValueOf(blankFlagValue).CanConvert(reflect.TypeFor[*reflect.Value]()) {
 		t, err := GetTypeForFlagValue(unwrapped)
 		if err != nil {
 			return status.InternalErrorf("Error getting type for copy of flag %s: %s", name, err)
@@ -329,7 +329,7 @@ func setWithOverride(flagset *flag.FlagSet, flagValue flag.Value, name, newValue
 		// reflect.Value instead of aliasing their value directly (such as, for
 		// example, JSONSliceFlag and JSONStructFlag) in order to correctly
 		// initialize them.
-		blankValueAddr := reflect.ValueOf(blankFlagValue).Convert(reflect.TypeOf((*reflect.Value)(nil))).Interface().(*reflect.Value)
+		blankValueAddr := reflect.ValueOf(blankFlagValue).Convert(reflect.TypeFor[*reflect.Value]()).Interface().(*reflect.Value)
 		*blankValueAddr = reflect.New(t.Elem())
 	}
 

--- a/server/util/flagutil/types/autoflags/autoflags.go
+++ b/server/util/flagutil/types/autoflags/autoflags.go
@@ -19,7 +19,7 @@ import (
 // output, or use `DeprecatedTag(migrationPlan)` to mark a flag that has been
 // deprecated and provide its migration plan.
 func New[T any](flagset *flag.FlagSet, name string, defaultValue T, usage string, tags ...flagtags.Taggable) *T {
-	value := reflect.New(reflect.TypeOf((*T)(nil)).Elem()).Interface().(*T)
+	value := reflect.New(reflect.TypeFor[T]()).Interface().(*T)
 	Var(flagset, value, name, defaultValue, usage, tags...)
 	return value
 }

--- a/server/util/flagutil/types/types.go
+++ b/server/util/flagutil/types/types.go
@@ -66,7 +66,7 @@ func NewJSONSliceFlag[T any](slice *T) *JSONSliceFlag[T] {
 }
 
 func JSONSlice[T any](flagset *flag.FlagSet, name string, defaultValue T, usage string) *T {
-	value := reflect.New(reflect.TypeOf((*T)(nil)).Elem()).Interface().(*T)
+	value := reflect.New(reflect.TypeFor[T]()).Interface().(*T)
 	JSONSliceVar(flagset, value, name, defaultValue, usage)
 	return value
 }
@@ -78,9 +78,9 @@ func JSONSliceVar[T any](flagset *flag.FlagSet, value *T, name string, defaultVa
 	}
 	v := reflect.ValueOf(value)
 	if src.IsNil() && !v.Elem().IsNil() {
-		v.Elem().Set(reflect.New(reflect.TypeOf((*T)(nil)).Elem()).Elem())
+		v.Elem().Set(reflect.New(reflect.TypeFor[T]()).Elem())
 	} else if v.Elem().Len() != src.Len() || v.Elem().IsNil() {
-		v.Elem().Set(reflect.MakeSlice(reflect.TypeOf((*T)(nil)).Elem(), src.Len(), src.Len()))
+		v.Elem().Set(reflect.MakeSlice(reflect.TypeFor[T](), src.Len(), src.Len()))
 	}
 	reflect.Copy(v.Elem(), src)
 	flagset.Var((*JSONSliceFlag[T])(&v), name, usage)
@@ -105,7 +105,7 @@ func (f *JSONSliceFlag[T]) Set(values string) error {
 	}
 	v := (reflect.Value)(*f).Elem()
 	if _, ok := a.([]any); ok {
-		dst := reflect.New(reflect.TypeOf((*T)(nil)).Elem()).Interface()
+		dst := reflect.New(reflect.TypeFor[T]()).Interface()
 		if err := json.Unmarshal([]byte(values), dst); err != nil {
 			return err
 		}
@@ -113,7 +113,7 @@ func (f *JSONSliceFlag[T]) Set(values string) error {
 		return nil
 	}
 	if _, ok := a.(map[string]any); ok {
-		dst := reflect.New(reflect.TypeOf((*T)(nil)).Elem().Elem()).Interface()
+		dst := reflect.New(reflect.TypeFor[T]().Elem()).Interface()
 		if err := json.Unmarshal([]byte(values), dst); err != nil {
 			return err
 		}
@@ -180,7 +180,7 @@ func (f *JSONSliceFlag[T]) Expand(mapping func(string) (string, error)) error {
 	if err != nil {
 		return err
 	}
-	sl := reflect.MakeSlice(reflect.TypeOf((*T)(nil)).Elem(), 0, 0)
+	sl := reflect.MakeSlice(reflect.TypeFor[T](), 0, 0)
 	v := (reflect.Value)(*f)
 	v.Elem().Set(sl)
 	return f.Set(string(exp))
@@ -196,7 +196,7 @@ func (f *JSONSliceFlag[T]) Accumulate(slice any) error {
 }
 
 func (f *JSONSliceFlag[T]) AliasedType() reflect.Type {
-	return reflect.TypeOf((*T)(nil))
+	return reflect.TypeFor[*T]()
 }
 
 func (f *JSONSliceFlag[T]) Slice() T {
@@ -211,7 +211,7 @@ func NewJSONStructFlag[T any](value *T) *JSONStructFlag[T] {
 }
 
 func JSONStruct[T any](flagset *flag.FlagSet, name string, defaultValue T, usage string) *T {
-	value := reflect.New(reflect.TypeOf((*T)(nil)).Elem()).Interface().(*T)
+	value := reflect.New(reflect.TypeFor[T]()).Interface().(*T)
 	JSONStructVar(flagset, value, name, defaultValue, usage)
 	return value
 }
@@ -240,7 +240,7 @@ func (f *JSONStructFlag[T]) String() string {
 
 func (f *JSONStructFlag[T]) Set(values string) error {
 	v := (reflect.Value)(*f).Elem()
-	dst := reflect.New(reflect.TypeOf((*T)(nil)).Elem()).Interface().(*T)
+	dst := reflect.New(reflect.TypeFor[T]()).Interface().(*T)
 	if err := json.Unmarshal([]byte(values), dst); err != nil {
 		return err
 	}
@@ -265,7 +265,7 @@ func (f *JSONStructFlag[T]) Expand(mapping func(string) (string, error)) error {
 }
 
 func (f *JSONStructFlag[T]) AliasedType() reflect.Type {
-	return reflect.TypeOf((*T)(nil))
+	return reflect.TypeFor[*T]()
 }
 
 func (f *JSONStructFlag[T]) Struct() T {
@@ -280,7 +280,7 @@ func NewJSONMapFlag[T any](value *T) *JSONMapFlag[T] {
 }
 
 func JSONMap[T any](flagset *flag.FlagSet, name string, defaultValue T, usage string) *T {
-	value := reflect.New(reflect.TypeOf((*T)(nil)).Elem()).Interface().(*T)
+	value := reflect.New(reflect.TypeFor[T]()).Interface().(*T)
 	JSONMapVar(flagset, value, name, defaultValue, usage)
 	return value
 }
@@ -294,7 +294,7 @@ func JSONMapVar[T any](flagset *flag.FlagSet, value *T, name string, defaultValu
 	// Copy the default into a fresh map so the flag's storage isn't aliased
 	// with the caller's default — subsequent Set/Merge calls must not
 	// mutate the caller's map.
-	m := reflect.MakeMapWithSize(reflect.TypeOf((*T)(nil)).Elem(), src.Len())
+	m := reflect.MakeMapWithSize(reflect.TypeFor[T](), src.Len())
 	if !src.IsNil() {
 		iter := src.MapRange()
 		for iter.Next() {
@@ -321,7 +321,7 @@ func (f *JSONMapFlag[T]) String() string {
 // key conflicts), mirroring the append semantics of JSONSliceFlag.Set.
 func (f *JSONMapFlag[T]) Set(values string) error {
 	v := (reflect.Value)(*f).Elem()
-	dst := reflect.New(reflect.TypeOf((*T)(nil)).Elem()).Interface().(*T)
+	dst := reflect.New(reflect.TypeFor[T]()).Interface().(*T)
 	if err := json.Unmarshal([]byte(values), dst); err != nil {
 		return err
 	}
@@ -371,7 +371,7 @@ func (f *JSONMapFlag[T]) Expand(mapping func(string) (string, error)) error {
 }
 
 func (f *JSONMapFlag[T]) AliasedType() reflect.Type {
-	return reflect.TypeOf((*T)(nil))
+	return reflect.TypeFor[*T]()
 }
 
 func (f *JSONMapFlag[T]) Map() T {
@@ -435,7 +435,7 @@ func (f *StringSliceFlag) Accumulate(slice any) error {
 }
 
 func (f *StringSliceFlag) AliasedType() reflect.Type {
-	return reflect.TypeOf((*[]string)(nil))
+	return reflect.TypeFor[*[]string]()
 }
 
 type URLFlag url.URL
@@ -487,11 +487,11 @@ func (f *URLFlag) MarshalYAML() (any, error) {
 }
 
 func (f *URLFlag) AliasedType() reflect.Type {
-	return reflect.TypeOf((*url.URL)(nil))
+	return reflect.TypeFor[*url.URL]()
 }
 
 func (f *URLFlag) YAMLTypeAlias() reflect.Type {
-	return reflect.TypeOf((*URLFlag)(nil))
+	return reflect.TypeFor[*URLFlag]()
 }
 
 func (f *URLFlag) YAMLTypeString() string {

--- a/server/util/flagutil/types/types_test.go
+++ b/server/util/flagutil/types/types_test.go
@@ -68,7 +68,7 @@ func TestStringSliceFlag(t *testing.T) {
 	assert.Equal(t, []string{"yes", "si", "hai", "yes", "si", "hai"}, testSlice)
 
 	// `String` should not panic on zero-constructed flag
-	assert.Equal(t, "", reflect.New(reflect.TypeOf((*StringSliceFlag)(nil)).Elem()).Interface().(flag.Value).String())
+	assert.Equal(t, "", reflect.New(reflect.TypeFor[StringSliceFlag]()).Interface().(flag.Value).String())
 }
 
 func TestStructSliceFlag(t *testing.T) {
@@ -117,7 +117,7 @@ func TestStructSliceFlag(t *testing.T) {
 	assert.Equal(t, []testStruct{{}, {Field: 1}, {Meadow: "Paradise"}, {}, {Field: 1}, {Meadow: "Paradise"}}, testSlice)
 
 	// `String` should not panic on zero-constructed flag
-	assert.Equal(t, "[]", reflect.New(reflect.TypeOf((*JSONSliceFlag[[]testStruct])(nil)).Elem()).Interface().(flag.Value).String())
+	assert.Equal(t, "[]", reflect.New(reflect.TypeFor[JSONSliceFlag[[]testStruct]]()).Interface().(flag.Value).String())
 }
 
 func TestProtoSliceFlag(t *testing.T) {
@@ -166,7 +166,7 @@ func TestProtoSliceFlag(t *testing.T) {
 	assert.Equal(t, []*timestamppb.Timestamp{{}, {Seconds: 1}, {Nanos: 99}, {}, {Seconds: 1}, {Nanos: 99}}, testSlice)
 
 	// `String` should not panic on zero-constructed flag
-	assert.Equal(t, "[]", reflect.New(reflect.TypeOf((*JSONSliceFlag[[]*timestamppb.Timestamp])(nil)).Elem()).Interface().(flag.Value).String())
+	assert.Equal(t, "[]", reflect.New(reflect.TypeFor[JSONSliceFlag[[]*timestamppb.Timestamp]]()).Interface().(flag.Value).String())
 }
 
 func TestJSONStructFlag(t *testing.T) {
@@ -189,7 +189,7 @@ func TestJSONStructFlag(t *testing.T) {
 	assert.Equal(t, testStruct{Field: 5, Meadow: "runnymede"}, (flags.Lookup(flagName).Value.(*JSONStructFlag[testStruct]).Struct()))
 
 	// `String` should not panic on zero-constructed flag
-	assert.Equal(t, "{}", reflect.New(reflect.TypeOf((*JSONStructFlag[testStruct])(nil)).Elem()).Interface().(flag.Value).String())
+	assert.Equal(t, "{}", reflect.New(reflect.TypeFor[JSONStructFlag[testStruct]]()).Interface().(flag.Value).String())
 }
 
 func TestJSONMapFlag(t *testing.T) {
@@ -229,7 +229,7 @@ func TestJSONMapFlag(t *testing.T) {
 	assert.Error(t, err)
 
 	// `String` should not panic on zero-constructed flag.
-	assert.Equal(t, "{}", reflect.New(reflect.TypeOf((*JSONMapFlag[map[string]string])(nil)).Elem()).Interface().(flag.Value).String())
+	assert.Equal(t, "{}", reflect.New(reflect.TypeFor[JSONMapFlag[map[string]string]]()).Interface().(flag.Value).String())
 }
 
 func TestFlagAlias(t *testing.T) {
@@ -253,10 +253,10 @@ func TestFlagAlias(t *testing.T) {
 	assert.Equal(t, "string", asf.(common.NameAliasable).AliasedName())
 	asfType, err := common.GetTypeForFlagValue(asf)
 	require.NoError(t, err)
-	assert.Equal(t, reflect.TypeOf((*string)(nil)), asfType)
+	assert.Equal(t, reflect.TypeFor[*string](), asfType)
 	asfYAMLType, err := flagyaml.GetYAMLTypeForFlagValue(asf)
 	require.NoError(t, err)
-	assert.Equal(t, reflect.TypeOf((*string)(nil)), asfYAMLType)
+	assert.Equal(t, reflect.TypeFor[*string](), asfYAMLType)
 
 	aasf := flags.Lookup("string_alias").Value
 	assert.Equal(t, "meow", aasf.String())
@@ -264,10 +264,10 @@ func TestFlagAlias(t *testing.T) {
 	assert.Equal(t, "string", aasf.(common.NameAliasable).AliasedName())
 	aasfType, err := common.GetTypeForFlagValue(asf)
 	require.NoError(t, err)
-	assert.Equal(t, reflect.TypeOf((*string)(nil)), aasfType)
+	assert.Equal(t, reflect.TypeFor[*string](), aasfType)
 	aasfYAMLType, err := flagyaml.GetYAMLTypeForFlagValue(asf)
 	require.NoError(t, err)
-	assert.Equal(t, reflect.TypeOf((*string)(nil)), aasfYAMLType)
+	assert.Equal(t, reflect.TypeFor[*string](), aasfYAMLType)
 
 	p := Alias[string](flags, "string_alias_alias")
 	assert.Equal(t, aas, p)
@@ -527,9 +527,9 @@ deprecated_string_slice:
 	assert.True(t, ok)
 
 	// `String` should not panic on zero-constructed flag
-	assert.Equal(t, "[]", reflect.New(reflect.TypeOf((*tags.TaggedFlagValue[[]testStruct, *JSONSliceFlag[[]testStruct]])(nil)).Elem()).Interface().(flag.Value).String())
-	assert.Equal(t, "{}", reflect.New(reflect.TypeOf((*tags.TaggedFlagValue[struct{}, *JSONStructFlag[struct{}]])(nil)).Elem()).Interface().(flag.Value).String())
-	assert.Equal(t, "", reflect.New(reflect.TypeOf((*tags.TaggedFlagValue[string, flag.Value])(nil)).Elem()).Interface().(flag.Value).String())
+	assert.Equal(t, "[]", reflect.New(reflect.TypeFor[tags.TaggedFlagValue[[]testStruct, *JSONSliceFlag[[]testStruct]]]()).Interface().(flag.Value).String())
+	assert.Equal(t, "{}", reflect.New(reflect.TypeFor[tags.TaggedFlagValue[struct{}, *JSONStructFlag[struct{}]]]()).Interface().(flag.Value).String())
+	assert.Equal(t, "", reflect.New(reflect.TypeFor[tags.TaggedFlagValue[string, flag.Value]]()).Interface().(flag.Value).String())
 }
 
 func TestDeprecate(t *testing.T) {
@@ -594,5 +594,5 @@ deprecated_string_slice:
 
 func TestURLFlag(t *testing.T) {
 	// `String` should not panic on zero-constructed flag
-	assert.Equal(t, "", reflect.New(reflect.TypeOf((*URLFlag)(nil)).Elem()).Interface().(flag.Value).String())
+	assert.Equal(t, "", reflect.New(reflect.TypeFor[URLFlag]()).Interface().(flag.Value).String())
 }

--- a/server/util/flagutil/yaml/yaml.go
+++ b/server/util/flagutil/yaml/yaml.go
@@ -132,13 +132,7 @@ func GetYAMLTypeString(yamlValue any) string {
 	if v, ok := yamlValue.(YAMLTypeStringable); ok {
 		return v.YAMLTypeString()
 	}
-	value := reflect.ValueOf(yamlValue)
-	if value.CanAddr() {
-		if v, ok := value.Addr().Interface().(YAMLTypeStringable); ok {
-			return v.YAMLTypeString()
-		}
-	}
-	t := value.Type()
+	t := reflect.TypeOf(yamlValue)
 	for t.Kind() == reflect.Ptr {
 		t = t.Elem()
 	}

--- a/server/util/flagutil/yaml/yaml_test.go
+++ b/server/util/flagutil/yaml/yaml_test.go
@@ -55,23 +55,23 @@ func TestGenerateYAMLTypeMapFromFlags(t *testing.T) {
 	)
 	require.NoError(t, err)
 	expected := map[string]any{
-		"bool": reflect.TypeOf((*bool)(nil)),
+		"bool": reflect.TypeFor[*bool](),
 		"one": map[string]any{
 			"two": map[string]any{
-				"int":          reflect.TypeOf((*int)(nil)),
-				"string_slice": reflect.TypeOf((*[]string)(nil)),
+				"int":          reflect.TypeFor[*int](),
+				"string_slice": reflect.TypeFor[*[]string](),
 				"two_and_a_half": map[string]any{
-					"float64": reflect.TypeOf((*float64)(nil)),
+					"float64": reflect.TypeFor[*float64](),
 				},
 				"three": map[string]any{
-					"struct_slice": reflect.TypeOf((*[]testStruct)(nil)),
+					"struct_slice": reflect.TypeFor[*[]testStruct](),
 				},
 			},
 		},
 		"a": map[string]any{
 			"b": map[string]any{
-				"string": reflect.TypeOf((*string)(nil)),
-				"url":    reflect.TypeOf((*flagtypes.URLFlag)(nil)),
+				"string": reflect.TypeFor[*string](),
+				"url":    reflect.TypeFor[*flagtypes.URLFlag](),
 			},
 		},
 	}
@@ -120,27 +120,27 @@ func TestBadGenerateYAMLTypeMapFromFlags(t *testing.T) {
 
 func TestRetypeAndFilterYAMLMap(t *testing.T) {
 	typeMap := map[string]any{
-		"bool": reflect.TypeOf((*bool)(nil)),
+		"bool": reflect.TypeFor[*bool](),
 		"one": map[string]any{
 			"two": map[string]any{
-				"int":          reflect.TypeOf((*int)(nil)),
-				"string_slice": reflect.TypeOf((*[]string)(nil)),
+				"int":          reflect.TypeFor[*int](),
+				"string_slice": reflect.TypeFor[*[]string](),
 				"two_and_a_half": map[string]any{
-					"float64": reflect.TypeOf((*float64)(nil)),
+					"float64": reflect.TypeFor[*float64](),
 				},
 				"three": map[string]any{
-					"struct_slice": reflect.TypeOf((*[]testStruct)(nil)),
+					"struct_slice": reflect.TypeFor[*[]testStruct](),
 				},
 			},
 		},
 		"a": map[string]any{
 			"b": map[string]any{
-				"string": reflect.TypeOf((*string)(nil)),
-				"url":    reflect.TypeOf((*flagtypes.URLFlag)(nil)),
+				"string": reflect.TypeFor[*string](),
+				"url":    reflect.TypeFor[*flagtypes.URLFlag](),
 			},
 		},
 		"foo": map[string]any{
-			"bar": reflect.TypeOf((*int64)(nil)),
+			"bar": reflect.TypeFor[*int64](),
 		},
 	}
 	yamlData := `
@@ -199,7 +199,7 @@ first:
 
 func TestBadRetypeAndFilterYAMLMap(t *testing.T) {
 	typeMap := map[string]any{
-		"bool": reflect.TypeOf((*bool)(nil)),
+		"bool": reflect.TypeFor[*bool](),
 	}
 	yamlData := `
 bool: 7

--- a/server/util/relayauth/relayauth.go
+++ b/server/util/relayauth/relayauth.go
@@ -197,8 +197,7 @@ func (v *Verifier) Verify(credential string) (*Identity, error) {
 		return cert.PublicKey, nil
 	})
 	if err != nil {
-		var verr *jwt.ValidationError
-		if errors.As(err, &verr) {
+		if verr, ok := errors.AsType[*jwt.ValidationError](err); ok {
 			switch {
 			case verr.Errors&jwt.ValidationErrorSignatureInvalid != 0:
 				return nil, fmt.Errorf("relayauth: credential signature is invalid: %w", err)

--- a/server/util/status/status.go
+++ b/server/util/status/status.go
@@ -278,8 +278,7 @@ func WrapError(err error, msg string) error {
 	if err == nil {
 		return nil
 	}
-	var statusErr *statusError
-	if errors.As(err, &statusErr) {
+	if statusErr, ok := errors.AsType[*statusError](err); ok {
 		statusErr.err = fmt.Errorf("%s: %w", msg, statusErr.err)
 		return statusErr
 	}
@@ -343,8 +342,7 @@ func Message(err error) string {
 		return ""
 	}
 
-	var statusErr *statusError
-	if errors.As(err, &statusErr) {
+	if statusErr, ok := errors.AsType[*statusError](err); ok {
 		return statusErr.err.Error()
 	}
 


### PR DESCRIPTION
Generic error and reflection helpers express the desired type
directly instead of using temporary pointers or intermediate
interface assertions. Migrate eligible calls and enable errorsastype,
reflecttypefor, and the newer reflecttypeassert check.
