### PR TITLE
Require lease_id to be set ReEnqueueTask requests.

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -2210,9 +2210,8 @@ func (s *SchedulerServer) LeaseTask(stream scpb.Scheduler_LeaseTaskServer) error
 			} else {
 				log.CtxWarningf(ctx, "Could not release lease for task %q: %s", taskID, err)
 			}
-
 			if req.GetReEnqueue() {
-				if _, err := s.ReEnqueueTask(ctx, &scpb.ReEnqueueTaskRequest{TaskId: taskID, Reason: req.GetReEnqueueReason().GetMessage()}); err != nil {
+				if err := s.reEnqueueTask(ctx, taskID, "" /*=leaseID*/, "" /*=reconnectToken*/, probesPerTask, req.GetReEnqueueReason().GetMessage()); err != nil {
 					log.CtxErrorf(ctx, "LeaseTask %q tried to re-enqueue task requested by executor but failed with err: %s", taskID, err)
 				}
 			}
@@ -2790,6 +2789,9 @@ func emitRemoteRunnerMetric(ctx context.Context, task *repb.ExecutionTask, md *s
 }
 
 func (s *SchedulerServer) ReEnqueueTask(ctx context.Context, req *scpb.ReEnqueueTaskRequest) (*scpb.ReEnqueueTaskResponse, error) {
+	if req.GetLeaseId() == "" {
+		return nil, status.FailedPreconditionError("lease id is required")
+	}
 	ctx = log.EnrichContext(ctx, log.ExecutionIDKey, req.GetTaskId())
 	reconnectToken := ""
 	if err := s.reEnqueueTask(ctx, req.GetTaskId(), req.GetLeaseId(), reconnectToken, probesPerTask, req.GetReason()); err != nil {

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -2790,6 +2790,7 @@ func emitRemoteRunnerMetric(ctx context.Context, task *repb.ExecutionTask, md *s
 
 func (s *SchedulerServer) ReEnqueueTask(ctx context.Context, req *scpb.ReEnqueueTaskRequest) (*scpb.ReEnqueueTaskResponse, error) {
 	if req.GetLeaseId() == "" {
+		log.CtxWarning(ctx, "Rejected re-enqueue with no lease id")
 		return nil, status.FailedPreconditionError("lease id is required")
 	}
 	ctx = log.EnrichContext(ctx, log.ExecutionIDKey, req.GetTaskId())

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -808,9 +808,7 @@ func TestExecutorReEnqueue_NoLeaseID(t *testing.T) {
 		TaskId: taskID,
 		Reason: "for fun",
 	})
-	require.NoError(t, err)
-	// On a successful re-enqueue the executor should receive the task again.
-	fe.WaitForTask(taskID)
+	require.True(t, status.IsFailedPreconditionError(err), "expected FailedPrecondition error, got: %v", err)
 }
 
 func TestExecutorReEnqueue_MatchingLeaseID(t *testing.T) {


### PR DESCRIPTION
Apps have been handing out lease IDs for multiple years so any reasonably recent executor should be setting the field.