### PR TITLE
blobstore: preserve S3 download errors

### DIFF
--- a/server/backends/blobstore/aws/BUILD
+++ b/server/backends/blobstore/aws/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "aws",
@@ -21,5 +21,19 @@ go_library(
         "@com_github_aws_aws_sdk_go_v2_service_s3//:s3",
         "@com_github_aws_aws_sdk_go_v2_service_s3//types",
         "@com_github_aws_aws_sdk_go_v2_service_sts//:sts",
+    ],
+)
+
+go_test(
+    name = "aws_test",
+    srcs = ["aws_test.go"],
+    embed = [":aws"],
+    deps = [
+        "//server/backends/blobstore/util",
+        "//server/util/status",
+        "@com_github_aws_aws_sdk_go_v2_feature_s3_manager//:manager",
+        "@com_github_aws_aws_sdk_go_v2_service_s3//:s3",
+        "@com_github_aws_aws_sdk_go_v2_service_s3//types",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/backends/blobstore/aws/aws.go
+++ b/server/backends/blobstore/aws/aws.go
@@ -208,6 +208,7 @@ func (a *AwsS3BlobStore) download(ctx context.Context, blobName string) ([]byte,
 		if errors.As(err, &nsk) {
 			return nil, status.NotFoundError(err.Error())
 		}
+		return nil, err
 	}
 
 	return buff.Bytes(), nil

--- a/server/backends/blobstore/aws/aws_test.go
+++ b/server/backends/blobstore/aws/aws_test.go
@@ -1,0 +1,94 @@
+package aws
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/buildbuddy-io/buildbuddy/server/backends/blobstore/util"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeDownloadClient struct {
+	getObject func(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+}
+
+func (c *fakeDownloadClient) GetObject(ctx context.Context, input *s3.GetObjectInput, options ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	return c.getObject(ctx, input, options...)
+}
+
+type errorReader struct {
+	err error
+}
+
+func (r errorReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func newTestBlobStore(client *fakeDownloadClient) *AwsS3BlobStore {
+	bucket := "bucket"
+	return &AwsS3BlobStore{
+		bucket: &bucket,
+		downloader: manager.NewDownloader(client, func(d *manager.Downloader) {
+			d.Concurrency = 1
+			d.PartBodyMaxRetries = 0
+		}),
+	}
+}
+
+func TestDownloadNoSuchKey(t *testing.T) {
+	store := newTestBlobStore(&fakeDownloadClient{
+		getObject: func(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+			return nil, fmt.Errorf("request failed: %w", &types.NoSuchKey{})
+		},
+	})
+
+	data, err := store.download(context.Background(), "missing")
+	require.Nil(t, data)
+	require.Error(t, err)
+	require.True(t, status.IsNotFoundError(err))
+}
+
+func TestDownloadReturnsErrorWithoutPartialData(t *testing.T) {
+	downloadErr := errors.New("download failed")
+	partialData := []byte("partial data")
+	store := newTestBlobStore(&fakeDownloadClient{
+		getObject: func(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+			contentLength := int64(len(partialData))
+			return &s3.GetObjectOutput{
+				Body:          io.NopCloser(io.MultiReader(bytes.NewReader(partialData), errorReader{err: downloadErr})),
+				ContentLength: &contentLength,
+			}, nil
+		},
+	})
+
+	data, err := store.download(context.Background(), "blob")
+	require.Nil(t, data)
+	require.ErrorIs(t, err, downloadErr)
+}
+
+func TestReadBlobDecompressesDownloadedData(t *testing.T) {
+	want := []byte("uncompressed data")
+	compressed, err := util.Compress(want)
+	require.NoError(t, err)
+	store := newTestBlobStore(&fakeDownloadClient{
+		getObject: func(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+			contentLength := int64(len(compressed))
+			return &s3.GetObjectOutput{
+				Body:          io.NopCloser(bytes.NewReader(compressed)),
+				ContentLength: &contentLength,
+			}, nil
+		},
+	})
+
+	data, err := store.ReadBlob(context.Background(), "blob")
+	require.NoError(t, err)
+	require.Equal(t, want, data)
+}


### PR DESCRIPTION
S3 downloads currently report success after authentication, transport,
or body-read failures, potentially returning an empty or partial blob.
Only NoSuchKey errors are handled, so every other downloader error
is silently discarded.

Propagate the downloader error and discard partial data while
preserving the existing NoSuchKey-to-NotFound mapping. Add regression
coverage using the real SDK downloader with a fake client for wrapped
missing-object errors, a body-read failure after partial output,
and successful compressed reads.

