### PR TITLE
cleanup(CDC): remove enabled experiments

### DIFF
--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -1227,9 +1227,7 @@ func (s *ByteStreamServerProxy) writeChunkingEnabled(ctx context.Context) bool {
 	if cdc.IsChunked(ctx) {
 		return false
 	}
-	return s.efp != nil &&
-		s.efp.Boolean(ctx, "cache_proxy.intercept_and_chunk_large_writes", false) &&
-		chunking.Enabled(ctx, s.efp)
+	return s.efp != nil && s.efp.Boolean(ctx, "cache_proxy.intercept_and_chunk_large_writes", false)
 }
 
 type writeChunkedResult struct {
@@ -1347,7 +1345,7 @@ func (s *ByteStreamServerProxy) writeChunked(ctx context.Context, stream bspb.By
 		return nil
 	}
 
-	chunker, err := chunking.NewChunker(ctx, int(chunking.AvgChunkSizeBytes(ctx, s.efp)), chunkWriteFn)
+	chunker, err := chunking.NewChunker(ctx, int(chunking.AvgChunkSizeBytes()), chunkWriteFn)
 	if err != nil {
 		return writeChunkedResult{}, status.InternalErrorf("creating chunker: %s", err)
 	}

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -1305,14 +1305,6 @@ func BenchmarkWriteUnique(b *testing.B) {
 
 func TestReadChunked(t *testing.T) {
 	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
 		"cache_proxy.attempt_chunked_reads": {
 			State:          memprovider.Enabled,
 			DefaultVariant: "true",
@@ -1538,14 +1530,6 @@ func TestReadChecksPreconditions(t *testing.T) {
 func TestReadChunkedFastPathSkipsSplitBlob(t *testing.T) {
 	// Setup environment.
 	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
 		"cache_proxy.attempt_chunked_reads": {
 			State:          memprovider.Enabled,
 			DefaultVariant: "true",
@@ -1694,14 +1678,6 @@ func TestReadChunkedFastPathSkipsSplitBlob(t *testing.T) {
 
 func TestReadChunkedEncryptedRemoteOnly(t *testing.T) {
 	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
 		"cache_proxy.attempt_chunked_reads": {
 			State:          memprovider.Enabled,
 			DefaultVariant: "true",
@@ -1858,14 +1834,6 @@ func TestReadChunkedEncryptedRemoteOnly(t *testing.T) {
 
 func TestReadChunkedEncryptedRemoteOnlyFallsBackToFullBlob(t *testing.T) {
 	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
 		"cache_proxy.attempt_chunked_reads": {
 			State:          memprovider.Enabled,
 			DefaultVariant: "true",
@@ -1972,14 +1940,6 @@ func TestReadChunkedEncryptedRemoteOnlyFallsBackToFullBlob(t *testing.T) {
 
 func TestReadChunkedCompressedWarmLocal(t *testing.T) {
 	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
 		"cache_proxy.attempt_chunked_reads": {
 			State:          memprovider.Enabled,
 			DefaultVariant: "true",
@@ -2244,14 +2204,6 @@ func (r *faultyReader) Read(p []byte) (int, error) {
 
 func TestReadChunkedWithOffset(t *testing.T) {
 	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
 		"cache_proxy.attempt_chunked_reads": {
 			State:          memprovider.Enabled,
 			DefaultVariant: "true",
@@ -2421,14 +2373,6 @@ func TestReadChunkedWithOffset(t *testing.T) {
 
 func TestReadChunkedFallsBackToLocalBlob(t *testing.T) {
 	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
 		"cache_proxy.attempt_chunked_reads": {
 			State:          memprovider.Enabled,
 			DefaultVariant: "true",
@@ -2513,14 +2457,6 @@ func TestReadChunkedFallsBackToLocalBlob(t *testing.T) {
 
 func TestReadChunkedPartialLocalFailure(t *testing.T) {
 	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
 		"cache_proxy.attempt_chunked_reads": {
 			State:          memprovider.Enabled,
 			DefaultVariant: "true",
@@ -2682,14 +2618,6 @@ func TestReadRemoteChunkRetryClassification(t *testing.T) {
 
 func TestWriteChunked(t *testing.T) {
 	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
 		"cache_proxy.intercept_and_chunk_large_writes": {
 			State:          memprovider.Enabled,
 			DefaultVariant: "true",
@@ -2849,14 +2777,6 @@ func TestWriteChunked(t *testing.T) {
 
 func TestWriteChunkedEncryptedRemoteOnly(t *testing.T) {
 	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
 		"cache_proxy.intercept_and_chunk_large_writes": {
 			State:          memprovider.Enabled,
 			DefaultVariant: "true",
@@ -3009,14 +2929,6 @@ func TestWriteChunkedGroupsFindMissingAndBatchesUploads(t *testing.T) {
 	flags.Set(t, "cache.zstd_transcoding_enabled", true)
 
 	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
 		"cache_proxy.intercept_and_chunk_large_writes": {
 			State:          memprovider.Enabled,
 			DefaultVariant: "true",
@@ -3172,14 +3084,6 @@ func TestWriteChunkedGroupsFindMissingAndBatchesUploads(t *testing.T) {
 
 func TestWriteChunkedFallbackBelowThreshold(t *testing.T) {
 	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
 		"cache_proxy.intercept_and_chunk_large_writes": {
 			State:          memprovider.Enabled,
 			DefaultVariant: "true",
@@ -3357,14 +3261,6 @@ func setupChunkedBenchmarkEnv(b *testing.B) (bspb.ByteStreamClient, context.Cont
 	log.Configure()
 
 	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
 		"cache_proxy.intercept_and_chunk_large_writes": {
 			State:          memprovider.Enabled,
 			DefaultVariant: "true",
@@ -3449,14 +3345,6 @@ func setupChunkedReadBenchmarkEnv(b *testing.B) *chunkedReadBenchmarkEnv {
 	log.Configure()
 
 	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
 		"cache_proxy.attempt_chunked_reads": {
 			State:          memprovider.Enabled,
 			DefaultVariant: "true",
@@ -3588,7 +3476,7 @@ func prepareChunkedReadBenchmarkData(b *testing.B, ctx context.Context, size int
 		})
 		return nil
 	}
-	cdcChunker, err := chunking.NewChunker(ctx, int(chunking.AvgChunkSizeBytes(ctx, nil)), writeChunkFn)
+	cdcChunker, err := chunking.NewChunker(ctx, int(chunking.AvgChunkSizeBytes()), writeChunkFn)
 	require.NoError(b, err)
 	_, err = cdcChunker.Write(originalData)
 	require.NoError(b, err)

--- a/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy_test.go
+++ b/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy_test.go
@@ -439,7 +439,6 @@ func TestFindMissingBlobs_BypassCache(t *testing.T) {
 	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
 	fp, err := experiments.NewFlagProvider(t.Name())
 	require.NoError(t, err)
-
 	ctx := testContext()
 	conn, requestCount, _ := runRemoteCASS(ctx, testenv.GetTestEnv(t), t)
 	proxyEnv := testenv.GetTestEnv(t)
@@ -851,26 +850,10 @@ func BenchmarkBatchUpdateBlobs(b *testing.B) {
 }
 
 func TestSpliceBlob(t *testing.T) {
-	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
-	})
-	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
-	fp, err := experiments.NewFlagProvider(t.Name())
-	require.NoError(t, err)
-
 	ctx := testContext()
 	remoteEnv := testenv.GetTestEnv(t)
-	remoteEnv.SetExperimentFlagProvider(fp)
 	conn, requestCount, _ := runRemoteCASS(ctx, remoteEnv, t)
 	proxyEnv := testenv.GetTestEnv(t)
-	proxyEnv.SetExperimentFlagProvider(fp)
 	proxyConn := runCASProxy(ctx, conn, proxyEnv, t)
 	proxy := repb.NewContentAddressableStorageClient(proxyConn)
 
@@ -903,26 +886,10 @@ func TestSpliceBlob(t *testing.T) {
 }
 
 func TestSplitBlob(t *testing.T) {
-	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
-	})
-	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
-	fp, err := experiments.NewFlagProvider(t.Name())
-	require.NoError(t, err)
-
 	ctx := testContext()
 	remoteEnv := testenv.GetTestEnv(t)
-	remoteEnv.SetExperimentFlagProvider(fp)
 	conn, _, _ := runRemoteCASS(ctx, remoteEnv, t)
 	proxyEnv := testenv.GetTestEnv(t)
-	proxyEnv.SetExperimentFlagProvider(fp)
 	proxyConn := runCASProxy(ctx, conn, proxyEnv, t)
 	proxy := repb.NewContentAddressableStorageClient(proxyConn)
 	remote := repb.NewContentAddressableStorageClient(conn)

--- a/enterprise/server/remote_cache/chunking/BUILD
+++ b/enterprise/server/remote_cache/chunking/BUILD
@@ -5,7 +5,6 @@ go_test(
     srcs = ["chunking_test.go"],
     deps = [
         "//enterprise/server/backends/pebble_cache",
-        "//enterprise/server/experiments",
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//server/interfaces",
@@ -15,8 +14,6 @@ go_test(
         "//server/testutil/testfs",
         "//server/util/prefix",
         "//server/util/testing/flags",
-        "@com_github_open_feature_go_sdk//openfeature",
-        "@com_github_open_feature_go_sdk//openfeature/memprovider",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/enterprise/server/remote_cache/chunking/chunking_test.go
+++ b/enterprise/server/remote_cache/chunking/chunking_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/pebble_cache"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/experiments"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/chunking"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
@@ -15,8 +14,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
-	"github.com/open-feature/go-sdk/openfeature"
-	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -32,25 +29,6 @@ type getMultiCountingCache struct {
 func (c *getMultiCountingCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
 	c.getMultiCalls += len(resources)
 	return c.Cache.GetMulti(ctx, resources)
-}
-
-func TestAvgChunkSizeOverride(t *testing.T) {
-	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.avg_chunk_size_override": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "half_mb",
-			Variants: map[string]any{
-				"half_mb": 512 * 1024,
-			},
-		},
-	})
-	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
-	fp, err := experiments.NewFlagProvider(t.Name())
-	require.NoError(t, err)
-
-	ctx := context.Background()
-
-	require.Equal(t, uint64(512*1024), chunking.FastCDCParams(ctx, fp).GetAvgChunkSizeBytes())
 }
 
 func TestStore_SharedValidationMarkerSkipsRehashForIdenticalManifest(t *testing.T) {
@@ -80,7 +58,7 @@ func TestStore_SharedValidationMarkerSkipsRehashForIdenticalManifest(t *testing.
 	require.NoError(t, err)
 
 	var chunkDigests []*repb.Digest
-	c, err := chunking.NewChunker(ctx, int(chunking.AvgChunkSizeBytes(ctx, nil)), func(data []byte) error {
+	c, err := chunking.NewChunker(ctx, int(chunking.AvgChunkSizeBytes()), func(data []byte) error {
 		d, err := digest.Compute(bytes.NewReader(data), repb.DigestFunction_BLAKE3)
 		if err != nil {
 			return err

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -679,8 +679,7 @@ func (s *ExecutionServer) getActionResultFromCache(ctx context.Context, d *diges
 	if err != nil {
 		return nil, err
 	}
-	chunkingEnabled := chunking.Enabled(ctx, s.env.GetExperimentFlagProvider())
-	if err := action_cache_server.ValidateActionResult(ctx, s.cache, d.GetInstanceName(), d.GetDigestFunction(), chunkingEnabled, s.env.GetExperimentFlagProvider(), actionResult); err != nil {
+	if err := action_cache_server.ValidateActionResult(ctx, s.cache, d.GetInstanceName(), d.GetDigestFunction(), actionResult); err != nil {
 		return nil, err
 	}
 	return actionResult, nil
@@ -952,14 +951,14 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 		uploadOutputsChunked = efp.Boolean(ctx, "executor.upload_outputs_chunked", uploadOutputsChunked)
 		downloadInputsChunked = efp.Boolean(ctx, "executor.download_inputs_chunked", downloadInputsChunked)
 	}
-	if chunking.Enabled(ctx, efp) && uploadOutputsChunked {
+	if uploadOutputsChunked {
 		executionTask.Experiments = append(executionTask.Experiments, "executor.upload_outputs_chunked")
 		executionTask.FastCdc_2020Params = chunking.FastCDCWriteParams(ctx, efp)
 		if efp != nil && efp.Boolean(ctx, cdc.SpliceWithoutValidationExperiment, false) {
 			executionTask.Experiments = append(executionTask.Experiments, cdc.SpliceWithoutValidationExperiment)
 		}
 	}
-	if chunking.Enabled(ctx, efp) && downloadInputsChunked {
+	if downloadInputsChunked {
 		executionTask.Experiments = append(executionTask.Experiments, "executor.download_inputs_chunked")
 	}
 

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -337,13 +337,6 @@ func TestDispatch_UploadOutputsChunkedMaxWriteSize(t *testing.T) {
 {
   "$schema": "https://flagd.dev/schema/v0/flags.json",
   "flags": {
-    "cache.chunking_enabled": {
-      "state": "ENABLED",
-      "variants": {
-        "on": true
-      },
-      "defaultVariant": "on"
-    },
     "executor.upload_outputs_chunked": {
       "state": "ENABLED",
       "variants": {

--- a/server/cache/dirtools/BUILD
+++ b/server/cache/dirtools/BUILD
@@ -39,7 +39,6 @@ go_test(
     srcs = ["dirtools_test.go"],
     deps = [
         ":dirtools",
-        "//enterprise/server/experiments",
         "//enterprise/server/remote_execution/filecache",
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
@@ -57,8 +56,6 @@ go_test(
         "//server/util/proto",
         "//server/util/rpcutil",
         "//server/util/testing/flags",
-        "@com_github_open_feature_go_sdk//openfeature",
-        "@com_github_open_feature_go_sdk//openfeature/memprovider",
         "@com_github_roaringbitmap_roaring//:roaring",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/server/cache/dirtools/dirtools_test.go
+++ b/server/cache/dirtools/dirtools_test.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/RoaringBitmap/roaring"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/experiments"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache"
 	"github.com/buildbuddy-io/buildbuddy/server/cache/dirtools"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -32,8 +31,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/rpcutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
-	"github.com/open-feature/go-sdk/openfeature"
-	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -1651,24 +1648,7 @@ func TestDownloadTreeDirectlyToFileCache(t *testing.T) {
 func TestDownloadTree_ChunkedInputFiles_ReusesCachedChunksAndUpdatesLocations(t *testing.T) {
 	flags.Set(t, "cache.client.enable_download_compression", false)
 
-	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
-	})
-	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
-
-	fp, err := experiments.NewFlagProvider(t.Name())
-	require.NoError(t, err)
-
 	env, ctx := testEnv(t)
-	env.SetExperimentFlagProvider(fp)
-
 	fileCache := &countingFileCache{
 		FileCache: env.GetFileCache(),
 		adds:      make(map[string]int),

--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -79,16 +79,13 @@ func NewActionCacheServer(env environment.Env) (*ActionCacheServer, error) {
 	}, nil
 }
 
-func checkFilesExist(ctx context.Context, cache interfaces.Cache, instanceName string, digestFunction repb.DigestFunction_Value, chunkingEnabled bool, maxChunkSizeBytes int64, digests []*rspb.ResourceName) error {
+func checkFilesExist(ctx context.Context, cache interfaces.Cache, instanceName string, digestFunction repb.DigestFunction_Value, maxChunkSizeBytes int64, digests []*rspb.ResourceName) error {
 	missing, err := cache.FindMissing(findmissing.ContextWithPurpose(ctx, repb.FindMissingBlobsRequest_AC_VALIDATION), digests)
 	if err != nil {
 		return err
 	}
 	if len(missing) == 0 {
 		return nil
-	}
-	if !chunkingEnabled {
-		return status.NotFoundErrorf("ActionResult output file %q not found in cache", chunking.DigestsSummary(missing))
 	}
 	for _, d := range missing {
 		if d.GetSizeBytes() <= maxChunkSizeBytes {
@@ -117,14 +114,13 @@ func checkFilesExist(ctx context.Context, cache interfaces.Cache, instanceName s
 	return eg.Wait()
 }
 
-func readOutputTree(ctx context.Context, cache interfaces.Cache, instanceName string, digestFunction repb.DigestFunction_Value, chunkingEnabled bool, maxChunkSizeBytes int64, chunkedReadLimiter *semaphore.Weighted, treeDigest *repb.Digest) (*repb.Tree, error) {
+func readOutputTree(ctx context.Context, cache interfaces.Cache, instanceName string, digestFunction repb.DigestFunction_Value, maxChunkSizeBytes int64, chunkedReadLimiter *semaphore.Weighted, treeDigest *repb.Digest) (*repb.Tree, error) {
 	rn := digest.NewResourceName(treeDigest, instanceName, rspb.CacheType_CAS, digestFunction).ToProto()
 	blob, err := cache.Get(ctx, rn)
 	if err != nil {
 		isNotFound := status.IsNotFoundError(err) || os.IsNotExist(err)
 		treeSizeBytes := treeDigest.GetSizeBytes()
 		if !isNotFound ||
-			!chunkingEnabled ||
 			treeSizeBytes <= maxChunkSizeBytes ||
 			treeSizeBytes > rpcutil.GRPCMaxSizeBytes {
 			return nil, err
@@ -153,8 +149,8 @@ func readOutputTree(ctx context.Context, cache interfaces.Cache, instanceName st
 	return tree, nil
 }
 
-func ValidateActionResult(ctx context.Context, cache interfaces.Cache, remoteInstanceName string, digestFunction repb.DigestFunction_Value, chunkingEnabled bool, efp interfaces.ExperimentFlagProvider, r *repb.ActionResult) error {
-	maxChunkSizeBytes := chunking.MaxChunkSizeBytes(ctx, efp)
+func ValidateActionResult(ctx context.Context, cache interfaces.Cache, remoteInstanceName string, digestFunction repb.DigestFunction_Value, r *repb.ActionResult) error {
+	maxChunkSizeBytes := chunking.MaxChunkSizeBytes()
 	outputFileDigests := make([]*rspb.ResourceName, 0, len(r.OutputFiles))
 	mu := &sync.Mutex{}
 	appendDigest := func(d *repb.Digest) {
@@ -174,7 +170,7 @@ func ValidateActionResult(ctx context.Context, cache interfaces.Cache, remoteIns
 	for _, d := range r.OutputDirectories {
 		dc := d
 		g.Go(func() error {
-			tree, err := readOutputTree(gCtx, cache, remoteInstanceName, digestFunction, chunkingEnabled, maxChunkSizeBytes, chunkedTreeReadLimiter, dc.GetTreeDigest())
+			tree, err := readOutputTree(gCtx, cache, remoteInstanceName, digestFunction, maxChunkSizeBytes, chunkedTreeReadLimiter, dc.GetTreeDigest())
 			if err != nil {
 				return err
 			}
@@ -193,7 +189,7 @@ func ValidateActionResult(ctx context.Context, cache interfaces.Cache, remoteIns
 		return err
 	}
 
-	return checkFilesExist(ctx, cache, remoteInstanceName, digestFunction, chunkingEnabled, maxChunkSizeBytes, outputFileDigests)
+	return checkFilesExist(ctx, cache, remoteInstanceName, digestFunction, maxChunkSizeBytes, outputFileDigests)
 }
 
 func setWorkerMetadata(ar *repb.ActionResult) {
@@ -250,8 +246,7 @@ func (s *ActionCacheServer) fetchActionResult(ctx context.Context, rn *digest.AC
 		return nil, nil, 0, err
 	}
 
-	chunkingEnabled := chunking.Enabled(ctx, s.env.GetExperimentFlagProvider())
-	if err := ValidateActionResult(ctx, s.cache, req.GetInstanceName(), req.GetDigestFunction(), chunkingEnabled, s.env.GetExperimentFlagProvider(), rsp); err != nil {
+	if err := ValidateActionResult(ctx, s.cache, req.GetInstanceName(), req.GetDigestFunction(), rsp); err != nil {
 		return nil, nil, 0, status.NotFoundErrorf("ActionResult (%s) not found: %s", req.GetActionDigest(), err)
 	}
 	// The default limit on incoming gRPC messages is 4MB and Bazel doesn't

--- a/server/remote_cache/action_cache_server/action_cache_server_test.go
+++ b/server/remote_cache/action_cache_server/action_cache_server_test.go
@@ -722,13 +722,7 @@ func TestValidateActionResult_ChunkedOutputFile(t *testing.T) {
 		},
 	}
 
-	chunkingEnabled := true
-	require.NoError(t, action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, chunkingEnabled, te.GetExperimentFlagProvider(), ar))
-
-	chunkingDisabled := false
-	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, chunkingDisabled, te.GetExperimentFlagProvider(), ar)
-	require.Error(t, err)
-	assert.True(t, status.IsNotFoundError(err))
+	require.NoError(t, action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, ar))
 }
 
 func TestValidateActionResult_ChunkedOutputDirectoryTree(t *testing.T) {
@@ -760,18 +754,14 @@ func TestValidateActionResult_ChunkedOutputDirectoryTree(t *testing.T) {
 			{Path: "output", TreeDigest: treeDigest},
 		},
 	}
-	require.NoError(t, action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar))
+	require.NoError(t, action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, ar))
 	require.NoError(t, action_cache_server.ValidateActionResult(ctx, &getErrorCache{
 		Cache: cache,
 		match: func(r *rspb.ResourceName) bool {
 			return r.GetCacheType() == rspb.CacheType_CAS && digest.Equal(r.GetDigest(), treeDigest)
 		},
 		err: os.ErrNotExist,
-	}, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar))
-
-	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, false, te.GetExperimentFlagProvider(), ar)
-	require.Error(t, err)
-	assert.True(t, status.IsNotFoundError(err))
+	}, "", repb.DigestFunction_SHA256, ar))
 
 	tree.Root.Files[0].Name = "y" + tree.Root.Files[0].GetName()[1:]
 	corruptTreeData, err := proto.Marshal(tree)
@@ -781,7 +771,7 @@ func TestValidateActionResult_ChunkedOutputDirectoryTree(t *testing.T) {
 	for i, data := range corruptChunkData {
 		require.NoError(t, cache.Set(ctx, chunkRNs[i], data))
 	}
-	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar)
+	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, ar)
 	require.Error(t, err)
 	require.True(t, status.IsDataLossError(err), "expected DataLoss, got %s", err)
 
@@ -789,7 +779,7 @@ func TestValidateActionResult_ChunkedOutputDirectoryTree(t *testing.T) {
 		require.NoError(t, cache.Set(ctx, chunkRNs[i], data))
 	}
 	require.NoError(t, cache.Delete(ctx, chunkRNs[1]))
-	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar)
+	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, ar)
 	require.Error(t, err)
 	assert.True(t, status.IsNotFoundError(err))
 }
@@ -810,7 +800,7 @@ func TestValidateActionResult_ChunkedOutputDirectoryTreeInfersDigestFunction(t *
 	treeDigest, _ := storeChunkedBlob(t, ctx, cache, treeData, repb.DigestFunction_SHA1)
 	ar := &repb.ActionResult{OutputDirectories: []*repb.OutputDirectory{{TreeDigest: treeDigest}}}
 
-	require.NoError(t, action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_UNKNOWN, true, te.GetExperimentFlagProvider(), ar))
+	require.NoError(t, action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_UNKNOWN, ar))
 }
 
 func TestValidateActionResult_DoesNotReconstructOversizedOutputDirectoryTree(t *testing.T) {
@@ -832,7 +822,7 @@ func TestValidateActionResult_DoesNotReconstructOversizedOutputDirectoryTree(t *
 		SizeBytes: rpcutil.GRPCMaxSizeBytes + 1,
 	}}}}
 
-	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar)
+	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, ar)
 	require.Error(t, err)
 	assert.True(t, status.IsNotFoundError(err))
 }
@@ -871,11 +861,11 @@ func TestValidateActionResult_ManyChunkedOutputFiles(t *testing.T) {
 		lastChunkRN = chunk2RN
 	}
 
-	require.NoError(t, action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar))
+	require.NoError(t, action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, ar))
 
 	// Deleting a single chunk should make validation fail with NotFound.
 	require.NoError(t, cache.Delete(ctx, lastChunkRN))
-	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar)
+	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, ar)
 	require.Error(t, err)
 	assert.True(t, status.IsNotFoundError(err))
 }
@@ -915,7 +905,7 @@ func TestValidateActionResult_DiscardsChunkedOutputFileBelowCurrentWriteThreshol
 		},
 	}
 
-	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, te.GetExperimentFlagProvider(), ar)
+	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, ar)
 	require.Error(t, err)
 	assert.True(t, status.IsNotFoundError(err))
 }

--- a/server/remote_cache/byte_stream_server/BUILD
+++ b/server/remote_cache/byte_stream_server/BUILD
@@ -45,7 +45,6 @@ go_test(
     srcs = ["byte_stream_server_test.go"],
     embed = [":byte_stream_server"],
     deps = [
-        "//enterprise/server/experiments",
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//server/backends/memory_metrics_collector",
@@ -66,8 +65,6 @@ go_test(
         "//server/util/status",
         "//server/util/testing/flags",
         "@com_github_google_uuid//:uuid",
-        "@com_github_open_feature_go_sdk//openfeature",
-        "@com_github_open_feature_go_sdk//openfeature/memprovider",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -199,7 +199,7 @@ func (s *ByteStreamServer) ReadCASResource(ctx context.Context, r *digest.CASRes
 	}
 	reader, err := s.cache.Reader(ctx, cacheRN.ToProto(), offset, limit)
 	if err != nil {
-		if status.IsNotFoundError(err) && chunking.ShouldReadChunked(ctx, s.env.GetExperimentFlagProvider(), cacheRN.GetDigest().GetSizeBytes(), offset, limit) {
+		if status.IsNotFoundError(err) && chunking.ShouldReadChunked(cacheRN.GetDigest().GetSizeBytes(), offset, limit) {
 			reader, err = s.attemptReadChunked(ctx, cacheRN, offset)
 		}
 		if err != nil {

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/experiments"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/memory_metrics_collector"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
@@ -29,8 +28,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
-	"github.com/open-feature/go-sdk/openfeature"
-	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
@@ -790,26 +787,9 @@ func newUUID(t *testing.T) string {
 }
 
 func TestReadChunked(t *testing.T) {
-	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
-	})
-	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
-
-	fp, err := experiments.NewFlagProvider(t.Name())
-	require.NoError(t, err)
-
 	ctx := context.Background()
 	te := testenv.GetTestEnv(t)
-	te.SetExperimentFlagProvider(fp)
-
-	ctx, err = prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
 	require.NoError(t, err)
 
 	clientConn := runByteStreamServer(ctx, t, te)
@@ -843,26 +823,9 @@ func TestReadChunked(t *testing.T) {
 }
 
 func TestReadChunked_NonZeroOffset(t *testing.T) {
-	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
-	})
-	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
-
-	fp, err := experiments.NewFlagProvider(t.Name())
-	require.NoError(t, err)
-
 	ctx := context.Background()
 	te := testenv.GetTestEnv(t)
-	te.SetExperimentFlagProvider(fp)
-
-	ctx, err = prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
 	require.NoError(t, err)
 
 	clientConn := runByteStreamServer(ctx, t, te)
@@ -930,27 +893,11 @@ func TestReadChunked_NonZeroOffset(t *testing.T) {
 }
 
 func TestReadChunked_NonZeroOffset_ZstdBLAKE3(t *testing.T) {
-	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
-	})
-	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
 	flags.Set(t, "cache.zstd_transcoding_enabled", true)
-
-	fp, err := experiments.NewFlagProvider(t.Name())
-	require.NoError(t, err)
 
 	ctx := context.Background()
 	te := testenv.GetTestEnv(t)
-	te.SetExperimentFlagProvider(fp)
-
-	ctx, err = prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
 	require.NoError(t, err)
 
 	clientConn := runByteStreamServer(ctx, t, te)
@@ -1209,28 +1156,13 @@ func TestNewByteStreamServer_BufferPoolAccommodatesCompressedChunkOverhead(t *te
 
 func TestReadChunked_ZstdBLAKE3_PassthroughIncompressible(t *testing.T) {
 	chunkSize := int64(1024 * 1024)
-	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
-	})
-	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
 	flags.Set(t, "cache.zstd_transcoding_enabled", true)
-
-	fp, err := experiments.NewFlagProvider(t.Name())
-	require.NoError(t, err)
 
 	ctx := context.Background()
 	te := testenv.GetTestEnv(t)
-	te.SetExperimentFlagProvider(fp)
 	te.SetCache(&casCompressionCache{Cache: te.GetCache()})
 
-	ctx, err = prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
 	require.NoError(t, err)
 
 	clientConn := runByteStreamServer(ctx, t, te)
@@ -1289,28 +1221,13 @@ func TestReadChunked_ZstdBLAKE3_PassthroughIncompressible(t *testing.T) {
 }
 
 func TestReadChunked_ZstdPassthroughCompressedChunkLargerThanCompressBound(t *testing.T) {
-	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
-	})
-	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
 	flags.Set(t, "cache.zstd_transcoding_enabled", true)
-
-	fp, err := experiments.NewFlagProvider(t.Name())
-	require.NoError(t, err)
 
 	ctx := context.Background()
 	te := testenv.GetTestEnv(t)
-	te.SetExperimentFlagProvider(fp)
 	te.SetCache(&casCompressionCache{Cache: te.GetCache()})
 
-	ctx, err = prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
 	require.NoError(t, err)
 
 	clientConn := runByteStreamServer(ctx, t, te)
@@ -1376,26 +1293,9 @@ func TestReadChunked_ZstdPassthroughCompressedChunkLargerThanCompressBound(t *te
 }
 
 func TestReadChunked_MissingManifest(t *testing.T) {
-	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
-	})
-	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
-
-	fp, err := experiments.NewFlagProvider(t.Name())
-	require.NoError(t, err)
-
 	ctx := context.Background()
 	te := testenv.GetTestEnv(t)
-	te.SetExperimentFlagProvider(fp)
-
-	ctx, err = prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
 	require.NoError(t, err)
 
 	clientConn := runByteStreamServer(ctx, t, te)
@@ -1448,28 +1348,12 @@ func TestReadChunked_UsesParallelReads(t *testing.T) {
 		{name: "zstd_many_chunks", chunkCount: 2 * defaultChunkedReadMaxInFlight, want: defaultChunkedReadMaxInFlight, compressor: repb.Compressor_ZSTD},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-				"cache.chunking_enabled": {
-					State:          memprovider.Enabled,
-					DefaultVariant: "true",
-					Variants: map[string]any{
-						"true":  true,
-						"false": false,
-					},
-				},
-			})
-			require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
-
-			fp, err := experiments.NewFlagProvider(t.Name())
-			require.NoError(t, err)
 			if tc.compressor == repb.Compressor_ZSTD {
 				flags.Set(t, "cache.zstd_transcoding_enabled", true)
 			}
 
 			ctx := context.Background()
 			te := testenv.GetTestEnv(t)
-			te.SetExperimentFlagProvider(fp)
-
 			baseCache := te.GetCache()
 			if tc.compressor == repb.Compressor_ZSTD {
 				baseCache = &casCompressionCache{Cache: baseCache}
@@ -1482,7 +1366,7 @@ func TestReadChunked_UsesParallelReads(t *testing.T) {
 			}
 			te.SetCache(cache)
 
-			ctx, err = prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+			ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
 			require.NoError(t, err)
 
 			clientConn := runByteStreamServer(ctx, t, te)

--- a/server/remote_cache/cachetools/BUILD
+++ b/server/remote_cache/cachetools/BUILD
@@ -49,7 +49,6 @@ go_test(
     srcs = ["cachetools_test.go"],
     deps = [
         ":cachetools",
-        "//enterprise/server/experiments",
         "//proto:cache_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
@@ -65,8 +64,6 @@ go_test(
         "//server/util/status",
         "//server/util/testing/flags",
         "@com_github_google_go_cmp//cmp",
-        "@com_github_open_feature_go_sdk//openfeature",
-        "@com_github_open_feature_go_sdk//openfeature/memprovider",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",

--- a/server/remote_cache/cachetools/cachetools_test.go
+++ b/server/remote_cache/cachetools/cachetools_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/experiments"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/chunking"
@@ -26,8 +25,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/google/go-cmp/cmp"
-	"github.com/open-feature/go-sdk/openfeature"
-	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -1459,22 +1456,7 @@ func TestUploadFromReaderWithCompression(t *testing.T) {
 }
 
 func TestBatchCASUploader_ChunkedUpload(t *testing.T) {
-	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
-	})
-	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
-	fp, err := experiments.NewFlagProvider(t.Name())
-	require.NoError(t, err)
-
 	te := testenv.GetTestEnv(t)
-	te.SetExperimentFlagProvider(fp)
 	_, runServer, localGRPClis := testenv.RegisterLocalGRPCServer(t, te)
 	testcache.Setup(t, te, localGRPClis)
 	go runServer()
@@ -1483,13 +1465,13 @@ func TestBatchCASUploader_ChunkedUpload(t *testing.T) {
 	blobSize := int64(5 * 1024 * 1024)
 	rn, buf := testdigest.RandomCASResourceBuf(t, blobSize)
 
-	ul := cachetools.NewBatchCASUploader(ctx, te, rn.GetInstanceName(), rn.GetDigestFunction(), chunking.FastCDCParams(ctx, nil))
+	ul := cachetools.NewBatchCASUploader(ctx, te, rn.GetInstanceName(), rn.GetDigestFunction(), chunking.FastCDCParams())
 	require.NoError(t, ul.Upload(rn.GetDigest(), cachetools.NewBytesReadSeekCloser(buf)))
 	require.NoError(t, ul.Wait())
 
 	casRN := digest.NewCASResourceName(rn.GetDigest(), rn.GetInstanceName(), rn.GetDigestFunction())
 	out := &bytes.Buffer{}
-	err = cachetools.GetBlob(ctx, te.GetByteStreamClient(), casRN, out)
+	err := cachetools.GetBlob(ctx, te.GetByteStreamClient(), casRN, out)
 	require.NoError(t, err)
 	require.Equal(t, buf, out.Bytes())
 }
@@ -1505,7 +1487,7 @@ func TestBatchCASUploader_ChunkedUploadDetectsConcurrentMutation(t *testing.T) {
 	require.NoError(t, err)
 	buf[0] = 'x'
 
-	ul := cachetools.NewBatchCASUploader(t.Context(), te, "", repb.DigestFunction_SHA256, chunking.FastCDCParams(t.Context(), nil))
+	ul := cachetools.NewBatchCASUploader(t.Context(), te, "", repb.DigestFunction_SHA256, chunking.FastCDCParams())
 	require.NoError(t, ul.Upload(d, cachetools.NewBytesReadSeekCloser(buf)))
 	err = ul.Wait()
 	require.Error(t, err)
@@ -1514,22 +1496,7 @@ func TestBatchCASUploader_ChunkedUploadDetectsConcurrentMutation(t *testing.T) {
 }
 
 func TestBatchCASUploader_SkipsChunkedUploadAboveMaxSize(t *testing.T) {
-	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
-	})
-	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
-	fp, err := experiments.NewFlagProvider(t.Name())
-	require.NoError(t, err)
-
 	te := testenv.GetTestEnv(t)
-	te.SetExperimentFlagProvider(fp)
 	_, runServer, localGRPClis := testenv.RegisterLocalGRPCServer(t, te)
 	testcache.Setup(t, te, localGRPClis)
 	go runServer()
@@ -1538,7 +1505,7 @@ func TestBatchCASUploader_SkipsChunkedUploadAboveMaxSize(t *testing.T) {
 	blobSize := int64(5 * 1024 * 1024)
 	rn, buf := testdigest.RandomCASResourceBuf(t, blobSize)
 
-	chunkingParams := chunking.FastCDCParams(ctx, nil)
+	chunkingParams := chunking.FastCDCParams()
 	chunkingParams.BuildbuddyMaxChunkedWriteSizeBytes = 2 * 1024 * 1024
 	ul := cachetools.NewBatchCASUploader(ctx, te, rn.GetInstanceName(), rn.GetDigestFunction(), chunkingParams)
 	require.NoError(t, ul.Upload(rn.GetDigest(), cachetools.NewBytesReadSeekCloser(buf)))
@@ -1546,7 +1513,7 @@ func TestBatchCASUploader_SkipsChunkedUploadAboveMaxSize(t *testing.T) {
 
 	casRN := digest.NewCASResourceName(rn.GetDigest(), rn.GetInstanceName(), rn.GetDigestFunction())
 	out := &bytes.Buffer{}
-	err = cachetools.GetBlob(ctx, te.GetByteStreamClient(), casRN, out)
+	err := cachetools.GetBlob(ctx, te.GetByteStreamClient(), casRN, out)
 	require.NoError(t, err)
 	require.Equal(t, buf, out.Bytes())
 

--- a/server/remote_cache/capabilities_server/BUILD
+++ b/server/remote_cache/capabilities_server/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "capabilities_server",
@@ -15,5 +15,19 @@ go_library(
         "//server/remote_cache/config",
         "//server/remote_cache/digest",
         "//server/util/bazel_request",
+    ],
+)
+
+go_test(
+    name = "capabilities_server_test",
+    srcs = ["capabilities_server_test.go"],
+    deps = [
+        ":capabilities_server",
+        "//proto:remote_execution_go_proto",
+        "//server/interfaces",
+        "//server/testutil/testenv",
+        "//server/util/testing/flags",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/remote_cache/capabilities_server/capabilities_server.go
+++ b/server/remote_cache/capabilities_server/capabilities_server.go
@@ -67,7 +67,6 @@ func (s *CapabilitiesServer) GetCapabilities(ctx context.Context, req *repb.GetC
 		compressors = []repb.Compressor_Value{repb.Compressor_IDENTITY, repb.Compressor_ZSTD}
 	}
 	if s.supportCAS {
-		chunkingEnabled := chunking.Enabled(ctx, s.env.GetExperimentFlagProvider())
 		c.CacheCapabilities = &repb.CacheCapabilities{
 			DigestFunctions: digest.SupportedDigestFunctions(),
 			ActionCacheUpdateCapabilities: &repb.ActionCacheUpdateCapabilities{
@@ -85,12 +84,9 @@ func (s *CapabilitiesServer) GetCapabilities(ctx context.Context, req *repb.GetC
 			SymlinkAbsolutePathStrategy:     repb.SymlinkAbsolutePathStrategy_ALLOWED,
 			SupportedCompressors:            compressors,
 			SupportedBatchUpdateCompressors: compressors,
-			SplitBlobSupport:                chunkingEnabled,
-			SpliceBlobSupport:               chunkingEnabled,
-		}
-
-		if chunkingEnabled {
-			c.CacheCapabilities.FastCdc_2020Params = chunking.FastCDCParams(ctx, s.env.GetExperimentFlagProvider())
+			SplitBlobSupport:                true,
+			SpliceBlobSupport:               true,
+			FastCdc_2020Params:              chunking.FastCDCParams(),
 		}
 	}
 	if s.supportRemoteExec {

--- a/server/remote_cache/capabilities_server/capabilities_server_test.go
+++ b/server/remote_cache/capabilities_server/capabilities_server_test.go
@@ -1,0 +1,40 @@
+package capabilities_server_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/capabilities_server"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+type cdcDisabledFlagProvider struct {
+	interfaces.ExperimentFlagProvider
+}
+
+func (cdcDisabledFlagProvider) Boolean(ctx context.Context, flagName string, defaultValue bool, opts ...any) bool {
+	return false
+}
+
+func (cdcDisabledFlagProvider) Int64(ctx context.Context, flagName string, defaultValue int64, opts ...any) int64 {
+	return 512 * 1024
+}
+
+func TestGetCapabilities_CDCDoesNotVaryWithExperiments(t *testing.T) {
+	flags.Set(t, "cache.avg_chunk_size_bytes", 1024*1024)
+	env := testenv.GetTestEnv(t)
+	env.SetExperimentFlagProvider(cdcDisabledFlagProvider{})
+	s := capabilities_server.NewCapabilitiesServer(env, true, false, false)
+
+	rsp, err := s.GetCapabilities(t.Context(), &repb.GetCapabilitiesRequest{})
+	require.NoError(t, err)
+	assert.True(t, rsp.GetCacheCapabilities().GetSplitBlobSupport())
+	assert.True(t, rsp.GetCacheCapabilities().GetSpliceBlobSupport())
+	assert.Equal(t, uint64(1024*1024), rsp.GetCacheCapabilities().GetFastCdc_2020Params().GetAvgChunkSizeBytes())
+}

--- a/server/remote_cache/chunking/BUILD
+++ b/server/remote_cache/chunking/BUILD
@@ -11,7 +11,6 @@ go_library(
         "//server/interfaces",
         "//server/metrics",
         "//server/remote_cache/digest",
-        "//server/util/alert",
         "//server/util/compression",
         "//server/util/findmissing",
         "//server/util/log",

--- a/server/remote_cache/chunking/chunking.go
+++ b/server/remote_cache/chunking/chunking.go
@@ -16,7 +16,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
-	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/compression"
 	"github.com/buildbuddy-io/buildbuddy/server/util/findmissing"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -47,25 +46,13 @@ const (
 	defaultMaxChunkedWriteSizeBytes = -1
 )
 
-func AvgChunkSizeBytes(ctx context.Context, efp interfaces.ExperimentFlagProvider) int64 {
-	if efp == nil {
-		return *avgChunkSizeBytes
-	}
-	if v := efp.Int64(ctx, "cache.avg_chunk_size_override", 0); v > 0 {
-		if v < 1024 || v > 1024*1024 || v&(v-1) != 0 {
-			alert.CtxUnexpectedEvent(ctx, "invalid_cache_avg_chunk_size_override", "Ignoring invalid cache.avg_chunk_size_override %d", v)
-			return *avgChunkSizeBytes
-		}
-		return v
-	}
+func AvgChunkSizeBytes() int64 {
 	return *avgChunkSizeBytes
 }
 
 // FastCDCParams returns the FastCDC2020 parameters if chunking is configured.
-// The avg chunk size may vary by group. This is safe because manifests are AC
-// entries, and AC entries are namespaced by group in the cache key.
-func FastCDCParams(ctx context.Context, efp interfaces.ExperimentFlagProvider) *repb.FastCdc2020Params {
-	v := AvgChunkSizeBytes(ctx, efp)
+func FastCDCParams() *repb.FastCdc2020Params {
+	v := AvgChunkSizeBytes()
 	if v <= 0 {
 		return nil
 	}
@@ -76,15 +63,15 @@ func FastCDCParams(ctx context.Context, efp interfaces.ExperimentFlagProvider) *
 }
 
 func FastCDCWriteParams(ctx context.Context, efp interfaces.ExperimentFlagProvider) *repb.FastCdc2020Params {
-	params := FastCDCParams(ctx, efp)
+	params := FastCDCParams()
 	if params != nil {
 		params.BuildbuddyMaxChunkedWriteSizeBytes = MaxWriteSizeBytes(ctx, efp)
 	}
 	return params
 }
 
-func MaxChunkSizeBytes(ctx context.Context, efp interfaces.ExperimentFlagProvider) int64 {
-	return AvgChunkSizeBytes(ctx, efp) * 4
+func MaxChunkSizeBytes() int64 {
+	return AvgChunkSizeBytes() * 4
 }
 
 // MaxSupportedChunkSizeBytes is the process-wide chunk size buffer consumers
@@ -105,8 +92,8 @@ func MaxCompressedChunkReadSizeBytes() int64 {
 // at most MaxChunkSizeBytes(). Presence and AC validation should instead use
 // MaxChunkSizeBytes(), so blobs below the current write threshold are not
 // accepted as manifest-only.
-func MinChunkedReadFallbackSizeBytes(ctx context.Context, efp interfaces.ExperimentFlagProvider) int64 {
-	return min(*minChunkedReadFallbackSizeBytes, MaxChunkSizeBytes(ctx, efp))
+func MinChunkedReadFallbackSizeBytes() int64 {
+	return min(*minChunkedReadFallbackSizeBytes, MaxChunkSizeBytes())
 }
 
 func MaxWriteSizeBytes(ctx context.Context, efp interfaces.ExperimentFlagProvider) int64 {
@@ -117,7 +104,7 @@ func MaxWriteSizeBytes(ctx context.Context, efp interfaces.ExperimentFlagProvide
 }
 
 func ShouldUploadChunked(ctx context.Context, efp interfaces.ExperimentFlagProvider, d *repb.Digest) bool {
-	return ShouldUploadChunkedWithMax(d, AvgChunkSizeBytes(ctx, efp), MaxWriteSizeBytes(ctx, efp))
+	return ShouldUploadChunkedWithMax(d, AvgChunkSizeBytes(), MaxWriteSizeBytes(ctx, efp))
 }
 
 // ShouldUploadChunkedWithMax returns whether a blob is eligible for chunked upload.
@@ -140,23 +127,14 @@ func ValidateConfig() error {
 	return nil
 }
 
-func Enabled(ctx context.Context, efp interfaces.ExperimentFlagProvider) bool {
-	return efp == nil || efp.Boolean(ctx, "cache.chunking_enabled", true)
-}
-
-func ShouldReadChunked(ctx context.Context, efp interfaces.ExperimentFlagProvider, digestSizeBytes, offset, limit int64) bool {
-	// Check digest first since it's faster than reading efp flag
-	// and very likely to be false.
-	return digestSizeBytes > MinChunkedReadFallbackSizeBytes(ctx, efp) &&
-		limit == 0 &&
-		Enabled(ctx, efp)
+func ShouldReadChunked(digestSizeBytes, offset, limit int64) bool {
+	return digestSizeBytes > MinChunkedReadFallbackSizeBytes() && limit == 0
 }
 
 func ShouldReadChunkedOnProxy(ctx context.Context, efp interfaces.ExperimentFlagProvider, digestSizeBytes, offset, limit int64) bool {
-	return digestSizeBytes > MaxChunkSizeBytes(ctx, efp) &&
+	return digestSizeBytes > MaxChunkSizeBytes() &&
 		limit == 0 &&
-		(efp == nil ||
-			(Enabled(ctx, efp) && efp.Boolean(ctx, "cache_proxy.attempt_chunked_reads", true)))
+		(efp == nil || efp.Boolean(ctx, "cache_proxy.attempt_chunked_reads", true))
 }
 
 type WriteFunc func([]byte) error

--- a/server/remote_cache/chunking/chunking_test.go
+++ b/server/remote_cache/chunking/chunking_test.go
@@ -33,10 +33,9 @@ type getMultiBatchRecordingCache struct {
 }
 
 func TestAvgChunkSizeDefault(t *testing.T) {
-	ctx := context.Background()
-	require.Equal(t, int64(1024*1024), chunking.AvgChunkSizeBytes(ctx, nil))
-	require.Equal(t, uint64(1024*1024), chunking.FastCDCParams(ctx, nil).GetAvgChunkSizeBytes())
-	require.Equal(t, int64(4*1024*1024), chunking.MaxChunkSizeBytes(ctx, nil))
+	require.Equal(t, int64(1024*1024), chunking.AvgChunkSizeBytes())
+	require.Equal(t, uint64(1024*1024), chunking.FastCDCParams().GetAvgChunkSizeBytes())
+	require.Equal(t, int64(4*1024*1024), chunking.MaxChunkSizeBytes())
 }
 
 func (c *getMultiBatchRecordingCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
@@ -140,11 +139,11 @@ func TestShouldReadChunkedUsesReadFallbackThreshold(t *testing.T) {
 		Hash:      "hash",
 		SizeBytes: 3 * 1024 * 1024,
 	}))
-	assert.True(t, chunking.ShouldReadChunked(ctx, nil, 3*1024*1024, 0, 0))
+	assert.True(t, chunking.ShouldReadChunked(3*1024*1024, 0, 0))
 	assert.False(t, chunking.ShouldReadChunkedOnProxy(ctx, nil, 3*1024*1024, 0, 0))
 	assert.True(t, chunking.ShouldReadChunkedOnProxy(ctx, nil, 5*1024*1024, 0, 0))
-	assert.False(t, chunking.ShouldReadChunked(ctx, nil, 2*1024*1024, 0, 0))
-	assert.False(t, chunking.ShouldReadChunked(ctx, nil, 3*1024*1024, 0, 1024))
+	assert.False(t, chunking.ShouldReadChunked(2*1024*1024, 0, 0))
+	assert.False(t, chunking.ShouldReadChunked(3*1024*1024, 0, 1024))
 }
 
 func TestReadFallbackThresholdClampsToMaxChunkSize(t *testing.T) {
@@ -152,9 +151,7 @@ func TestReadFallbackThresholdClampsToMaxChunkSize(t *testing.T) {
 	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 4*1024*1024+1)
 
 	require.NoError(t, chunking.ValidateConfig())
-	ctx := context.Background()
-	efp := booleanFlagProvider{}
-	require.Equal(t, chunking.MaxChunkSizeBytes(ctx, efp), chunking.MinChunkedReadFallbackSizeBytes(ctx, efp))
+	require.Equal(t, chunking.MaxChunkSizeBytes(), chunking.MinChunkedReadFallbackSizeBytes())
 }
 
 func TestGetBlobRejectsForgedManifestSizes(t *testing.T) {
@@ -281,7 +278,7 @@ func TestStoreAndLoad(t *testing.T) {
 			require.NoError(t, err)
 
 			var chunkDigests []*repb.Digest
-			c, err := chunking.NewChunker(ctx, int(chunking.AvgChunkSizeBytes(ctx, nil)), func(data []byte) error {
+			c, err := chunking.NewChunker(ctx, int(chunking.AvgChunkSizeBytes()), func(data []byte) error {
 				d, err := digest.Compute(bytes.NewReader(data), repb.DigestFunction_SHA256)
 				if err != nil {
 					return err
@@ -344,7 +341,7 @@ func TestStore_MissingChunk(t *testing.T) {
 	require.NoError(t, err)
 
 	var chunkDigests []*repb.Digest
-	c, err := chunking.NewChunker(ctx, int(chunking.AvgChunkSizeBytes(ctx, nil)), func(data []byte) error {
+	c, err := chunking.NewChunker(ctx, int(chunking.AvgChunkSizeBytes()), func(data []byte) error {
 		d, err := digest.Compute(bytes.NewReader(data), repb.DigestFunction_SHA256)
 		if err != nil {
 			return err
@@ -652,8 +649,7 @@ func (c *findMissingTrackingCache) FindMissing(ctx context.Context, resources []
 
 type booleanFlagProvider struct {
 	interfaces.ExperimentFlagProvider
-	values    map[string]bool
-	intValues map[string]int64
+	values map[string]bool
 }
 
 func (p booleanFlagProvider) Boolean(ctx context.Context, flagName string, defaultValue bool, opts ...any) bool {
@@ -664,38 +660,12 @@ func (p booleanFlagProvider) Boolean(ctx context.Context, flagName string, defau
 	return v
 }
 
-func (p booleanFlagProvider) Int64(ctx context.Context, flagName string, defaultValue int64, opts ...any) int64 {
-	v, ok := p.intValues[flagName]
-	if ok {
-		return v
-	}
-	return defaultValue
-}
-
-func TestEnabled_FallsBackToExperimentFlag(t *testing.T) {
-	ctx := context.Background()
-	assert.True(t, chunking.Enabled(ctx, nil))
-}
-
-func TestEnabled_UsesExperimentFlag(t *testing.T) {
-	ctx := context.Background()
-	assert.False(t, chunking.Enabled(ctx, booleanFlagProvider{
-		values: map[string]bool{"cache.chunking_enabled": false},
-	}))
-	assert.True(t, chunking.Enabled(ctx, booleanFlagProvider{
-		values: map[string]bool{"cache.chunking_enabled": true},
-	}))
-}
-
 func TestShouldReadChunkedOnProxy_UsesExperimentFlag(t *testing.T) {
 	ctx := context.Background()
-	size := chunking.MaxChunkSizeBytes(ctx, nil) + 1
+	size := chunking.MaxChunkSizeBytes() + 1
 	assert.True(t, chunking.ShouldReadChunkedOnProxy(ctx, nil, size, 0, 0))
 	assert.False(t, chunking.ShouldReadChunkedOnProxy(ctx, booleanFlagProvider{
 		values: map[string]bool{"cache_proxy.attempt_chunked_reads": false},
-	}, size, 0, 0))
-	assert.False(t, chunking.ShouldReadChunkedOnProxy(ctx, booleanFlagProvider{
-		values: map[string]bool{"cache.chunking_enabled": false},
 	}, size, 0, 0))
 }
 

--- a/server/remote_cache/content_addressable_storage_server/BUILD
+++ b/server/remote_cache/content_addressable_storage_server/BUILD
@@ -81,7 +81,6 @@ go_test(
         "@com_github_buildbuddy_io_fastcdc2020//fastcdc",
         "@com_github_google_uuid//:uuid",
         "@com_github_open_feature_go_sdk//openfeature",
-        "@com_github_open_feature_go_sdk//openfeature/memprovider",
         "@com_github_open_feature_go_sdk_contrib_providers_flagd//pkg",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_stretchr_testify//assert",

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -143,9 +143,10 @@ func (s *ContentAddressableStorageServer) FindMissingBlobs(ctx context.Context, 
 	// Otherwise, only check manifests for blobs above the current whole-blob
 	// write threshold. Blobs at or below the threshold should be uploaded as
 	// whole blobs.
-	if efp := s.env.GetExperimentFlagProvider(); len(missing) > 0 && !cdc.IsChunked(ctx) && chunking.Enabled(ctx, efp) {
+	if len(missing) > 0 && !cdc.IsChunked(ctx) {
 		checker := chunking.NewMissingChunkChecker(s.cache, repb.FindMissingBlobsRequest_FMB_CHUNK_VALIDATION)
-		maxChunkSizeBytes := chunking.MaxChunkSizeBytes(ctx, efp)
+		maxChunkSizeBytes := chunking.MaxChunkSizeBytes()
+		efp := s.env.GetExperimentFlagProvider()
 
 		var mu sync.Mutex
 		stillMissing := make([]*repb.Digest, 0, len(missing))
@@ -403,12 +404,7 @@ func (s *ContentAddressableStorageServer) BatchReadBlobs(ctx context.Context, re
 	cacheRequest := make([]*rspb.ResourceName, 0, len(req.Digests))
 	rsp.Responses = make([]*repb.BatchReadBlobsResponse_Response, 0, len(req.Digests))
 	clientAcceptsZstd := remote_cache_config.ZstdTranscodingEnabled() && clientAcceptsCompressor(req.AcceptableCompressors, repb.Compressor_ZSTD)
-	efp := s.env.GetExperimentFlagProvider()
-	chunkingEnabled := chunking.Enabled(ctx, efp)
-	chunkedReadFallbackSizeBytes := int64(0)
-	if chunkingEnabled {
-		chunkedReadFallbackSizeBytes = chunking.MinChunkedReadFallbackSizeBytes(ctx, efp)
-	}
+	chunkedReadFallbackSizeBytes := chunking.MinChunkedReadFallbackSizeBytes()
 	readZstd := clientAcceptsZstd && s.cache.SupportsCompressor(repb.Compressor_ZSTD)
 
 	requestedResources := make([]*digest.ResourceName, 0, len(req.GetDigests()))
@@ -448,7 +444,7 @@ func (s *ContentAddressableStorageServer) BatchReadBlobs(ctx context.Context, re
 		// It's unexpected, but BatchReadBlobs may be used for blobs that are
 		// large enough to be chunked. If the blob was not found and it's large
 		// enough to be chunked, try to reassemble it from CDC chunks.
-		if (!ok || os.IsNotExist(err)) && chunkingEnabled && rn.GetDigest().GetSizeBytes() > chunkedReadFallbackSizeBytes {
+		if (!ok || os.IsNotExist(err)) && rn.GetDigest().GetSizeBytes() > chunkedReadFallbackSizeBytes {
 			if assembled, assembleErr := s.readChunkedBlob(ctx, rn.GetDigest(), req.GetInstanceName(), req.GetDigestFunction(), readZstd); assembleErr == nil {
 				data = assembled
 				ok = true
@@ -1246,10 +1242,6 @@ func (s *ContentAddressableStorageServer) spliceBlob(ctx context.Context, req *r
 		}, nil
 	}
 
-	if !chunking.Enabled(ctx, s.env.GetExperimentFlagProvider()) {
-		return nil, status.UnimplementedErrorf("SpliceBlob RPC is not currently enabled")
-	}
-
 	if cf := req.GetChunkingFunction(); cf != repb.ChunkingFunction_UNKNOWN && cf != repb.ChunkingFunction_FAST_CDC_2020 {
 		return nil, status.InvalidArgumentErrorf("unsupported chunking function %v in request %s", cf, req)
 	}
@@ -1360,10 +1352,6 @@ func (s *ContentAddressableStorageServer) splitBlob(ctx context.Context, req *re
 	ctx, err := prefix.AttachUserPrefixToContext(ctx, s.env.GetAuthenticator())
 	if err != nil {
 		return nil, err
-	}
-
-	if !chunking.Enabled(ctx, s.env.GetExperimentFlagProvider()) {
-		return nil, status.UnimplementedErrorf("SplitBlob RPC is not currently enabled")
 	}
 
 	cf := req.GetChunkingFunction()

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/google/uuid"
 	flagd "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg"
 	"github.com/open-feature/go-sdk/openfeature"
-	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -887,26 +886,9 @@ func TestGetTreeMissingRoot(t *testing.T) {
 }
 
 func TestSpliceAndSplitBlob(t *testing.T) {
-	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
-	})
-	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
-
-	fp, err := experiments.NewFlagProvider(t.Name())
-	require.NoError(t, err)
-
 	ctx := context.Background()
 	te := testenv.GetTestEnv(t)
-	te.SetExperimentFlagProvider(fp)
-
-	ctx, err = prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
 	require.NoError(t, err)
 
 	clientConn := runCASServer(ctx, t, te)
@@ -1085,11 +1067,6 @@ func TestSpliceBlobWithoutValidation(t *testing.T) {
 {
   "$schema": "https://flagd.dev/schema/v0/flags.json",
   "flags": {
-    "cache.chunking_enabled": {
-      "state": "ENABLED",
-      "variants": {"enabled": true},
-      "defaultVariant": "enabled"
-    },
     "splice-without-validation": {
       "state": "ENABLED",
       "variants": {"enabled": true, "disabled": false},
@@ -1111,7 +1088,6 @@ func TestSpliceBlobWithoutValidation(t *testing.T) {
 			fp, err := experiments.NewFlagProvider(t.Name())
 			require.NoError(t, err)
 			env.SetExperimentFlagProvider(fp)
-
 			ctx := testauth.WithAuthenticatedUserInfo(t.Context(), user)
 			ctx, err = prefix.AttachUserPrefixToContext(ctx, env.GetAuthenticator())
 			require.NoError(t, err)
@@ -1174,26 +1150,9 @@ func TestSpliceBlobWithoutValidation(t *testing.T) {
 }
 
 func TestSplitBlobNotFound(t *testing.T) {
-	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
-	})
-	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
-
-	fp, err := experiments.NewFlagProvider(t.Name())
-	require.NoError(t, err)
-
 	ctx := context.Background()
 	te := testenv.GetTestEnv(t)
-	te.SetExperimentFlagProvider(fp)
-
-	ctx, err = prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
 	require.NoError(t, err)
 
 	clientConn := runCASServer(ctx, t, te)
@@ -1273,26 +1232,9 @@ func TestSplitBlobRejectsLayeredManifest(t *testing.T) {
 }
 
 func TestSpliceBlobSingleChunk(t *testing.T) {
-	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
-	})
-	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
-
-	fp, err := experiments.NewFlagProvider(t.Name())
-	require.NoError(t, err)
-
 	ctx := context.Background()
 	te := testenv.GetTestEnv(t)
-	te.SetExperimentFlagProvider(fp)
-
-	ctx, err = prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
 	require.NoError(t, err)
 
 	clientConn := runCASServer(ctx, t, te)
@@ -1329,26 +1271,9 @@ func TestSpliceBlobSingleChunk(t *testing.T) {
 }
 
 func TestFindMissingBlobsWithChunkedBlob(t *testing.T) {
-	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
-	})
-	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
-
-	fp, err := experiments.NewFlagProvider(t.Name())
-	require.NoError(t, err)
-
 	ctx := context.Background()
 	te := testenv.GetTestEnv(t)
-	te.SetExperimentFlagProvider(fp)
-
-	ctx, err = prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
 	require.NoError(t, err)
 
 	clientConn := runCASServer(ctx, t, te)
@@ -1469,30 +1394,14 @@ func TestBatchReadBlobsWithChunkedBlob(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-				"cache.chunking_enabled": {
-					State:          memprovider.Enabled,
-					DefaultVariant: "true",
-					Variants: map[string]any{
-						"true":  true,
-						"false": false,
-					},
-				},
-			})
-			require.NoError(t, openfeature.SetProviderAndWait(testProvider))
-
-			fp, err := experiments.NewFlagProvider(t.Name())
-			require.NoError(t, err)
-
 			ctx := context.Background()
 			te := testenv.GetTestEnv(t)
-			te.SetExperimentFlagProvider(fp)
 			if tc.useCompressionCache {
 				flags.Set(t, "cache.zstd_transcoding_enabled", true)
 				te.SetCache(&casCompressionCache{Cache: te.GetCache()})
 			}
 
-			ctx, err = prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+			ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
 			require.NoError(t, err)
 
 			clientConn := runCASServer(ctx, t, te)
@@ -1553,26 +1462,9 @@ func TestBatchReadBlobsWithChunkedBlob(t *testing.T) {
 }
 
 func TestBatchReadBlobsWithMismatchedChunkedManifest(t *testing.T) {
-	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
-	})
-	require.NoError(t, openfeature.SetProviderAndWait(testProvider))
-
-	fp, err := experiments.NewFlagProvider(t.Name())
-	require.NoError(t, err)
-
 	ctx := context.Background()
 	te := testenv.GetTestEnv(t)
-	te.SetExperimentFlagProvider(fp)
-
-	ctx, err = prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
 	require.NoError(t, err)
 
 	clientConn := runCASServer(ctx, t, te)
@@ -1619,22 +1511,6 @@ func TestSpliceBlobReadOnlyKey(t *testing.T) {
 	ctx := context.Background()
 	te := testenv.GetTestEnv(t)
 
-	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-		"cache.chunking_enabled": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "true",
-			Variants: map[string]any{
-				"true":  true,
-				"false": false,
-			},
-		},
-	})
-	require.NoError(t, openfeature.SetProviderAndWait(testProvider))
-
-	fp, err := experiments.NewFlagProvider("test")
-	require.NoError(t, err)
-	te.SetExperimentFlagProvider(fp)
-
 	readOnlyUser := &testauth.TestUser{
 		UserID:       "US1",
 		GroupID:      "GR1",
@@ -1654,7 +1530,7 @@ func TestSpliceBlobReadOnlyKey(t *testing.T) {
 		DigestFunction: repb.DigestFunction_BLAKE3,
 	}
 
-	_, err = casClient.SpliceBlob(ctx, spliceReq)
+	_, err := casClient.SpliceBlob(ctx, spliceReq)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
`chunking_enabled` simply supports the Split/Splice APIs and has been enabled by default for some time now (both internally and onprem), it doesn't do any active logic changes, just support.

`chunk_size_override` was a migration tool. The migration is done, and arguably Capbailities should not differ by request. This is a cleanup so that we can support proxy CDC in on-prem deployments through capabilities, rather than flags.