### PR TITLE
Don't delete 'shared' objects from GCS on delete/evict

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2570,8 +2570,10 @@ func (p *PebbleCache) deleteFileAndMetadata(ctx context.Context, key filestore.P
 		// Already deleted; see comment above.
 		break
 	case storageMetadata.GetGcsMetadata() != nil:
-		if err := p.fileStorer.DeleteStoredBlob(ctx, storageMetadata.GetGcsMetadata()); err != nil {
-			return err
+		if !storageMetadata.GetGcsMetadata().GetShared() {
+			if err := p.fileStorer.DeleteStoredBlob(ctx, storageMetadata.GetGcsMetadata()); err != nil {
+				return err
+			}
 		}
 	default:
 		return status.FailedPreconditionErrorf("Unknown storage metadata type: %+v", storageMetadata)
@@ -3567,8 +3569,10 @@ func (e *partitionEvictor) deleteFile(rawKey []byte, key filestore.PebbleKey, gr
 	case storageMetadata.GetInlineMetadata() != nil:
 		break
 	case storageMetadata.GetGcsMetadata() != nil:
-		if err := e.fileStorer.DeleteStoredBlob(context.TODO(), storageMetadata.GetGcsMetadata()); err != nil {
-			return err
+		if !storageMetadata.GetGcsMetadata().GetShared() {
+			if err := e.fileStorer.DeleteStoredBlob(context.TODO(), storageMetadata.GetGcsMetadata()); err != nil {
+				return err
+			}
 		}
 	default:
 		return status.FailedPreconditionErrorf("Unknown storage metadata type: %+v", storageMetadata)

--- a/enterprise/server/backends/pebble_cache/pebble_cache_internal_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_internal_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/filestore"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/pebble"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/mockgcs"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/lockmap"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -143,20 +144,41 @@ func fileMetadata(i int, eligible bool) *sgpb.FileMetadata {
 // eligible, eligibleEvery=0: none).
 func newBenchEvictor(b *testing.B, eligibleEvery int) (*partitionEvictor, pebble.IPebbleDB) {
 	b.Helper()
-	db, err := pebble.Open("", "bench", &cpebble.Options{FS: vfs.NewMem()})
-	require.NoError(b, err)
-	b.Cleanup(func() { db.Close() })
+	db := newMemDB(b)
 	fileStorer := filestore.New()
 	for i := range numKeys {
 		md := fileMetadata(i, eligibleEvery > 0 && i%eligibleEvery == 0)
-		key, err := fileStorer.PebbleKey(md.GetFileRecord())
-		require.NoError(b, err)
-		keyBytes, err := key.Bytes(filestore.Version5)
-		require.NoError(b, err)
-		buf, err := md.MarshalVT()
-		require.NoError(b, err)
-		require.NoError(b, db.Set(keyBytes, buf, cpebble.NoSync))
+		writeFileMetadata(b, db, fileStorer, md)
 	}
+	return newTestEvictor(b, fileStorer, db), db
+}
+
+func newMemDB(tb testing.TB) pebble.IPebbleDB {
+	tb.Helper()
+	db, err := pebble.Open("", "test", &cpebble.Options{FS: vfs.NewMem()})
+	require.NoError(tb, err)
+	tb.Cleanup(func() { db.Close() })
+	return db
+}
+
+// writeFileMetadata stores md in db under its pebble key and returns the key
+// and its raw bytes.
+func writeFileMetadata(tb testing.TB, db pebble.IPebbleDB, fileStorer filestore.Store, md *sgpb.FileMetadata) (filestore.PebbleKey, []byte) {
+	tb.Helper()
+	key, err := fileStorer.PebbleKey(md.GetFileRecord())
+	require.NoError(tb, err)
+	keyBytes, err := key.Bytes(filestore.Version5)
+	require.NoError(tb, err)
+	buf, err := md.MarshalVT()
+	require.NoError(tb, err)
+	require.NoError(tb, db.Set(keyBytes, buf, cpebble.NoSync))
+	return key, keyBytes
+}
+
+// newTestEvictor builds a real partitionEvictor over db for the bench
+// partition. It does not start the sampler or delete workers.
+func newTestEvictor(tb testing.TB, fileStorer filestore.Store, db pebble.IPebbleDB) *partitionEvictor {
+	tb.Helper()
 	part := disk.Partition{
 		ID:                benchPartitionID,
 		MaxSizeBytes:      100,
@@ -180,8 +202,54 @@ func newBenchEvictor(b *testing.B, eligibleEvery int) (*partitionEvictor, pebble
 		20,            /*=deleteBufferSize*/
 		1,             /*=numDeleteWorkers*/
 	)
-	require.NoError(b, err)
-	return evictor, db
+	require.NoError(tb, err)
+	return evictor
+}
+
+// TestEvictorDeleteFileGCSBlob asserts that evicting a record that owns its
+// GCS blob deletes the blob, while evicting a record for a shared blob leaves
+// the blob in place for the other records that refer to it.
+func TestEvictorDeleteFileGCSBlob(t *testing.T) {
+	for _, shared := range []bool{false, true} {
+		t.Run(fmt.Sprintf("shared=%v", shared), func(t *testing.T) {
+			ctx := context.Background()
+			clock := clockwork.NewFakeClock()
+			gcs := mockgcs.New(clock)
+			fileStorer := filestore.New(filestore.WithGCSBlobstore(gcs, "app"), filestore.WithClock(clock))
+			db := newMemDB(t)
+
+			md := fileMetadata(0, true /*=eligible*/)
+			bw, err := fileStorer.BlobWriter(ctx, md.GetFileRecord())
+			require.NoError(t, err)
+			_, err = bw.Write([]byte("blob contents"))
+			require.NoError(t, err)
+			require.NoError(t, bw.Commit())
+			require.NoError(t, bw.Close())
+			md.StorageMetadata = bw.Metadata()
+			md.StorageMetadata.GcsMetadata.Shared = shared
+			blobName := md.GetStorageMetadata().GetGcsMetadata().GetBlobName()
+			key, keyBytes := writeFileMetadata(t, db, fileStorer, md)
+
+			evictor := newTestEvictor(t, fileStorer, db)
+			err = evictor.deleteFile(keyBytes, key, md.GetFileRecord().GetIsolation().GetGroupId(), md.GetLastModifyUsec(), md.GetStoredSizeBytes(), md.GetStorageMetadata())
+			require.NoError(t, err)
+
+			// The record is always deleted.
+			_, closer, err := db.Get(keyBytes)
+			require.ErrorIs(t, err, cpebble.ErrNotFound)
+			if closer != nil {
+				closer.Close()
+			}
+
+			// The blob is only deleted if the record owned it.
+			_, err = gcs.Reader(ctx, blobName, 0, 0)
+			if shared {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
 }
 
 // BenchmarkSampleGenerator runs the real sampler goroutine end to end —

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -4274,6 +4274,53 @@ func TestWriteReference(t *testing.T) {
 		require.True(t, status.IsNotFoundError(err), "expected NotFoundError, got %s", err)
 	})
 
+	t.Run("take ownership deletes the blob", func(t *testing.T) {
+		te := testenv.GetTestEnv(t)
+		te.SetAuthenticator(testauth.NewTestAuthenticator(t, emptyUserMap))
+		ctx := getAnonContext(t, te)
+		src, dst, _ := setup(t, te, minAutoZstd)
+
+		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
+		require.NoError(t, src.Set(ctx, rn, buf))
+		ref, err := src.ReadReference(ctx, rn)
+		require.NoError(t, err)
+		require.NoError(t, dst.WriteReference(ctx, ref, rn, false /*=mustClone*/))
+
+		// The accepting cache owns the blob, so deleting its record deletes
+		// the blob out from under the source cache.
+		require.NoError(t, dst.Delete(ctx, rn))
+		_, err = src.Get(ctx, rn)
+		require.True(t, status.IsNotFoundError(err), "expected NotFoundError, got %s", err)
+	})
+
+	t.Run("shared blob survives delete", func(t *testing.T) {
+		te := testenv.GetTestEnv(t)
+		te.SetAuthenticator(testauth.NewTestAuthenticator(t, emptyUserMap))
+		ctx := getAnonContext(t, te)
+		src, dst, _ := setup(t, te, minAutoZstd)
+
+		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
+		require.NoError(t, src.Set(ctx, rn, buf))
+		ref, err := src.ReadReference(ctx, rn)
+		require.NoError(t, err)
+		ref.GetMetadata().GetStorageMetadata().GetGcsMetadata().Shared = true
+		require.NoError(t, dst.WriteReference(ctx, ref, rn, false /*=mustClone*/))
+
+		// The shared bit is stored with the accepting cache's record.
+		dstRef, err := dst.ReadReference(ctx, rn)
+		require.NoError(t, err)
+		require.True(t, dstRef.GetMetadata().GetStorageMetadata().GetGcsMetadata().GetShared())
+
+		// Deleting a record for a shared blob leaves the blob in place for
+		// the other records that refer to it.
+		require.NoError(t, dst.Delete(ctx, rn))
+		_, err = dst.Get(ctx, rn)
+		require.True(t, status.IsNotFoundError(err), "expected NotFoundError, got %s", err)
+		got, err := src.Get(ctx, rn)
+		require.NoError(t, err)
+		require.Equal(t, buf, got)
+	})
+
 	t.Run("clone", func(t *testing.T) {
 		te := testenv.GetTestEnv(t)
 		te.SetAuthenticator(testauth.NewTestAuthenticator(t, emptyUserMap))

--- a/proto/storage.proto
+++ b/proto/storage.proto
@@ -48,6 +48,13 @@ message StorageMetadata {
     // This is used in conjunction with a bucket LifecycleCondition that
     // deletes objects after DaysSinceCustomTime is exceeded.
     int64 last_custom_time_usec = 2 [(view.name) = "FindMissing"];
+
+    // If true, this record does not own the stored object: other records (on
+    // other cache peers) may refer to the same object. In this case, the object
+    // should not be deleted when the record is deleted or evicted. Doing so
+    // could lead to data loss on cache peers. Instead, these objects are
+    // cleaned up by GCS's object lifecycle management.
+    bool shared = 3;
   }
   GCSMetadata gcs_metadata = 5 [(view.name) = "FindMissing"];
 


### PR DESCRIPTION
This is change 1 of 2 to stop triple-writing artifacts to GCS. This change adds a new bit to the `GCSMetadata` indicating that a GCS object is "shared" (between peers) and updates the pebble cache's deletion and eviction logic to not delete these objects on deletion / eviction.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/8257