### PR TITLE
cli/detect: add `--temp_dir` flag for temporary output bases

### DIFF
--- a/cli/detect/nondeterminism.go
+++ b/cli/detect/nondeterminism.go
@@ -70,6 +70,7 @@ var (
 	)
 	notifyEmail = nondeterminismFlags.Bool("notify_email", false, "Send an email to workspace admins when nondeterminism is detected.")
 	notifySlack = nondeterminismFlags.String("notify_slack", "", "Name of the BuildBuddy secret with the Slack webhook URL to notify when nondeterminism is detected.")
+	tempDir     = nondeterminismFlags.String("temp_dir", "", "Directory in which temporary output bases and build logs will be created. Defaults to the OS temp directory.")
 )
 
 var errNondeterminismDetected = errors.New("nondeterminism detected")
@@ -97,6 +98,7 @@ type options struct {
 	bazelArgs     *arg.BazelArgs
 	besBackend    string
 	besResultsURL string
+	tempDir       string
 }
 
 type checker struct {
@@ -151,6 +153,7 @@ func handleNondeterminism(args []string) (int, error) {
 		bazelArgs:     bazelArgs,
 		besBackend:    *besBackend,
 		besResultsURL: *besResultsURL,
+		tempDir:       *tempDir,
 	}
 
 	c := &checker{
@@ -188,7 +191,7 @@ func parseBazelCommand(command string) (*arg.BazelArgs, error) {
 }
 
 func (c *checker) Run(ctx context.Context) error {
-	m, err := newBuildMetadata()
+	m, err := newBuildMetadata(c.opts.tempDir)
 	if err != nil {
 		return err
 	}
@@ -278,8 +281,13 @@ func (c *checker) notifyNondeterminism(ctx context.Context, m *buildMetadata) er
 	return nil
 }
 
-func newBuildMetadata() (*buildMetadata, error) {
-	dir, err := os.MkdirTemp("", "nondeterminism-check-*")
+func newBuildMetadata(tempDir string) (*buildMetadata, error) {
+	if tempDir != "" {
+		if err := os.MkdirAll(tempDir, 0755); err != nil {
+			return nil, err
+		}
+	}
+	dir, err := os.MkdirTemp(tempDir, "nondeterminism-check-*")
 	if err != nil {
 		return nil, err
 	}

--- a/cli/detect/nondeterminism_test.go
+++ b/cli/detect/nondeterminism_test.go
@@ -124,7 +124,7 @@ func TestRunReturnsNilWhenNoDiffs(t *testing.T) {
 }
 
 func TestRemovesOutputBaseAfterEachRun(t *testing.T) {
-	m, err := newBuildMetadata()
+	m, err := newBuildMetadata("")
 	require.NoError(t, err)
 	defer os.RemoveAll(m.tempDir)
 
@@ -161,6 +161,58 @@ func TestRemovesOutputBaseAfterEachRun(t *testing.T) {
 	require.Equal(t, []string{"build", "shutdown", "clean", "build", "shutdown", "clean"}, bazelCommands(runner.runs))
 	require.NoDirExists(t, filepath.Join(m.tempDir, "output_base_1"))
 	require.NoDirExists(t, filepath.Join(m.tempDir, "output_base_2"))
+}
+
+func TestNewBuildMetadata_DefaultTempDir(t *testing.T) {
+	m, err := newBuildMetadata("")
+	require.NoError(t, err)
+	defer os.RemoveAll(m.tempDir)
+
+	require.DirExists(t, m.tempDir)
+	assert.Contains(t, m.tempDir, "nondeterminism-check-")
+	assert.Equal(t, filepath.Dir(m.tempDir), filepath.Clean(os.TempDir()))
+}
+
+func TestNewBuildMetadata_CustomTempDir(t *testing.T) {
+	customDir := filepath.Join(t.TempDir(), "sub-temp")
+	m, err := newBuildMetadata(customDir)
+	require.NoError(t, err)
+	defer os.RemoveAll(m.tempDir)
+
+	require.DirExists(t, m.tempDir)
+	assert.True(t, strings.HasPrefix(m.tempDir, customDir))
+}
+
+func TestRunUsesCustomTempDir(t *testing.T) {
+	customDir := t.TempDir()
+	explainer := &fakeExplainer{diff: &spawn_diff.DiffResult{}}
+	var outputBases []string
+	runner := &fakeRunner{
+		onRun: func(ctx context.Context, call commandCall) error {
+			for _, a := range call.args {
+				if val, ok := strings.CutPrefix(a, "--output_base="); ok {
+					outputBases = append(outputBases, val)
+				}
+			}
+			return nil
+		},
+	}
+	c := &checker{
+		opts: options{
+			bazelArgs:     bazelArgsForTest(t, "build", "//foo:bar"),
+			besBackend:    defaultBESBackend,
+			besResultsURL: defaultBESResultsURL,
+			tempDir:       customDir,
+		},
+		runner:    runner,
+		explainer: explainer,
+	}
+
+	require.NoError(t, c.Run(context.Background()))
+	require.Len(t, outputBases, 6) // build, shutdown, clean for each of the 2 builds
+	for _, base := range outputBases {
+		assert.True(t, strings.HasPrefix(base, customDir), "output base %s should be within custom temp dir %s", base, customDir)
+	}
 }
 
 func bazelArgsForTest(t *testing.T, args ...string) *arg.BazelArgs {


### PR DESCRIPTION
tmpfs on my machine is too small to contain two full output bases of my bazel repo, so this  adds a flag to allow putting them somewhere else.