### PR TITLE
fix screwy css on donut charts from recharts upgrade

### DIFF
--- a/app/components/chart/donut_chart.css
+++ b/app/components/chart/donut_chart.css
@@ -4,6 +4,7 @@
   align-items: center;
 }
 
+.donut-chart .recharts-wrapper,
 .donut-chart .recharts-responsive-container {
   flex-shrink: 0;
   margin-right: 32px;

--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -962,6 +962,7 @@
   margin-right: 32px;
 }
 
+.cache-chart .recharts-wrapper,
 .cache-chart .recharts-responsive-container {
   flex-shrink: 0;
   margin-right: 32px;


### PR DESCRIPTION
leaving the old css selectors so that a rollback of recharts 3 will be easier (if needed).  i'll take it back out in a week or so.

before:
<img width="405" height="510" alt="image" src="https://github.com/user-attachments/assets/5307757e-aa57-48cd-a614-9f86c03de334" />
after:
<img width="435" height="502" alt="image" src="https://github.com/user-attachments/assets/dd54a20f-4099-4f23-abdf-930f889928d2" />
