### PR TITLE
Add a `Visibility` column to the APIKeys table

### DIFF
--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -496,6 +496,10 @@ type APIKey struct {
 	// authenticated user. Keys created by the server or by an
 	// API-key-authenticated caller do not have this field set.
 	CreatedByUserID string `gorm:"default:''"`
+	// If true, this key may only be seen or managed by server admins. These
+	// keys are used for internal purposes on behalf of the group, such as
+	// registering self-hosted executors.
+	ServerAdminOnly bool `gorm:"not null;default:0"`
 }
 
 func (k *APIKey) TableName() string {


### PR DESCRIPTION
This will (eventually) replace the `visibile_to_developers` column and expand support to allow API keys that are only visible to server admins, for example.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/8185