### PR TITLE
Revert "Add a `Visibility` column to the APIKeys table"

### DIFF
--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -496,10 +496,6 @@ type APIKey struct {
 	// authenticated user. Keys created by the server or by an
 	// API-key-authenticated caller do not have this field set.
 	CreatedByUserID string `gorm:"default:''"`
-	// If true, this key may only be seen or managed by server admins. These
-	// keys are used for internal purposes on behalf of the group, such as
-	// registering self-hosted executors.
-	ServerAdminOnly bool `gorm:"not null;default:0"`
 }
 
 func (k *APIKey) TableName() string {


### PR DESCRIPTION
Forgot to push the commit that made this change to the branch. The change I submitted just had the `ServerAdminOnly` column.

Reverts buildbuddy-io/buildbuddy#13315