### PR TITLE
Dereference references returned by `DistributedCache.GetWithMetadata`

### DIFF
--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -621,12 +621,16 @@ func (c *Proxy) RemoteMetadata(ctx context.Context, peer string, r *rspb.Resourc
 	if err != nil {
 		return nil, err
 	}
+	return cacheMetadataFromProto(md), nil
+}
+
+func cacheMetadataFromProto(md *dcpb.MetadataResponse) *interfaces.CacheMetadata {
 	return &interfaces.CacheMetadata{
 		StoredSizeBytes:    md.GetStoredSizeBytes(),
 		DigestSizeBytes:    md.GetDigestSizeBytes(),
 		LastAccessTimeUsec: md.GetLastAccessUsec(),
 		LastModifyTimeUsec: md.GetLastModifyUsec(),
-	}, nil
+	}
 }
 
 func (c *Proxy) RemoteGetWithMetadata(ctx context.Context, peer string, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
@@ -634,6 +638,8 @@ func (c *Proxy) RemoteGetWithMetadata(ctx context.Context, peer string, r *rspb.
 	if err != nil {
 		return nil, nil, err
 	}
+	// The requester resource, captured before possible modification below.
+	requested := r
 	// Fetch compressed data over the wire and decompress it locally, like
 	// RemoteReader and RemoteGetMulti do.
 	decompress := c.shouldReadCompressed(r)
@@ -645,20 +651,62 @@ func (c *Proxy) RemoteGetWithMetadata(ctx context.Context, peer string, r *rspb.
 	if err != nil {
 		return nil, nil, err
 	}
-	data := rsp.GetData()
-	if decompress {
-		data, err = compression.DecompressZstd(make([]byte, 0, digest.SafeBufferSize(r, maxDecompressBufSizeBytes)), data)
+	var data []byte
+	// If the peer sends bytes and a reference, use the bytes.
+	if ref := rsp.GetReference(); ref != nil && len(rsp.GetData()) == 0 && requested.GetDigest().GetSizeBytes() > 0 {
+		rc, err := c.dereference(ctx, peer, ref, requested, 0, 0)
+		if err != nil {
+			recordGetWithMetadataResponseMetrics("reference", requested, status.MetricsLabel(err))
+			return nil, nil, err
+		}
+		defer rc.Close()
+		buf := bytes.NewBuffer(make([]byte, 0, digest.SafeBufferSize(requested, maxDecompressBufSizeBytes)))
+		_, err = io.Copy(buf, rc)
+		recordGetWithMetadataResponseMetrics("reference", requested, status.MetricsLabel(err))
 		if err != nil {
 			return nil, nil, err
 		}
+		data = buf.Bytes()
+	} else if decompress {
+		data, err = compression.DecompressZstd(make([]byte, 0, digest.SafeBufferSize(r, maxDecompressBufSizeBytes)), rsp.GetData())
+		recordGetWithMetadataResponseMetrics("bytes", requested, status.MetricsLabel(err))
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		data = rsp.GetData()
+		recordGetWithMetadataResponseMetrics("bytes", requested, codes.OK.String())
 	}
-	md := rsp.GetMetadata()
-	return data, &interfaces.CacheMetadata{
-		StoredSizeBytes:    md.GetStoredSizeBytes(),
-		DigestSizeBytes:    md.GetDigestSizeBytes(),
-		LastAccessTimeUsec: md.GetLastAccessUsec(),
-		LastModifyTimeUsec: md.GetLastModifyUsec(),
-	}, nil
+	return data, cacheMetadataFromProto(rsp.GetMetadata()), nil
+}
+
+func recordGetWithMetadataResponseMetrics(responseType string, r *rspb.ResourceName, statusLabel string) {
+	labels := prometheus.Labels{
+		metrics.DistributedCacheReadResponseType: responseType,
+		metrics.StatusHumanReadableLabel:         statusLabel,
+	}
+	metrics.DistributedCacheGetWithMetadataResponseCount.With(labels).Inc()
+	metrics.DistributedCacheGetWithMetadataResponseSizeBytes.With(labels).Add(float64(r.GetDigest().GetSizeBytes()))
+}
+
+// referenceMatches reports whether ref identifies the content named by r.
+// Compressor, encryption, and partition/group are peer-local and may
+// legitimately differ, so they are not compared.
+func referenceMatches(ref *refpb.Reference, r *rspb.ResourceName) bool {
+	fr := ref.GetMetadata().GetFileRecord()
+	// CAS content is instance-independent, so the instance name only
+	// matters for other cache types.
+	if fr.GetIsolation().GetCacheType() != rspb.CacheType_CAS && fr.GetIsolation().GetRemoteInstanceName() != r.GetInstanceName() {
+		return false
+	}
+	return digest.Equal(fr.GetDigest(), r.GetDigest()) &&
+		fr.GetDigestFunction() == r.GetDigestFunction() &&
+		fr.GetIsolation().GetCacheType() == r.GetCacheType()
+}
+
+func referenceMismatchError(peer string, ref *refpb.Reference, r *rspb.ResourceName) error {
+	return status.InternalErrorf("peer %q returned a reference for %s, but %s was requested",
+		peer, digest.String(ref.GetMetadata().GetFileRecord().GetDigest()), digest.String(r.GetDigest()))
 }
 
 func (c *Proxy) RemoteFindMissing(ctx context.Context, peer string, resources []*rspb.ResourceName) ([]*repb.Digest, error) {
@@ -806,19 +854,7 @@ func (c *Proxy) remoteRead(ctx context.Context, peer string, r *rspb.ResourceNam
 		// proto to the pool, but the reference may live longer, so clone it.
 		ref := rc.rsp.GetReference().CloneVT()
 
-		// Confirm the reference identifies the requested content. Compressor,
-		// encryption, and partition/group are peer-local and may legitimately
-		// differ; the instance name is only ignored for CAS, where content is
-		// instance-independent.
-		fr := ref.GetMetadata().GetFileRecord()
-		frd := ref.GetMetadata().GetFileRecord().GetDigest()
-		refMatches := frd.GetHash() == r.GetDigest().GetHash() &&
-			frd.GetSizeBytes() == r.GetDigest().GetSizeBytes() &&
-			fr.GetDigestFunction() == r.GetDigestFunction() &&
-			fr.GetIsolation().GetCacheType() == r.GetCacheType()
-		if fr.GetIsolation().GetCacheType() != rspb.CacheType_CAS {
-			refMatches = refMatches && fr.GetIsolation().GetRemoteInstanceName() == r.GetInstanceName()
-		}
+		refMatches := referenceMatches(ref, r)
 
 		// If the server is also streaming the data, serve those bytes to the
 		// caller and verify that dereferencing the reference produces the
@@ -838,7 +874,7 @@ func (c *Proxy) remoteRead(ctx context.Context, peer string, r *rspb.ResourceNam
 			recordReadResponseMetrics("bytes", r, codes.OK.String())
 			if !refMatches {
 				// Verification is best-effort: log bad refs, but don't fail.
-				c.log.Errorf("Reference verification failed for %q from peer %q: reference identifies %s/%d", ResourceIsolationString(r), peer, frd.GetHash(), frd.GetSizeBytes())
+				c.log.Errorf("Reference verification failed for %q: %s", ResourceIsolationString(r), referenceMismatchError(peer, ref, r))
 				metrics.DistributedCacheReferenceVerificationCount.With(
 					prometheus.Labels{
 						metrics.GroupID:                  groupIDForMetrics(ctx),
@@ -867,6 +903,7 @@ func (c *Proxy) remoteRead(ctx context.Context, peer string, r *rspb.ResourceNam
 		if !refMatches {
 			rc.Close()
 			recordReadResponseMetrics("reference", r, codes.Internal.String())
+			frd := ref.GetMetadata().GetFileRecord().GetDigest()
 			return nil, nil, status.InternalErrorf("peer %q returned a reference for %s/%d, but %s/%d was requested",
 				peer, frd.GetHash(), frd.GetSizeBytes(), r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes())
 		}
@@ -924,6 +961,9 @@ func recordWriteRequestMetrics(requestType string, r *rspb.ResourceName, statusL
 }
 
 func (c *Proxy) dereference(ctx context.Context, peer string, ref *refpb.Reference, requested *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
+	if !referenceMatches(ref, requested) {
+		return nil, referenceMismatchError(peer, ref, requested)
+	}
 	refCache, ok := c.cache.(interfaces.ReferenceCache)
 	if !ok {
 		return nil, status.FailedPreconditionErrorf("peer %q returned a reference, but the local cache (%T) cannot dereference", peer, c.cache)

--- a/enterprise/server/util/distributed_client/distributed_client_test.go
+++ b/enterprise/server/util/distributed_client/distributed_client_test.go
@@ -1045,9 +1045,13 @@ func TestRemoteGetWithMetadata(t *testing.T) {
 	require.NoError(t, te.GetCache().Set(ctx, r, buf))
 
 	// Client-side: data and metadata round-trip through the RPC.
+	before := getWithMetadataResponseCount(t, "bytes", "OK")
+	beforeSize := getWithMetadataResponseSize(t, "bytes", "OK")
 	data, md, err := c.RemoteGetWithMetadata(ctx, peer, r)
 	require.NoError(t, err)
 	require.Equal(t, buf, data)
+	require.Equal(t, before+1, getWithMetadataResponseCount(t, "bytes", "OK"))
+	require.Equal(t, beforeSize+100, getWithMetadataResponseSize(t, "bytes", "OK"))
 
 	cacheMD, err := te.GetCache().Metadata(ctx, r)
 	require.NoError(t, err)
@@ -1378,6 +1382,29 @@ func (s *referenceReadServer) Read(req *dcpb.ReadRequest, stream dcpb.Distribute
 	return nil
 }
 
+// GetWithMetadata answers with the configured reference plus any configured
+// data chunks concatenated; with no chunks this is the shape a peer sends
+// when serving GetWithMetadata by reference.
+func (s *referenceReadServer) GetWithMetadata(ctx context.Context, req *dcpb.GetWithMetadataRequest) (*dcpb.GetWithMetadataResponse, error) {
+	s.mu.Lock()
+	s.lastCompressor = req.GetResource().GetCompressor()
+	s.mu.Unlock()
+	var data []byte
+	for _, chunk := range s.dataChunks {
+		data = append(data, chunk...)
+	}
+	return &dcpb.GetWithMetadataResponse{
+		Data:      data,
+		Reference: s.ref,
+		Metadata: &dcpb.MetadataResponse{
+			StoredSizeBytes: s.ref.GetMetadata().GetStoredSizeBytes(),
+			DigestSizeBytes: s.ref.GetMetadata().GetFileRecord().GetDigest().GetSizeBytes(),
+			LastAccessUsec:  s.ref.GetMetadata().GetLastAccessUsec(),
+			LastModifyUsec:  s.ref.GetMetadata().GetLastModifyUsec(),
+		},
+	}, nil
+}
+
 func (s *referenceReadServer) LastCompressor() repb.Compressor_Value {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1494,6 +1521,20 @@ func newReferenceTestProxy(t *testing.T, te *testenv.TestEnv, blobs map[string][
 	require.NoError(t, c.StartListening())
 	waitUntilServerIsAlive(localPeer)
 	return c, cache
+}
+
+func getWithMetadataResponseCount(t *testing.T, responseType, statusCode string) float64 {
+	return testmetrics.CounterValueForLabels(t, metrics.DistributedCacheGetWithMetadataResponseCount, prometheus.Labels{
+		metrics.DistributedCacheReadResponseType: responseType,
+		metrics.StatusHumanReadableLabel:         statusCode,
+	})
+}
+
+func getWithMetadataResponseSize(t *testing.T, responseType, statusCode string) float64 {
+	return testmetrics.CounterValueForLabels(t, metrics.DistributedCacheGetWithMetadataResponseSizeBytes, prometheus.Labels{
+		metrics.DistributedCacheReadResponseType: responseType,
+		metrics.StatusHumanReadableLabel:         statusCode,
+	})
 }
 
 // readResponseCount returns the current value of the distributed cache read
@@ -1632,6 +1673,130 @@ func TestRemoteReadReference(t *testing.T) {
 		// The failed dereference is recorded under its status code, not OK.
 		require.Equal(t, before+1, readResponseCount(t, "reference", "NotFound"))
 		require.Equal(t, beforeOK, readResponseCount(t, "reference", "OK"))
+	})
+}
+
+func TestRemoteGetWithMetadataReference(t *testing.T) {
+	te := getTestEnv(t, emptyUserMap)
+	ctx, err := prefix.AttachUserPrefixToContext(context.Background(), te.GetAuthenticator())
+	require.NoError(t, err)
+
+	const blobName = "blobs/test-blob"
+	rn, buf := testdigest.RandomCASResourceBuf(t, 100)
+	withMetadata := func(ref *refpb.Reference) *refpb.Reference {
+		ref.Metadata.StoredSizeBytes = 100
+		ref.Metadata.LastAccessUsec = 1234
+		ref.Metadata.LastModifyUsec = 5678
+		return ref
+	}
+
+	t.Run("identity", func(t *testing.T) {
+		peer := startReferenceReadServer(t, withMetadata(makeReference(rn, blobName, repb.Compressor_IDENTITY)))
+		c, fake := newReferenceTestProxy(t, te, map[string][]byte{blobName: buf})
+		before := getWithMetadataResponseCount(t, "reference", "OK")
+		beforeSize := getWithMetadataResponseSize(t, "reference", "OK")
+		got, md, err := c.RemoteGetWithMetadata(ctx, peer, rn)
+		require.NoError(t, err)
+		require.Equal(t, buf, got)
+		require.Equal(t, before+1, getWithMetadataResponseCount(t, "reference", "OK"))
+		require.Equal(t, beforeSize+100, getWithMetadataResponseSize(t, "reference", "OK"))
+		require.Equal(t, int64(100), md.StoredSizeBytes)
+		require.Equal(t, rn.GetDigest().GetSizeBytes(), md.DigestSizeBytes)
+		require.Equal(t, int64(1234), md.LastAccessTimeUsec)
+		require.Equal(t, int64(5678), md.LastModifyTimeUsec)
+		gotRN, gotOffset, gotLimit := fake.LastDereference()
+		require.Equal(t, repb.Compressor_IDENTITY, gotRN.GetCompressor())
+		require.Equal(t, int64(0), gotOffset)
+		require.Equal(t, int64(0), gotLimit)
+	})
+
+	t.Run("decompress transport rewrite", func(t *testing.T) {
+		// With compressed reads enabled, the request is rewritten to ZSTD for
+		// transport. On a reference response, Dereference must see the
+		// caller's original IDENTITY resource so no decompression is needed.
+		bigRN, bigBuf := testdigest.RandomCASResourceBuf(t, 200)
+		peer, srv := startReferenceReadServerWithRecorder(t, makeReference(bigRN, blobName, repb.Compressor_ZSTD))
+		c, fake := newReferenceTestProxy(t, te, map[string][]byte{blobName: bigBuf})
+		c.SetEnableCompressedReads(true)
+		got, _, err := c.RemoteGetWithMetadata(ctx, peer, bigRN)
+		require.NoError(t, err)
+		require.Equal(t, bigBuf, got)
+		require.Equal(t, repb.Compressor_ZSTD, srv.LastCompressor())
+		gotRN, _, _ := fake.LastDereference()
+		require.Equal(t, repb.Compressor_IDENTITY, gotRN.GetCompressor())
+	})
+
+	t.Run("digest mismatch is rejected", func(t *testing.T) {
+		otherRN, _ := testdigest.RandomCASResourceBuf(t, 100)
+		peer := startReferenceReadServer(t, makeReference(otherRN, blobName, repb.Compressor_IDENTITY))
+		c, _ := newReferenceTestProxy(t, te, map[string][]byte{blobName: buf})
+		_, _, err := c.RemoteGetWithMetadata(ctx, peer, rn)
+		require.Error(t, err)
+		require.True(t, status.IsInternalError(err), "expected InternalError, got %s", err)
+		require.Contains(t, err.Error(), "returned a reference for")
+	})
+
+	t.Run("stored instance name may differ", func(t *testing.T) {
+		storedRN := rn.CloneVT()
+		storedRN.InstanceName = "instance-at-first-write"
+		peer := startReferenceReadServer(t, makeReference(storedRN, blobName, repb.Compressor_IDENTITY))
+		c, _ := newReferenceTestProxy(t, te, map[string][]byte{blobName: buf})
+		got, _, err := c.RemoteGetWithMetadata(ctx, peer, rn)
+		require.NoError(t, err)
+		require.Equal(t, buf, got)
+	})
+
+	t.Run("cache that cannot dereference is rejected", func(t *testing.T) {
+		peer := startReferenceReadServer(t, makeReference(rn, blobName, repb.Compressor_IDENTITY))
+		localPeer := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+		c := distributed_client.New(te, te.GetCache(), localPeer)
+		require.NoError(t, c.StartListening())
+		waitUntilServerIsAlive(localPeer)
+		_, _, err := c.RemoteGetWithMetadata(ctx, peer, rn)
+		require.Error(t, err)
+		require.True(t, status.IsFailedPreconditionError(err), "expected FailedPreconditionError, got %s", err)
+	})
+
+	t.Run("missing blob is not found", func(t *testing.T) {
+		peer := startReferenceReadServer(t, makeReference(rn, "blobs/no-such-blob", repb.Compressor_IDENTITY))
+		c, _ := newReferenceTestProxy(t, te, map[string][]byte{blobName: buf})
+		before := getWithMetadataResponseCount(t, "reference", "NotFound")
+		beforeOK := getWithMetadataResponseCount(t, "reference", "OK")
+		_, _, err := c.RemoteGetWithMetadata(ctx, peer, rn)
+		require.Error(t, err)
+		require.True(t, status.IsNotFoundError(err), "expected NotFoundError, got %s", err)
+		// The failed dereference is recorded under its status code, not OK.
+		require.Equal(t, before+1, getWithMetadataResponseCount(t, "reference", "NotFound"))
+		require.Equal(t, beforeOK, getWithMetadataResponseCount(t, "reference", "OK"))
+	})
+
+	t.Run("bytes are authoritative when sent with a reference", func(t *testing.T) {
+		// The reference points at a missing blob, so the bytes must be used
+		// without dereferencing.
+		peer, _ := startVerifyingReadServer(t, makeReference(rn, "blobs/no-such-blob", repb.Compressor_IDENTITY), [][]byte{buf})
+		c, fake := newReferenceTestProxy(t, te, map[string][]byte{})
+		beforeBytes := getWithMetadataResponseCount(t, "bytes", "OK")
+		beforeRef := getWithMetadataResponseCount(t, "reference", "OK")
+		got, _, err := c.RemoteGetWithMetadata(ctx, peer, rn)
+		require.NoError(t, err)
+		require.Equal(t, buf, got)
+		gotRN, _, _ := fake.LastDereference()
+		require.Nil(t, gotRN)
+		require.Equal(t, beforeBytes+1, getWithMetadataResponseCount(t, "bytes", "OK"))
+		require.Equal(t, beforeRef, getWithMetadataResponseCount(t, "reference", "OK"))
+	})
+
+	t.Run("empty blob is served from bytes even with a reference", func(t *testing.T) {
+		// A 0-byte blob's inline payload is indistinguishable from no
+		// payload, so the reference must be ignored rather than dereferenced.
+		emptyRN, _ := testdigest.RandomCASResourceBuf(t, 0)
+		peer := startReferenceReadServer(t, makeReference(emptyRN, "blobs/no-such-blob", repb.Compressor_IDENTITY))
+		c, fake := newReferenceTestProxy(t, te, map[string][]byte{})
+		got, _, err := c.RemoteGetWithMetadata(ctx, peer, emptyRN)
+		require.NoError(t, err)
+		require.Empty(t, got)
+		gotRN, _, _ := fake.LastDereference()
+		require.Nil(t, gotRN)
 	})
 }
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1130,6 +1130,38 @@ var (
 		StatusHumanReadableLabel,
 	})
 
+	// DistributedCacheGetWithMetadataResponseCount counts distributed cache
+	// peer GetWithMetadata responses by whether the payload was received as
+	// a reference to shared storage or as inline bytes, and by the gRPC
+	// status code of turning the response into bytes ("OK" on success).
+	// Responses that fail before any payload is received have no payload
+	// type and are not counted.
+	DistributedCacheGetWithMetadataResponseCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "distributed_cache_get_with_metadata_response_count",
+		Help:      "Count of distributed cache peer GetWithMetadata responses, by whether the payload was received as a reference or as inline bytes, and by status code.",
+	}, []string{
+		DistributedCacheReadResponseType,
+		StatusHumanReadableLabel,
+	})
+
+	// DistributedCacheGetWithMetadataResponseSizeBytes totals the digest
+	// sizes of blobs fetched from peers via GetWithMetadata, by whether the
+	// payload was received as a reference to shared storage or as inline
+	// bytes, and by the gRPC status code of turning the response into bytes
+	// ("OK" on success). Sizes are the requested digest's (uncompressed)
+	// size rather than the exact bytes transferred.
+	DistributedCacheGetWithMetadataResponseSizeBytes = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "distributed_cache_get_with_metadata_response_size_bytes",
+		Help:      "Total digest sizes of blobs fetched from distributed cache peers via GetWithMetadata, by whether the payload was received as a reference or as inline bytes, and by status code.",
+	}, []string{
+		DistributedCacheReadResponseType,
+		StatusHumanReadableLabel,
+	})
+
 	// DistributedCacheReferenceVerificationCount counts verifications of
 	// references received alongside streamed bytes on distributed cache
 	// reads, by outcome: "success" (the dereferenced bytes matched the


### PR DESCRIPTION
This is the client half of serving `GetWithMetadata` by reference, following #13223 (proto) and ahead of a server-side change (to come). When a peer returns a reference in place of bytes, `RemoteGetWithMetadata` now dereferences it through the local cache using the caller's original resource, so the transport-only ZSTD rewrite never leaks into what `Dereference` sees. If a peer ever sends both bytes and a reference, the bytes win, matching `RemoteReader`.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/8252