### PR TITLE
Dereference GCS references in `DistributedCache.RemoteGetMulti` responses

### DIFF
--- a/enterprise/server/util/distributed_client/BUILD
+++ b/enterprise/server/util/distributed_client/BUILD
@@ -39,6 +39,7 @@ go_library(
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//reflection",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -35,6 +35,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/rpcutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -70,6 +71,10 @@ const (
 	// decompressed peer response, since digest sizes are client-supplied.
 	// The buffer grows as needed.
 	maxDecompressBufSizeBytes = 4 * 1024 * 1024
+
+	// getMultiDereferenceConcurrency bounds how many references in a single
+	// GetMulti response are dereferenced from shared storage at once.
+	getMultiDereferenceConcurrency = 10
 )
 
 var (
@@ -724,9 +729,15 @@ func (c *Proxy) RemoteGetMulti(ctx context.Context, peer string, resources []*rs
 		return nil, err
 	}
 	resultMap := make(map[*repb.Digest][]byte, len(rsp.GetKeyValue()))
+	var references []*dcpb.KV
 	for _, keyValue := range rsp.GetKeyValue() {
 		rn, ok := hashResources[keyValue.GetKey().GetKey()]
 		if !ok {
+			continue
+		}
+		// If the peer sent bytes and a reference, use the bytes.
+		if keyValue.GetValueReference() != nil && len(keyValue.GetValue()) == 0 {
+			references = append(references, keyValue)
 			continue
 		}
 		d := rn.GetDigest()
@@ -734,12 +745,106 @@ func (c *Proxy) RemoteGetMulti(ctx context.Context, peer string, resources []*rs
 		if compressedHashes.Contains(d.GetHash()) {
 			buf, err = compression.DecompressZstd(make([]byte, 0, digest.SafeBufferSize(rn, maxDecompressBufSizeBytes)), buf)
 			if err != nil {
+				recordGetMultiResponseMetrics("bytes", rn, status.MetricsLabel(err))
 				return nil, err
 			}
 		}
+		recordGetMultiResponseMetrics("bytes", rn, codes.OK.String())
 		resultMap[d] = buf
 	}
+	if len(references) == 0 {
+		return resultMap, nil
+	}
+	if err := c.dereferenceMulti(ctx, peer, references, hashResources, resultMap); err != nil {
+		return nil, err
+	}
 	return resultMap, nil
+}
+
+// dereferenceMulti resolves the referenced values of a GetMulti response from
+// peer into resultMap, dereferencing concurrently.
+func (c *Proxy) dereferenceMulti(ctx context.Context, peer string, kvs []*dcpb.KV, requested map[string]*rspb.ResourceName, resultMap map[*repb.Digest][]byte) error {
+	refCache, ok := c.cache.(interfaces.ReferenceCache)
+	if !ok {
+		for _, kv := range kvs {
+			recordGetMultiResponseMetrics("reference", requested[kv.GetKey().GetKey()], codes.FailedPrecondition.String())
+		}
+		return status.FailedPreconditionErrorf("peer %q returned references, but the local cache (%T) cannot dereference", peer, c.cache)
+	}
+	var mu sync.Mutex
+	var eg errgroup.Group
+	eg.SetLimit(getMultiDereferenceConcurrency)
+	for _, kv := range kvs {
+		rn := requested[kv.GetKey().GetKey()]
+		ref := kv.GetValueReference()
+		eg.Go(func() error {
+			if !referenceMatches(ref, rn) {
+				frd := ref.GetMetadata().GetFileRecord().GetDigest()
+				c.log.Errorf("GetMulti(%q) from peer %q returned a reference for %s/%d; treating as a miss", ResourceIsolationString(rn), peer, frd.GetHash(), frd.GetSizeBytes())
+				recordGetMultiResponseMetrics("reference", rn, codes.Internal.String())
+				return nil
+			}
+			buf, err := dereferenceToBytes(ctx, refCache, ref, rn)
+			recordGetMultiResponseMetrics("reference", rn, status.MetricsLabel(err))
+			if err != nil {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				c.log.Warningf("GetMulti(%q) from peer %q could not dereference; treating as a miss: %s", ResourceIsolationString(rn), peer, err)
+				return nil
+			}
+			mu.Lock()
+			resultMap[rn.GetDigest()] = buf
+			mu.Unlock()
+			return nil
+		})
+	}
+	return eg.Wait()
+}
+
+func dereferenceToBytes(ctx context.Context, refCache interfaces.ReferenceCache, ref *refpb.Reference, rn *rspb.ResourceName) ([]byte, error) {
+	rc, err := refCache.Dereference(ctx, ref, rn, 0, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+	if rn.GetCompressor() != repb.Compressor_IDENTITY {
+		buf := bytes.NewBuffer(make([]byte, 0, digest.SafeBufferSize(rn, maxDecompressBufSizeBytes)))
+		if _, err := buf.ReadFrom(rc); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	}
+	size := rn.GetDigest().GetSizeBytes()
+	buf := make([]byte, size)
+	if _, err := io.ReadFull(rc, buf); err != nil {
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			return nil, status.InternalErrorf("dereferenced value for %s/%d is shorter than expected", rn.GetDigest().GetHash(), size)
+		}
+		return nil, err
+	}
+	var extra [1]byte
+	n, err := rc.Read(extra[:])
+	if n > 0 {
+		return nil, status.InternalErrorf("dereferenced value for %s/%d is longer than expected", rn.GetDigest().GetHash(), size)
+	}
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	return buf, nil
+}
+
+func referenceMatches(ref *refpb.Reference, r *rspb.ResourceName) bool {
+	fr := ref.GetMetadata().GetFileRecord()
+	frd := fr.GetDigest()
+	matches := frd.GetHash() == r.GetDigest().GetHash() &&
+		frd.GetSizeBytes() == r.GetDigest().GetSizeBytes() &&
+		fr.GetDigestFunction() == r.GetDigestFunction() &&
+		fr.GetIsolation().GetCacheType() == r.GetCacheType()
+	if fr.GetIsolation().GetCacheType() != rspb.CacheType_CAS {
+		matches = matches && fr.GetIsolation().GetRemoteInstanceName() == r.GetInstanceName()
+	}
+	return matches
 }
 
 func (c *Proxy) RemoteReader(ctx context.Context, peer string, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
@@ -776,19 +881,8 @@ func (c *Proxy) RemoteReader(ctx context.Context, peer string, r *rspb.ResourceN
 		// proto to the pool, but the reference may live longer, so clone it.
 		ref := rc.rsp.GetReference().CloneVT()
 
-		// Confirm the reference identifies the requested content. Compressor,
-		// encryption, and partition/group are peer-local and may legitimately
-		// differ; the instance name is only ignored for CAS, where content is
-		// instance-independent.
-		fr := ref.GetMetadata().GetFileRecord()
 		frd := ref.GetMetadata().GetFileRecord().GetDigest()
-		refMatches := frd.GetHash() == r.GetDigest().GetHash() &&
-			frd.GetSizeBytes() == r.GetDigest().GetSizeBytes() &&
-			fr.GetDigestFunction() == r.GetDigestFunction() &&
-			fr.GetIsolation().GetCacheType() == r.GetCacheType()
-		if fr.GetIsolation().GetCacheType() != rspb.CacheType_CAS {
-			refMatches = refMatches && fr.GetIsolation().GetRemoteInstanceName() == r.GetInstanceName()
-		}
+		refMatches := referenceMatches(ref, r)
 
 		// If the server is also streaming the data, serve those bytes to the
 		// caller and verify that dereferencing the reference produces the
@@ -881,6 +975,19 @@ func recordReadResponseMetrics(responseType string, r *rspb.ResourceName, status
 	}
 	metrics.DistributedCacheReadResponseCount.With(labels).Inc()
 	metrics.DistributedCacheReadResponseSizeBytes.With(labels).Add(float64(r.GetDigest().GetSizeBytes()))
+}
+
+// recordGetMultiResponseMetrics records that one value of a peer GetMulti
+// response was received as responseType ("reference" or "bytes") and the
+// status of turning it into bytes, attributing the requested digest's size
+// to it.
+func recordGetMultiResponseMetrics(responseType string, r *rspb.ResourceName, statusLabel string) {
+	labels := prometheus.Labels{
+		metrics.DistributedCacheReadResponseType: responseType,
+		metrics.StatusHumanReadableLabel:         statusLabel,
+	}
+	metrics.DistributedCacheGetMultiResponseCount.With(labels).Inc()
+	metrics.DistributedCacheGetMultiResponseSizeBytes.With(labels).Add(float64(r.GetDigest().GetSizeBytes()))
 }
 
 // recordWriteRequestMetrics records that a peer write committed with its

--- a/enterprise/server/util/distributed_client/distributed_client_test.go
+++ b/enterprise/server/util/distributed_client/distributed_client_test.go
@@ -1505,6 +1505,166 @@ func readResponseCount(t *testing.T, responseType, statusCode string) float64 {
 	})
 }
 
+// getMultiResponseCount returns the current value of the distributed cache
+// GetMulti response counter for the given response type and status code.
+func getMultiResponseCount(t *testing.T, responseType, statusCode string) float64 {
+	return testmetrics.CounterValueForLabels(t, metrics.DistributedCacheGetMultiResponseCount, prometheus.Labels{
+		metrics.DistributedCacheReadResponseType: responseType,
+		metrics.StatusHumanReadableLabel:         statusCode,
+	})
+}
+
+// getMultiServer is a DistributedCache server whose GetMulti RPC returns a
+// canned set of KVs regardless of the request.
+type getMultiServer struct {
+	dcpb.UnimplementedDistributedCacheServer
+	kvs []*dcpb.KV
+}
+
+func (s *getMultiServer) GetMulti(ctx context.Context, req *dcpb.GetMultiRequest) (*dcpb.GetMultiResponse, error) {
+	return &dcpb.GetMultiResponse{KeyValue: s.kvs}, nil
+}
+
+func startGetMultiServer(t *testing.T, kvs ...*dcpb.KV) string {
+	t.Helper()
+	lis, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	srv := grpc.NewServer()
+	dcpb.RegisterDistributedCacheServer(srv, &getMultiServer{kvs: kvs})
+	t.Cleanup(srv.Stop)
+	go srv.Serve(lis)
+	waitUntilServerIsAlive(lis.Addr().String())
+	return lis.Addr().String()
+}
+
+func TestRemoteGetMultiReference(t *testing.T) {
+	te := getTestEnv(t, emptyUserMap)
+	ctx, err := prefix.AttachUserPrefixToContext(context.Background(), te.GetAuthenticator())
+	require.NoError(t, err)
+
+	const blobName = "blobs/test-blob"
+	// Large enough that, with compressed reads enabled, the client requests
+	// compressed bytes over the wire.
+	rn, buf := testdigest.RandomCASResourceBuf(t, 1000)
+	inlineRN, inlineBuf := testdigest.RandomCASResourceBuf(t, 50)
+	refKV := func(ref *refpb.Reference) *dcpb.KV {
+		return &dcpb.KV{Key: &dcpb.Key{Key: rn.GetDigest().GetHash(), SizeBytes: rn.GetDigest().GetSizeBytes()}, ValueReference: ref}
+	}
+	inlineKV := &dcpb.KV{Key: &dcpb.Key{Key: inlineRN.GetDigest().GetHash(), SizeBytes: inlineRN.GetDigest().GetSizeBytes()}, Value: inlineBuf}
+
+	t.Run("reference is dereferenced", func(t *testing.T) {
+		peer := startGetMultiServer(t, refKV(makeReference(rn, blobName, repb.Compressor_IDENTITY)))
+		c, fake := newReferenceTestProxy(t, te, map[string][]byte{blobName: buf})
+		before := getMultiResponseCount(t, "reference", "OK")
+		got, err := c.RemoteGetMulti(ctx, peer, []*rspb.ResourceName{rn})
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Equal(t, buf, got[rn.GetDigest()])
+		gotRN, gotOffset, gotLimit := fake.LastDereference()
+		require.Equal(t, repb.Compressor_IDENTITY, gotRN.GetCompressor())
+		require.Zero(t, gotOffset)
+		require.Zero(t, gotLimit)
+		require.Equal(t, before+1, getMultiResponseCount(t, "reference", "OK"))
+	})
+
+	t.Run("reference is dereferenced as the requested resource under compressed reads", func(t *testing.T) {
+		peer := startGetMultiServer(t, refKV(makeReference(rn, blobName, repb.Compressor_IDENTITY)))
+		c, fake := newReferenceTestProxy(t, te, map[string][]byte{blobName: buf})
+		// The client rewrites the wire request to ZSTD, but must dereference
+		// as the IDENTITY resource the caller asked for.
+		c.SetEnableCompressedReads(true)
+		got, err := c.RemoteGetMulti(ctx, peer, []*rspb.ResourceName{rn})
+		require.NoError(t, err)
+		require.Equal(t, buf, got[rn.GetDigest()])
+		gotRN, _, _ := fake.LastDereference()
+		require.Equal(t, repb.Compressor_IDENTITY, gotRN.GetCompressor())
+	})
+
+	t.Run("inline bytes win when both are set", func(t *testing.T) {
+		both := refKV(makeReference(rn, "blobs/missing", repb.Compressor_IDENTITY))
+		both.Value = buf
+		peer := startGetMultiServer(t, both)
+		c, fake := newReferenceTestProxy(t, te, map[string][]byte{})
+		got, err := c.RemoteGetMulti(ctx, peer, []*rspb.ResourceName{rn})
+		require.NoError(t, err)
+		require.Equal(t, buf, got[rn.GetDigest()])
+		gotRN, _, _ := fake.LastDereference()
+		require.Nil(t, gotRN, "expected no dereference")
+	})
+
+	t.Run("wrong-length blob is treated as a miss", func(t *testing.T) {
+		peer := startGetMultiServer(t, inlineKV, refKV(makeReference(rn, blobName, repb.Compressor_IDENTITY)))
+		before := getMultiResponseCount(t, "reference", "Internal")
+		for _, blob := range [][]byte{buf[:len(buf)-1], append(append([]byte{}, buf...), 'x')} {
+			c, _ := newReferenceTestProxy(t, te, map[string][]byte{blobName: blob})
+			got, err := c.RemoteGetMulti(ctx, peer, []*rspb.ResourceName{rn, inlineRN})
+			require.NoError(t, err)
+			require.Len(t, got, 1)
+			require.Equal(t, inlineBuf, got[inlineRN.GetDigest()])
+		}
+		require.Equal(t, before+2, getMultiResponseCount(t, "reference", "Internal"))
+	})
+
+	t.Run("references and inline values are mixed", func(t *testing.T) {
+		peer := startGetMultiServer(t, inlineKV, refKV(makeReference(rn, blobName, repb.Compressor_IDENTITY)))
+		c, _ := newReferenceTestProxy(t, te, map[string][]byte{blobName: buf})
+		refBefore, bytesBefore := getMultiResponseCount(t, "reference", "OK"), getMultiResponseCount(t, "bytes", "OK")
+		got, err := c.RemoteGetMulti(ctx, peer, []*rspb.ResourceName{rn, inlineRN})
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		require.Equal(t, buf, got[rn.GetDigest()])
+		require.Equal(t, inlineBuf, got[inlineRN.GetDigest()])
+		require.Equal(t, refBefore+1, getMultiResponseCount(t, "reference", "OK"))
+		require.Equal(t, bytesBefore+1, getMultiResponseCount(t, "bytes", "OK"))
+	})
+
+	t.Run("digest mismatch is treated as a miss", func(t *testing.T) {
+		otherRN, _ := testdigest.RandomCASResourceBuf(t, 1000)
+		peer := startGetMultiServer(t, inlineKV, refKV(makeReference(otherRN, blobName, repb.Compressor_IDENTITY)))
+		c, _ := newReferenceTestProxy(t, te, map[string][]byte{blobName: buf})
+		before := getMultiResponseCount(t, "reference", "Internal")
+		got, err := c.RemoteGetMulti(ctx, peer, []*rspb.ResourceName{rn, inlineRN})
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Equal(t, inlineBuf, got[inlineRN.GetDigest()])
+		require.Equal(t, before+1, getMultiResponseCount(t, "reference", "Internal"))
+	})
+
+	t.Run("missing blob is treated as a miss", func(t *testing.T) {
+		peer := startGetMultiServer(t, inlineKV, refKV(makeReference(rn, "blobs/missing", repb.Compressor_IDENTITY)))
+		c, _ := newReferenceTestProxy(t, te, map[string][]byte{blobName: buf})
+		before := getMultiResponseCount(t, "reference", "NotFound")
+		got, err := c.RemoteGetMulti(ctx, peer, []*rspb.ResourceName{rn, inlineRN})
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Equal(t, inlineBuf, got[inlineRN.GetDigest()])
+		require.Equal(t, before+1, getMultiResponseCount(t, "reference", "NotFound"))
+	})
+
+	t.Run("cache that cannot dereference is rejected", func(t *testing.T) {
+		peer := startGetMultiServer(t, inlineKV, refKV(makeReference(rn, blobName, repb.Compressor_IDENTITY)))
+		localPeer := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+		c := distributed_client.New(te, te.GetCache(), localPeer)
+		require.NoError(t, c.StartListening())
+		waitUntilServerIsAlive(localPeer)
+		before := getMultiResponseCount(t, "reference", "FailedPrecondition")
+		_, err := c.RemoteGetMulti(ctx, peer, []*rspb.ResourceName{rn, inlineRN})
+		require.True(t, status.IsFailedPreconditionError(err), "expected FailedPreconditionError, got %v", err)
+		require.Equal(t, before+1, getMultiResponseCount(t, "reference", "FailedPrecondition"))
+	})
+
+	t.Run("inline values are returned when nothing is referenced", func(t *testing.T) {
+		peer := startGetMultiServer(t, inlineKV)
+		localPeer := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+		c := distributed_client.New(te, te.GetCache(), localPeer)
+		require.NoError(t, c.StartListening())
+		waitUntilServerIsAlive(localPeer)
+		got, err := c.RemoteGetMulti(ctx, peer, []*rspb.ResourceName{inlineRN})
+		require.NoError(t, err)
+		require.Equal(t, inlineBuf, got[inlineRN.GetDigest()])
+	})
+}
+
 func TestRemoteReadReference(t *testing.T) {
 	te := getTestEnv(t, emptyUserMap)
 	ctx, err := prefix.AttachUserPrefixToContext(context.Background(), te.GetAuthenticator())

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1063,6 +1063,38 @@ var (
 		StatusHumanReadableLabel,
 	})
 
+	// DistributedCacheGetMultiResponseCount counts values received from
+	// distributed cache peers via GetMulti, by whether each value was
+	// received as a reference to shared storage or as inline bytes, and by
+	// the gRPC status code of turning it into bytes ("OK" on success). Each
+	// value in a response is counted separately. Values the peer does not
+	// have are omitted from the response and not counted.
+	DistributedCacheGetMultiResponseCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "distributed_cache_get_multi_response_count",
+		Help:      "Count of values received from distributed cache peers via GetMulti, by whether the value was received as a reference or as inline bytes, and by status code.",
+	}, []string{
+		DistributedCacheReadResponseType,
+		StatusHumanReadableLabel,
+	})
+
+	// DistributedCacheGetMultiResponseSizeBytes totals the digest sizes of
+	// values received from distributed cache peers via GetMulti, by whether
+	// each value was received as a reference to shared storage or as inline
+	// bytes, and by the gRPC status code of turning it into bytes ("OK" on
+	// success). Sizes are the requested digest's (uncompressed) size rather
+	// than the exact bytes transferred.
+	DistributedCacheGetMultiResponseSizeBytes = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "distributed_cache_get_multi_response_size_bytes",
+		Help:      "Total digest sizes of values received from distributed cache peers via GetMulti, by whether the value was received as a reference or as inline bytes, and by status code.",
+	}, []string{
+		DistributedCacheReadResponseType,
+		StatusHumanReadableLabel,
+	})
+
 	// DistributedCacheWriteRequestCount counts distributed cache writes by
 	// whether the payload was sent as a reference or as inline bytes, and by
 	// the commit's gRPC status code ("OK" on success). Writes short-circuited


### PR DESCRIPTION
This is the client-side half of sending GCS references in `GetMulti`. #13180 added the reference field to the KV proto, and a follow-up will have the server populate it behind an experiment. Once that experiment is on, a client that does not understand references would see an empty value and return a zero-length blob, so this change must be deployed everywhere first.

`RemoteGetMulti` now resolves referenced values through the local cache's `Dereference()`, concurrently, and merges them with the inline values. It dereferences as the resource the caller asked for rather than the transport-rewritten compressed one, so the local cache reconciles the compressor. A reference that does not identify the requested digest, or a blob that cannot be read or is the wrong length, is treated as a miss and omitted rather than failing the batch. This matches how `PebbleCache.GetMulti` already handles per-value read failures on the server side, and means a partially rolled back fleet degrades to misses instead of bad data. The one exception is a local cache that cannot dereference at all, which is a misconfiguration on this node and returns an error instead. If a peer ever sends both bytes and a reference, the bytes win.

Metrics are recorded on the client, per value, the same way the read and write paths record theirs.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/8251