### PR TITLE
go: use test-managed contexts

### DIFF
--- a/enterprise/server/cache_proxy_registration/cache_proxy_registration_test.go
+++ b/enterprise/server/cache_proxy_registration/cache_proxy_registration_test.go
@@ -148,8 +148,7 @@ func TestStreamHeartbeats_ShutdownRemovesProxy(t *testing.T) {
 	registry, client := startTestRegistry(t, map[string]interfaces.UserInfo{testAPIKey: streamUser})
 
 	node := &cppb.CacheProxyNode{Host: "host-x", ProxyId: "proxy-x", Version: "v1"}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	streamCtx := outgoingCtx(ctx, testAPIKey)
 
 	shutdownCh := make(chan struct{})
@@ -194,8 +193,7 @@ func TestStreamHeartbeats_UnauthorizedReturnsError(t *testing.T) {
 	noCap := userWithCapabilities("U1", testGroupID, cappb.Capability_CACHE_WRITE)
 	_, client := startTestRegistry(t, map[string]interfaces.UserInfo{"NOCAP_KEY": noCap})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	streamCtx := outgoingCtx(ctx, "NOCAP_KEY")
 
 	err := streamHeartbeats(streamCtx, make(chan struct{}), client, &cppb.CacheProxyNode{Host: "h", ProxyId: "id"})

--- a/rules/go/analyzer/def.bzl
+++ b/rules/go/analyzer/def.bzl
@@ -23,7 +23,7 @@ ANALYZERS = [
     "stringscutprefix",
     "stringsseq",
     "stringsbuilder",
-    # "testingcontext",
+    "testingcontext",
     "waitgroupgo",
 ]
 

--- a/server/util/watchdog/watchdog_test.go
+++ b/server/util/watchdog/watchdog_test.go
@@ -1,7 +1,6 @@
 package watchdog_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -49,8 +48,7 @@ func TestDisabledWatchdogIsValidForever(t *testing.T) {
 
 func TestCrossThreadUsage(t *testing.T) {
 	clock := clockwork.NewFakeClock()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	wdt := watchdog.NewWithClock(clock, time.Hour)
 	go func() {


### PR DESCRIPTION
Testing contexts provide cancellation tied to the test lifecycle
without a separate cancellation closure. Apply the testingcontext
modernizer where the existing cancellation pattern is equivalent and
enable the check for future tests.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>