### PR TITLE
[CLI] Don't parse bb CLI subcommands as bazel commands

### DIFF
--- a/cli/arg/BUILD
+++ b/cli/arg/BUILD
@@ -8,6 +8,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/arg",
     deps = [
         "//cli/parser",
+        "//cli/parser/bazel_command",
         "//cli/parser/bbrc",
         "//cli/parser/parsed",
     ],

--- a/cli/arg/arg.go
+++ b/cli/arg/arg.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/parser"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazel_command"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/bbrc"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/parsed"
 )
@@ -163,7 +164,7 @@ func (a *BazelArgs) Prepend(arg string) error {
 }
 
 func prepend(args []string, arg string) []string {
-	_, commandIndex := parser.GetBazelCommandAndIndex(args)
+	_, commandIndex := bazel_command.GetCommandAndIndex(args)
 	if commandIndex == -1 {
 		return append([]string{arg}, args...)
 	}

--- a/cli/cli_command/cli_command.go
+++ b/cli/cli_command/cli_command.go
@@ -5,29 +5,154 @@ import "flag"
 type Command struct {
 	Name    string
 	Help    string
-	Handler func(args []string) (exitCode int, err error)
 	Aliases []string
-	// Flags used for `bb help <command>`
+	// Handler runs the command.
+	//
+	// It is nil until Register in cli_command/register is called.
+	Handler func(args []string) (exitCode int, err error)
+	// Flags used for `bb help <command>`.
+	//
+	// It is nil until Register in cli_command/register is called, and remains
+	// nil for commands that declare no flags.
 	Flags *flag.FlagSet
 }
 
-var (
-	// Commands is a slice of all known CLI commands, sorted by their Name fields.
-	//
-	// It is nil until Register in cli_command/register is called.
-	Commands []*Command
+// Commands is a slice of all known CLI commands.
+//
+// Handlers and flags are attached to these commands by Register in
+// cli_command/register.
+var Commands = []*Command{
+	{
+		Name: "add",
+		Help: "Adds a dependency to your WORKSPACE file.",
+	},
+	{
+		Name: "agent",
+		Help: "Runs an AI coding agent to analyze data.",
+	},
+	{
+		Name: "analyze",
+		Help: "Analyzes the dependency graph.",
+	},
+	{
+		Name:    "ask",
+		Help:    "Asks for suggestions about your last invocation.",
+		Aliases: []string{"wtf", "huh"},
+	},
+	{
+		Name: "box",
+		Help: "Starts a remote Firecracker VM box and opens a session in it.",
+	},
+	{
+		Name: "detect",
+		Help: "Detects issues in the current workspace.",
+	},
+	{
+		Name: "download",
+		Help: "Downloads artifacts from a remote cache.",
+	},
+	{
+		Name: "execute",
+		Help: "Executes arbitrary commands using remote execution.",
+	},
+	{
+		Name: "execution",
+		Help: "Remote execution tools",
+	},
+	{
+		Name: "fix",
+		Help: "Applies fixes to WORKSPACE and BUILD files.",
+	},
+	// Handle 'help' command separately. It operates on parsed args rather than raw
+	// ones, so it does not fit the Handler signature and is dispatched by
+	// cli/cmd/bb before the args are resolved (see cli/help).
+	{
+		Name: "install",
+		Help: "Installs a bb plugin (https://buildbuddy.io/plugins).",
+	},
+	{
+		Name: "login",
+		Help: "Configures bb commands to use your BuildBuddy API key.",
+	},
+	{
+		Name: "logout",
+		Help: "Configures bb commands to no longer use your saved API key.",
+	},
+	{
+		Name: "print",
+		Help: "Displays various log file types written by bazel.",
+	},
+	{
+		Name: "record",
+		Help: "Records command output and streams it to BuildBuddy.",
+	},
+	{
+		Name: "remote",
+		Help: "Runs a bazel command in the cloud with BuildBuddy's hosted bazel service.",
+	},
+	{
+		Name: "remote-download",
+		Help: "Fetches a remote asset via an intermediate cache.",
+	},
+	{
+		Name: "search",
+		Help: "Searches for code in the remote codesearch index.",
+	},
+	{
+		Name: "ssh",
+		Help: "Runs an SSH client on a user-mode wireguard network.",
+	},
+	{
+		Name: "ssh-server",
+		Help: "Runs an SSH server on a user-mode wireguard network.",
+	},
+	{
+		Name: "index",
+		Help: "Sends updates to the remote codesearch index.",
+	},
+	{
+		Name: "ui",
+		Help: "Opens an interactive terminal UI for viewing builds.",
+	},
+	{
+		Name: "update",
+		Help: "Updates the bb CLI to the latest version.",
+	},
+	{
+		Name: "upload",
+		Help: "Uploads files to the remote cache.",
+	},
+	{
+		Name: "version",
+		Help: "Prints bb cli version info.",
+	},
+	{
+		Name: "view",
+		Help: "Views build logs from BuildBuddy.",
+	},
+	{
+		Name: "explain",
+		Help: "Explains your build using collected profiles and compact execution logs.",
+	},
+}
 
+var (
 	// CommandsByName is a map of every known CLI command, each indexed by its
 	// Name field.
-	//
-	// It is nil until Register in cli_command/register is called.
-	CommandsByName map[string]*Command
+	CommandsByName = make(map[string]*Command, len(Commands))
 
 	// Aliases maps every known alias to its corresponding CLI command.
-	//
-	// It is nil until Register in cli_command/register is called.
-	Aliases map[string]*Command
+	Aliases = map[string]*Command{}
 )
+
+func init() {
+	for _, command := range Commands {
+		CommandsByName[command.Name] = command
+		for _, alias := range command.Aliases {
+			Aliases[alias] = command
+		}
+	}
+}
 
 // GetCommand returns the Command corresponding to the provided command name or
 // alias, or nil if no such Command exists.
@@ -39,4 +164,10 @@ func GetCommand(commandName string) *Command {
 		return command
 	}
 	return nil
+}
+
+// IsCommand returns whether name is recognized as a bb CLI command name or
+// alias.
+func IsCommand(name string) bool {
+	return GetCommand(name) != nil
 }

--- a/cli/cli_command/register/BUILD
+++ b/cli/cli_command/register/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//cli:__subpackages__"])
 
@@ -36,5 +36,15 @@ go_library(
         "//cli/upload",
         "//cli/versioncmd",
         "//cli/view",
+    ],
+)
+
+go_test(
+    name = "register_test",
+    srcs = ["register_test.go"],
+    deps = [
+        ":register",
+        "//cli/cli_command",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/cli/cli_command/register/register.go
+++ b/cli/cli_command/register/register.go
@@ -1,6 +1,8 @@
 package register
 
 import (
+	"flag"
+	"fmt"
 	"sync"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/add"
@@ -33,9 +35,49 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/view"
 )
 
-// Register registers all known cli commands in the structures laid out in
-// cli/cli_command. It is meant to be called immediately on CLI
-// startup.
+// implementation holds the parts of a cli command that require importing its
+// handler package. The commands themselves (names, help text and aliases) are
+// declared in cli_command.Commands, which stays dependency-free so that the
+// list of cli command names can be consulted without pulling in every handler.
+type implementation struct {
+	handler func(args []string) (exitCode int, err error)
+	flags   *flag.FlagSet
+}
+
+// implementationsByCommandName must contain exactly one entry per command in
+// cli_command.Commands; register panics otherwise.
+var implementationsByCommandName = map[string]implementation{
+	"add":             {handler: add.HandleAdd, flags: add.Flags},
+	"agent":           {handler: agent.HandleAgent, flags: agentflags.SharedAgentFlags},
+	"analyze":         {handler: analyze.HandleAnalyze, flags: analyze.Flags},
+	"ask":             {handler: ask.HandleAsk, flags: ask.Flags},
+	"box":             {handler: box.HandleBox, flags: box.Flags},
+	"detect":          {handler: detect.HandleDetect, flags: detect.Flags},
+	"download":        {handler: download.HandleDownload, flags: download.Flags},
+	"execute":         {handler: execute.HandleExecute, flags: execute.Flags},
+	"execution":       {handler: execution.HandleExecution, flags: execution.Flags},
+	"explain":         {handler: explain.HandleExplain, flags: explain.Flags},
+	"fix":             {handler: fix.HandleFix, flags: fix.Flags},
+	"index":           {handler: index.HandleIndex, flags: index.Flags},
+	"install":         {handler: plugin.HandleInstall, flags: plugin.Flags},
+	"login":           {handler: login.HandleLogin, flags: login.Flags},
+	"logout":          {handler: login.HandleLogout},
+	"print":           {handler: printlog.HandlePrint, flags: printlog.Flags},
+	"record":          {handler: record.HandleRecord, flags: record.Flags},
+	"remote":          {handler: remotebazel.HandleRemoteBazel, flags: remotebazel.RemoteFlagset},
+	"remote-download": {handler: remote_download.HandleRemoteDownload, flags: remote_download.Flags},
+	"search":          {handler: search.HandleSearch, flags: search.Flags},
+	"ssh":             {handler: ssh.HandleSSH, flags: ssh.Flags},
+	"ssh-server":      {handler: ssh_server.HandleSSHServer, flags: ssh_server.Flags},
+	"ui":              {handler: ui.HandleUI, flags: ui.Flags},
+	"update":          {handler: update.HandleUpdate, flags: update.Flags},
+	"upload":          {handler: upload.HandleUpload, flags: upload.Flags},
+	"version":         {handler: versioncmd.HandleVersion},
+	"view":            {handler: view.HandleView, flags: view.Flags},
+}
+
+// Register attaches the handler and flags of every command declared in
+// cli_command.Commands. It is meant to be called immediately on CLI startup.
 //
 // This indirection prevents dependency cycles from occurring when, for example,
 // an imported package tries to use the parser, which itself needs to know all
@@ -43,180 +85,17 @@ import (
 var Register = sync.OnceFunc(register)
 
 func register() {
-	cli_command.Commands = []*cli_command.Command{
-		{
-			Name:    "add",
-			Help:    "Adds a dependency to your WORKSPACE file.",
-			Handler: add.HandleAdd,
-			Flags:   add.Flags,
-		},
-		{
-			Name:    "agent",
-			Help:    "Runs an AI coding agent to analyze data.",
-			Handler: agent.HandleAgent,
-			Flags:   agentflags.SharedAgentFlags,
-		},
-		{
-			Name:    "analyze",
-			Help:    "Analyzes the dependency graph.",
-			Handler: analyze.HandleAnalyze,
-			Flags:   analyze.Flags,
-		},
-		{
-			Name:    "ask",
-			Help:    "Asks for suggestions about your last invocation.",
-			Handler: ask.HandleAsk,
-			Aliases: []string{"wtf", "huh"},
-			Flags:   ask.Flags,
-		},
-		{
-			Name:    "box",
-			Help:    "Starts a remote Firecracker VM box and opens a session in it.",
-			Handler: box.HandleBox,
-			Flags:   box.Flags,
-		},
-		{
-			Name:    "detect",
-			Help:    "Detects issues in the current workspace.",
-			Handler: detect.HandleDetect,
-			Flags:   detect.Flags,
-		},
-		{
-			Name:    "download",
-			Help:    "Downloads artifacts from a remote cache.",
-			Handler: download.HandleDownload,
-			Flags:   download.Flags,
-		},
-		{
-			Name:    "execute",
-			Help:    "Executes arbitrary commands using remote execution.",
-			Handler: execute.HandleExecute,
-			Flags:   execute.Flags,
-		},
-		{
-			Name:    "execution",
-			Help:    "Remote execution tools",
-			Handler: execution.HandleExecution,
-			Flags:   execution.Flags,
-		},
-		{
-			Name:    "fix",
-			Help:    "Applies fixes to WORKSPACE and BUILD files.",
-			Handler: fix.HandleFix,
-			Flags:   fix.Flags,
-		},
-		// Handle 'help' command separately to avoid circular dependency with `cli_command`
-		// package
-		{
-			Name:    "install",
-			Help:    "Installs a bb plugin (https://buildbuddy.io/plugins).",
-			Handler: plugin.HandleInstall,
-			Flags:   plugin.Flags,
-		},
-		{
-			Name:    "login",
-			Help:    "Configures bb commands to use your BuildBuddy API key.",
-			Handler: login.HandleLogin,
-			Flags:   login.Flags,
-		},
-		{
-			Name:    "logout",
-			Help:    "Configures bb commands to no longer use your saved API key.",
-			Handler: login.HandleLogout,
-		},
-		{
-			Name:    "print",
-			Help:    "Displays various log file types written by bazel.",
-			Handler: printlog.HandlePrint,
-			Flags:   printlog.Flags,
-		},
-		{
-			Name:    "record",
-			Help:    "Records command output and streams it to BuildBuddy.",
-			Handler: record.HandleRecord,
-			Flags:   record.Flags,
-		},
-		{
-			Name:    "remote",
-			Help:    "Runs a bazel command in the cloud with BuildBuddy's hosted bazel service.",
-			Handler: remotebazel.HandleRemoteBazel,
-			Flags:   remotebazel.RemoteFlagset,
-		},
-		{
-			Name:    "remote-download",
-			Help:    "Fetches a remote asset via an intermediate cache.",
-			Handler: remote_download.HandleRemoteDownload,
-			Flags:   remote_download.Flags,
-		},
-		{
-			Name:    "search",
-			Help:    "Searches for code in the remote codesearch index.",
-			Handler: search.HandleSearch,
-			Flags:   search.Flags,
-		},
-		{
-			Name:    "ssh",
-			Help:    "Runs an SSH client on a user-mode wireguard network.",
-			Handler: ssh.HandleSSH,
-			Flags:   ssh.Flags,
-		},
-		{
-			Name:    "ssh-server",
-			Help:    "Runs an SSH server on a user-mode wireguard network.",
-			Handler: ssh_server.HandleSSHServer,
-			Flags:   ssh_server.Flags,
-		},
-		{
-			Name:    "index",
-			Help:    "Sends updates to the remote codesearch index.",
-			Handler: index.HandleIndex,
-			Flags:   index.Flags,
-		},
-		{
-			Name:    "ui",
-			Help:    "Opens an interactive terminal UI for viewing builds.",
-			Handler: ui.HandleUI,
-			Flags:   ui.Flags,
-		},
-		{
-			Name:    "update",
-			Help:    "Updates the bb CLI to the latest version.",
-			Handler: update.HandleUpdate,
-			Flags:   update.Flags,
-		},
-		{
-			Name:    "upload",
-			Help:    "Uploads files to the remote cache.",
-			Handler: upload.HandleUpload,
-			Flags:   upload.Flags,
-		},
-		{
-			Name:    "version",
-			Help:    "Prints bb cli version info.",
-			Handler: versioncmd.HandleVersion,
-		},
-		{
-			Name:    "view",
-			Help:    "Views build logs from BuildBuddy.",
-			Handler: view.HandleView,
-			Flags:   view.Flags,
-		},
-		{
-			Name:    "explain",
-			Help:    "Explains your build using collected profiles and compact execution logs.",
-			Handler: explain.HandleExplain,
-			Flags:   explain.Flags,
-		},
-	}
-	cli_command.CommandsByName = make(
-		map[string]*cli_command.Command,
-		len(cli_command.Commands),
-	)
-	cli_command.Aliases = make(map[string]*cli_command.Command)
 	for _, command := range cli_command.Commands {
-		cli_command.CommandsByName[command.Name] = command
-		for _, alias := range command.Aliases {
-			cli_command.Aliases[alias] = command
+		impl, ok := implementationsByCommandName[command.Name]
+		if !ok {
+			panic(fmt.Sprintf("cli command %q has no registered handler", command.Name))
+		}
+		command.Handler = impl.handler
+		command.Flags = impl.flags
+	}
+	for name := range implementationsByCommandName {
+		if _, ok := cli_command.CommandsByName[name]; !ok {
+			panic(fmt.Sprintf("handler registered for unknown cli command %q", name))
 		}
 	}
 }

--- a/cli/cli_command/register/register_test.go
+++ b/cli/cli_command/register/register_test.go
@@ -1,0 +1,20 @@
+package register_test
+
+import (
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/cli_command"
+	"github.com/buildbuddy-io/buildbuddy/cli/cli_command/register"
+	"github.com/stretchr/testify/require"
+)
+
+// Register panics if the declared commands and the registered handlers get out
+// of sync, so this also guards against that.
+func TestRegisterAttachesHandlers(t *testing.T) {
+	register.Register()
+
+	require.NotEmpty(t, cli_command.Commands)
+	for _, command := range cli_command.Commands {
+		require.NotNil(t, command.Handler, "command %q has no handler", command.Name)
+	}
+}

--- a/cli/detect/BUILD
+++ b/cli/detect/BUILD
@@ -33,6 +33,7 @@ go_test(
     deps = [
         "//cli/arg",
         "//cli/parser",
+        "//cli/parser/bazel_command",
         "//cli/parser/test_data",
         "//proto:spawn_diff_go_proto",
         "@com_github_stretchr_testify//assert",

--- a/cli/detect/nondeterminism_test.go
+++ b/cli/detect/nondeterminism_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazel_command"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/test_data"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -131,7 +132,7 @@ func TestRemovesOutputBaseAfterEachRun(t *testing.T) {
 	var runner fakeRunner
 	var buildRuns int
 	runner.onRun = func(ctx context.Context, call commandCall) error {
-		command, _ := parser.GetBazelCommandAndIndex(call.args)
+		command, _ := bazel_command.GetCommandAndIndex(call.args)
 		if command == "shutdown" {
 			return nil
 		}
@@ -184,7 +185,7 @@ func outputBaseFromArgs(t *testing.T, args []string) string {
 func bazelCommands(calls []commandCall) []string {
 	var commands []string
 	for _, call := range calls {
-		command, _ := parser.GetBazelCommandAndIndex(call.args)
+		command, _ := bazel_command.GetCommandAndIndex(call.args)
 		commands = append(commands, command)
 	}
 	return commands

--- a/cli/parser/bazel_command/BUILD
+++ b/cli/parser/bazel_command/BUILD
@@ -1,12 +1,20 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
-package(default_visibility = ["//cli:__subpackages__"])
+# gazelle:default_visibility //cli:__subpackages__,//enterprise:__subpackages__,//server:__subpackages__
+package(default_visibility = [
+    "//cli:__subpackages__",
+    "//enterprise:__subpackages__",
+    "//server:__subpackages__",
+])
 
 go_library(
     name = "bazel_command",
     srcs = ["bazel_command.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/parser/bazel_command",
-    deps = ["//server/util/lib/set"],
+    deps = [
+        "//cli/cli_command",
+        "//server/util/lib/set",
+    ],
 )
 
 go_test(

--- a/cli/parser/bazel_command/bazel_command.go
+++ b/cli/parser/bazel_command/bazel_command.go
@@ -1,6 +1,9 @@
 package bazel_command
 
-import "github.com/buildbuddy-io/buildbuddy/server/util/lib/set"
+import (
+	"github.com/buildbuddy-io/buildbuddy/cli/cli_command"
+	"github.com/buildbuddy-io/buildbuddy/server/util/lib/set"
+)
 
 var (
 	commands = set.Set[string]{
@@ -64,4 +67,33 @@ func IsCommand(command string) bool {
 // if command has no parent.
 func Parent(command string) string {
 	return parentByCommand[command]
+}
+
+// GetCommandAndIndex returns the bazel command in args and its index, or an
+// empty string and -1 if args contains no bazel command.
+// Ex. For `bazel build //...` it will return `build` and `1`.
+// This can be helpful for splitting bazel commands into their different
+// components.
+//
+// We hard-code the commands here because running `bazel help` to generate them
+// can result in undesirable behavior. For example if it's run with different
+// startup options than the last bazel command, it will restart the bazel
+// server.
+//
+// TODO: More robust parsing of startup options. For example, this has a bug
+// that passing `bazel --output_base build test ...` returns "build" as the
+// bazel command, even though "build" is the argument to --output_base.
+func GetCommandAndIndex(args []string) (string, int) {
+	for i, a := range args {
+		// Check for bazel commands first, since a few names (like "version")
+		// are both a bazel command and a bb CLI command, and bazel wins when
+		// the args are being interpreted as a bazel command at all.
+		if IsCommand(a) {
+			return a, i
+		}
+		if cli_command.IsCommand(a) {
+			return "", -1
+		}
+	}
+	return "", -1
 }

--- a/cli/parser/bazel_command/bazel_command_test.go
+++ b/cli/parser/bazel_command/bazel_command_test.go
@@ -19,3 +19,61 @@ func TestParent(t *testing.T) {
 	assert.Empty(t, bazel_command.Parent("build"))
 	assert.Empty(t, bazel_command.Parent("not-a-bazel-command"))
 }
+
+func TestGetCommandAndIndex(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		args          []string
+		expectedCmd   string
+		expectedIndex int
+	}{
+		{
+			name:          "bazel command",
+			args:          []string{"build", "//..."},
+			expectedCmd:   "build",
+			expectedIndex: 0,
+		},
+		{
+			name:          "bazel command after startup options",
+			args:          []string{"--output_base=/tmp/foo", "analyze-profile", "profile.gz"},
+			expectedCmd:   "analyze-profile",
+			expectedIndex: 1,
+		},
+		{
+			name:          "bazel command after space-separated startup options",
+			args:          []string{"--output_base", "/tmp/foo", "analyze-profile", "profile.gz"},
+			expectedCmd:   "analyze-profile",
+			expectedIndex: 2,
+		},
+		{
+			name:          "cli command with a bazel command name as a subcommand",
+			args:          []string{"agent", "analyze-profile", "invocation-id"},
+			expectedCmd:   "",
+			expectedIndex: -1,
+		},
+		{
+			name:          "cli command with a bazel command name as an argument",
+			args:          []string{"install", "--path", "test"},
+			expectedCmd:   "",
+			expectedIndex: -1,
+		},
+		{
+			name:          "cli command alias",
+			args:          []string{"wtf", "test"},
+			expectedCmd:   "",
+			expectedIndex: -1,
+		},
+		{
+			name:          "no command",
+			args:          []string{"--output_base=/tmp/foo"},
+			expectedCmd:   "",
+			expectedIndex: -1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd, idx := bazel_command.GetCommandAndIndex(tc.args)
+			assert.Equal(t, tc.expectedCmd, cmd)
+			assert.Equal(t, tc.expectedIndex, idx)
+		})
+	}
+}

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -650,7 +650,7 @@ func GetParser() (*Parser, error) {
 func CanonicalizeArgs(args []string) ([]string, error) {
 	// Check for bazel command prior to running the parser to avoid the
 	// performance cost of generating the parser, which runs bazel.
-	bazelCommand, _ := GetBazelCommandAndIndex(args)
+	bazelCommand, _ := bazel_command.GetCommandAndIndex(args)
 	if bazelCommand == "" {
 		// Not a bazel command; no args to canonicalize.
 		return args, nil
@@ -1189,25 +1189,14 @@ func (p *Parser) consumeAndParseRCFiles(args *parsed.OrderedArgs, workspaceDir s
 	return parsedNamedConfigs, defaultConfig, nil
 }
 
-// TODO: Return an empty string if the subcommand happens to come after
-// a bb-specific command. For example, `bb install --path test` should
-// return an empty string, not "test".
-// TODO: More robust parsing of startup options. For example, this has a bug
-// that passing `bazel --output_base build test ...` returns "build" as the
-// bazel command, even though "build" is the argument to --output_base.
-func GetBazelCommandAndIndex(args []string) (string, int) {
-	for i, a := range args {
-		if bazel_command.IsCommand(a) {
-			return a, i
-		}
-	}
-	return "", -1
-}
-
 // GetFirstTargetPattern makes a best-attempt effort to return the first target
 // pattern in a bazel command.
 func GetFirstTargetPattern(args []string) string {
-	_, bazelCmdIdx := GetBazelCommandAndIndex(args)
+	_, bazelCmdIdx := bazel_command.GetCommandAndIndex(args)
+	if bazelCmdIdx == -1 {
+		// No bazel command, so there is no target pattern to find.
+		return ""
+	}
 	for i := bazelCmdIdx + 1; i < len(args); i++ {
 		s := args[i]
 		// Skip over the shortened compilation_mode flag and its value (Ex. -c opt)

--- a/cli/parser/parser_test.go
+++ b/cli/parser/parser_test.go
@@ -1201,6 +1201,11 @@ func TestGetFirstTargetPattern(t *testing.T) {
 			Args:            []string{"bazel", "build", "--config=remote", "-c", "opt", "-g"},
 			ExpectedPattern: "",
 		},
+		{
+			// Not a bazel command at all, so there is no target pattern.
+			Args:            []string{"install", "--path", "test"},
+			ExpectedPattern: "",
+		},
 	} {
 		assert.Equal(t, tc.ExpectedPattern, GetFirstTargetPattern(tc.Args), strings.Join(tc.Args, " "))
 	}

--- a/cli/plugin/BUILD
+++ b/cli/plugin/BUILD
@@ -11,7 +11,7 @@ go_library(
         "//cli/bazelisk",
         "//cli/config",
         "//cli/log",
-        "//cli/parser",
+        "//cli/parser/bazel_command",
         "//cli/storage",
         "//cli/terminal",
         "//cli/workspace",

--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -19,7 +19,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/bazelisk"
 	"github.com/buildbuddy-io/buildbuddy/cli/config"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
-	"github.com/buildbuddy-io/buildbuddy/cli/parser"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazel_command"
 	"github.com/buildbuddy-io/buildbuddy/cli/storage"
 	"github.com/buildbuddy-io/buildbuddy/cli/terminal"
 	"github.com/buildbuddy-io/buildbuddy/cli/workspace"
@@ -1020,7 +1020,7 @@ func RunBazeliskWithPlugins(args []string, outputPath string, plugins []*Plugin)
 }
 
 func addTerminalFlags(args []string) []string {
-	_, idx := parser.GetBazelCommandAndIndex(args)
+	_, idx := bazel_command.GetCommandAndIndex(args)
 	if idx == -1 {
 		return args
 	}

--- a/cli/remotebazel/BUILD
+++ b/cli/remotebazel/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//cli/log",
         "//cli/login",
         "//cli/parser",
+        "//cli/parser/bazel_command",
         "//cli/storage",
         "//cli/terminal",
         "//proto:build_event_stream_go_proto",

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -24,6 +24,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/cli/login"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazel_command"
 	"github.com/buildbuddy-io/buildbuddy/cli/storage"
 	"github.com/buildbuddy-io/buildbuddy/cli/terminal"
 	"github.com/buildbuddy-io/buildbuddy/server/cache/dirtools"
@@ -1530,7 +1531,7 @@ func HandleRemoteBazel(commandLineArgs []string) (int, error) {
 		// Read API key from command line if it is set.
 		apiKey = arg.Get(bazelArgs, "remote_header=x-buildbuddy-api-key")
 
-		bazelCmd, _ := parser.GetBazelCommandAndIndex(bazelArgs)
+		bazelCmd, _ := bazel_command.GetCommandAndIndex(bazelArgs)
 		if bazelCmd == "build" || (bazelCmd == "run" && !*runRemotely) {
 			fetchOutputs = true
 			if bazelCmd == "run" {
@@ -1691,7 +1692,7 @@ func parseRemoteCliFlags(args []string) ([]string, error) {
 	endParsingIndex := len(args)
 	if !runBashScript {
 		// Stop parsing flags when we reach the bazel command
-		_, bazelCmdIdx := parser.GetBazelCommandAndIndex(args)
+		_, bazelCmdIdx := bazel_command.GetCommandAndIndex(args)
 		if bazelCmdIdx == -1 {
 			return nil, status.InvalidArgumentErrorf("no bazel command passed to run remotely")
 		}

--- a/enterprise/server/cmd/ci_runner/BUILD
+++ b/enterprise/server/cmd/ci_runner/BUILD
@@ -14,6 +14,7 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/cmd/ci_runner",
     deps = [
+        "//cli/parser/bazel_command",
         "//enterprise/server/bes_artifacts",
         "//enterprise/server/util/ci_runner_env",
         "//enterprise/server/workflow/config",

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -25,6 +25,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazel_command"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/bes_artifacts"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ci_runner_env"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/workflow/config"
@@ -3057,7 +3058,7 @@ func runBazelWrapper() error {
 	// our bazel options. This can happen if the command is a `bb` CLI command
 	// and `bb` is being invoked via bazelisk (e.g. by setting
 	// USE_BAZEL_VERSION=buildbuddy-io/vX.Y.Z in env)
-	bazelSubcmd, cmdIdx := bazel.GetBazelCommandAndIndex(originalArgs)
+	bazelSubcmd, cmdIdx := bazel_command.GetCommandAndIndex(originalArgs)
 	if cmdIdx == -1 {
 		return runOrExec(bazelBin, append([]string{bazelBin}, originalArgs...), os.Environ())
 	}

--- a/server/util/bazel/BUILD
+++ b/server/util/bazel/BUILD
@@ -21,6 +21,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/bazel",
     visibility = ["//visibility:public"],
     deps = [
+        "//cli/parser/bazel_command",
         "//server/util/log",
         "//server/util/status",
     ],

--- a/server/util/bazel/bazel.go
+++ b/server/util/bazel/bazel.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazel_command"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 )
@@ -100,64 +101,15 @@ func FindWorkspaceFile(startDir string) (string, error) {
 	return "", status.NotFoundError("could not detect workspace root (WORKSPACE.bazel, WORKSPACE, MODULE, MODULE.bazel file not found)")
 }
 
-// Hard coded list of bazel commands.
-var bazelCommands = map[string]struct{}{
-	"analyze-profile":    {},
-	"aquery":             {},
-	"build":              {},
-	"canonicalize-flags": {},
-	"clean":              {},
-	"coverage":           {},
-	"cquery":             {},
-	"dump":               {},
-	"fetch":              {},
-	"help":               {},
-	"info":               {},
-	"license":            {},
-	"mobile-install":     {},
-	"mod":                {},
-	"print_action":       {},
-	"query":              {},
-	"run":                {},
-	"shutdown":           {},
-	"sync":               {},
-	"test":               {},
-	"vendor":             {},
-	"version":            {},
-}
-
-// GetBazelCommandAndIndex returns the bazel command and its index in the string.
-// Ex. For `bazel build //...` it will return `build` and `1`.
-// This can be helpful for splitting bazel commands into their different components.
-//
-// We hard-code the commands here because running `bazel help` to generate them
-// can result in undesirable behavior. For example if it's run with different
-// startup options than the last bazel command, it will restart the bazel server.
-//
-// TODO: Return an empty string if the subcommand happens to come after
-// a bb-specific command. For example, `bb install --path test` should
-// return an empty string, not "test".
-// TODO: More robust parsing of startup options. For example, this has a bug
-// that passing `bazel --output_base build test ...` returns "build" as the
-// bazel command, even though "build" is the argument to --output_base.
-func GetBazelCommandAndIndex(args []string) (string, int) {
-	for i, a := range args {
-		if _, ok := bazelCommands[a]; ok {
-			return a, i
-		}
-	}
-	return "", -1
-}
-
 // GetStartupOptions makes a best-attempt effort to return the startup options for a bazel command.
 // Ex. for `bazel --digest_function=blake3 build //...` it will return ['--digest_function=blake3']
 func GetStartupOptions(bazelCommandArgs []string) ([]string, error) {
-	_, cmdIdx := GetBazelCommandAndIndex(bazelCommandArgs)
+	_, cmdIdx := bazel_command.GetCommandAndIndex(bazelCommandArgs)
 	if cmdIdx == -1 {
 		return nil, status.InvalidArgumentErrorf("no bazel command in %v", bazelCommandArgs)
 	}
 	startupOptions := bazelCommandArgs[:cmdIdx]
-	if len(startupOptions) > 0 && startupOptions[0] == bazelCommand || startupOptions[0] == bazeliskCommand {
+	if len(startupOptions) > 0 && (startupOptions[0] == bazelCommand || startupOptions[0] == bazeliskCommand) {
 		startupOptions = startupOptions[1:]
 	}
 	return startupOptions, nil


### PR DESCRIPTION
We were incorrectly parsing CLI subcommands that share the same name as a bazel command (`bazel agent analyze-profile`)

In this PR, GetBazelCommandAndIndex stops looking for a bazel command if it sees a CLI command first.

There's a larger diff to account for import cycles