### PR TITLE
go: manage goroutines with WaitGroup.Go

### DIFF
--- a/cli/explain/compactgraph/compactgraph.go
+++ b/cli/explain/compactgraph/compactgraph.go
@@ -250,29 +250,25 @@ func Diff(old, new *CompactGraph) (*spawn_diff.DiffResult, error) {
 	diffWG := sync.WaitGroup{}
 	// Diff runfiles tree spawns first to compute exact content hashes that are used when diffing other spawns.
 	for _, output := range commonRunfilesTrees {
-		diffWG.Add(1)
-		go func() {
-			defer diffWG.Done()
+		diffWG.Go(func() {
 			spawnDiff, localChange, invalidatedBy := diffRunfilesTrees(old.spawns[output], new.spawns[output], oldResolveSymlinks, newResolveSymlinks, old.settings.workspaceRunfilesDirectory, old.settings.hashFunction)
 			diffResults.Store(output, &diffResult{
 				spawnDiff:     spawnDiff,
 				localChange:   localChange,
 				invalidatedBy: invalidatedBy,
 			})
-		}()
+		})
 	}
 	diffWG.Wait()
 	for _, output := range commonSpawnOutputs {
-		diffWG.Add(1)
-		go func() {
-			defer diffWG.Done()
+		diffWG.Go(func() {
 			spawnDiff, localChange, invalidatedBy := diffSpawns(old.spawns[output], new.spawns[output], oldResolveSymlinks, newResolveSymlinks)
 			diffResults.Store(output, &diffResult{
 				spawnDiff:     spawnDiff,
 				localChange:   localChange,
 				invalidatedBy: invalidatedBy,
 			})
-		}()
+		})
 	}
 	diffWG.Wait()
 
@@ -320,11 +316,9 @@ func Diff(old, new *CompactGraph) (*spawn_diff.DiffResult, error) {
 		if result.localChange || !foundTransitiveCause {
 			if len(result.invalidates) > 0 {
 				// result.invalidates isn't modified after this point as the spawns are visited in topological order.
-				diffWG.Add(1)
-				go func() {
-					defer diffWG.Done()
+				diffWG.Go(func() {
 					result.spawnDiff.GetModified().TransitivelyInvalidated = flattenInvalidates(result.invalidates, isExecOutputPath(output))
-				}()
+				})
 			}
 			spawnDiffs = append(spawnDiffs, result.spawnDiff)
 		}

--- a/enterprise/server/atime_updater/atime_updater_test.go
+++ b/enterprise/server/atime_updater/atime_updater_test.go
@@ -631,11 +631,9 @@ func BenchmarkEnqueue(b *testing.B) {
 			for _, instance := range instances {
 				for _, digest := range digests {
 					for _, ctx := range contexts {
-						wg.Add(1)
-						go func() {
+						wg.Go(func() {
 							updater.Enqueue(ctx, instance, []*repb.Digest{digest}, repb.DigestFunction_SHA256)
-							wg.Done()
-						}()
+						})
 					}
 				}
 			}

--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -1201,25 +1201,21 @@ func (mc *MigrationCache) Stop() error {
 	var wg sync.WaitGroup
 	var srcShutdownErr, dstShutdownErr error
 	if src, canStopSrc := mc.defaultConfigDoNotUseDirectly.src.(interfaces.StoppableCache); canStopSrc {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			srcShutdownErr = src.Stop()
 			if srcShutdownErr != nil {
 				log.Warningf("Migration src cache shutdown err: %s", srcShutdownErr)
 			}
-		}()
+		})
 	}
 
 	if dest, canStopDest := mc.defaultConfigDoNotUseDirectly.dest.(interfaces.StoppableCache); canStopDest {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			dstShutdownErr = dest.Stop()
 			if dstShutdownErr != nil {
 				log.Warningf("Migration dest cache shutdown err: %s", dstShutdownErr)
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/enterprise/server/batch_operator/batch_operator_test.go
+++ b/enterprise/server/batch_operator/batch_operator_test.go
@@ -633,11 +633,9 @@ func BenchmarkEnqueue(b *testing.B) {
 			for _, instance := range instances {
 				for _, digest := range digests {
 					for _, ctx := range contexts {
-						wg.Add(1)
-						go func() {
+						wg.Go(func() {
 							updater.Enqueue(ctx, instance, []*repb.Digest{digest}, repb.DigestFunction_SHA256)
-							wg.Done()
-						}()
+						})
 					}
 				}
 			}

--- a/enterprise/server/crypter_key_cache/crypter_key_cache_test.go
+++ b/enterprise/server/crypter_key_cache/crypter_key_cache_test.go
@@ -359,24 +359,20 @@ func TestRaciness(t *testing.T) {
 	numGoroutines := 100
 
 	for range numGoroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			key, err := cache.EncryptionKey(ctx)
 			require.NoError(t, err)
 			require.Equal(t, expectedKey, key.Key)
-		}()
+		})
 	}
 	wg.Wait()
 
 	for range numGoroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			key, err := cache.DecryptionKey(ctx, expectedMetadata)
 			require.NoError(t, err)
 			require.Equal(t, expectedKey, key.Key)
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/enterprise/server/hit_tracker_client/hit_tracker_client.go
+++ b/enterprise/server/hit_tracker_client/hit_tracker_client.go
@@ -84,12 +84,10 @@ func newHitTrackerClient(ctx context.Context, env *real_environment.RealEnv, con
 	}
 	go factory.batcher()
 	for i := 0; i < *remoteHitTrackerWorkers; i++ {
-		factory.wg.Add(1)
-		go func() {
+		factory.wg.Go(func() {
 			ticker := env.GetClock().NewTicker(*remoteHitTrackerPollInterval).Chan()
 			factory.sender(ctx, ticker)
-			factory.wg.Done()
-		}()
+		})
 	}
 	env.GetHealthChecker().RegisterShutdownFunction(factory.shutdown)
 	return &factory

--- a/enterprise/server/hit_tracker_client/hit_tracker_client_test.go
+++ b/enterprise/server/hit_tracker_client/hit_tracker_client_test.go
@@ -376,11 +376,9 @@ func BenchmarkEnqueue(b *testing.B) {
 		hitTracker := hitTrackerFactory.NewCASHitTracker(b.Context(), &repb.RequestMetadata{})
 		wg := sync.WaitGroup{}
 		for range numToEnqueue {
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				hitTracker.TrackDownload(aDigest).CloseWithBytesTransferred(1, 2, repb.Compressor_IDENTITY, "test")
-				wg.Done()
-			}()
+			})
 		}
 		wg.Wait()
 	}

--- a/enterprise/server/oci/ocifetcher/ocifetcher_test.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher_test.go
@@ -2058,9 +2058,7 @@ func runConcurrentFetchBlob(
 	var wg sync.WaitGroup
 
 	for i := range numRequests {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 
 			stream := streamFactory(i)
 			err := server.FetchBlob(req, stream)
@@ -2070,7 +2068,7 @@ func runConcurrentFetchBlob(
 				data: stream.collectData(),
 				err:  err,
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -980,14 +980,12 @@ func TestFirecracker_LocalSnapshotSharing(t *testing.T) {
 	// when writing sharable snapshots
 	var wg sync.WaitGroup
 	for i := range 3 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			c := containers[i]
 			// Each new VM shouldn't have trouble saving snapshots themselves
 			err := c.Pause(ctx)
 			require.NoError(t, err)
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/enterprise/server/remote_execution/runner/runner_test.go
+++ b/enterprise/server/remote_execution/runner/runner_test.go
@@ -558,11 +558,9 @@ func TestRunnerPool_Shutdown_RunnersReturnRetriableOrNilError(t *testing.T) {
 
 		var wg sync.WaitGroup
 		for range numTasks {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				errs <- runTask()
-			}()
+			})
 			// Random, tiny delay to stagger the tasks a bit more.
 			sleepRandMicros(1)
 		}

--- a/enterprise/server/scheduling/scheduler_client/scheduler_client.go
+++ b/enterprise/server/scheduling/scheduler_client/scheduler_client.go
@@ -435,11 +435,9 @@ func (r *Registration) watchRunState(rootContext context.Context) {
 
 			// Restart if it should be running
 			if running {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				wg.Go(func() {
 					r.maintainRegistrationAndStreamWork(ctx)
-				}()
+				})
 			}
 		}
 	}

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -493,9 +493,7 @@ func (e *fakeExecutor) Register() {
 	require.NoError(e.t, err)
 
 	recvChan := make(chan Result[*scpb.RegisterAndStreamWorkResponse], 1)
-	e.wg.Add(1)
-	go func() {
-		defer e.wg.Done()
+	e.wg.Go(func() {
 		for {
 			msg, err := stream.Recv()
 			recvChan <- Result[*scpb.RegisterAndStreamWorkResponse]{Value: msg, Err: err}
@@ -503,10 +501,8 @@ func (e *fakeExecutor) Register() {
 				return
 			}
 		}
-	}()
-	e.wg.Add(1)
-	go func() {
-		defer e.wg.Done()
+	})
+	e.wg.Go(func() {
 		for {
 			select {
 			case <-ctx.Done():
@@ -551,7 +547,7 @@ func (e *fakeExecutor) Register() {
 				require.NoError(e.t, err)
 			}
 		}
-	}()
+	})
 
 	// Give the executor a moment to register with the scheduler.
 	// TODO: explicitly wait for a scheduler reply.

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -196,13 +196,11 @@ func (r *Env) shutdownBuildBuddyServers() {
 	var wg sync.WaitGroup
 	for app := range r.buildBuddyServers {
 		app.env.GetHealthChecker().Shutdown()
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			log.Infof("Waiting for buildbuddy server with port %d to shut down.", app.port)
 			app.env.GetHealthChecker().WaitForGracefulShutdown()
 			log.Infof("Shut down for buildbuddy server with port %d completed.", app.port)
-		}()
+		})
 	}
 	wg.Wait()
 	log.Info("Buildbuddy servers are shut down")
@@ -327,13 +325,11 @@ func NewRBETestEnvWithOptions(t *testing.T, opts *EnvOptions) *Env {
 		var wg sync.WaitGroup
 		for id, e := range rbe.executors {
 			e.env.GetHealthChecker().Shutdown()
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				log.Infof("Waiting for executor %q to shut down.", id)
 				e.env.GetHealthChecker().WaitForGracefulShutdown()
 				log.Infof("Shut down for executor %q completed.", id)
-				wg.Done()
-			}()
+			})
 		}
 		log.Warningf("Waiting for executor shutdown to finish...")
 		wg.Wait()

--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -1398,16 +1398,14 @@ func TestSaturateTaskQueue(t *testing.T) {
 	}
 	var wg sync.WaitGroup
 	for range 10 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 
 			cmd := rbe.Execute(cmdProto, &rbetest.ExecuteOpts{DoNotCacheAction: true})
 			res := cmd.Wait()
 
 			require.NoError(t, res.Err)
 			require.Equal(t, 0, res.ExitCode)
-		}()
+		})
 	}
 	wg.Wait()
 }
@@ -1944,12 +1942,10 @@ func TestActionMerging_ScheduledConcurrently(t *testing.T) {
 		wg := sync.WaitGroup{}
 		ops := make(chan string, 5)
 		for i := range 5 {
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				exec := rbe.Execute(cmd, &rbetest.ExecuteOpts{CheckCache: true, InvocationID: fmt.Sprintf("invocation%d", i)})
 				ops <- exec.WaitAccepted()
-				wg.Done()
-			}()
+			})
 		}
 		wg.Wait()
 		close(ops)
@@ -2137,16 +2133,14 @@ func TestActionMerging_DisabledWithDoNotCache(t *testing.T) {
 	wg := sync.WaitGroup{}
 	ops := make(chan string, numOps)
 	for i := range numOps {
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			exec := rbe.Execute(cmd, &rbetest.ExecuteOpts{
 				CheckCache:       true,
 				DoNotCacheAction: true,
 				InvocationID:     fmt.Sprintf("invocation%d", i),
 			})
 			ops <- exec.WaitAccepted()
-			wg.Done()
-		}()
+		})
 	}
 	wg.Wait()
 	close(ops)

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -227,14 +227,12 @@ func NewWorkflowService(env environment.Env) *workflowService {
 
 func (ws *workflowService) startBackgroundWorkers() {
 	for range webhookWorkerCount {
-		ws.wg.Add(1)
-		go func() {
-			defer ws.wg.Done()
+		ws.wg.Go(func() {
 
 			for task := range ws.tasks {
 				ws.runStartWorkflowTask(task)
 			}
-		}()
+		})
 	}
 	ws.env.GetHealthChecker().RegisterShutdownFunction(func(ctx context.Context) error {
 		// Wait until the HTTP server shuts down to ensure that all in-flight
@@ -515,9 +513,7 @@ func (ws *workflowService) ExecuteWorkflow(ctx context.Context, req *wfpb.Execut
 		}
 		actionStatuses = append(actionStatuses, actionStatus)
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 
 			var invocationID string
 			var statusErr error
@@ -559,7 +555,7 @@ func (ws *workflowService) ExecuteWorkflow(ctx context.Context, req *wfpb.Execut
 				log.CtxWarning(executionCtx, statusErr.Error())
 				return
 			}
-		}()
+		})
 	}
 	wg.Wait()
 
@@ -1568,16 +1564,14 @@ func (ws *workflowService) startWorkflow(ctx context.Context, gitProvider interf
 
 		// Start executions in parallel to help reduce workflow start latency
 		// for repos with lots of workflow actions.
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			// Webhook triggered workflows should always be retried, because they
 			// don't have a client to retry for them
 			shouldRetry := true
 			if _, err := ws.executeWorkflowAction(ctx, apiKey, wf, wd, isTrusted, action, invocationID, nil /*=extraCIRunnerArgs*/, env, shouldRetry); err != nil {
 				log.CtxErrorf(ctx, "Failed to execute workflow %s (%s) action %q: %s", wf.WorkflowID, wf.RepoURL, action.Name, err)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 	return nil

--- a/enterprise/server/workflow/service/service_test.go
+++ b/enterprise/server/workflow/service/service_test.go
@@ -1568,12 +1568,10 @@ actions:
 	var wg sync.WaitGroup
 	errCh := make(chan error, 2)
 	for range 2 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			// Intentionally use a non-authenticated context, like the cron scheduler would.
 			errCh <- te.GetWorkflowService().RunScheduledWorkflows(t.Context())
-		}()
+		})
 	}
 	wg.Wait()
 	close(errCh)
@@ -1759,11 +1757,9 @@ actions:
 	var wg sync.WaitGroup
 	errCh := make(chan error, 2)
 	for range 2 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			errCh <- te.GetWorkflowService().HandleRepositoryEvent(ctx, repo, webhookData, "faketoken")
-		}()
+		})
 	}
 	wg.Wait()
 	close(errCh)

--- a/rules/go/analyzer/def.bzl
+++ b/rules/go/analyzer/def.bzl
@@ -24,7 +24,7 @@ ANALYZERS = [
     "stringsseq",
     "stringsbuilder",
     # "testingcontext",
-    # "waitgroup",
+    "waitgroupgo",
 ]
 
 MODERNIZE_ANALYZERS = ["//rules/go/analyzer:" + analyzer for analyzer in ANALYZERS]

--- a/server/cache/dirtools/dirtools.go
+++ b/server/cache/dirtools/dirtools.go
@@ -317,9 +317,7 @@ func uploadMissingFiles(ctx context.Context, uploader *cachetools.BatchCASUpload
 	cas := env.GetContentAddressableStorageClient()
 
 	for batch := range slices.Chunk(filesToUpload, 1000) {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			req := &repb.FindMissingBlobsRequest{
 				DigestFunction: digestFunction,
 				InstanceName:   instanceName,
@@ -353,7 +351,7 @@ func uploadMissingFiles(ctx context.Context, uploader *cachetools.BatchCASUpload
 				// If the reader errored and returned, don't block forever
 			case batches <- batchResult{files: batch, presentBytes: presentBytes}:
 			}
-		}()
+		})
 	}
 
 	go func() {

--- a/tools/tasksize_stress/tasksize_stress_test.go
+++ b/tools/tasksize_stress/tasksize_stress_test.go
@@ -43,12 +43,10 @@ func fullyUtilizeCPUCores(numGoroutines int, dur time.Duration) {
 	var wg sync.WaitGroup
 	end := time.Now().Add(dur)
 	for range numGoroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for time.Now().Before(end) {
 			}
-		}()
+		})
 	}
 	wg.Wait()
 }


### PR DESCRIPTION
WaitGroup.Go pairs task registration and completion with goroutine
creation. Replace eligible Add/go/Done sequences and enable the
analyzer under its current waitgroupgo name so new code keeps task
lifecycle management together.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>