### PR TITLE
go: use typed atomic values

### DIFF
--- a/enterprise/server/billing/metronome/metronome_test.go
+++ b/enterprise/server/billing/metronome/metronome_test.go
@@ -58,13 +58,13 @@ func TestIngestEvents(t *testing.T) {
 }
 
 func TestIngestEventsBatching(t *testing.T) {
-	var requests int32
-	var totalEvents int32
+	var requests atomic.Int32
+	var totalEvents atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&requests, 1)
+		requests.Add(1)
 		var batch []metronome.MetronomeEvent
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&batch))
-		atomic.AddInt32(&totalEvents, int32(len(batch)))
+		totalEvents.Add(int32(len(batch)))
 	}))
 	defer server.Close()
 
@@ -84,14 +84,14 @@ func TestIngestEventsBatching(t *testing.T) {
 	c, err := metronome.NewClient(nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, c.ReportUsage(t.Context(), events))
-	assert.EqualValues(t, 3, atomic.LoadInt32(&requests))
-	assert.EqualValues(t, n, atomic.LoadInt32(&totalEvents))
+	assert.EqualValues(t, 3, requests.Load())
+	assert.EqualValues(t, n, totalEvents.Load())
 }
 
 func TestIngestRetriesTransientFailures(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if atomic.AddInt32(&attempts, 1) < 3 {
+		if attempts.Add(1) < 3 {
 			http.Error(w, "boom", http.StatusServiceUnavailable)
 			return
 		}
@@ -111,13 +111,13 @@ func TestIngestRetriesTransientFailures(t *testing.T) {
 	require.NoError(t, c.ReportUsage(t.Context(), []metronome.UsageEvent{{
 		GroupID: "GR1", PeriodStart: periodStart, PeriodEnd: periodStart.Add(metronome.WindowSize), SKU: sku.BuildEventsBESCount, Count: 1,
 	}}))
-	assert.EqualValues(t, 3, atomic.LoadInt32(&attempts))
+	assert.EqualValues(t, 3, attempts.Load())
 }
 
 func TestIngestDoesNotRetryClientErrors(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&attempts, 1)
+		attempts.Add(1)
 		http.Error(w, "bad", http.StatusBadRequest)
 	}))
 	defer server.Close()
@@ -136,13 +136,13 @@ func TestIngestDoesNotRetryClientErrors(t *testing.T) {
 	}})
 	require.Error(t, err)
 	assert.True(t, status.IsInvalidArgumentError(err))
-	assert.EqualValues(t, 1, atomic.LoadInt32(&attempts))
+	assert.EqualValues(t, 1, attempts.Load())
 }
 
 func TestReportUsageRejectsInvalidPeriods(t *testing.T) {
-	var requests int32
+	var requests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&requests, 1)
+		requests.Add(1)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -183,7 +183,7 @@ func TestReportUsageRejectsInvalidPeriods(t *testing.T) {
 			assert.True(t, status.IsInvalidArgumentError(err))
 		})
 	}
-	assert.EqualValues(t, 0, atomic.LoadInt32(&requests))
+	assert.EqualValues(t, 0, requests.Load())
 }
 
 func TestTransactionIDDeterministic(t *testing.T) {

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -132,7 +132,7 @@ type Env struct {
 	executors                     map[string]*Executor
 	testCommandController         *testCommandController
 	// Used to generate executor names when not specified.
-	executorNameCounter uint64
+	executorNameCounter atomic.Uint64
 	envOpts             *enterprise_testenv.Options
 
 	AppProxy     *testgrpc.Proxy
@@ -823,7 +823,7 @@ func (r *Env) AddExecutorWithOptions(t testing.TB, opts *ExecutorOptions) *Execu
 // otherwise use AddExecutorWithOptions and specify a custom Name.
 // Blocks until executor registers with the scheduler.
 func (r *Env) AddExecutor(t testing.TB) *Executor {
-	name := fmt.Sprintf("unnamedExecutor%d", atomic.AddUint64(&r.executorNameCounter, 1))
+	name := fmt.Sprintf("unnamedExecutor%d", r.executorNameCounter.Add(1))
 	return r.AddExecutorWithOptions(t, &ExecutorOptions{Name: name})
 }
 
@@ -847,7 +847,7 @@ func (r *Env) AddSingleTaskExecutorWithOptions(t testing.TB, options *ExecutorOp
 // otherwise use AddSingleTaskExecutorWithOptions and specify a custom Name.
 // Blocks until executor registers with the scheduler.
 func (r *Env) AddSingleTaskExecutor(t testing.TB) *Executor {
-	name := fmt.Sprintf("unnamedExecutor%d_singleTask", atomic.AddUint64(&r.executorNameCounter, 1))
+	name := fmt.Sprintf("unnamedExecutor%d_singleTask", r.executorNameCounter.Add(1))
 	return r.AddSingleTaskExecutorWithOptions(t, &ExecutorOptions{Name: name})
 }
 
@@ -871,7 +871,7 @@ func (r *Env) AddNamedExecutors(t testing.TB, names []string) []*Executor {
 func (r *Env) AddExecutors(t testing.TB, n int) []*Executor {
 	var names []string
 	for range n {
-		name := fmt.Sprintf("unnamedExecutor%d", atomic.AddUint64(&r.executorNameCounter, 1))
+		name := fmt.Sprintf("unnamedExecutor%d", r.executorNameCounter.Add(1))
 		names = append(names, name)
 	}
 	return r.AddNamedExecutors(t, names)

--- a/enterprise/server/util/pebble/pebble.go
+++ b/enterprise/server/util/pebble/pebble.go
@@ -649,11 +649,11 @@ func LookupProto(iter Iterator, key []byte, pb proto.Message) error {
 
 type MetricsCollector struct {
 	// Atomicly accessed metrics updated by pebble callbacks.
-	writeStallCount      int64
-	writeStallDuration   time.Duration
-	writeStallStartNanos int64
-	diskSlowCount        int64
-	diskStallCount       int64
+	writeStallCount      atomic.Int64
+	writeStallDuration   atomic.Int64
+	writeStallStartNanos atomic.Int64
+	diskSlowCount        atomic.Int64
+	diskStallCount       atomic.Int64
 }
 
 func (mc *MetricsCollector) BackgroundError(err error) {
@@ -661,25 +661,24 @@ func (mc *MetricsCollector) BackgroundError(err error) {
 }
 
 func (mc *MetricsCollector) WriteStallStats() (int64, time.Duration) {
-	count := atomic.LoadInt64(&mc.writeStallCount)
-	durationInt := atomic.LoadInt64((*int64)(&mc.writeStallDuration))
-	return count, time.Duration(durationInt)
+	count := mc.writeStallCount.Load()
+	return count, time.Duration(mc.writeStallDuration.Load())
 }
 
 func (mc *MetricsCollector) DiskStallStats() (int64, int64) {
-	slowCount := atomic.LoadInt64(&mc.diskSlowCount)
-	stallCount := atomic.LoadInt64(&mc.diskStallCount)
+	slowCount := mc.diskSlowCount.Load()
+	stallCount := mc.diskStallCount.Load()
 	return slowCount, stallCount
 }
 
 func (mc *MetricsCollector) WriteStallBegin(info pebble.WriteStallBeginInfo) {
 	startNanos := time.Now().UnixNano()
-	atomic.StoreInt64(&mc.writeStallStartNanos, startNanos)
-	atomic.AddInt64(&mc.writeStallCount, 1)
+	mc.writeStallStartNanos.Store(startNanos)
+	mc.writeStallCount.Add(1)
 }
 
 func (mc *MetricsCollector) WriteStallEnd() {
-	startNanos := atomic.SwapInt64(&mc.writeStallStartNanos, 0)
+	startNanos := mc.writeStallStartNanos.Swap(0)
 	if startNanos == 0 {
 		return
 	}
@@ -687,16 +686,16 @@ func (mc *MetricsCollector) WriteStallEnd() {
 	if stallDuration < 0 {
 		return
 	}
-	atomic.AddInt64((*int64)(&mc.writeStallDuration), stallDuration)
+	mc.writeStallDuration.Add(stallDuration)
 }
 
 func (mc *MetricsCollector) DiskSlow(info pebble.DiskSlowInfo) {
 	if info.Duration.Seconds() >= maxSyncDuration.Seconds() {
-		atomic.AddInt64(&mc.diskStallCount, 1)
+		mc.diskStallCount.Add(1)
 		log.Errorf("Pebble Cache: disk stall: unable to write %q in %.2f seconds.", info.Path, info.Duration.Seconds())
 		return
 	}
-	atomic.AddInt64(&mc.diskSlowCount, 1)
+	mc.diskSlowCount.Add(1)
 }
 
 func (mc *MetricsCollector) UpdateMetrics(m *Metrics, om Metrics, cacheName string) error {

--- a/enterprise/server/util/vfs_server/vfs_server.go
+++ b/enterprise/server/util/vfs_server/vfs_server.go
@@ -371,11 +371,9 @@ type Server struct {
 
 	server *grpc.Server
 
-	nextNodeID atomic.Uint64
-
 	mu                 sync.Mutex
 	blocks             int64
-	nextId             uint64
+	nextId             atomic.Uint64
 	nodes              map[uint64]*fsNode
 	internalTaskCtx    context.Context
 	root               *fsNode
@@ -410,7 +408,7 @@ func New(env environment.Env, workspacePath string) (*Server, error) {
 		root:             rootNode,
 		nodes:            nodes,
 	}
-	atomic.StoreUint64(&s.nextId, vfscommon.RootInodeId+1)
+	s.nextId.Store(vfscommon.RootInodeId + 1)
 	return s, nil
 }
 
@@ -433,7 +431,7 @@ func (p *Server) taskCtx() context.Context {
 }
 
 func (p *Server) addNode(node *fsNode) uint64 {
-	id := atomic.AddUint64(&p.nextId, 1)
+	id := p.nextId.Add(1)
 	node.server = p
 	node.id = id
 	p.mu.Lock()

--- a/rules/go/analyzer/def.bzl
+++ b/rules/go/analyzer/def.bzl
@@ -1,4 +1,5 @@
 ANALYZERS = [
+    "atomictypes",
     "reflecttypeassert",
     "errorsastype",
     "embedlit",

--- a/server/util/qps/qps.go
+++ b/server/util/qps/qps.go
@@ -9,28 +9,28 @@ import (
 )
 
 type bin struct {
-	c uint64
+	c atomic.Uint64
 }
 
 func (b *bin) Get() uint64 {
-	return atomic.LoadUint64(&b.c)
+	return b.c.Load()
 }
 func (b *bin) Add(d uint64) {
-	atomic.AddUint64(&b.c, d)
+	b.c.Add(d)
 }
 func (b *bin) Inc() {
 	b.Add(1)
 }
 func (b *bin) Reset() {
-	atomic.StoreUint64(&b.c, 0)
+	b.c.Store(0)
 }
 
 type Counter struct {
 	counts [60]bin
-	idx    uint64
+	idx    atomic.Uint64
 	// The number of bins that should be included in the average. After the
 	// first full averaging period elapses, this will always equal len(counts).
-	nValidBins uint64
+	nValidBins atomic.Uint64
 	window     time.Duration
 	clock      clockwork.Clock
 	startOnce  sync.Once
@@ -41,12 +41,13 @@ type Counter struct {
 // window. The caller must call Stop() on the returned counter when it is no
 // longer needed.
 func NewCounter(window time.Duration, clock clockwork.Clock) *Counter {
-	return &Counter{
-		nValidBins: 1,
-		window:     window,
-		clock:      clock,
-		stop:       make(chan struct{}),
+	c := &Counter{
+		window: window,
+		clock:  clock,
+		stop:   make(chan struct{}),
 	}
+	c.nValidBins.Store(1)
+	return c
 }
 
 func (c *Counter) bin(idx int) *bin {
@@ -55,13 +56,13 @@ func (c *Counter) bin(idx int) *bin {
 }
 
 func (c *Counter) currentBin() *bin {
-	idx := atomic.LoadUint64(&c.idx)
+	idx := c.idx.Load()
 	return c.bin(int(idx))
 }
 
 func (c *Counter) Get() float64 {
 	sum := uint64(0)
-	nValidBins := atomic.LoadUint64(&c.nValidBins)
+	nValidBins := c.nValidBins.Load()
 	for i := 0; i < int(nValidBins); i++ {
 		sum += c.bin(i).Get()
 	}
@@ -74,15 +75,15 @@ func (c *Counter) Get() float64 {
 // Advances to the next bin, resets its current count, and marks it valid if
 // it is still marked invalid.
 func (c *Counter) update() {
-	idx := atomic.LoadUint64(&c.idx)
+	idx := c.idx.Load()
 	idx = (idx + 1) % uint64(len(c.counts))
-	atomic.StoreUint64(&c.idx, idx)
+	c.idx.Store(idx)
 
 	c.bin(int(idx)).Reset()
 
-	nv := atomic.LoadUint64(&c.nValidBins)
+	nv := c.nValidBins.Load()
 	nv = min(nv+1, uint64(len(c.counts)))
-	atomic.StoreUint64(&c.nValidBins, nv)
+	c.nValidBins.Store(nv)
 }
 
 func (c *Counter) start() {


### PR DESCRIPTION
Typed atomic values keep synchronization operations attached to their
storage and prevent accidental non-atomic access. Replace eligible
primitive atomic variables and calls using the modernizer, preserving
the existing operations and ordering, and enable atomictypes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>